### PR TITLE
Add Code Coverage information output to the cli and for textfiles

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -81,7 +81,7 @@ class PHPUnit_TextUI_Command
       'configuration=' => NULL,
       'coverage-html=' => NULL,
       'coverage-clover=' => NULL,
-      'coverage-cli=' => NULL,
+      'coverage-text=' => NULL,
       'debug' => NULL,
       'exclude-group=' => NULL,
       'filter=' => NULL,
@@ -276,14 +276,15 @@ class PHPUnit_TextUI_Command
 
                 case '--coverage-clover': 
                 case '--coverage-html': 
-                case '--coverage-cli': {
+                case '--coverage-text': {
                     if (extension_loaded('tokenizer') && extension_loaded('xdebug')) {
                         if($option[0] == '--coverage-clover') {
                             $this->arguments['coverageClover'] = $option[1];
                         } else if($option[0] == 'coverage--html') {
                             $this->arguments['reportDirectory'] = $option[1];
                         } else {
-                            $this->arguments['coverageCli'] = $option[1];
+                            $this->arguments['coverageText'] = $option[1];
+                            $this->arguments['coverageTextShowUncoveredFiles'] = false;
                         }
                     } else if (!extension_loaded('tokenizer')) {
                         $this->showExtensionNotLoadedMessage(
@@ -607,7 +608,7 @@ class PHPUnit_TextUI_Command
 
             $logging = $configuration->getLoggingConfiguration();
 
-            if (isset($logging['coverage-html']) || isset($logging['coverage-clover']) || isset($logging['coverage-cli']) ) {
+            if (isset($logging['coverage-html']) || isset($logging['coverage-clover']) || isset($logging['coverage-text']) ) {
                 if (!extension_loaded('tokenizer')) {
                     $this->showExtensionNotLoadedMessage(
                       'tokenizer', 'No code coverage will be generated.'
@@ -865,7 +866,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
 
   --coverage-html <dir>     Generate code coverage report in HTML format.
   --coverage-clover <file>  Write code coverage data in Clover XML format.
-  --coverage-cli <type>     Write code coverage to cli. Modes: short, long, all
+  --coverage-text <file>   Write code coverage to file or output it directly (=cli).
 
   --testdox-html <file>     Write agile documentation in HTML format to file.
   --testdox-text <file>     Write agile documentation in Text format to file.

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -81,6 +81,7 @@ class PHPUnit_TextUI_Command
       'configuration=' => NULL,
       'coverage-html=' => NULL,
       'coverage-clover=' => NULL,
+      'coverage-cli=' => NULL,
       'debug' => NULL,
       'exclude-group=' => NULL,
       'filter=' => NULL,
@@ -273,38 +274,25 @@ class PHPUnit_TextUI_Command
                 }
                 break;
 
-                case '--coverage-clover': {
-                    if (extension_loaded('tokenizer') &&
-                        extension_loaded('xdebug')) {
-                        $this->arguments['coverageClover'] = $option[1];
-                    } else {
-                        if (!extension_loaded('tokenizer')) {
-                            $this->showExtensionNotLoadedMessage(
-                              'tokenizer', 'No code coverage will be generated.'
-                            );
+                case '--coverage-clover': 
+                case '--coverage-html': 
+                case '--coverage-cli': {
+                    if (extension_loaded('tokenizer') && extension_loaded('xdebug')) {
+                        if($option[0] == '--coverage-clover') {
+                            $this->arguments['coverageClover'] = $option[1];
+                        } else if($option[0] == 'coverage--html') {
+                            $this->arguments['reportDirectory'] = $option[1];
                         } else {
-                            $this->showExtensionNotLoadedMessage(
-                              'Xdebug', 'No code coverage will be generated.'
-                            );
+                            $this->arguments['coverageCli'] = $option[1];
                         }
-                    }
-                }
-                break;
-
-                case '--coverage-html': {
-                    if (extension_loaded('tokenizer') &&
-                        extension_loaded('xdebug')) {
-                        $this->arguments['reportDirectory'] = $option[1];
+                    } else if (!extension_loaded('tokenizer')) {
+                        $this->showExtensionNotLoadedMessage(
+                            'tokenizer', 'No code coverage will be generated.'
+                        );
                     } else {
-                        if (!extension_loaded('tokenizer')) {
-                            $this->showExtensionNotLoadedMessage(
-                              'tokenizer', 'No code coverage will be generated.'
-                            );
-                        } else {
-                            $this->showExtensionNotLoadedMessage(
-                              'Xdebug', 'No code coverage will be generated.'
-                            );
-                        }
+                        $this->showExtensionNotLoadedMessage(
+                            'Xdebug', 'No code coverage will be generated.'
+                        );
                     }
                 }
                 break;
@@ -619,21 +607,7 @@ class PHPUnit_TextUI_Command
 
             $logging = $configuration->getLoggingConfiguration();
 
-            if (isset($logging['coverage-html'])) {
-                if (!extension_loaded('tokenizer')) {
-                    $this->showExtensionNotLoadedMessage(
-                      'tokenizer', 'No code coverage will be generated.'
-                    );
-                }
-
-                else if (!extension_loaded('Xdebug')) {
-                    $this->showExtensionNotLoadedMessage(
-                      'Xdebug', 'No code coverage will be generated.'
-                    );
-               }
-            }
-
-            if (isset($logging['coverage-clover'])) {
+            if (isset($logging['coverage-html']) || isset($logging['coverage-clover']) || isset($logging['coverage-cli']) ) {
                 if (!extension_loaded('tokenizer')) {
                     $this->showExtensionNotLoadedMessage(
                       'tokenizer', 'No code coverage will be generated.'
@@ -891,6 +865,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
 
   --coverage-html <dir>     Generate code coverage report in HTML format.
   --coverage-clover <file>  Write code coverage data in Clover XML format.
+  --coverage-cli <type>     Write code coverage to cli. Modes: short, long, all
 
   --testdox-html <file>     Write agile documentation in HTML format to file.
   --testdox-text <file>     Write agile documentation in Text format to file.

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -356,7 +356,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 if (!isset($arguments['coverageTextShowUncoveredFiles'])) {
                     $arguments['coverageTextShowUncoveredFiles'] = false;
                 }
-                $writer = new PHP_CodeCoverage_Report_Cli(
+                $writer = new PHP_CodeCoverage_Report_Text(
                   $outputStream,
                   $title,
                   $arguments['reportLowUpperBound'],

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -353,9 +353,6 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
                     $colors = false;
                 }
-                if (!isset($arguments['coverageTextShowUncoveredFiles'])) {
-                    $arguments['coverageTextShowUncoveredFiles'] = false;
-                }
                 $writer = new PHP_CodeCoverage_Report_Text(
                   $outputStream,
                   $title,
@@ -610,6 +607,9 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($loggingConfiguration['coverage-text']) &&
                 !isset($arguments['coverageText'])) {
                 $arguments['coverageText'] = $loggingConfiguration['coverage-text'];
+            }
+            if (isset($loggingConfiguration['coverageTextShowUncoveredFiles'])) {
+                $arguments['coverageTextShowUncoveredFiles'] = $loggingConfiguration['coverageTextShowUncoveredFiles'];
             }
 
             if (isset($loggingConfiguration['json']) &&

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -342,19 +342,23 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 unset($writer);
             }
             
-            if (isset($arguments['coverageCli'])) {
+            if (isset($arguments['coverageText'])) {
                 $this->printer->write(
-                  "\nGenerating cli code coverage report, this may take a moment."
+                  "\nGenerating textual code coverage report, this may take a moment."
                 );
+                if($arguments['coverageText'] == "cli") {
+                    $outputStream = $this->printer;
+                } else {
+                    $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
+                }
                 $writer = new PHP_CodeCoverage_Report_Cli(
-                  $this->printer,
+                  $outputStream,
                   $title,
                   $arguments['reportLowUpperBound'],
-                  $arguments['reportHighLowerBound']
+                  $arguments['reportHighLowerBound'],
+                  $arguments['coverageTextShowUncoveredFiles']
                 );
-                $writer->process(
-                  $this->codeCoverage, $arguments['coverageCli']
-                );
+                $writer->process($this->codeCoverage);
                 $this->printer->write("\n");
             }
         }
@@ -596,9 +600,9 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $arguments['coverageClover'] = $loggingConfiguration['coverage-clover'];
             }
 
-            if (isset($loggingConfiguration['coverage-cli']) &&
-                !isset($arguments['coverageCli'])) {
-                $arguments['coverageCli'] = $loggingConfiguration['coverage-cli'];
+            if (isset($loggingConfiguration['coverage-text']) &&
+                !isset($arguments['coverageText'])) {
+                $arguments['coverageText'] = $loggingConfiguration['coverage-text'];
             }
 
             if (isset($loggingConfiguration['json']) &&

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -348,8 +348,13 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 );
                 if($arguments['coverageText'] == "cli") {
                     $outputStream = $this->printer;
+                    $colors = (bool)$arguments['colors'];
                 } else {
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
+                    $colors = false;
+                }
+                if (!isset($arguments['coverageTextShowUncoveredFiles'])) {
+                    $arguments['coverageTextShowUncoveredFiles'] = false;
                 }
                 $writer = new PHP_CodeCoverage_Report_Cli(
                   $outputStream,
@@ -358,7 +363,9 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                   $arguments['reportHighLowerBound'],
                   $arguments['coverageTextShowUncoveredFiles']
                 );
-                $writer->process($this->codeCoverage);
+                $writer->process(
+                    $this->codeCoverage, $colors
+                );
                 $this->printer->write("\n");
             }
         }

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -341,6 +341,22 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $this->printer->write("\n");
                 unset($writer);
             }
+            
+            if (isset($arguments['coverageCli'])) {
+                $this->printer->write(
+                  "\nGenerating cli code coverage report, this may take a moment."
+                );
+                $writer = new PHP_CodeCoverage_Report_Cli(
+                  $this->printer,
+                  $title,
+                  $arguments['reportLowUpperBound'],
+                  $arguments['reportHighLowerBound']
+                );
+                $writer->process(
+                  $this->codeCoverage, $arguments['coverageCli']
+                );
+                $this->printer->write("\n");
+            }
         }
 
         return $result;
@@ -578,6 +594,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($loggingConfiguration['coverage-clover']) &&
                 !isset($arguments['coverageClover'])) {
                 $arguments['coverageClover'] = $loggingConfiguration['coverage-clover'];
+            }
+
+            if (isset($loggingConfiguration['coverage-cli']) &&
+                !isset($arguments['coverageCli'])) {
+                $arguments['coverageCli'] = $loggingConfiguration['coverage-cli'];
             }
 
             if (isset($loggingConfiguration['json']) &&

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -375,8 +375,8 @@ class PHPUnit_Util_Configuration
 
         foreach ($this->xpath->query('logging/log') as $log) {
             $type   = (string)$log->getAttribute('type');
-            if($type == 'coverage-cli') {
-                $target = $log->getAttribute('verbosity');
+            if($type == 'coverage-text' && $log->getAttribute('target') == "cli") {
+                $target = "cli";
             } else {
                 $target = $this->toAbsolutePath((string)$log->getAttribute('target'));
             }
@@ -419,6 +419,15 @@ class PHPUnit_Util_Configuration
                       (string)$log->getAttribute('logIncompleteSkipped'),
                       FALSE
                     );
+                }
+            } else if ($type == 'coverage-text') {
+                if($log->hasAttribute('showUncoveredFiles')) {
+                    $result['coverageTextShowUncoveredFiles'] = $this->getBoolean(
+                      (string)$log->getAttribute('showUncoveredFiles'),
+                      FALSE
+                    );
+                } else {
+                    $result['coverageTextShowUncoveredFiles'] = false;
                 }
             }
 

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -420,14 +420,14 @@ class PHPUnit_Util_Configuration
                       FALSE
                     );
                 }
-            } else if ($type == 'coverage-text') {
-                if($log->hasAttribute('showUncoveredFiles')) {
+            } 
+            
+            else if ($type == 'coverage-text') {
+                if ($log->hasAttribute('showUncoveredFiles')) {
                     $result['coverageTextShowUncoveredFiles'] = $this->getBoolean(
                       (string)$log->getAttribute('showUncoveredFiles'),
                       FALSE
                     );
-                } else {
-                    $result['coverageTextShowUncoveredFiles'] = false;
                 }
             }
 

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -375,7 +375,11 @@ class PHPUnit_Util_Configuration
 
         foreach ($this->xpath->query('logging/log') as $log) {
             $type   = (string)$log->getAttribute('type');
-            $target = $this->toAbsolutePath((string)$log->getAttribute('target'));
+            if($type == 'coverage-cli') {
+                $target = $log->getAttribute('verbosity');
+            } else {
+                $target = $this->toAbsolutePath((string)$log->getAttribute('target'));
+            }
 
             if ($type == 'coverage-html') {
                 if ($log->hasAttribute('title')) {
@@ -420,7 +424,6 @@ class PHPUnit_Util_Configuration
 
             $result[$type] = $target;
         }
-
         return $result;
     }
 

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -427,7 +427,7 @@ class PHPUnit_Util_Configuration
                     $result['coverageTextShowUncoveredFiles'] = $this->getBoolean(
                       (string)$log->getAttribute('showUncoveredFiles'),
                       FALSE
-                    );
+                  );
                 }
             }
 

--- a/PHPUnit/Util/Printer.php
+++ b/PHPUnit/Util/Printer.php
@@ -55,7 +55,7 @@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release 2.0.0
  */
-abstract class PHPUnit_Util_Printer
+class PHPUnit_Util_Printer
 {
     /**
      * If TRUE, flush output after every write.


### PR DESCRIPTION
Especially working with smaller projects or working on a new class using --filter it can be quite nice to get instant feedback regarding code coverage information.

My current way to work is to have the html coverage output in a 'refresh all the time' browser window but it would be nice to have the needed information displayed in the terminal.

I've added `<log type="coverage-text" target="cli" showUncoveredFiles="true"/>` and `--coverage-text` as options.

The current output with your bankaccount project when using `--filter Bank`:

http://dl.dropbox.com/u/3615626/tmp/phpunit-bankaccount-filtered-showAll.png

and with the default setting of `showUncoveredFiles="true"`:

http://dl.dropbox.com/u/3615626/tmp/phpunit-bankaccount-filtered-showOnlyCovered.png

It sorts the classes by namespace() if the have one. If not it takes the package(@) and classnames.

---

Should you pull the changes I'd of course update the documentation too
