### PR TITLE
Positional argument count check introduced

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -554,6 +554,15 @@ class PHPUnit_TextUI_Command
         $this->handleCustomTestSuite();
 
         if (!isset($this->arguments['test'])) {
+            if (count($this->options[1]) > 2) {
+                $this->showMessage(
+                    'More than two positional arguments provided.',
+                    false
+                );
+                $this->showHelp();
+                exit(PHPUnit_TextUI_TestRunner::FAILURE_EXIT);
+            }
+        
             if (isset($this->options[1][0])) {
                 $this->arguments['test'] = $this->options[1][0];
             }

--- a/Tests/TextUI/positional-arguments.phpt
+++ b/Tests/TextUI/positional-arguments.phpt
@@ -1,0 +1,18 @@
+--TEST--
+phpunit FailureTest ../_files/FailureTest.php SomethingElse
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'FailureTest';
+$_SERVER['argv'][3] = dirname(dirname(__FILE__)) . '/_files/FailureTest.php';
+$_SERVER['argv'][4] = 'SomethingElse';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+More than two positional arguments provided.
+
+Usage: %s


### PR DESCRIPTION
According to documentation, phpunit.php accepts at most two positional arguments.

It would be worth to check it and abort respectively.
