### PR TITLE
Possible correction for unit test for fail method

### DIFF
--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -88,7 +88,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
             return;
         }
 
-        $this->fail();
+       throw new PHPUnit_Framework_AssertionFailedError('Fail did not throw fail exception');
     }
 
     /**


### PR DESCRIPTION
In the test for fail() if fail() does not send the correct exception, the test uses fail() to mark the test as not failed.  If the fail() returns nothing or doesn't throw an exception, the test could be marked as passed.  It seems that it would be better for this test to throw the failed exception itself so as to not rely on the method that it is testing.
