### PR TITLE
Progress color

### DIFF
--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -455,7 +455,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      */
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->writeProgress('E');
+        $out = 'E';
+        if ($this->colors) {
+            $out = "\x1b[31;1mE\x1b[0m";
+        }
+        $this->writeProgress($out);
         $this->lastTestFailed = TRUE;
     }
 
@@ -468,7 +472,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      */
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
-        $this->writeProgress('F');
+        $out = 'F';
+        if ($this->colors) {
+            $out = "\x1b[41;37mF\x1b[0m";
+        }
+        $this->writeProgress($out);
         $this->lastTestFailed = TRUE;
     }
 
@@ -481,7 +489,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      */
     public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->writeProgress('I');
+        $out = 'I';
+        if ($this->colors) {
+            $out = "\x1b[33;1mI\x1b[0m";
+        }
+        $this->writeProgress($out);
         $this->lastTestFailed = TRUE;
     }
 
@@ -495,7 +507,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      */
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
-        $this->writeProgress('S');
+        $out = 'S';
+        if ($this->colors) {
+            $out = "\x1b[36;1mS\x1b[0m";
+        }
+        $this->writeProgress($out);
         $this->lastTestFailed = TRUE;
     }
 


### PR DESCRIPTION
I really love the coloured output that PHPUnit has. It lets me check test results from the corner of my vision. It would be even better if the test result progress had colours as well. This would give a bit more visual feedback that could be helpful. I've added colours to all the non-pass progress indicators. I didn't add any tests, as I didn't see any existing ones for coloured output.
