### PR TITLE
new phpdoc annotation feature: @assert instanceof <Class>

### DIFF
--- a/PHPUnit/Util/Skeleton/Template/TestMethodInstance.tpl.dist
+++ b/PHPUnit/Util/Skeleton/Template/TestMethodInstance.tpl.dist
@@ -1,0 +1,8 @@
+
+    /**
+     * Generated from @assert {annotation}.
+     */
+    public function test{methodName}()
+    {
+        $this->assertInstanceOf('{expected}', $this->object->{origMethodName}({arguments}));
+    }

--- a/PHPUnit/Util/Skeleton/Template/TestMethodInstanceStatic.tpl.dist
+++ b/PHPUnit/Util/Skeleton/Template/TestMethodInstanceStatic.tpl.dist
@@ -1,0 +1,8 @@
+
+    /**
+     * Generated from @assert {annotation}.
+     */
+    public function test{methodName}()
+    {
+        $this->assertInstanceOf('{expected}', {className}::{origMethodName}({arguments}));
+    }

--- a/PHPUnit/Util/Skeleton/Test.php
+++ b/PHPUnit/Util/Skeleton/Test.php
@@ -215,6 +215,11 @@ class PHPUnit_Util_Skeleton_Test extends PHPUnit_Util_Skeleton
                                     $assertion = 'exception';
                                 }
                                 break;
+								
+								case 'instanceof': {
+									$assertion = 'instance';
+								}
+								break;
 
                                 default: {
                                     throw new PHPUnit_Framework_Exception(
@@ -229,6 +234,10 @@ class PHPUnit_Util_Skeleton_Test extends PHPUnit_Util_Skeleton
                             if ($assertion == 'exception') {
                                 $template = 'TestMethodException';
                             }
+							
+							else if ($assertion == 'instance') {
+								$template = 'TestMethodInstance';
+							}
 
                             else if ($assertion == 'Equals' &&
                                      strtolower($matches[3]) == 'true') {


### PR DESCRIPTION
_Opening against master branch._

I think it might be useful feature.

Example:

``` php
/**
 * @assert ('TEST.COM') instanceof Domain
 */
public static function getByName($name) {

    /* code */
}
```

Then, when I generate skeleton:

``` php
/**
 * Generated from @assert ('TEST.COM') instanceof Domain.
 */
public function testGetByName2()
{
    $this->assertInstanceOf('Domain', Domain::getByName('TEST.COM'));
}
```

Wooh!
