### PR TITLE
Add the ability to specify a FilterIterator in the config for a TestSuite.

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -72,6 +72,13 @@
  *     <testsuite name="My Test Suite">
  *       <directory suffix="Test.php">/path/to/files</directory>
  *       <file>/path/to/MyTest.php</file>
+ *       <filter class="MyFilterIterator" file="/optional/path/to/MyFilterIterator.php">
+ *         <arguments>
+ *           <element key="0">
+ *             <string>Bad Test</string>
+ *           </element>
+ *         </arguments>
+ *       </filter>
  *     </testsuite>
  *   </testsuites>
  *

--- a/Tests/_files/configuration.xml
+++ b/Tests/_files/configuration.xml
@@ -18,6 +18,15 @@
     <testsuite name="My Test Suite">
       <directory suffix="Test.php">/path/to/files</directory>
       <file>/path/to/MyTest.php</file>
+      <filter class="MyFilterIterator" file="/optional/path/to/MyFilterIterator.php">
+        <arguments>
+          <array>
+            <element key="0">
+              <string>BadTest</string>
+            </element>
+          </array>
+        </arguments>
+      </filter>
     </testsuite>
   </testsuites>
 


### PR DESCRIPTION
Add a <filter> tag element to <testSuite> so that you can specify a
FilterIterator in a manner similar to a TestListener that can be used
to as a FilterIterator in the IncludePathTestCollector.

This will allow finer control of whitelisting, and now allow
blacklisting of files included in the test suite.

Simply create a FilterIterator that filters based on the current
SplFileInfo.
