### PR TITLE
Sync "using from git docs" with master

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,7 +75,10 @@ The following commands can be used to check out the appropriate branches for PHP
     cd phpunit-mock-objects && git checkout 1.0 && cd ..
     cd phpunit-selenium && git checkout 1.0 && cd ..
 
-The following commands can be used to check out the appropriate branches for PHPUnit 3.6:
+The following commands can be used to check out the appropriate branches and new dependencies for PHPUnit 3.6:
+
+    git clone git://github.com/sebastianbergmann/phpunit-story.git
+    git clone git://github.com/sebastianbergmann/php-invoker.git
 
     cd phpunit && git checkout master && cd ..
     cd dbunit && git checkout master && cd ..
@@ -84,3 +87,4 @@ The following commands can be used to check out the appropriate branches for PHP
     cd php-token-stream && git checkout master && cd ..
     cd phpunit-mock-objects && git checkout master && cd ..
     cd phpunit-selenium && git checkout master && cd ..
+    cd php-invoker && git checkout master && cd ..


### PR DESCRIPTION
The 3.5 branch README features 3.6/master checkout instructions but those where not in sync with the master branch. If they are there they should work.
