### PR TITLE
include_path_refactor

### DIFF
--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -365,19 +365,6 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             return;
         }
 
-        if (!file_exists($filename)) {
-            $includePaths = explode(PATH_SEPARATOR, get_include_path());
-
-            foreach ($includePaths as $includePath) {
-                $file = $includePath . DIRECTORY_SEPARATOR . $filename;
-
-                if (file_exists($file)) {
-                    $filename = $file;
-                    break;
-                }
-            }
-        }
-
         PHPUnit_Util_Class::collectStart();
         PHPUnit_Util_Fileloader::checkAndLoad($filename, $syntaxCheck);
         $newClasses = PHPUnit_Util_Class::collectEnd();

--- a/PHPUnit/Runner/StandardTestSuiteLoader.php
+++ b/PHPUnit/Runner/StandardTestSuiteLoader.php
@@ -75,20 +75,6 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
         }
 
         if (!class_exists($suiteClassName, FALSE)) {
-            if (!file_exists($suiteClassFile)) {
-                $includePaths = explode(PATH_SEPARATOR, get_include_path());
-
-                foreach ($includePaths as $includePath) {
-                    $file = $includePath . DIRECTORY_SEPARATOR .
-                            $suiteClassFile;
-
-                    if (file_exists($file)) {
-                        $suiteClassFile = $file;
-                        break;
-                    }
-                }
-            }
-
             PHPUnit_Util_Class::collectStart();
             PHPUnit_Util_Fileloader::checkAndLoad($suiteClassFile, $syntaxCheck);
             $loadedClasses = PHPUnit_Util_Class::collectEnd();

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -147,11 +147,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $this->handleConfiguration($arguments);
 
         if (isset($arguments['bootstrap'])) {
-            $bootstrap = PHPUnit_Util_Fileloader::load($arguments['bootstrap']);
-
-            if ($bootstrap) {
-                $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $bootstrap;
-            }
+            $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $arguments['bootstrap'];
         }
 
         if ($arguments['backupGlobals'] === FALSE) {

--- a/PHPUnit/Util/Fileloader.php
+++ b/PHPUnit/Util/Fileloader.php
@@ -68,21 +68,21 @@ class PHPUnit_Util_Fileloader
      */
     public static function checkAndLoad($filename, $syntaxCheck = FALSE)
     {
-        if (!is_readable($filename)) {
-            $filename = './' . $filename;
-        }
-
-        if (!is_readable($filename)) {
+        $includePathFilename = PHPUnit_Util_Filesystem::fileExistsInIncludePath(
+            $filename
+        );	
+	
+        if (!$includePathFilename || !is_readable($includePathFilename)) {
             throw new RuntimeException(
               sprintf('Cannot open file "%s".' . "\n", $filename)
             );
         }
 
         if ($syntaxCheck) {
-            self::syntaxCheck($filename);
+            self::syntaxCheck($includePathFilename);
         }
 
-        self::load($filename);
+        self::load($includePathFilename);
     }
 
     /**
@@ -94,10 +94,6 @@ class PHPUnit_Util_Fileloader
      */
     public static function load($filename)
     {
-        $filename = PHPUnit_Util_Filesystem::fileExistsInIncludePath(
-          $filename
-        );
-
         $oldVariableNames = array_keys(get_defined_vars());
 
         include_once $filename;


### PR DESCRIPTION
I believe #104 and #64 reference a similar issue.  While `PHPUnit_Util_Fileloader::checkAndLoad()` is intended to use the `include_path` in all cases I've found, it actually only checks `$filename` and `./$filename`.  Then, if the file is not readable, PHPUnit prints an error message saying "Cannot open file ./$filename." This can be especially confusing if the user has provided an absolute path.  For example, the error message from #64 is:

```
Cannot open file "./c:\Program Files\Apache Software Foundation\Apache2.2\htdocs\domspl\test\phpunit\unit\lib\UnitTestSuite.php".
```
