### PR TITLE
Aggregate option(3.5)

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -77,6 +77,7 @@ class PHPUnit_TextUI_Command
      * @var array
      */
     protected $longOptions = array(
+      'aggregate=' => NULL,
       'colors' => NULL,
       'bootstrap=' => NULL,
       'configuration=' => NULL,
@@ -264,6 +265,11 @@ class PHPUnit_TextUI_Command
                 case 'c':
                 case '--configuration': {
                     $this->arguments['configuration'] = $option[1];
+                }
+                break;
+
+                case '--aggregate': {
+                    $this->arguments['aggregate'] = $option[1];
                 }
                 break;
 
@@ -828,6 +834,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --log-dbus                Log test execution to DBUS.
   --log-json <file>         Log test execution in JSON format.
 
+  --aggregate <file>        Aggregate data from previous runs. And overwrites file with the merged data.
   --coverage-html <dir>     Generate code coverage report in HTML format.
   --coverage-clover <file>  Write code coverage data in Clover XML format.
 

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -312,6 +312,20 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         }
 
         if (extension_loaded('tokenizer') && extension_loaded('xdebug')) {
+            if ( $arguments['aggregate'] ) {
+                $aggregate = $arguments['aggregate'];
+                $codeCoverage = &$result->getCodeCoverage();
+                if ( is_file($aggregate) ){
+                    $data = file_get_contents($aggregate);
+                    $agCoverage = unserialize($data);
+                    if ( $agCoverage) {
+                        $codeCoverage->merge($agCoverage);
+                    }
+                }
+                $data = serialize($codeCoverage);
+                file_put_contents($aggregate,$data);
+            }
+
             if (isset($arguments['coverageClover'])) {
                 $this->printer->write(
                   "\nWriting code coverage data to XML file, this may take " .


### PR DESCRIPTION
I created a new option "--aggregate=<file>", which can merge the previous data file with the present data for coverage test and then overwrites the file.

I'm using this for testing huge code that is difficult to test all code each time.

I wrote the following sources.
- TextUI/Command.php
  Add "aggregate=" option.
  Add "--aggregate <file>" comment.
- TextUI/TestRunner.php
  Add logics of loading from the file, merging data, and saving coverage data with a file.

Regards,
Hiroaki Kubota 
 hiroaki.kubota@mail.rakuten.co.jp
 Rakuten , Inc.
