### PR TITLE
Suggested improvements on testdox grouping

### DIFF
--- a/PHPUnit/Util/TestDox/NamePrettifier.php
+++ b/PHPUnit/Util/TestDox/NamePrettifier.php
@@ -109,11 +109,11 @@ class PHPUnit_Util_TestDox_NamePrettifier
             return $buffer;
         }
 
-        $string = preg_replace('#\d+$#', '', $name);
+        $string = preg_replace('#\d+$#', '', $name, -1, $count);
 
         if (in_array($string, $this->strings)) {
             $name = $string;
-        } else {
+        } else if ($count == 0) {
             $this->strings[] = $string;
         }
 

--- a/Tests/Util/TestDox/NamePrettifierTest.php
+++ b/Tests/Util/TestDox/NamePrettifierTest.php
@@ -101,4 +101,13 @@ class Util_TestDox_NamePrettifierTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Foo for bar is 0', $this->namePrettifier->prettifyTestMethod('testFooForBarIs0'));
         $this->assertEquals('Foo for baz is 1', $this->namePrettifier->prettifyTestMethod('testFooForBazIs1'));
     }
+
+    /**
+     * @ticket 224
+     */
+    public function testTestNameIsNotGroupedWhenNotInSequence()
+    {
+        $this->assertEquals('Sets redirect header on 301', $this->namePrettifier->prettifyTestMethod('testSetsRedirectHeaderOn301'));
+        $this->assertEquals('Sets redirect header on 302', $this->namePrettifier->prettifyTestMethod('testSetsRedirectHeaderOn302'));
+    }
 }


### PR DESCRIPTION
This is just a small suggestion on how we could improve the way tests are grouped by the `PHPUnit_Util_TestDox_ResultPrinter` (inspired by #224).  Right now tests can be grouped like so:

```
class FooTest extends PHPUnit_Framework_TestCase
{
    public function testFoo(){}
    public function testFoo2(){}
    public function testFoo3(){}
}
```

To yield:

```
Foo
 [x] Foo
```

Yet, a single test with a number can be printed like so:

```
class FooTest extends PHPUnit_Framework_TestCase
{
    public function testFoo2(){}
}
```

To yield:

```
Foo
 [x] Foo 2
```

The problem is when you run into a situation like this:

```
class BugTest extends PHPUnit_Framework_TestCase
{ 
   public function testSetsRedirectHeaderOn301(){}
   public function testSetsRedirectHeaderOn302(){} 
}
```

Which yields:

```
Bug
 [x] Sets redirect header on 301 
 [x] Sets redirect header on
```

So instead of not removing the number from the end of the first test and then grouping the remaining tests, I suggest we only group tests if the first test has no number.  Of course this still leaves the functionality somewhat dependent on the order of the tests, though the end-result is a bit of an improvement I think.
