### PR TITLE
Add addMockObject to TestCase class.

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -904,6 +904,16 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
         $this->mockObjects = array();
     }
+    
+    /**
+     * Adds a mock object to the list of active mock objects.
+     * 
+     * @param PHPUnit_Framework_MockObject_MockObject $mock The mock object instance.
+     */
+    protected function addMockObject(PHPUnit_Framework_MockObject_MockObject $mock)
+    {
+        $this->mockObjects[] = $mock;
+    }
 
     /**
      * Sets the name of a TestCase.


### PR DESCRIPTION
Hi Sebastian,

some classes are not mockable in a test case using $this->getMock. For example the class [GearmanClient](http://php.net/manual/en/class.gearmanclient.php) has the method _echo_ which leads to a syntax error in the mocking process by phpunit. This is because _echo_ is a reserved name in php.

The next problem with this class are the default values.

Function addServer per [definition](http://www.php.net/manual/en/gearmanclient.addserver.php):

```
function addServer ([ string $host = 127.0.0.1 [, int $port = 4730 ]] )
```

Function addServer in phpunit mock:

```
function addServer ($host, $port)
```

Method calls like 

```
$mockObject->addServer();
```

are failing, while being valid for the real class.

One could easily create his own mock of the class but will have to pass on using phpunits testing features like $mock->expect(), which are awesome.

A better solution would be to take the source code created by phpunit and make it valid by adding the default values and removing the method _echo_. The resulting class has all the features a native phpunit mock has.

The problem with this approach is that this mock will never be called after the test because phpunit doesn't know it.

It could be added by calling this:

```
// We are in a test case.
$mock = new GearmanClientMock();
$this->mockObjects[] = $mock.
```

BUT, the property $mockObjects of the TestCase class is private and therefore not alterable by the extending test case.
## Solutions
1. Declare $mockObjects as protected.
2. Add a method to register a external created mock, called something like
   
   protected function addMockObject(PHPUnit_Framework_MockObject_MockObject $mock)

I've added a pull request as an example for solution number 2.

What do you guys think about this?
