### PR TITLE
Fix for #174 - Using an xml file doesn't report a missing xDebug extension

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -281,11 +281,11 @@ class PHPUnit_TextUI_Command
                     } else {
                         if (!extension_loaded('tokenizer')) {
                             $this->showMessage(
-                              'The tokenizer extension is not loaded.'
+                              'The tokenizer extension is not loaded. No --coverage-clover will be generated.'
                             );
                         } else {
                             $this->showMessage(
-                              'The Xdebug extension is not loaded.'
+                              'The Xdebug extension is not loaded. No --coverage-clover will be generated.'
                             );
                         }
                     }
@@ -299,11 +299,11 @@ class PHPUnit_TextUI_Command
                     } else {
                         if (!extension_loaded('tokenizer')) {
                             $this->showMessage(
-                              'The tokenizer extension is not loaded.'
+                              'The tokenizer extension is not loaded. No --coverage-html will be generated.'
                             );
                         } else {
                             $this->showMessage(
-                              'The Xdebug extension is not loaded.'
+                              'The Xdebug extension is not loaded. No --coverage-html will be generated.'
                             );
                         }
                     }
@@ -621,6 +621,31 @@ class PHPUnit_TextUI_Command
                 $this->arguments['loader'] = $this->handleLoader(
                   $phpunit['testSuiteLoaderClass'], $file
                 );
+            }
+
+            $logging = $configuration->getLoggingConfiguration();
+            if(isset($logging["coverage-html"])) {
+                if (!extension_loaded('tokenizer')) {
+                    $this->showMessage(
+                        'The tokenizer extension is not loaded. No coverage-html will be generated.', false
+                    );
+                } else {
+                    $this->showMessage(
+                        'The Xdebug extension is not loaded. No coverage-html will be generated.', false
+                    );
+               }
+            }
+
+            if(isset($logging["coverage-clover"])) {
+                if (!extension_loaded('tokenizer')) {
+                    $this->showMessage(
+                        'The tokenizer extension is not loaded. No coverage-clover will be generated.', false
+                    );
+                } else {
+                    $this->showMessage(
+                        'The Xdebug extension is not loaded. No coverage-clover will be generated.', false
+                    );
+               }
             }
 
             $configuration->handlePHPConfiguration();


### PR DESCRIPTION
Change the behavior to "report but don't die" in case there is coverage-html or coverage-clover in the phpunit.xml but no xDebug extension is installed
