### PR TITLE
"Deprecated feature" feature

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -1204,15 +1204,13 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function assertType($expected, $actual, $message = '')
     {
-        file_put_contents(
-          'php://stderr',
-          "\n\n" .
-          'assertType() will be removed in PHPUnit 3.6 and should no longer ' .
-          'be used. assertInternalType() should be used for asserting ' .
-          'internal types such as "integer" or "string" whereas ' .
-          'assertInstanceOf() should be used for asserting that an object is ' .
-          "an instance of a specified class or interface.\n\n"
-        );
+        $message = 'assertType() will be removed in PHPUnit 3.6 and should no longer ' .
+            'be used. assertInternalType() should be used for asserting ' .
+            'internal types such as "integer" or "string" whereas ' .
+            'assertInstanceOf() should be used for asserting that an object is ' .
+            'an instance of a specified class or interface.';
+
+        PHPUnit_Framework_DeprecatedFeatureListener::log($message);
 
         if (is_string($expected)) {
             if (PHPUnit_Util_Type::isType($expected)) {
@@ -1251,15 +1249,13 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function assertAttributeType($expected, $attributeName, $classOrObject, $message = '')
     {
-        file_put_contents(
-          'php://stderr',
-          "\n\n" .
-          'assertAttributeType() will be removed in PHPUnit 3.6 and should ' .
-          'no longer be used. assertAttributeInternalType() should be used ' .
-          'for asserting internal types such as "integer" or "string" ' .
-          'whereas assertAttributeInstanceOf() should be used for asserting ' .
-          "that an object is an instance of a specified class or interface.\n\n"
-        );
+        $message = 'assertAttributeType() will be removed in PHPUnit 3.6 and should ' .
+            'no longer be used. assertAttributeInternalType() should be used ' .
+            'for asserting internal types such as "integer" or "string" ' .
+            'whereas assertAttributeInstanceOf() should be used for asserting ' .
+            'that an object is an instance of a specified class or interface.';
+
+        PHPUnit_Framework_DeprecatedFeatureListener::log($message);
 
         self::assertType(
           $expected,
@@ -1279,15 +1275,13 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function assertNotType($expected, $actual, $message = '')
     {
-        file_put_contents(
-          'php://stderr',
-          "\n\n" .
-          'assertNotType() will be removed in PHPUnit 3.6 and should no ' .
-          'longer be used. assertNotInternalType() should be used for ' .
-          'asserting internal types such as "integer" or "string" whereas ' .
-          'assertNotInstanceOf() should be used for asserting that an object ' .
-          "is not an instance of a specified class or interface.\n\n"
-        );
+        $message = 'assertNotType() will be removed in PHPUnit 3.6 and should no ' .
+            'longer be used. assertNotInternalType() should be used for ' .
+            'asserting internal types such as "integer" or "string" whereas ' .
+            'assertNotInstanceOf() should be used for asserting that an object ' .
+            'is not an instance of a specified class or interface.';
+
+        PHPUnit_Framework_DeprecatedFeatureListener::log($message);
 
         if (is_string($expected)) {
             if (PHPUnit_Util_Type::isType($expected)) {
@@ -1326,16 +1320,14 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function assertAttributeNotType($expected, $attributeName, $classOrObject, $message = '')
     {
-        file_put_contents(
-          'php://stderr',
-          "\n\n" .
-          'assertAttributeNotType() will be removed in PHPUnit 3.6 and ' .
-          'should no longer be used. assertAttributeNotInternalType() should ' .
-          'be used for asserting internal types such as "integer" or ' .
-          '"string" whereas assertAttributeNotInstanceOf() should be used ' .
-          'for asserting that an object is an instance of a specified class ' .
-          "or interface.\n\n"
-        );
+        $message = 'assertAttributeNotType() will be removed in PHPUnit 3.6 and ' .
+            'should no longer be used. assertAttributeNotInternalType() should ' .
+            'be used for asserting internal types such as "integer" or ' .
+            '"string" whereas assertAttributeNotInstanceOf() should be used ' .
+            'for asserting that an object is an instance of a specified class ' .
+            'or interface.';
+
+        PHPUnit_Framework_DeprecatedFeatureListener::log($message);
 
         self::assertNotType(
           $expected,

--- a/PHPUnit/Framework/DeprecatedFeature.php
+++ b/PHPUnit/Framework/DeprecatedFeature.php
@@ -1,0 +1,30 @@
+<?php
+
+class PHPUnit_Framework_DeprecatedFeature
+{
+    
+    protected $traceInfo = array();
+    protected $message = null;
+    
+    public function __construct($message, Array $traceInfo = null)
+    {
+        $this->message = $message;
+        if ($traceInfo) {
+            $this->traceInfo = $traceInfo;
+        }
+    }
+    
+    public function __toString()
+    {
+        $string = '';
+        if (isset($this->traceInfo['file'])) {
+            $string .= $this->traceInfo['file'];
+            if (isset($this->traceInfo['line'])) {
+                $string .= ':' . $this->traceInfo['line'] . ' - ';
+            }
+        }
+        $string .= $this->message;
+        return $string;
+    }
+    
+}

--- a/PHPUnit/Framework/DeprecatedFeature.php
+++ b/PHPUnit/Framework/DeprecatedFeature.php
@@ -1,11 +1,81 @@
 <?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2010, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Ralph Schindler <ralph.schindler@zend.com>
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.5.6
+ */
 
+/**
+ * Class to hold the information about a deprecated feature that was used
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Ralph Schindler <ralph.schindler@zend.com>
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Interface available since Release 3.5.6
+ */
 class PHPUnit_Framework_DeprecatedFeature
 {
-    
+
+    /**
+     * @var array
+     */
     protected $traceInfo = array();
+
+    /**
+     * @var string
+     */
     protected $message = null;
-    
+
+    /**
+     * Constructs a deprecated feature object
+     *
+     * @param  string $message
+     * @param  array  $traceInfo
+     */
     public function __construct($message, Array $traceInfo = null)
     {
         $this->message = $message;
@@ -13,7 +83,12 @@ class PHPUnit_Framework_DeprecatedFeature
             $this->traceInfo = $traceInfo;
         }
     }
-    
+
+    /**
+     * Build a string representation of the deprecated feature that was raised
+     *
+     * @return string
+     */
     public function __toString()
     {
         $string = '';

--- a/PHPUnit/Framework/DeprecatedFeatureListener.php
+++ b/PHPUnit/Framework/DeprecatedFeatureListener.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2010, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Ralph Schindler <ralph.schindler@zend.com>
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.5.6
+ */
+
+/**
+ * Abstract base class for constraints. which are placed upon any value.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Ralph Schindler <ralph.schindler@zend.com>
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2010 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Interface available since Release 3.5.6
+ */
+class PHPUnit_Framework_DeprecatedFeatureListener implements PHPUnit_Framework_TestListener
+{
+    protected static $currentTest = null;
+    
+    public static function log($message, $backtraceDepth = 2)
+    {
+        
+        if ($backtraceDepth !== false) {
+            $trace = debug_backtrace(false);
+            
+            if (is_int($backtraceDepth)) {
+                $traceItem = $trace[$backtraceDepth];
+            }
+            
+            // fill in missing file (debug_backtrace does not fill in line file from call_user_func)
+            if (!isset($traceItem['file'])) {
+                $reflectionClass = new ReflectionClass($traceItem['class']);
+                $traceItem['file'] = $reflectionClass->getFileName();
+            }
+            
+            // fill in missing line (debug_backtrace does not fill in line file from call_user_func)
+            if (!isset($traceItem['line']) && isset($traceItem['class']) && isset($traceItem['function'])) {
+                $reflectionClass = (isset($reflectionClass)) ? $reflectionClass : new ReflectionClass($traceItem['class']);
+                $methodReflection = $reflectionClass->getMethod($traceItem['function']);
+                $traceItem['line'] = '(between ' . $methodReflection->getStartLine() . ' and ' . $methodReflection->getEndLine() . ')';
+            }
+        }
+        
+        $deprecatedFeature = new PHPUnit_Framework_DeprecatedFeature($message, $traceItem);
+        
+        if (self::$currentTest instanceof PHPUnit_Framework_TestCase) {
+            /* @var $result PHPUnit_Framework_TestResult */
+            $result = self::$currentTest->getResult();
+            $result->addDeprecatedFeature($deprecatedFeature);
+        } else {
+            file_put_contents('php://stderr', $deprecatedFeature->__toString());
+        }
+    }
+    
+    /**
+     * An error occurred.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  Exception              $e
+     * @param  float                  $time
+     */
+    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {}
+
+    /**
+     * A failure occurred.
+     *
+     * @param  PHPUnit_Framework_Test                 $test
+     * @param  PHPUnit_Framework_AssertionFailedError $e
+     * @param  float                                  $time
+     */
+    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+    {}
+
+    /**
+     * Incomplete test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  Exception              $e
+     * @param  float                  $time
+     */
+    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {}
+
+    /**
+     * Skipped test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  Exception              $e
+     * @param  float                  $time
+     * @since  Method available since Release 3.0.0
+     */
+    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {}
+
+    /**
+     * A test suite started.
+     *
+     * @param  PHPUnit_Framework_TestSuite $suite
+     * @since  Method available since Release 2.2.0
+     */
+    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {}
+
+    /**
+     * A test suite ended.
+     *
+     * @param  PHPUnit_Framework_TestSuite $suite
+     * @since  Method available since Release 2.2.0
+     */
+    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {}
+
+    /**
+     * A test started.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function startTest(PHPUnit_Framework_Test $test)
+    {
+        self::$currentTest = $test;
+    }
+
+    /**
+     * A test ended.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  float                  $time
+     */
+    public function endTest(PHPUnit_Framework_Test $test, $time)
+    {
+        self::$currentTest = null;
+    }
+    
+}
+

--- a/PHPUnit/Framework/DeprecatedFeatureListener.php
+++ b/PHPUnit/Framework/DeprecatedFeatureListener.php
@@ -45,7 +45,7 @@
  */
 
 /**
- * Abstract base class for constraints. which are placed upon any value.
+ * A listener that is utilized to notify the developer that a deprecated feature was used in a test
  *
  * @package    PHPUnit
  * @subpackage Framework
@@ -59,8 +59,23 @@
  */
 class PHPUnit_Framework_DeprecatedFeatureListener implements PHPUnit_Framework_TestListener
 {
+
+    /**
+     * This will minimally be a PHPUnit_Framework_Test, but most likely a PHPUnit_Framework_TestCase
+     * 
+     * @var PHPUnit_Framework_TestCase
+     */
     protected static $currentTest = null;
-    
+
+    /**
+     * This is the publically accessible API for notifying the system that a deprecated feature has been used
+     * 
+     * If it is run via a TestRunner and the test extends PHPUnit_Framework_TestCase, then this will inject
+     * the result into the test runner for display, if not, it will throw the notice to STDERR.
+     * 
+     * @param string $message
+     * @param int|bool $backtraceDepth
+     */
     public static function log($message, $backtraceDepth = 2)
     {
         

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -917,6 +917,15 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @param mixed $result
+     * @since  Method available since Release 3.5.6
+     */
+    public function getCurrentRunResult()
+    {
+        return $this->result;
+    }
+
+    /**
      * This method is a wrapper for the ini_set() function that automatically
      * resets the modified php.ini setting to its original value after the
      * test is run.

--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -83,6 +83,11 @@ class PHPUnit_Framework_TestResult implements Countable
     /**
      * @var array
      */
+    protected $deprecatedFeatures = array();
+
+    /**
+     * @var array
+     */
     protected $failures = array();
 
     /**
@@ -323,6 +328,16 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
+     * Adds a deprecated feature notice to the list of deprecated features used during run
+     *
+     * @param PHPUnit_Framework_DeprecatedFeature $deprecatedFeature
+     */
+    public function addDeprecatedFeature(PHPUnit_Framework_DeprecatedFeature $deprecatedFeature)
+    {
+        $this->deprecatedFeatures[] = $deprecatedFeature;
+    }
+    
+    /**
      * Informs the result that a testsuite will be started.
      *
      * @param  PHPUnit_Framework_TestSuite $suite
@@ -469,6 +484,16 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
+     * Returns an Enumeration for the deprecated features used.
+     *
+     * @return array
+     */
+    public function deprecatedFeatures()
+    {
+        return $this->deprecatedFeatures;
+    }
+
+    /**
      * Gets the number of detected failures.
      *
      * @return integer
@@ -592,6 +617,7 @@ class PHPUnit_Framework_TestResult implements Countable
         $incomplete = FALSE;
         $skipped    = FALSE;
 
+        $test->setResult($this);
         $this->startTest($test);
 
         $errorHandlerSet = FALSE;

--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -415,6 +415,16 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
                 $this->write("\x1b[0m\x1b[2K");
             }
         }
+
+        if (($depCount = count($result->deprecatedFeatures())) > 0) {
+            if ($this->colors) {
+                $this->write(
+                  "\x1b[37;41m\x1b[2kWarning: Deprecated PHPUnit features are being used $depCount times in tests! Use --debug for greater detail.\n\x1b[0m\x1b[37;41m\x1b[2K"
+                );
+            } else {
+                $this->write("Warning: Deprecated PHPUnit features are being used $depCount times in tests! Use --debug for greater detail.\n");
+            }
+        }
     }
 
     /**
@@ -589,6 +599,15 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
     {
         if (!$this->lastTestFailed) {
             $this->writeProgress('.');
+        }
+
+        if ($this->debug && ($test instanceof PHPUnit_Framework_TestCase)) {
+            $deprecatedFeatures = $test->getCurrentRunResult()->deprecatedFeatures();
+            if (count($deprecatedFeatures) > 0) {
+                foreach ($deprecatedFeatures as $deprecatedFeature) {
+                    $this->write("\n" . $deprecatedFeature->__toString() . "\n");
+                }
+            }
         }
 
         if ($test instanceof PHPUnit_Framework_TestCase) {

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -230,6 +230,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
         $result->addListener($this->printer);
 
+        if ($this->printer instanceof PHPUnit_TextUI_ResultPrinter) {
+            $result->addListener(new PHPUnit_Framework_DeprecatedFeatureListener());
+        }
+
         if (isset($arguments['storyHTMLFile'])) {
             $result->addListener(
               new PHPUnit_Extensions_Story_ResultPrinter_HTML(


### PR DESCRIPTION
Hey Sebastian,

I've created some functionality to handle deprecation in PHPUnit.  The latest changes in the 3.5.x series made for some messy output with respect to the running of tests, particularly the usage of php://stderr to alert the developer of deprecation.

Ideally, there would be at least a full version that would allow the feature, but notify the user in a constructive manner.  Since it is not easy to turn off the deprecation notices with the framework, I wrote a listener that can be used to notify the developers, in a friendly way, of deprecated feature usage.

By default, the footer will display a "Warning: xxx" text with special instructions to use the --debug option to get greater detail about the deprecation.  Using --debug will then display the alerts in-line (in an endTest writer of the standard TestRunner).

I'd like to discuss this with you, i'll be online in #phpunit.  Thanks for your consideration.

-ralph
