### PR TITLE
Mocking fluent interfaces

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -1305,6 +1305,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * Returns the current object.
+     *
+     * This method is useful when mocking a fluent interface.
+     *
+     * @return PHPUnit_Framework_MockObject_Stub_ReturnSelf
+     * @since  Method available since Release 3.5.2
+     */
+    public static function returnSelf()
+    {
+        return new PHPUnit_Framework_MockObject_Stub_ReturnSelf();
+    }
+
+    /**
      *
      *
      * @param  Exception $exception


### PR DESCRIPTION
Along with a coming pull request to the mock objects repo, this will make it easy to mock a fluent interface.

```
$mock
  ->expects($this->any())
  ->method('setName')
  ->will($this->returnSelf());
```
