### PR TITLE
Improvements to testdox to allow specification of testdox "description" for each dataset in a dataProvider

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -282,6 +282,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $this->dataName = $dataName;
     }
 
+    public function getData()
+    {
+        return $this->data;
+    }
+
     /**
      * Returns a string representation of the test case.
      *
@@ -1351,7 +1356,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * @return string
      * @since  Method available since Release 3.3.0
      */
-    protected function getDataSetAsString($includeData = TRUE)
+    public function getDataSetAsString($includeData = TRUE)
     {
         $buffer = '';
 

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -474,7 +474,7 @@ class PHPUnit_TextUI_Command
                 break;
 
                 case '--testdox': {
-                    $this->arguments['printer'] = new PHPUnit_Util_TestDox_ResultPrinter_Text;
+                    $this->arguments['printer'] = new PHPUnit_Util_TestDox_ResultPrinter_Text(NULL, isset($this->arguments['verbose']) ? $this->arguments['verbose'] : false);
                 }
                 break;
 

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -257,7 +257,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         if (isset($arguments['testdoxTextFile'])) {
             $result->addListener(
               new PHPUnit_Util_TestDox_ResultPrinter_Text(
-                $arguments['testdoxTextFile']
+                  $arguments['testdoxTextFile'],
+                  $arguments['verbose']
               )
             );
         }

--- a/PHPUnit/Util/TestDox/ResultPrinter.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter.php
@@ -118,6 +118,17 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
     protected $currentTestMethodPrettified;
 
     /**
+     * @var array A lookup map to convert test status into a single character.
+     */
+    protected $testStatusIndicatorCharMap = array(
+            PHPUnit_Runner_BaseTestRunner::STATUS_PASSED     => 'X',
+            PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED    => 'S',
+            PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE => 'I',
+            PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE    => 'F',
+            PHPUnit_Runner_BaseTestRunner::STATUS_ERROR      => 'E',
+            PHPUnit_Runner_BaseTestRunner::SUITE_METHODNAME  => '-'
+        );
+    /**
      * Constructor.
      *
      * @param  resource  $out
@@ -297,22 +308,19 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
     {
         if ($test instanceof $this->testTypeOfInterest) {
             if (!isset($this->tests[$this->currentTestMethodPrettified])) {
-                if ($this->testStatus == PHPUnit_Runner_BaseTestRunner::STATUS_PASSED) {
-                    $this->tests[$this->currentTestMethodPrettified]['success'] = 1;
-                    $this->tests[$this->currentTestMethodPrettified]['failure'] = 0;
-                    $this->tests[$this->currentTestMethodPrettified]['errors'] = array();
-                } else {
-                    $this->tests[$this->currentTestMethodPrettified]['success'] = 0;
-                    $this->tests[$this->currentTestMethodPrettified]['failure'] = 1;
-                    $this->tests[$this->currentTestMethodPrettified]['errors'] = array($this->testError);
-                }
+                $this->tests[$this->currentTestMethodPrettified] = array('success' => 0, 'failure' => 0, 'errors' => array());
+            }
+
+            $this->tests[$this->currentTestMethodPrettified]['status'] = $this->testStatusIndicatorCharMap[$this->testStatus];
+            if ($this->testStatus == PHPUnit_Runner_BaseTestRunner::STATUS_PASSED) {
+                $this->tests[$this->currentTestMethodPrettified]['success']++;
             } else {
-                if ($this->testStatus == PHPUnit_Runner_BaseTestRunner::STATUS_PASSED) {
-                    $this->tests[$this->currentTestMethodPrettified]['success']++;
-                } else {
-                    $this->tests[$this->currentTestMethodPrettified]['failure']++;
-                    $this->tests[$this->currentTestMethodPrettified]['errors'][] = $this->testError;
-                }
+                $this->tests[$this->currentTestMethodPrettified]['failure']++;
+            }
+
+            if ($this->testError)
+            {
+                $this->tests[$this->currentTestMethodPrettified]['errors'][] = $this->testError;
             }
 
             $this->currentTestClassPrettified  = NULL;

--- a/PHPUnit/Util/TestDox/ResultPrinter.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter.php
@@ -283,19 +283,23 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
                 $this->currentTestMethodPrettified = $this->prettifier->prettifyTestMethod($test->getName(FALSE));
             }
 
-            if (isset($annotations['method']['dataProviderTestdoxArgument'][0])) {
-                $iterationTestName = NULL;
-                $dataProviderTestNameArgIndex = (int) $annotations['method']['dataProviderTestdoxArgument'][0];
-                $iterationArgs = $test->getData();
-                if (isset($iterationArgs[$dataProviderTestNameArgIndex]))
+            if (isset($annotations['method']['dataProviderTestdox'][0])) {
+                $tdArgumentSpec = $annotations['method']['dataProviderTestdox'][0];
+
+                // generate sprintf format string
+                $formatStr = NULL;
+                if (is_numeric($tdArgumentSpec))
                 {
-                    $iterationTestName =  ' ' . $iterationArgs[$dataProviderTestNameArgIndex];
+                    $formatStr = "%{$tdArgumentSpec}\$s";
                 }
                 else
                 {
-                    $iterationTestName = $test->getDataSetAsString(FALSE);
+                    $formatStr = $tdArgumentSpec;
                 }
-                $iterationTestName = trim($iterationTestName);
+
+                // generate pretty test name
+                $iterationArgs = $test->getData();
+                $iterationTestName = trim(vsprintf($formatStr, $iterationArgs));
                 $this->currentTestMethodPrettified .= ": {$iterationTestName}";
             }
 

--- a/PHPUnit/Util/TestDox/ResultPrinter.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter.php
@@ -118,6 +118,11 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
     protected $currentTestMethodPrettified;
 
     /**
+     * @var boolean Verbose
+     */
+    protected $verbose;
+
+    /**
      * @var array A lookup map to convert test status into a single character.
      */
     protected $testStatusIndicatorCharMap = array(
@@ -133,9 +138,11 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
      *
      * @param  resource  $out
      */
-    public function __construct($out = NULL)
+    public function __construct($out = NULL, $verbose = false)
     {
         parent::__construct($out);
+
+        $this->verbose = $verbose;
 
         $this->prettifier = new PHPUnit_Util_TestDox_NamePrettifier;
         $this->startRun();
@@ -267,31 +274,29 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
                 $annotations = $test->getAnnotations();
 
                 if (isset($annotations['method']['testdox'][0])) {
-                    $prettyTestName = $annotations['method']['testdox'][0];
-                    $iterationTestName = NULL;
-                    if (isset($annotations['method']['dataProviderTestdoxArgument'][0]))
-                    {
-                        $dataProviderTestNameArgIndex = (int) $annotations['method']['dataProviderTestdoxArgument'][0];
-                        $iterationArgs = $test->getData();
-                        if (isset($iterationArgs[$dataProviderTestNameArgIndex]))
-                        {
-                            $iterationTestName =  ' ' . $iterationArgs[$dataProviderTestNameArgIndex];
-                        }
-                    }
-                    if (!$iterationTestName)
-                    {
-                        $iterationTestName = $test->getDataSetAsString(FALSE);
-                    }
-                    $prettyTestName .= $iterationTestName;
-                    $prettyTestName = trim($prettyTestName);
-
-                    $this->currentTestMethodPrettified = $prettyTestName;
+                    $this->currentTestMethodPrettified = $annotations['method']['testdox'][0];
                     $prettified                        = TRUE;
                 }
             }
 
             if (!$prettified) {
                 $this->currentTestMethodPrettified = $this->prettifier->prettifyTestMethod($test->getName(FALSE));
+            }
+
+            if (isset($annotations['method']['dataProviderTestdoxArgument'][0])) {
+                $iterationTestName = NULL;
+                $dataProviderTestNameArgIndex = (int) $annotations['method']['dataProviderTestdoxArgument'][0];
+                $iterationArgs = $test->getData();
+                if (isset($iterationArgs[$dataProviderTestNameArgIndex]))
+                {
+                    $iterationTestName =  ' ' . $iterationArgs[$dataProviderTestNameArgIndex];
+                }
+                else
+                {
+                    $iterationTestName = $test->getDataSetAsString(FALSE);
+                }
+                $iterationTestName = trim($iterationTestName);
+                $this->currentTestMethodPrettified .= ": {$iterationTestName}";
             }
 
             $this->testStatus = PHPUnit_Runner_BaseTestRunner::STATUS_PASSED;

--- a/PHPUnit/Util/TestDox/ResultPrinter/HTML.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter/HTML.php
@@ -100,7 +100,12 @@ class PHPUnit_Util_TestDox_ResultPrinter_HTML extends PHPUnit_Util_TestDox_Resul
             $strikeClose = '';
         }
 
-        $this->write('<li>' . $strikeOpen . $name . $strikeClose . '</li>');
+        $errors = NULL;
+        foreach ($this->tests[$name]['errors'] as $error) {
+            $errors .= "<blockquote>{$error->getMessage()}</blockquote>";
+        }
+
+        $this->write('<li>' . $strikeOpen . $name . $strikeClose . $errors . '</li>');
     }
 
     /**

--- a/PHPUnit/Util/TestDox/ResultPrinter/Text.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter/Text.php
@@ -82,6 +82,37 @@ class PHPUnit_Util_TestDox_ResultPrinter_Text extends PHPUnit_Util_TestDox_Resul
         }
 
         $this->write($name . "\n");
+
+        foreach ($this->tests[$name]['errors'] as $error) {
+            $this->write("     +-> {$error->getMessage()}\n");
+            $trace = NULL;
+            $stepNum = 1;
+            $lineNum = $error->getLine();
+            $file = $error->getFile();
+            foreach ($error->getTrace() as $traceStep) {
+                $line = str_pad('', 8 + $stepNum);
+                $line .= ($stepNum == 1 ? '@' : ' ') . " ";
+                if (isset($traceStep['class']))
+                {
+                    $line .= "{$traceStep['class']}::";
+                }
+                $line .= "{$traceStep['function']}()";
+                if ($lineNum)
+                {
+                    $line .= ":{$lineNum}";
+                }
+
+                $line = str_pad($line, 75, " ", STR_PAD_RIGHT);
+                $line .= "{$file} ";
+                $this->write("{$line}\n");
+
+                // the trace step's file & line are the CALLER, not the current
+                $file = (isset($traceStep['file']) ? $traceStep['file'] : '<unknown>');
+                $lineNum = (isset($traceStep['line']) ? $traceStep['line'] : NULL);
+
+                $stepNum++;
+            }
+        }
     }
 
     /**

--- a/PHPUnit/Util/TestDox/ResultPrinter/Text.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter/Text.php
@@ -75,13 +75,7 @@ class PHPUnit_Util_TestDox_ResultPrinter_Text extends PHPUnit_Util_TestDox_Resul
      */
     protected function onTest($name, $success = TRUE)
     {
-        if ($success) {
-            $this->write(' [x] ');
-        } else {
-            $this->write(' [ ] ');
-        }
-
-        $this->write($name . "\n");
+        $this->write(" [{$this->tests[$name]['status']}] {$name}\n");
 
         foreach ($this->tests[$name]['errors'] as $error) {
             $this->write("     +-> {$error->getMessage()}\n");

--- a/PHPUnit/Util/TestDox/ResultPrinter/Text.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter/Text.php
@@ -77,34 +77,37 @@ class PHPUnit_Util_TestDox_ResultPrinter_Text extends PHPUnit_Util_TestDox_Resul
     {
         $this->write(" [{$this->tests[$name]['status']}] {$name}\n");
 
-        foreach ($this->tests[$name]['errors'] as $error) {
-            $this->write("     +-> {$error->getMessage()}\n");
-            $trace = NULL;
-            $stepNum = 1;
-            $lineNum = $error->getLine();
-            $file = $error->getFile();
-            foreach ($error->getTrace() as $traceStep) {
-                $line = str_pad('', 8 + $stepNum);
-                $line .= ($stepNum == 1 ? '@' : ' ') . " ";
-                if (isset($traceStep['class']))
-                {
-                    $line .= "{$traceStep['class']}::";
+        if ($this->verbose)
+        {
+            foreach ($this->tests[$name]['errors'] as $error) {
+                $this->write("     +-> {$error->getMessage()}\n");
+                $trace = NULL;
+                $stepNum = 1;
+                $lineNum = $error->getLine();
+                $file = $error->getFile();
+                foreach ($error->getTrace() as $traceStep) {
+                    $line = str_pad('', 8 + $stepNum);
+                    $line .= ($stepNum == 1 ? '@' : ' ') . " ";
+                    if (isset($traceStep['class']))
+                    {
+                        $line .= "{$traceStep['class']}::";
+                    }
+                    $line .= "{$traceStep['function']}()";
+                    if ($lineNum)
+                    {
+                        $line .= ":{$lineNum}";
+                    }
+
+                    $line = str_pad($line, 75, " ", STR_PAD_RIGHT);
+                    $line .= "{$file} ";
+                    $this->write("{$line}\n");
+
+                    // the trace step's file & line are the CALLER, not the current
+                    $file = (isset($traceStep['file']) ? $traceStep['file'] : '<unknown>');
+                    $lineNum = (isset($traceStep['line']) ? $traceStep['line'] : NULL);
+
+                    $stepNum++;
                 }
-                $line .= "{$traceStep['function']}()";
-                if ($lineNum)
-                {
-                    $line .= ":{$lineNum}";
-                }
-
-                $line = str_pad($line, 75, " ", STR_PAD_RIGHT);
-                $line .= "{$file} ";
-                $this->write("{$line}\n");
-
-                // the trace step's file & line are the CALLER, not the current
-                $file = (isset($traceStep['file']) ? $traceStep['file'] : '<unknown>');
-                $lineNum = (isset($traceStep['line']) ? $traceStep['line'] : NULL);
-
-                $stepNum++;
             }
         }
     }


### PR DESCRIPTION
We dataProvider frequently in our testing. We also like to use tests-as-docs via testdox. The current implementation of testdox is inadequate for use with dataProvider as you don't have the option to specify a "specification" per dataProvider dataset.

This patch is rebased against your current 3.5 branch and I hope that you can merge it in with the next 3.5 release. I have been forward-porting it since 3.4 and it continues to work great.

```
I have added a new annotation, @dataProviderTestdoxArgument, which if used in conjunction with @dataProvider on a test, will use the specified argument # as the testdox string.

Simultaneously, testdox mode now reports pass/fail [X] for *each* iteration of the dataProvider.

Example:
    /**
     * @dataProvider USAddressRequiredFieldsDataProvider
     * @testdox US Address Requires
     * @dataProviderTestdoxArgument 0
     */
    function testUSAddressRequiresFields($requiredField)
    {
        $address = Fixturenator::create('ValidUSAddress');
        $address->setValueForKey(NULL, $requiredField);
        $this->assertFalse($address->validateObject($errors));
    }
    function USAddressRequiredFieldsDataProvider()
    {
        return array(
            array('city'),
            array('state'),
            array('zip'),
        );
    }

Will Print Out:
Address
 [x] US Address Requires city
 [x] US Address Requires state
 [x] US Address Requires zip
```
