### PR TITLE
Fixes GH-260

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -1714,16 +1714,16 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
-     * Asserts that a hierarchy of DOMNodes matches.
+     * Asserts that a hierarchy of DOMElements matches.
      *
-     * @param DOMNode $expectedNode
-     * @param DOMNode $actualNode
+     * @param DOMElement $expectedNode
+     * @param DOMElement $actualNode
      * @param boolean $checkAttributes
      * @param string  $message
      * @author Mattis Stordalen Flister <mattis@xait.no>
      * @since  Method available since Release 3.3.0
      */
-    public static function assertEqualXMLStructure(DOMNode $expectedNode, DOMNode $actualNode, $checkAttributes = FALSE, $message = '')
+    public static function assertEqualXMLStructure(DOMElement $expectedNode, DOMElement $actualNode, $checkAttributes = FALSE, $message = '')
     {
         self::assertEquals(
           $expectedNode->tagName,

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -1716,36 +1716,36 @@ abstract class PHPUnit_Framework_Assert
     /**
      * Asserts that a hierarchy of DOMElements matches.
      *
-     * @param DOMElement $expectedNode
-     * @param DOMElement $actualNode
+     * @param DOMElement $expectedElement
+     * @param DOMElement $actualElement
      * @param boolean $checkAttributes
      * @param string  $message
      * @author Mattis Stordalen Flister <mattis@xait.no>
      * @since  Method available since Release 3.3.0
      */
-    public static function assertEqualXMLStructure(DOMElement $expectedNode, DOMElement $actualNode, $checkAttributes = FALSE, $message = '')
+    public static function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actualElement, $checkAttributes = FALSE, $message = '')
     {
         self::assertEquals(
-          $expectedNode->tagName,
-          $actualNode->tagName,
+          $expectedElement->tagName,
+          $actualElement->tagName,
           $message
         );
 
         if ($checkAttributes) {
             self::assertEquals(
-              $expectedNode->attributes->length,
-              $actualNode->attributes->length,
+              $expectedElement->attributes->length,
+              $actualElement->attributes->length,
               sprintf(
                 '%s%sNumber of attributes on node "%s" does not match',
                 $message,
                 !empty($message) ? "\n" : '',
-                $expectedNode->tagName
+                $expectedElement->tagName
               )
             );
 
-            for ($i = 0 ; $i < $expectedNode->attributes->length; $i++) {
-                $expectedAttribute = $expectedNode->attributes->item($i);
-                $actualAttribute   = $actualNode->attributes->getNamedItem(
+            for ($i = 0 ; $i < $expectedElement->attributes->length; $i++) {
+                $expectedAttribute = $expectedElement->attributes->item($i);
+                $actualAttribute   = $actualElement->attributes->getNamedItem(
                   $expectedAttribute->name
                 );
 
@@ -1756,31 +1756,31 @@ abstract class PHPUnit_Framework_Assert
                         $message,
                         !empty($message) ? "\n" : '',
                         $expectedAttribute->name,
-                        $expectedNode->tagName
+                        $expectedElement->tagName
                       )
                     );
                 }
             }
         }
 
-        PHPUnit_Util_XML::removeCharacterDataNodes($expectedNode);
-        PHPUnit_Util_XML::removeCharacterDataNodes($actualNode);
+        PHPUnit_Util_XML::removeCharacterDataNodes($expectedElement);
+        PHPUnit_Util_XML::removeCharacterDataNodes($actualElement);
 
         self::assertEquals(
-          $expectedNode->childNodes->length,
-          $actualNode->childNodes->length,
+          $expectedElement->childNodes->length,
+          $actualElement->childNodes->length,
           sprintf(
             '%s%sNumber of child nodes of "%s" differs',
             $message,
             !empty($message) ? "\n" : '',
-            $expectedNode->tagName
+            $expectedElement->tagName
           )
         );
 
-        for ($i = 0; $i < $expectedNode->childNodes->length; $i++) {
+        for ($i = 0; $i < $expectedElement->childNodes->length; $i++) {
             self::assertEqualXMLStructure(
-              $expectedNode->childNodes->item($i),
-              $actualNode->childNodes->item($i),
+              $expectedElement->childNodes->item($i),
+              $actualElement->childNodes->item($i),
               $checkAttributes,
               $message
             );

--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -494,16 +494,16 @@ function assertEmpty($actual, $message = '')
 }
 
 /**
- * Asserts that a hierarchy of DOMNodes matches.
+ * Asserts that a hierarchy of DOMElements matches.
  *
- * @param DOMNode $expectedNode
- * @param DOMNode $actualNode
+ * @param DOMElement $expectedNode
+ * @param DOMElement $actualNode
  * @param boolean $checkAttributes
  * @param string  $message
  * @author Mattis Stordalen Flister <mattis@xait.no>
  * @since  Method available since Release 3.3.0
  */
-function assertEqualXMLStructure(DOMNode $expectedNode, DOMNode $actualNode, $checkAttributes = FALSE, $message = '')
+function assertEqualXMLStructure(DOMElement $expectedNode, DOMElement $actualNode, $checkAttributes = FALSE, $message = '')
 {
     return PHPUnit_Framework_Assert::assertEqualXMLStructure($expectedNode, $actualNode, $checkAttributes, $message);
 }

--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -496,16 +496,16 @@ function assertEmpty($actual, $message = '')
 /**
  * Asserts that a hierarchy of DOMElements matches.
  *
- * @param DOMElement $expectedNode
- * @param DOMElement $actualNode
+ * @param DOMElement $expectedElement
+ * @param DOMElement $actualElement
  * @param boolean $checkAttributes
  * @param string  $message
  * @author Mattis Stordalen Flister <mattis@xait.no>
  * @since  Method available since Release 3.3.0
  */
-function assertEqualXMLStructure(DOMElement $expectedNode, DOMElement $actualNode, $checkAttributes = FALSE, $message = '')
+function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actualElement, $checkAttributes = FALSE, $message = '')
 {
-    return PHPUnit_Framework_Assert::assertEqualXMLStructure($expectedNode, $actualNode, $checkAttributes, $message);
+    return PHPUnit_Framework_Assert::assertEqualXMLStructure($expectedElement, $actualElement, $checkAttributes, $message);
 }
 
 /**


### PR DESCRIPTION
Judging from the code and tests for `PHPUnit_Framework_Assert::assertEqualXMLStructure()`, it seems that the real intent was to test `DomElement` objects and not all `DomNode` objects.  For example, the `$checkAttributes` parameter is only relevant for `DomElement` objects and will give errors if used with any other type of `DomNode`.
