### PR TITLE
Strict isolation

### DIFF
--- a/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
+++ b/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
@@ -11,6 +11,7 @@ function __phpunit_run_isolated_test()
 
     $result = new PHPUnit_Framework_TestResult;
     $result->collectRawCodeCoverageInformation({collectCodeCoverageInformation});
+    $result->strictMode({strict});
 
     $test = new {className}('{methodName}', unserialize('{data}'), '{dataName}');
     $test->setDependencyInput(unserialize('{dependencyInput}'));

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -578,6 +578,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $coverage = 'FALSE';
             }
 
+            if ($result->isStrict()) {
+                $strict = 'TRUE';
+            } else {
+                $strict = 'FALSE';
+            }
+
             $data            = addcslashes(serialize($this->data), "'");
             $dependencyInput = addcslashes(
               serialize($this->dependencyInput), "'"
@@ -596,7 +602,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 'constants'                      => $constants,
                 'globals'                        => $globals,
                 'include_path'                   => $includePath,
-                'included_files'                 => $includedFiles
+                'included_files'                 => $includedFiles,
+                'strict'                         => $strict
               )
             );
 

--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -569,6 +569,16 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
+     * Returns the strict mode configuration option
+     *
+     * @return boolean
+     */
+    public function isStrict()
+    {
+        return $this->strictMode;
+    }
+
+    /**
      * Runs a TestCase.
      *
      * @param  PHPUnit_Framework_Test $test

--- a/Tests/TextUI/strict-isolation.phpt
+++ b/Tests/TextUI/strict-isolation.phpt
@@ -1,0 +1,22 @@
+--TEST--
+phpunit --strict --process-isolation IncompleteTest ../_files/IncompleteTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--strict';
+$_SERVER['argv'][3] = '--process-isolation';
+$_SERVER['argv'][4] = 'NothingTest';
+$_SERVER['argv'][5] = dirname(dirname(__FILE__)) . '/_files/NothingTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+I
+
+Time: %i %s, Memory: %sMb
+
+OK, but incomplete or skipped tests!
+Tests: 1, Assertions: 0, Incomplete: 1.


### PR DESCRIPTION
Currently when using --process-isolation the --strict configuration option no longer works. This pull request fixes that issue

Thanks to Bill Hau for finding and debugging this issue
