### PR TITLE
Factory method for testrunner creation

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -134,7 +134,7 @@ class PHPUnit_TextUI_Command
     {
         $this->handleArguments($argv);
 
-        $runner = new PHPUnit_TextUI_TestRunner($this->arguments['loader']);
+        $runner = $this->createRunner();
 
         if (is_object($this->arguments['test']) &&
             $this->arguments['test'] instanceof PHPUnit_Framework_Test) {
@@ -201,6 +201,16 @@ class PHPUnit_TextUI_Command
                 exit(PHPUnit_TextUI_TestRunner::FAILURE_EXIT);
             }
         }
+    }
+
+    /**
+     * Create a TestRunner, override in subclasses.
+     *
+     * @return PHPUnit_TextUI_TestRunner
+     */
+    protected function createRunner()
+    {
+        return new PHPUnit_TextUI_TestRunner($this->arguments['loader']);
     }
 
     /**


### PR DESCRIPTION
Currently TestResult objects come from a factory method which makes extending PHPUnit straightforward.  However, the test runner is constructed without such a method.  Having a factory method would make extending  PHPUnit at the testrunner level easier.
