### PR TITLE
Don't generate an absolute path at this stage

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -335,7 +335,7 @@ class PHPUnit_Util_Configuration
             $arguments = array();
 
             if ($listener->hasAttribute('file')) {
-                $file = $this->toAbsolutePath((string)$listener->getAttribute('file'));
+                $file = (string)$listener->getAttribute('file');
             }
 
             if ($listener->childNodes->item(1) instanceof DOMElement &&


### PR DESCRIPTION
`PHPUnit_Util_Configuration` should not generate an absolute path of the content in the file attribute of the `<listener>` tag. This path might resolve to a file inside the include_path. The `PHPUnit_TextUI_TestRunner::handleConfiguration()` methods checks if the path is in the include_path at a later stage. Fixes #231
