### PR TITLE
3.5

### DIFF
--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -261,7 +261,7 @@ class PHPUnit_Framework_TestResult implements Countable
             $this->errors[] = new PHPUnit_Framework_TestFailure($test, $e);
             $notifyMethod   = 'addError';
 
-            if ($this->stopOnError) {
+            if ($this->stopOnError || $this->stopOnFailure) {
                 $this->stop();
             }
         }
@@ -309,7 +309,7 @@ class PHPUnit_Framework_TestResult implements Countable
             $this->failures[] = new PHPUnit_Framework_TestFailure($test, $e);
             $notifyMethod     = 'addFailure';
 
-            if ($this->stopOnFailure || $this->stopOnError) {
+            if ($this->stopOnFailure) {
                 $this->stop();
             }
         }


### PR DESCRIPTION
Correcting the logic of how --stop-on-error and --stop-on-failure interrupt the tests' execution

According to the docs:
--stop-on-error          Stop execution upon first error.
--stop-on-failure        Stop execution upon first error or failure.

However, currently, if an error occurs, and --stop-on-failure is specified, the execution isn't interrupted. The patch is fixing that.
