### PR TITLE
Added exceptions for E_DEPRECATED and E_USER_DEPRECATED

### DIFF
--- a/PHPUnit/Framework/Error/Deprecated.php
+++ b/PHPUnit/Framework/Error/Deprecated.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2002-2011, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Error
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2011 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.3.0
+ */
+
+/**
+ * Wrapper for PHP deprecated errors.
+ * You can disable deprecated-to-exception conversion by setting
+ *
+ * <code>
+ * PHPUnit_Framework_Error_Deprecated::$enabled = FALSE;
+ * </code>
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Error
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2002-2011 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.3.0
+ */
+class PHPUnit_Framework_Error_Deprecated extends PHPUnit_Framework_Error
+{
+    public static $enabled = TRUE;
+}

--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -48,6 +48,7 @@
 require_once 'PHPUnit/Framework/Error.php';
 require_once 'PHPUnit/Framework/Error/Notice.php';
 require_once 'PHPUnit/Framework/Error/Warning.php';
+require_once 'PHPUnit/Framework/Error/Deprecated.php';
 
 /**
  * Error handler that converts PHP errors and warnings to exceptions.
@@ -113,6 +114,14 @@ class PHPUnit_Util_ErrorHandler
             }
 
             $exception = 'PHPUnit_Framework_Error_Warning';
+        }
+
+        else if ($errno == E_DEPRECATED || $errno == E_USER_DEPRECATED) {
+            if (PHPUnit_Framework_Error_Deprecated::$enabled !== TRUE) {
+                return FALSE;
+            }
+
+            $exception = 'PHPUnit_Framework_Error_Deprecated';
         }
 
         else {

--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -116,7 +116,7 @@ class PHPUnit_Util_ErrorHandler
             $exception = 'PHPUnit_Framework_Error_Warning';
         }
 
-        else if ($errno == E_DEPRECATED || $errno == E_USER_DEPRECATED) {
+        else if (version_compare(PHP_VERSION, '5.3', '>=') && ($errno == E_DEPRECATED || $errno == E_USER_DEPRECATED)) {
             if (PHPUnit_Framework_Error_Deprecated::$enabled !== TRUE) {
                 return FALSE;
             }


### PR DESCRIPTION
The error-to-exception handler will now generate PHPUnit_Framework_Error_Deprecated exceptions when a E_DEPRECATED or E_USER_DEPRECATED error is triggered. The code uses version_compare to make sure that no E_NOTICE will be triggered on PHP < 5.3 about missing constants (E_DEPRECATED and E_USER_DEPRECATED was introduced in 5.3)
