### PR TITLE
Remove strict incomplete duplication

### DIFF
--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -649,7 +649,15 @@ class PHPUnit_Framework_TestResult implements Countable
 
         $test->addToAssertionCount(PHPUnit_Framework_Assert::getCount());
 
-        if ($this->strictAssertions && $test->getNumAssertions() == 0) {
+        if ($error === TRUE) {
+            $this->addError($test, $e, $time);
+        }
+
+        else if ($failure === TRUE) {
+            $this->addFailure($test, $e, $time);
+        }
+
+        else if ($this->strictAssertions && $test->getNumAssertions() == 0) {
             $this->addFailure(
               $test,
               new PHPUnit_Framework_IncompleteTestError(
@@ -657,14 +665,6 @@ class PHPUnit_Framework_TestResult implements Countable
               ),
               $time
             );
-        }
-
-        if ($error === TRUE) {
-            $this->addError($test, $e, $time);
-        }
-
-        else if ($failure === TRUE) {
-            $this->addFailure($test, $e, $time);
         }
 
         $this->endTest($test, $time);

--- a/Tests/TextUI/strict-incomplete.phpt
+++ b/Tests/TextUI/strict-incomplete.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit --strict IncompleteTest ../_files/IncompleteTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--strict';
+$_SERVER['argv'][3] = 'IncompleteTest';
+$_SERVER['argv'][4] = dirname(dirname(__FILE__)) . '/_files/IncompleteTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+I
+
+Time: %i %s, Memory: %sMb
+
+OK, but incomplete or skipped tests!
+Tests: 1, Assertions: 0, Incomplete: 1.

--- a/Tests/_files/IncompleteTest.php
+++ b/Tests/_files/IncompleteTest.php
@@ -1,0 +1,8 @@
+<?php
+class IncompleteTest extends PHPUnit_Framework_TestCase
+{
+    public function testIncomplete()
+    {
+        $this->markTestIncomplete('Test incomplete');
+    }
+}


### PR DESCRIPTION
A colleague found an issue with the --strict option when used in tests that have no assertions and are marked as incomplete. If you mark a test with no assertions as incomplete you would end up with two incomplete results for the same test which is confusing and technically wrong.

This pull request fixes that issue
