### PR TITLE
Assert count

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -2592,4 +2592,34 @@ abstract class PHPUnit_Framework_Assert
     {
         self::$count = 0;
     }
+
+    /**
+     * Asserts the count of an array, Iterator or Countable object
+     *
+     * @param integer $expectedCount
+     * @param mixed $element
+     * @param string $message
+     */
+    public function assertCount($expectedCount, $element, $message = '')
+    {
+        if (!is_int($expectedCount)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                1, 'integer'
+            );
+        }
+
+        if (!$element instanceof Countable &&
+            !$element instanceof Iterator &&
+            !is_array($element)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                2, 'countable type'
+            );
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_Count(
+            $expectedCount
+        );
+
+        self::assertThat($element, $constraint, $message);
+    }
 }

--- a/PHPUnit/Framework/Constraint/Count.php
+++ b/PHPUnit/Framework/Constraint/Count.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2010, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.5.x
+ */
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.5.x
+ */
+
+class PHPUnit_Framework_Constraint_Count extends PHPUnit_Framework_Constraint
+{
+
+    /**
+     * @var integer
+     */
+    protected $_expectedCount = 0;
+
+    /**
+     * @param integer $expected
+     * @param boolean $strict
+     */
+    public function __construct($expected)
+    {
+        $this->_expectedCount = $expected;
+    }
+
+    /**
+     * Evaluate
+     *
+     * @param mixed $other
+     * @return boolean
+     */
+    public function evaluate($other)
+    {
+        if ($this->_expectedCount === $this->getCountOf($other)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $other
+     * @return boolean
+     */
+    protected function getCountOf($other)
+    {
+        if ($other instanceof Countable ||
+            is_array($other)) {
+            return count($other);
+        } else if ($other instanceof Iterator) {
+            return iterator_count($other);
+        }
+    }
+
+    /**
+     * @param mixed   $other
+     * @param string  $description
+     * @param boolean $not
+     * @return string
+     */
+    protected function failureDescription($other, $description, $not)
+    {
+        return 'Count of ' . $this->getCountOf($other) .
+        ' does not match expected count of ' . $this->_expectedCount;
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return 'count matches ';
+    }
+}

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -4520,4 +4520,63 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         $this->fail();
     }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertCount
+     */
+    public function testAssertCount()
+    {
+        $this->assertCount(2, array(1,2));
+
+        try {
+            $this->assertCount(2, array(1,2,3));
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            $this->assertEquals('Count of 3 does not match expected count of 2', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertCount
+     */
+    public function testAssertCountThrowsExceptionIfExpectedCountIsNoInteger()
+    {
+
+        try {
+            $this->assertCount('a', array());
+        }
+
+        catch (InvalidArgumentException $e) {
+            $this->assertEquals('Argument #1 of PHPUnit_Framework_Assert::assertCount() must be a integer', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertCount
+     */
+    public function testAssertCountThrowsExceptionIfElementIsNotCountable()
+    {
+
+        try {
+            $this->assertCount(2, '');
+        }
+
+        catch (InvalidArgumentException $e) {
+            $this->assertEquals('Argument #2 of PHPUnit_Framework_Assert::assertCount() must be a countable type', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail();
+    }
 }

--- a/Tests/Framework/ConstraintTest.php
+++ b/Tests/Framework/ConstraintTest.php
@@ -46,6 +46,8 @@ require_once 'PHPUnit/Framework/TestCase.php';
 
 require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ClassWithNonPublicAttributes.php';
 
+require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'TestIterator.php';
+
 /**
  *
  *
@@ -2475,6 +2477,62 @@ class Framework_ConstraintTest extends PHPUnit_Framework_TestCase
         catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $this->assertEquals(
               "custom message\nFailed asserting that an array is empty.",
+              $e->getDescription()
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_Count
+     */
+    public function testConstraintCountWithAnArray()
+    {
+        $constraint = new PHPUnit_Framework_Constraint_Count(5);
+
+        $this->assertTrue($constraint->evaluate(array(1,2,3,4,5)));
+        $this->assertFalse($constraint->evaluate(array(1,2,3,4)));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_Count
+     */
+    public function testConstraintCountWithAnIteratorWhichDoesNotImplementCountable()
+    {
+        $constraint = new PHPUnit_Framework_Constraint_Count(5);
+
+        $this->assertTrue($constraint->evaluate(new TestIterator(array(1,2,3,4,5))));
+        $this->assertFalse($constraint->evaluate(new TestIterator(array(1,2,3,4))));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_Count
+     */
+    public function testConstraintCountWithAnObjectImplementingCountable()
+    {
+        $constraint = new PHPUnit_Framework_Constraint_Count(5);
+
+        $this->assertTrue($constraint->evaluate(new ArrayObject(array(1,2,3,4,5))));
+        $this->assertFalse($constraint->evaluate(new ArrayObject(array(1,2,3,4))));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_Count
+     */
+    public function testConstraintCountFailing()
+    {
+        $constraint = new PHPUnit_Framework_Constraint_Count(5);
+
+        try {
+            $constraint->fail(array(1,2), '');
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+              "Count of 2 does not match expected count of 5",
               $e->getDescription()
             );
 


### PR DESCRIPTION
I added an assert which i was missing for quite some time, I often used

$this->assertEquals(5, count($array), ' ... ');  

Which now could be replaced with a more readable:

$this->assertCount(5, $array, ' ... ');

The assert supports arrays, Countables (objects implementing the Countable-Interface) and iterators using iterator_count().

Possible documentation commit can be found here:

http://github.com/robo47/phpunit-documentation/commit/0ad291a544c92ffa5e6a8901017b78feed24e786

Would be nice to see it included in a future release of phpunit.
