### PR TITLE
3.5: Process isolation on Windows

### DIFF
--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -141,6 +141,11 @@ class PHPUnit_Util_PHP
           self::getPhpBinary(), self::$descriptorSpec, $pipes
         );
 
+        if($_SERVER["OS"] == "Windows_NT") {
+            // workaround for bug in Windows, see also: http://bugs.php.net/bug.php?id=52911
+            sleep(2);
+        }
+
         if (is_resource($process)) {
             if ($result !== NULL) {
                 $result->startTest($test);


### PR DESCRIPTION
Implemented a workaround for a blocking bug in `proc_open` on Windows, as suggested per http://bugs.php.net/bug.php?id=52911.

It delays each test run by 2\* seconds, making the testing quite slow, but usable.
- the comment on php.net suggested 1 second, but my machine (Core2Quad Q9450) required 2 seconds
