### PR TITLE
Minor documentation fix for PHPUnit_Framework_Assert::assertTag()

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -1947,7 +1947,7 @@ abstract class PHPUnit_Framework_Assert
      *
      * // Matcher that asserts that there is a "span" tag with content matching
      * // the regular expression pattern.
-     * $matcher = array('tag' => 'span', 'content' => '/Try P(HP|ython)/');
+     * $matcher = array('tag' => 'span', 'content' => 'regexp:/Try P(HP|ython)/');
      *
      * // Matcher that asserts that there is a "span" with an "list" class
      * // attribute.


### PR DESCRIPTION
There was a slight discrepancy between how `PHPUnit_Framework_Assert::assertTag()` looked for regular expressions (that is, how `PHPUnit_Util_XML::findNodes()` called by `assertTag()` looks for reg exp).
