### PR TITLE
Return value map

### DIFF
--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -1767,6 +1767,18 @@ function returnValue($value)
 }
 
 /**
+ *
+ *
+ * @param  array $valueMap
+ * @return PHPUnit_Framework_MockObject_Stub_ReturnValueMap
+ * @since  Method available since Release 3.6.0
+ */
+function returnValueMap(array $valueMap)
+{
+    return PHPUnit_Framework_TestCase::returnValueMap($valueMap);
+}
+
+/**
  * Returns a PHPUnit_Framework_Constraint_StringContains matcher object.
  *
  * @param  string  $string

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -1406,6 +1406,20 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     /**
      *
      *
+     * @param  array $valueMap
+     * @return PHPUnit_Framework_MockObject_Stub_ReturnValueMap
+     * @since  Method available since Release 3.6.0
+     */
+    public static function returnValueMap(array $valueMap)
+    {
+        return new PHPUnit_Framework_MockObject_Stub_ReturnValueMap(
+          $valueMap
+        );
+    }
+
+    /**
+     *
+     *
      * @param  integer $argumentIndex
      * @return PHPUnit_Framework_MockObject_Stub_ReturnArgument
      * @since  Method available since Release 3.3.0


### PR DESCRIPTION
Added support for stubbing a method by returning a value from a map.

See also: https://github.com/sebastianbergmann/phpunit-mock-objects/pull/53
