### PR TITLE
3.5

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -1033,7 +1033,11 @@ abstract class PHPUnit_Framework_Assert
     public static function assertInstanceOf($expected, $actual, $message = '')
     {
         if (is_string($expected)) {
-            if (class_exists($expected) || interface_exists($expected)) {
+            if ($expected[0] == '\\')
+						{
+							$expected = substr($expected, 1);
+						}
+						if (class_exists($expected) || interface_exists($expected)) {
                 $constraint = new PHPUnit_Framework_Constraint_IsInstanceOf(
                   $expected
                 );


### PR DESCRIPTION
Sebastian,

I think it's unexpected behavior in PHP's class_exists and interface_exists functions that if you pass the root \ of a namespaced class such as \DateTime or \namespace\subnamespace\class_name that it squelches a warning, I'll be searching for and potentially passing a bug for this later.  For now this patch would allow that notation style to work with assertTypeOf.

Thanks,

Shawn
