### PR TITLE
Multiple <includePath> elements. 

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -433,7 +433,7 @@ class PHPUnit_Util_Configuration
     public function getPHPConfiguration()
     {
         $result = array(
-          'include_path' => '',
+          'include_path' => array(),
           'ini'          => array(),
           'const'        => array(),
           'var'          => array(),
@@ -446,10 +446,10 @@ class PHPUnit_Util_Configuration
           'request'      => array()
         );
 
-        $nl = $this->xpath->query('php/includePath');
+        foreach($this->xpath->query('php/includePath') as $includePath) {
+            $path = (string)$includePath->nodeValue;
 
-        if ($nl->length == 1) {
-            $result['include_path'] = $this->toAbsolutePath((string)$nl->item(0)->nodeValue);
+            $result['include_path'][] = $this->toAbsolutePath($path);
         }
 
         foreach ($this->xpath->query('php/ini') as $ini) {
@@ -487,10 +487,11 @@ class PHPUnit_Util_Configuration
     {
         $configuration = $this->getPHPConfiguration();
 
-        if ($configuration['include_path'] != '') {
+        if (! empty($configuration['include_path'])) {
             ini_set(
               'include_path',
-              $configuration['include_path'] . PATH_SEPARATOR .
+              implode(PATH_SEPARATOR, $configuration['include_path']) .
+              PATH_SEPARATOR .
               ini_get('include_path')
             );
         }

--- a/Tests/Util/ConfigurationTest.php
+++ b/Tests/Util/ConfigurationTest.php
@@ -241,7 +241,11 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
           array(
-            'include_path' => dirname(dirname(__FILE__)).'/_files/.',
+            'include_path' =>
+            array(
+              dirname(dirname(__FILE__)) . '/_files/.',
+              '/path/to/lib'
+            ),
             'ini'=> array('foo' => 'bar'),
             'const'=> array('foo' => FALSE, 'bar' => TRUE),
             'var'=> array('foo' => FALSE),
@@ -264,6 +268,8 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->configuration->handlePHPConfiguration();
 
+        $path = dirname(dirname(__FILE__)) . '/_files/.' . PATH_SEPARATOR . '/path/to/lib';
+        $this->assertStringStartsWith($path, ini_get('include_path'));
         $this->assertEquals(FALSE, foo);
         $this->assertEquals(TRUE, bar);
         $this->assertEquals(FALSE, $GLOBALS['foo']);

--- a/Tests/_files/configuration.xml
+++ b/Tests/_files/configuration.xml
@@ -85,6 +85,7 @@
 
   <php>
     <includePath>.</includePath>
+    <includePath>/path/to/lib</includePath>
     <ini name="foo" value="bar"/>
     <const name="foo" value="false"/>
     <const name="bar" value="true"/>


### PR DESCRIPTION
I tried to add more than one <includePath> elements to xml configuration file, but I noticed that these were all ignored.

This is fix to accept multiple <includePath> elements.

(The first pull request is #305. I'm sorry for the trouble.)
