### PR TITLE
Include reference modifier only for method definition

### DIFF
--- a/PHPUnit/Util/Class.php
+++ b/PHPUnit/Util/Class.php
@@ -147,6 +147,7 @@ class PHPUnit_Util_Class
             }
 
             $default  = '';
+            $reference = '';
             $typeHint = '';
 
             if (!$forCall) {
@@ -170,19 +171,16 @@ class PHPUnit_Util_Class
                     $value   = $parameter->getDefaultValue();
                     $default = ' = ' . var_export($value, TRUE);
                 }
-
                 else if ($parameter->isOptional()) {
                     $default = ' = null';
                 }
+
+                if ($parameter->isPassedByReference()) {
+                    $reference = '&';
+                }
             }
 
-            $ref = '';
-
-            if ($parameter->isPassedByReference()) {
-                $ref = '&';
-            }
-
-            $parameters[] = $typeHint . $ref . $name . $default;
+            $parameters[] = $typeHint . $reference . $name . $default;
         }
 
         return join(', ', $parameters);


### PR DESCRIPTION
Parameters to new instances of `PHPUnit_Framework_MockObject_Invocation_Object` were being passed by reference causing the contents of each invocation to change when the bound variable was assigned.

Arguments should be passed by value in `mocked_object_method.tpl.dist` `{arguments_call}`.

Fixes https://github.com/sebastianbergmann/phpunit-mock-objects/issues/59
