### PR TITLE
Expected exception code

### DIFF
--- a/PHPUnit/Util/Test.php
+++ b/PHPUnit/Util/Test.php
@@ -128,6 +128,21 @@ class PHPUnit_Util_Test
 
             if (isset($matches[3])) {
                 $code = (int)$matches[3];
+                if( $code == 0 && strpos( $annotations['method']['expectedExceptionCode'][0], '::' ) !== false ) {
+                    $arrTag = explode( '::', $annotations['method']['expectedExceptionCode'][0] ); 
+                    $sPossibleClass = $arrTag[0];
+                    $sPossibleConstant = $arrTag[1];
+
+                    try {
+                        $cls = new ReflectionClass( $sPossibleClass );
+                        if ( $cls->hasConstant( $sPossibleConstant ) ) {
+                            $code = (int) $cls->getConstant( $sPossibleConstant );
+                        }
+                    } catch ( Exception $e ) {
+                        //The class could probably not be found but we'll just let the test cases continue for now.
+                    }
+
+                }
             }
 
             else if (isset($annotations['method']['expectedExceptionCode'])) {

--- a/Tests/Util/TestTest.php
+++ b/Tests/Util/TestTest.php
@@ -88,6 +88,11 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
           array('class' => 'Class', 'code' => 1234, 'message' => 'Message'),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSix')
         );
+
+        $this->assertEquals(
+          array('class' => 'Class', 'code' => ExceptionTest::CODE_ONE, 'message' =>''),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSeven')
+        );
     }
 
     public function testGetProvidedDataRegEx()

--- a/Tests/_files/ExceptionTest.php
+++ b/Tests/_files/ExceptionTest.php
@@ -1,6 +1,8 @@
 <?php
 class ExceptionTest extends PHPUnit_Framework_TestCase
 {
+    const CODE_ONE = 12345;
+
     /**
      * @expectedException FooBarBaz
      */
@@ -42,6 +44,14 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
      * @expectedExceptionCode 1234
      */
     public function testSix()
+    {
+    }
+
+    /**
+     * @expectedException Class
+     * @expectedExceptionCode ExceptionTest::CODE_ONE
+     */
+    public function testSeven()
     {
     }
 }


### PR DESCRIPTION
This allows for us to use the @expectedExceptionCode annotation as we would use the @dataProvider annotation by specifying a class name and a constant on that class instead of having to put a hardcoded integer as the expected code for the exception.
