### PR TITLE
Fixes XML string escaping by removing invalid characters

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -58,6 +58,11 @@
 class PHPUnit_Util_XML
 {
     /**
+     * Escapes a string for the use in XML documents
+     * Any Unicode character is allowed, excluding the surrogate blocks, FFFE, 
+     * and FFFF (not even as character reference).
+     * See http://www.w3.org/TR/xml/#charsets
+     *
      * @param  string $string
      * @return string
      * @author Kore Nordmann <mail@kore-nordmann.de>
@@ -66,10 +71,10 @@ class PHPUnit_Util_XML
     public static function prepareString($string)
     {
         return preg_replace(
-          '([\\x00-\\x04\\x0b\\x0c\\x0e-\\x1f\\x7f])e',
-          'sprintf( "&#x%02x;", ord( "\\1" ) )',
+          '([\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f])e',
+          '',
           htmlspecialchars(
-            self::convertToUtf8($string), ENT_COMPAT, 'UTF-8'
+            self::convertToUtf8($string), ENT_QUOTES, 'UTF-8'
           )
         );
     }

--- a/Tests/Util/XMLTest.php
+++ b/Tests/Util/XMLTest.php
@@ -325,4 +325,14 @@ class Util_XMLTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($tag, $converted);
     }
+    
+    public function testPrepareString() {
+        for($i = 0; $i < 256; $i++) {
+            $escapedString = PHPUnit_Util_XML::prepareString(chr($i));
+            
+            $xml = "<?xml version='1.0' encoding='UTF-8' ?><tag>$escapedString</tag>";
+
+            DOMDocument::loadXML($xml); // Throws an exception, if invalid chars are found
+        }
+    }
 }


### PR DESCRIPTION
Details are described in my commit note. I also added a test that checks all chars from 0 to 255 using DOMDocument::loadXML() - not sure how "standard" this implementation is, but for sure it is common in a PHP environment. Sorry for the delay.
