### PR TITLE
Catch unhandled exceptions thrown out of setUpBeforeClass functions

### DIFF
--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -665,6 +665,16 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
 
                 return $result;
             }
+            
+            catch (Exception $e) {
+                $numTests = count($this);
+                
+                for ($i = 0; $i < $numTests; $i++) {
+                    $result->addError($this, $e, 0);
+                }
+                
+                return $result;
+            }
         }
 
         if (empty($groups)) {


### PR DESCRIPTION
Currently if setUpBeforeClass throws an exception the entire test run is killed.
