### PR TITLE
If no assertions are made the code should not be marked as covered

### DIFF
--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -651,7 +651,12 @@ class PHPUnit_Framework_TestResult implements Countable
         if ($useXdebug) {
             $data = $this->codeCoverage->stop(FALSE);
 
-            if (!$this->strictMode || (!$incomplete && !$skipped)) {
+            $assertions = $test->getNumAssertions() + PHPUnit_Framework_Assert::getCount();
+            if ($this->strictMode && $assertions == 0) {
+                $incomplete = true;
+            }
+
+            if (!$incomplete && !$skipped) {
                 if ($this->collectRawCodeCoverageInformation) {
                     $this->rawCodeCoverageInformation[] = $data;
                 } else {


### PR DESCRIPTION
If you are running in --strict mode and no assertions are made, the code is still marked as covered, which is incorrect. In strict mode it should not mark the code as covered as the code has been run but not covered by unit tests

```
<?php
class A
{
    public function one()
    {
        return 1;
    }
    public function two()
    {
        return 2;
    }
}


<?php
require_once 'class.php';
class ATest extends PHPUnit_Framework_TestCase
{
    public function testOne()
    {
        $a = new A();
        $result = $a->one();
    }
    public function testTwo()
    {
        $a = new A();
        $result = $a->two();
        $this->assertEquals(2, $result);
    }
}
```

With this patch you will get the following output in a junit file as testOne does not actually cover A::one() with a unit test:

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="ATest" file="/Users/bselby/Desktop/classTest.php" tests="1" assertions="1" failures="0" errors="0" time="0.001715">
    <testcase name="testTwo" class="ATest" file="/Users/bselby/Desktop/classTest.php" line="20" assertions="1" time="0.001715"/>
  </testsuite>
</testsuites>
```
