### PR TITLE
Issue with assertTag and multiple children/parents

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -709,7 +709,7 @@ class PHPUnit_Util_XML
 
             foreach ($nodes as $node) {
                 if ($parentNode !== $node->parentNode) {
-                    break;
+                    continue;
                 }
 
                 $filtered[] = $node;

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -3557,6 +3557,16 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * @covers PHPUnit_Framework_Assert::assertTag
+    */
+    public function testAssertTagMultiplePossibleChildren()
+    {
+	$matcher = array('tag' => 'li',
+			 'parent' => array('tag' => 'ul', 'id' => 'another_ul'));
+	$this->assertTag($matcher, $this->html);
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertTag
      */
     public function testAssertTagChildTrue()

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -3561,9 +3561,9 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     */
     public function testAssertTagMultiplePossibleChildren()
     {
-	$matcher = array('tag' => 'li',
+        $matcher = array('tag' => 'li',
 			 'parent' => array('tag' => 'ul', 'id' => 'another_ul'));
-	$this->assertTag($matcher, $this->html);
+        $this->assertTag($matcher, $this->html);
     }
 
     /**

--- a/Tests/_files/SelectorAssertionsFixture.html
+++ b/Tests/_files/SelectorAssertionsFixture.html
@@ -12,6 +12,9 @@
     <li class="my_li">Test LI 2</li>
     <li class="my_li">Test LI 3</li>
   </ul>
+  <ul id="another_ul" class="my_ul_class">
+    <li class="my_li">Test LI 4</li>
+  </ul>
   <div id="test_id" class="my_test_class">
     <div id="test_child_id">
       <span id="test_subchild_id">My Subchild</span>


### PR DESCRIPTION
I ran into this issue today while testing XML - if you try to match an element with a parent, and there happens to be another element earlier in the document that matches everything but the parent, the match will fail.  The problem is that the parent-matching filter loops through the matched nodes and breaks the first time it encounters a node that does NOT have the given parent as its parent - any nodes later in the node array that DO have the given parent are ignored.  I've submitted a test case and some minor additions to the assertions fixture that should illustrate the issue better.

Given the fixture HTML and the test case matcher, and based on the documentation for assertTag, it seems to me that the match should succeed - but my apologies if I've overlooked something about the way assertTag is intended to behave when matching parents.
