### PR TITLE
Stub

### DIFF
--- a/PHPUnit/Extensions/SimpleStub.php
+++ b/PHPUnit/Extensions/SimpleStub.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * http://www.pensandoenred.com
+ * Copyright (C) 2011 Mario Nunes
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ * Repository of this class: https://github.com/mariotux/php-simple-stub
+ *
+ */
+
+class SimpleStub {
+
+    private $_object = null;
+    private $_call = array('name' => null, 'args' => null);
+
+    public function __construct($object = null) {
+        $this->_object = $object;
+    }
+
+    public function __call($name, $arguments) {
+        $this->_call['name'] = $name;
+        $this->_call['args'] = $arguments;
+        return $this;
+    }
+
+    public function returnValue($argument) {
+        if (method_exists($this->_object, $this->_call['name'])) {
+            return call_user_func_array(array($this->_object, $this->_call['name']), $this->_call['args']);
+        }
+        return $argument;
+    }
+
+}
+
+?>

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -44,6 +44,7 @@
  */
 
 require_once 'Text/Template.php';
+require_once 'PHPUnit/Extensions/SimpleStub.php';
 
 /**
  * A TestCase defines the fixture to run multiple tests.
@@ -1036,6 +1037,15 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $this->mockObjects[] = $mockObject;
 
         return $mockObject;
+    }
+
+    /**
+     * Return a SimpleStub
+     * 
+     * @param object $object
+     */
+    public function getStub($object = null){
+        return new SimpleStub($object);
     }
 
     /**


### PR DESCRIPTION
getStub method added in TestCase.php for use a SimpleStub in PHPUnit, this class is for make a Stub without using getMock, is not necessary to have implemented the method.

More info how to use this class: https://github.com/mariotux/php-simple-stub/blob/master/examples.php

I'm working on a version for use exceptions.
