### PR TITLE
eZ Components in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,6 +48,11 @@ The [#phpunit channel on the Freenode IRC network](irc://freenode.net/phpunit) i
 Using PHPUnit From a Git Checkout
 ---------------------------------
 
+First you'll need eZ Components' ConsoleTools:
+
+    pear channel-discover components.ez.no
+    pear install ezc/ConsoleTools
+
 The following commands can be used to perform the initial checkout of PHPUnit and its dependencies from Git:
 
     mkdir phpunit && cd phpunit


### PR DESCRIPTION
I've been playing with local compiles of PHP and xdebug, and wanted to try phpunit with it. Seems that eZ Components' ConsoleTools is also required! :)

I've only tried with master (3.6), but am guessing the same doc issue exists with respect to 3.5 given the installation instructions at http://www.phpunit.de/manual/3.5/en/installation.html .

Thanks!
