### PR TITLE
backupStaticAttributes causes memory exhaustion

### DIFF
--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -272,6 +272,9 @@ class PHPUnit_Util_GlobalState
 
         for ($i = $declaredClassesNum - 1; $i >= 0; $i--) {
             if (strpos($declaredClasses[$i], 'PHPUnit') !== 0 &&
+                strpos($declaredClasses[$i], 'PHP_CodeCoverage') !== 0 &&
+                strpos($declaredClasses[$i], 'PHP_TokenStream') !== 0 &&
+                strpos($declaredClasses[$i], 'PHP_Timer') !== 0 &&
                 !$declaredClasses[$i] instanceof PHPUnit_Framework_Test) {
                 $class = new ReflectionClass($declaredClasses[$i]);
 


### PR DESCRIPTION
If you enable backupStaticAttributes on a fairly big project you will run into memory issues. The reason is that backupStaticAttributes() in PHPUnit/Util/GlobalState.php only skips classes that begin with PHPUnit. But since code coverage and other utilities like the token stream have been moved out of PHPUnit itself and renamed PHP_\* they are now backed up as well.

A workaround for people experiencing this issue is to add a constructor with the following code to all test cases. Although this is really only feasible if you have your own subclass of PHPUnit_Framework_TestCase as a parent class for all your test cases.
    public function __construct($name = NULL, array $data = array(), $dataName = '')
    {
        parent::__construct($name, $data, $dataName);
        $this->backupStaticAttributesBlacklist += array(
            'PHP_CodeCoverage' => array('instance'),
            'PHP_CodeCoverage_Filter' => array('instance'),
            'PHP_CodeCoverage_Util' => array('ignoredLines', 'templateMethods'),
            'PHP_Timer' => array('startTimes',),
            'PHP_Token_Stream' => array('customTokens'),
            'PHP_Token_Stream_CachingFactory' => array('cache'),

```
        'phpbb_database_test_case' => array('already_connected'),
    );
}
```
