### PR TITLE
Fatal error when calling isPublic() on dynamically created variable

### DIFF
--- a/PHPUnit/Util/Class.php
+++ b/PHPUnit/Util/Class.php
@@ -321,7 +321,7 @@ class PHPUnit_Util_Class
             }
         }
 
-        if ($attribute->isPublic()) {
+        if ($attribute == NULL || $attribute->isPublic()) {
             return $object->$attributeName;
         } else {
             $array         = (array)$object;

--- a/Tests/Util/ClassTest.php
+++ b/Tests/Util/ClassTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2010, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.5.5
+ */
+
+require_once 'PHPUnit/Framework/TestCase.php';
+
+require_once 'PHPUnit/Util/Class.php';
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.5.5
+ */
+class Util_ClassTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that if a dynamic variable is defined on a class then
+     * the $attribute variable will be NULL, but the variable defined
+     * will be a public one so we are safe to return it
+     *
+     * Currently $attribute is NULL but we try and call isPublic() on it.
+     * This breaks for php 5.2.10
+     *
+     * @covers PHPUnit_Util_Class::getObjectAttribute
+     *
+     * @return void
+     */
+    public function testGetObjectAttributeCanHandleDynamicVariables()
+    {
+        $attributeName = '_variable';
+        $object = new stdClass();
+        $object->$attributeName = 'Test';
+
+        $actual = PHPUnit_Util_Class::getObjectAttribute($object, $attributeName);
+        $this->assertEquals('Test', $actual);
+    }
+}


### PR DESCRIPTION
When calling assertAttributeEquals() on a variable that is not defined in the class, but created dynamically PHPUnit_Util_Class::isPublic() causes a fatal as $attribute is NULL after the Reflection checks.

This is an issue with PHP version 5.2.10 (Which I know is not supported in PHPUnit 3.5 but this is the only issue we have encountered after using it since the RC's).

We now check to see if the $attribute is NULL, which means that reflection has found the variable but not as a variable on the class.
