### PR TITLE
Make --coverage-text command line switch default to STDOUT

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -82,7 +82,7 @@ class PHPUnit_TextUI_Command
       'coverage-html=' => NULL,
       'coverage-clover=' => NULL,
       'coverage-php=' => NULL,
-      'coverage-text=' => NULL,
+      'coverage-text==' => NULL,
       'debug' => NULL,
       'exclude-group=' => NULL,
       'filter=' => NULL,
@@ -317,6 +317,9 @@ class PHPUnit_TextUI_Command
                         break;
 
                         case '--coverage-text': {
+                            if($option[1] === NULL) {
+                                $option[1] = 'php://stdout';
+                            }
                             $this->arguments['coverageText'] = $option[1];
                             $this->arguments['coverageTextShowUncoveredFiles'] = FALSE;
                         }


### PR DESCRIPTION
`phpunit --coverage-text` is a lot easier to use than 
`phpunit --coverage-text=php://stdout` 

Especially since every typo can create folders that need to be cleaned up.
