### PR TITLE
3.5 - Support for E_USER_... error types

### DIFF
--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -93,7 +93,7 @@ class PHPUnit_Util_ErrorHandler
             }
         }
 
-        if ($errno == E_NOTICE || $errno == E_STRICT) {
+        if ($errno == E_NOTICE || $errno == E_USER_NOTICE || $errno == E_STRICT) {
             if (PHPUnit_Framework_Error_Notice::$enabled !== TRUE) {
                 return FALSE;
             }
@@ -101,7 +101,7 @@ class PHPUnit_Util_ErrorHandler
             $exception = 'PHPUnit_Framework_Error_Notice';
         }
 
-        else if ($errno == E_WARNING) {
+        else if ($errno == E_WARNING || $errno == E_USER_WARNING) {
             if (PHPUnit_Framework_Error_Warning::$enabled !== TRUE) {
                 return FALSE;
             }


### PR DESCRIPTION
`PHPUnit_Framework_Error_Warning::$enabled` can be used to disable the conversion of a warning into an exception. But it's only checked for `E_WARNING` and not for `E_USER_WARNING`.

Comparable same for `E_NOTICE` / `E_USER_NOTICE`.

Location: ErrorHandler.php ca. line 96.

With the changes applied it is possible to test own code that is triggering errors while having return values w/o the need of using the @ operator to suppress warnings in test-cases.

Additional Info: `E_ERROR` can not be disabled in PHPUnit Framework, but has an accompanying  `E_USER_ERROR` as well. Those are all three E_USER... constants that currently are available.
