### PR TITLE
Fix test suite class name detection in master

### DIFF
--- a/PHPUnit/Runner/StandardTestSuiteLoader.php
+++ b/PHPUnit/Runner/StandardTestSuiteLoader.php
@@ -75,7 +75,7 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
 
         if (!class_exists($suiteClassName, FALSE)) {
             PHPUnit_Util_Class::collectStart();
-            PHPUnit_Util_Fileloader::checkAndLoad($suiteClassFile);
+            $filename = PHPUnit_Util_Fileloader::checkAndLoad($suiteClassFile);
             $loadedClasses = PHPUnit_Util_Class::collectEnd();
         }
 
@@ -83,7 +83,9 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
             $offset = 0 - strlen($suiteClassName);
 
             foreach ($loadedClasses as $loadedClass) {
-                if (substr($loadedClass, $offset) === $suiteClassName) {
+                $class = new ReflectionClass($loadedClass);
+                if (substr($loadedClass, $offset) === $suiteClassName &&
+                    $class->getFileName() == $filename) {
                     $suiteClassName = $loadedClass;
                     break;
                 }


### PR DESCRIPTION
Sorry, didn't even notice I was on 3.5 by default. This is the same patch as provided in pull request #272 but this time for the master branch. The only thing modified was the removed "$syntaxCheck" parameter.
