### PR TITLE
Detailed progress reporting

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -117,7 +117,8 @@ class PHPUnit_TextUI_Command
       'static-backup' => NULL,
       'verbose' => NULL,
       'version' => NULL,
-      'wait' => NULL
+      'wait' => NULL,
+      'detailed-progress' => NULL
     );
 
     /**
@@ -524,6 +525,11 @@ class PHPUnit_TextUI_Command
                 }
                 break;
 
+                case '--detailed-progress': {
+                    $this->arguments['printer'] = new PHPUnit_TextUI_DetailedResultPrinter;
+                }
+                break;
+                
                 default: {
                     $optionName = str_replace('--', '', $option[0]);
 

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -526,7 +526,7 @@ class PHPUnit_TextUI_Command
                 break;
 
                 case '--detailed-progress': {
-                    $this->arguments['printer'] = new PHPUnit_TextUI_DetailedResultPrinter;
+                    $this->arguments['detailed-progress'] = TRUE;
                 }
                 break;
                 

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -859,6 +859,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --stop-on-incomplete      Stop execution upon first incomplete test.
   --strict                  Mark a test as incomplete if no assertions are made.
   --verbose                 Output more verbose information.
+  --detailed-progress       Output more detailed progress information.
   --wait                    Waits for a keystroke after each test.
 
   --skeleton-class          Generate Unit class for UnitTest in UnitTest.php.

--- a/PHPUnit/TextUI/DetailedResultPrinter.php
+++ b/PHPUnit/TextUI/DetailedResultPrinter.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2011, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage TextUI
+ * @author     Mattis Stordalen Flister <mattis.stordalen.flister@gmail.com>
+ * @copyright  2002-2011 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release xx
+ */
+
+/**
+ * Prints the result of a TextUI TestRunner run with detailed information.
+ *
+ * @package    PHPUnit
+ * @subpackage TextUI
+ * @author     Mattis Stordalen Flister <mattis.stordalen.flister@gmail.com>
+ * @copyright  2002-2011 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release xx
+ */
+class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
+{
+    private $tab_stops = 0;
+    private $test_failed = false;
+    
+    private $first_suite = true;
+    
+    private $maximum_columns = 50;
+    private $current_column = 0;
+    
+    /**
+     * An error occurred.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  Exception              $e
+     * @param  float                  $time
+     */
+    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+    	 $this->write('E');
+    	 $this->test_failed = true;
+    }
+
+    /**
+     * A failure occurred.
+     *
+     * @param  PHPUnit_Framework_Test                 $test
+     * @param  PHPUnit_Framework_AssertionFailedError $e
+     * @param  float                                  $time
+     */
+    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+    {
+    	 $this->write('F');
+    	 $this->test_failed = true;
+    }
+
+    /**
+     * Incomplete test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  Exception              $e
+     * @param  float                  $time
+     */
+    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        $this->write('I');
+        $this->test_failed = true;
+    }
+
+    /**
+     * Skipped test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  Exception              $e
+     * @param  float                  $time
+     * @since  Method available since Release 3.0.0
+     */
+    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+    	  $this->write('S');
+    	  $this->test_failed = true;
+    }
+
+    /**
+     * A test suite started.
+     *
+     * @param  PHPUnit_Framework_TestSuite $suite
+     * @since  Method available since Release 2.2.0
+     */
+    public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {
+    	  if($suite_name = $suite->getName()) {
+    	  	if($this->first_suite) {
+    	  		$this->first_suite = false;
+    	  	}
+    	  	
+    	  	else {
+		          $this->printNewLine();       
+    	  	}
+    	  	
+	    	  $this->tab_stops++;
+	    	  
+	        $this->write($suite_name);
+	        $this->printNewLine();    	  	
+    	  }
+    }
+
+    /**
+     * A test suite ended.
+     *
+     * @param  PHPUnit_Framework_TestSuite $suite
+     * @since  Method available since Release 2.2.0
+     */
+    public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
+    {
+    	 if($suite->getName()) {
+	    	 $this->tab_stops--;
+    	 }
+    }
+
+    /**
+     * A test started.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function startTest(PHPUnit_Framework_Test $test)
+    {
+    	 	
+    }
+
+    /**
+     * A test ended.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     * @param  float                  $time
+     */
+    public function endTest(PHPUnit_Framework_Test $test, $time) 
+    {  
+        if(!$this->test_failed) {
+        	 $this->write('.');
+        }
+        
+        $this->test_failed = false;
+    }
+    
+    public function write($buffer) {
+        parent::write($buffer);
+       
+        $this->current_column += strlen($buffer);
+        
+        if($this->current_column >= $this->maximum_columns) {
+        	  $this->printNewLine();
+        }
+    }
+    
+    private function printNewLine() {
+	      $padding = str_pad('', $this->tab_stops * 2);
+	      parent::write(PHP_EOL . $padding);
+	      $this->current_column = strlen($padding);
+    }
+    
+    public function __destruct() {
+    	$this->printNewLine();
+    }
+}

--- a/PHPUnit/TextUI/DetailedResultPrinter.php
+++ b/PHPUnit/TextUI/DetailedResultPrinter.php
@@ -57,13 +57,30 @@
  */
 class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
 {
-    private $tab_stops = 0;
-    private $test_failed = false;
+    /**
+     * @var boolean
+     */
+    private $testFailed = false;
     
-    private $first_suite = true;
+    /**
+     * @var boolean
+     */
+    private $firstSuite = true;
     
-    private $maximum_columns = 50;
-    private $current_column = 0;
+    /**
+     * @var int
+     */
+    private $maximumColumns = 70;
+    
+    /**
+     * @var int
+     */
+    private $currentColumn = 0;
+    
+    /**
+     * @var int
+     */
+    private $tabStops = 0;
     
     /**
      * An error occurred.
@@ -75,7 +92,7 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     	 $this->write('E');
-    	 $this->test_failed = true;
+    	 $this->testFailed = true;
     }
 
     /**
@@ -88,7 +105,7 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
     	 $this->write('F');
-    	 $this->test_failed = true;
+    	 $this->testFailed = true;
     }
 
     /**
@@ -101,7 +118,7 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
     public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         $this->write('I');
-        $this->test_failed = true;
+        $this->testFailed = true;
     }
 
     /**
@@ -115,7 +132,7 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
     	  $this->write('S');
-    	  $this->test_failed = true;
+    	  $this->testFailed = true;
     }
 
     /**
@@ -127,15 +144,15 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
     	  if($suite_name = $suite->getName()) {
-    	  	if($this->first_suite) {
-    	  		$this->first_suite = false;
+    	  	if($this->firstSuite) {
+    	  		$this->firstSuite = false;
     	  	}
     	  	
     	  	else {
 		          $this->printNewLine();       
     	  	}
     	  	
-	    	  $this->tab_stops++;
+	    	  $this->tabStops++;
 	    	  
 	        $this->write($suite_name);
 	        $this->printNewLine();    	  	
@@ -151,7 +168,7 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
     	 if($suite->getName()) {
-	    	 $this->tab_stops--;
+	    	 $this->tabStops--;
     	 }
     }
 
@@ -160,10 +177,7 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
      *
      * @param  PHPUnit_Framework_Test $test
      */
-    public function startTest(PHPUnit_Framework_Test $test)
-    {
-    	 	
-    }
+    public function startTest(PHPUnit_Framework_Test $test) { }
 
     /**
      * A test ended.
@@ -173,27 +187,27 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
      */
     public function endTest(PHPUnit_Framework_Test $test, $time) 
     {  
-        if(!$this->test_failed) {
+        if(!$this->testFailed) {
         	 $this->write('.');
         }
         
-        $this->test_failed = false;
+        $this->testFailed = false;
     }
     
     public function write($buffer) {
         parent::write($buffer);
        
-        $this->current_column += strlen($buffer);
+        $this->currentColumn += strlen($buffer);
         
-        if($this->current_column >= $this->maximum_columns) {
+        if($this->currentColumn >= $this->maximumColumns) {
         	  $this->printNewLine();
         }
     }
     
     private function printNewLine() {
-	      $padding = str_pad('', $this->tab_stops * 2);
+	      $padding = str_pad('', $this->tabStops * 2);
 	      parent::write(PHP_EOL . $padding);
-	      $this->current_column = strlen($padding);
+	      $this->currentColumn = strlen($padding);
     }
     
     public function __destruct() {

--- a/PHPUnit/TextUI/DetailedResultPrinter.php
+++ b/PHPUnit/TextUI/DetailedResultPrinter.php
@@ -55,86 +55,23 @@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release xx
  */
-class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
+class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_TextUI_ResultPrinter
 {
     /**
      * @var boolean
      */
-    private $testFailed = false;
-    
-    /**
-     * @var boolean
-     */
-    private $firstSuite = true;
+    protected $firstSuite = true;
     
     /**
      * @var int
      */
-    private $maximumColumns = 70;
+    protected $maxColumn = 70;
     
     /**
      * @var int
      */
-    private $currentColumn = 0;
+    protected $tabStops = 0;
     
-    /**
-     * @var int
-     */
-    private $tabStops = 0;
-    
-    /**
-     * An error occurred.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
-     */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-    	 $this->write('E');
-    	 $this->testFailed = true;
-    }
-
-    /**
-     * A failure occurred.
-     *
-     * @param  PHPUnit_Framework_Test                 $test
-     * @param  PHPUnit_Framework_AssertionFailedError $e
-     * @param  float                                  $time
-     */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
-    	 $this->write('F');
-    	 $this->testFailed = true;
-    }
-
-    /**
-     * Incomplete test.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
-     */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-        $this->write('I');
-        $this->testFailed = true;
-    }
-
-    /**
-     * Skipped test.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
-     * @since  Method available since Release 3.0.0
-     */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
-    {
-    	  $this->write('S');
-    	  $this->testFailed = true;
-    }
-
     /**
      * A test suite started.
      *
@@ -143,20 +80,20 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
      */
     public function startTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-    	  if($suite_name = $suite->getName()) {
-    	  	if($this->firstSuite) {
-    	  		$this->firstSuite = false;
-    	  	}
-    	  	
-    	  	else {
-		          $this->printNewLine();       
-    	  	}
-    	  	
-	    	  $this->tabStops++;
-	    	  
-	        $this->write($suite_name);
-	        $this->printNewLine();    	  	
-    	  }
+        if($suite_name = $suite->getName()) {
+            if($this->firstSuite) {
+                $this->firstSuite = false;
+            }
+
+            else {
+                $this->writeNewLine();
+            }
+
+            $this->tabStops++;
+
+            $this->write($suite_name);
+            $this->writeNewLine();
+        }
     }
 
     /**
@@ -167,9 +104,9 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
      */
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
-    	 if($suite->getName()) {
-	    	 $this->tabStops--;
-    	 }
+        if($suite->getName()) {
+            $this->tabStops--;
+        }
     }
 
     /**
@@ -177,40 +114,30 @@ class PHPUnit_TextUI_DetailedResultPrinter extends PHPUnit_Util_Printer implemen
      *
      * @param  PHPUnit_Framework_Test $test
      */
-    public function startTest(PHPUnit_Framework_Test $test) { }
+    public function startTest(PHPUnit_Framework_Test $test)
+    {
+    }
 
-    /**
-     * A test ended.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  float                  $time
-     */
-    public function endTest(PHPUnit_Framework_Test $test, $time) 
-    {  
-        if(!$this->testFailed) {
-        	 $this->write('.');
-        }
-        
-        $this->testFailed = false;
+    protected function writeProgress($progress) 
+    {
+        $this->write($progress);
     }
     
-    public function write($buffer) {
+    public function write($buffer) 
+    {
         parent::write($buffer);
        
-        $this->currentColumn += strlen($buffer);
+        $this->column += strlen($buffer);
         
-        if($this->currentColumn >= $this->maximumColumns) {
-        	  $this->printNewLine();
+        if($this->column >= $this->maxColumn) {
+            $this->writeNewLine();
         }
     }
     
-    private function printNewLine() {
-	      $padding = str_pad('', $this->tabStops * 2);
-	      parent::write(PHP_EOL . $padding);
-	      $this->currentColumn = strlen($padding);
-    }
-    
-    public function __destruct() {
-    	$this->printNewLine();
+    protected function writeNewLine() 
+    {
+        $padding = str_pad('', $this->tabStops * 2);
+        parent::write(PHP_EOL . $padding);
+        $this->column = strlen($padding);
     }
 }

--- a/PHPUnit/TextUI/SummaryPrinter.php
+++ b/PHPUnit/TextUI/SummaryPrinter.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2011, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage TextUI
+ * @author     Mattis Stordalen Flister <mattis.stordalen.flister@gmail.com>
+ * @copyright  2002-2011 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release xx
+ */
+
+require_once 'PHP/Timer.php';
+
+/**
+ * Prints the summary of a testrun
+ *
+ * @package    PHPUnit
+ * @subpackage TextUI
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2011 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release xx
+ */
+class PHPUnit_TextUI_SummaryPrinter {
+    /**
+     * @var boolean
+     */
+    protected $verbose = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $colors = FALSE;
+    
+    /**
+     * @var PHPUnit_Util_Printer
+     */
+    protected $printer;
+    
+    /**
+     * @var integer
+     */
+    protected $numAssertions = 0;
+
+    public function __construct(PHPUnit_Util_Printer $printer, $verbose = NULL, $colors = NULL) {
+        $this->printer = $printer;
+        
+        if (is_bool($verbose)) {
+            $this->verbose = $verbose;
+        } else {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'boolean');
+        }
+
+        if (is_bool($colors)) {
+            $this->colors = $colors;
+        } else {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(3, 'boolean');
+        }
+    }
+    
+    public function addAssertions($assertions) {
+        $this->numAssertions += $assertions;
+    }
+  
+    /**
+     * @param  PHPUnit_Framework_TestResult $result
+     */
+    public function printResult(PHPUnit_Framework_TestResult $result)
+    {
+        $this->printHeader();
+
+        if ($result->errorCount() > 0) {
+            $this->printErrors($result);
+        }
+
+        if ($result->failureCount() > 0) {
+            if ($result->errorCount() > 0) {
+                print "\n--\n\n";
+            }
+
+            $this->printFailures($result);
+        }
+
+        if ($this->verbose) {
+            if ($result->deprecatedFeaturesCount() > 0) {
+                if ($result->failureCount() > 0) {
+                    print "\n--\n\nDeprecated PHPUnit features are being used";
+                }
+
+                foreach ($result->deprecatedFeatures() as $deprecatedFeature) {
+                    $this->printer->write($deprecatedFeature . "\n\n");
+                }
+            }
+
+            if ($result->notImplementedCount() > 0) {
+                if ($result->failureCount() > 0) {
+                    print "\n--\n\n";
+                }
+
+                $this->printIncompletes($result);
+            }
+
+            if ($result->skippedCount() > 0) {
+                if ($result->notImplementedCount() > 0) {
+                    print "\n--\n\n";
+                }
+
+                $this->printSkipped($result);
+            }
+        }
+
+        $this->printFooter($result);
+    }
+    
+    /**
+     * @param  array   $defects
+     * @param  integer $count
+     * @param  string  $type
+     */
+    protected function printDefects(array $defects, $count, $type)
+    {
+        static $called = FALSE;
+
+        if ($count == 0) {
+            return;
+        }
+
+        $this->printer->write(
+          sprintf(
+            "%sThere %s %d %s%s:\n",
+
+            $called ? "\n" : '',
+            ($count == 1) ? 'was' : 'were',
+            $count,
+            $type,
+            ($count == 1) ? '' : 's'
+          )
+        );
+
+        $i = 1;
+
+        foreach ($defects as $defect) {
+            $this->printDefect($defect, $i++);
+        }
+
+        $called = TRUE;
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestFailure $defect
+     * @param  integer                       $count
+     */
+    protected function printDefect(PHPUnit_Framework_TestFailure $defect, $count)
+    {
+        $this->printDefectHeader($defect, $count);
+        $this->printDefectTrace($defect);
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestFailure $defect
+     * @param  integer                       $count
+     */
+    protected function printDefectHeader(PHPUnit_Framework_TestFailure $defect, $count)
+    {
+        $failedTest = $defect->failedTest();
+
+        if ($failedTest instanceof PHPUnit_Framework_SelfDescribing) {
+            $testName = $failedTest->toString();
+        } else {
+            $testName = get_class($failedTest);
+        }
+
+        $this->printer->write(
+          sprintf(
+            "\n%d) %s\n",
+
+            $count,
+            $testName
+          )
+        );
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestFailure $defect
+     */
+    protected function printDefectTrace(PHPUnit_Framework_TestFailure $defect)
+    {
+        $this->printer->write(
+          $defect->getExceptionAsString() . "\n" .
+          PHPUnit_Util_Filter::getFilteredStacktrace(
+            $defect->thrownException(),
+            FALSE
+          )
+        );
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult  $result
+     */
+    protected function printErrors(PHPUnit_Framework_TestResult $result)
+    {
+        $this->printDefects($result->errors(), $result->errorCount(), 'error');
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult  $result
+     */
+    protected function printFailures(PHPUnit_Framework_TestResult $result)
+    {
+        $this->printDefects(
+          $result->failures(),
+          $result->failureCount(),
+          'failure'
+        );
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult  $result
+     */
+    protected function printIncompletes(PHPUnit_Framework_TestResult $result)
+    {
+        $this->printDefects(
+          $result->notImplemented(),
+          $result->notImplementedCount(),
+          'incomplete test'
+        );
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult  $result
+     * @since  Method available since Release 3.0.0
+     */
+    protected function printSkipped(PHPUnit_Framework_TestResult $result)
+    {
+        $this->printDefects(
+          $result->skipped(),
+          $result->skippedCount(),
+          'skipped test'
+        );
+    }
+
+    protected function printHeader()
+    {
+        $this->printer->write("\n\n" . PHP_Timer::resourceUsage() . "\n\n");
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult  $result
+     */
+    protected function printFooter(PHPUnit_Framework_TestResult $result)
+    {
+        if ($result->wasSuccessful() &&
+            $result->allCompletlyImplemented() &&
+            $result->noneSkipped()) {
+            if ($this->colors) {
+                $this->printer->write("\x1b[30;42m\x1b[2K");
+            }
+
+            $this->printer->write(
+              sprintf(
+                "OK (%d test%s, %d assertion%s)\n",
+
+                count($result),
+                (count($result) == 1) ? '' : 's',
+                $this->numAssertions,
+                ($this->numAssertions == 1) ? '' : 's'
+              )
+            );
+
+            if ($this->colors) {
+                $this->printer->write("\x1b[0m\x1b[2K");
+            }
+        }
+
+        else if ((!$result->allCompletlyImplemented() ||
+                  !$result->noneSkipped()) &&
+                 $result->wasSuccessful()) {
+            if ($this->colors) {
+                $this->printer->write(
+                  "\x1b[30;43m\x1b[2KOK, but incomplete or skipped tests!\n" .
+                  "\x1b[0m\x1b[30;43m\x1b[2K"
+                );
+            } else {
+                $this->printer->write("OK, but incomplete or skipped tests!\n");
+            }
+
+            $this->printer->write(
+              sprintf(
+                "Tests: %d, Assertions: %d%s%s.\n",
+
+                count($result),
+                $this->numAssertions,
+                $this->getCountString(
+                  $result->notImplementedCount(), 'Incomplete'
+                ),
+                $this->getCountString(
+                  $result->skippedCount(), 'Skipped'
+                )
+              )
+            );
+
+            if ($this->colors) {
+                $this->printer->write("\x1b[0m\x1b[2K");
+            }
+        }
+
+        else {
+            $this->printer->write("\n");
+
+            if ($this->colors) {
+                $this->printer->write(
+                  "\x1b[37;41m\x1b[2KFAILURES!\n\x1b[0m\x1b[37;41m\x1b[2K"
+                );
+            } else {
+                $this->printer->write("FAILURES!\n");
+            }
+
+            $this->printer->write(
+              sprintf(
+                "Tests: %d, Assertions: %s%s%s%s%s.\n",
+
+                count($result),
+                $this->numAssertions,
+                $this->getCountString($result->failureCount(), 'Failures'),
+                $this->getCountString($result->errorCount(), 'Errors'),
+                $this->getCountString(
+                  $result->notImplementedCount(), 'Incomplete'
+                ),
+                $this->getCountString($result->skippedCount(), 'Skipped')
+              )
+            );
+
+            if ($this->colors) {
+                $this->printer->write("\x1b[0m\x1b[2K");
+            }
+        }
+
+        if (!$this->verbose &&
+            $result->deprecatedFeaturesCount() > 0) {
+            $message = sprintf(
+              "Warning: Deprecated PHPUnit features are being used %s times!\n".
+              "Use --verbose for more information.\n",
+              $result->deprecatedFeaturesCount()
+            );
+
+            if ($this->colors) {
+                $message = "\x1b[37;41m\x1b[2K" . $message .
+                           "\x1b[0m";
+            }
+
+            $this->printer->write("\n" . $message);
+        }
+    }
+
+    /**
+     * @param  integer $count
+     * @param  string  $name
+     * @return string
+     * @since  Method available since Release 3.0.0
+     */
+    protected function getCountString($count, $name)
+    {
+        $string = '';
+
+        if ($count > 0) {
+            $string = sprintf(
+              ', %s: %d',
+
+              $name,
+              $count
+            );
+        }
+
+        return $string;
+    }    
+}

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -204,12 +204,23 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $arguments['printer'] instanceof PHPUnit_Util_Printer) {
                 $this->printer = $arguments['printer'];
             } else {
-                $this->printer = new PHPUnit_TextUI_ResultPrinter(
-                  NULL,
-                  $arguments['verbose'],
-                  $arguments['colors'],
-                  $arguments['debug']
-                );
+                if(isset($arguments['detailed-progress'])) {
+                    $this->printer = new PHPUnit_TextUI_DetailedResultPrinter(
+                      NULL,
+                      $arguments['verbose'],
+                      $arguments['colors'],
+                      $arguments['debug']
+                    );
+                }
+                
+                else {
+                    $this->printer = new PHPUnit_TextUI_ResultPrinter(
+                      NULL,
+                      $arguments['verbose'],
+                      $arguments['colors'],
+                      $arguments['debug']
+                    );
+                }
             }
         }
 

--- a/Tests/TextUI/help.phpt
+++ b/Tests/TextUI/help.phpt
@@ -43,6 +43,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --stop-on-incomplete      Stop execution upon first incomplete test.
   --strict                  Mark a test as incomplete if no assertions are made.
   --verbose                 Output more verbose information.
+  --detailed-progress       Output more detailed progress information.
   --wait                    Waits for a keystroke after each test.
 
   --skeleton-class          Generate Unit class for UnitTest in UnitTest.php.

--- a/Tests/TextUI/help2.phpt
+++ b/Tests/TextUI/help2.phpt
@@ -44,6 +44,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --stop-on-incomplete      Stop execution upon first incomplete test.
   --strict                  Mark a test as incomplete if no assertions are made.
   --verbose                 Output more verbose information.
+  --detailed-progress       Output more detailed progress information.
   --wait                    Waits for a keystroke after each test.
 
   --skeleton-class          Generate Unit class for UnitTest in UnitTest.php.


### PR DESCRIPTION
Hi,

I have created a new switch, --detailed-progress, which resembles the output from the old --verbose behavior.

I also split up the class PHPUnit_TextUI_ResultPrinter into a new PHPUnit_TextUI_SummaryPrinter. Not sure if this is wanted, but I was thinking of refactoring PHPUnit_TextUI_DetailedResultPrinter so that it's no longer a subclass of PHPUnit_TextUI_ResultPrinter, and then it would be nice if the summary printer was reusable. 

I didn't dare do that just yet, since there are a couple of "instanceof PHPUnit_TextUI_ResultPrinter" checks in the code.
