### PR TITLE
Support for tests in PHAR.

### DIFF
--- a/PHPUnit/Util/Fileloader.php
+++ b/PHPUnit/Util/Fileloader.php
@@ -66,9 +66,24 @@ class PHPUnit_Util_Fileloader
      */
     public static function checkAndLoad($filename)
     {
-        $includePathFilename = PHPUnit_Util_Filesystem::fileExistsInIncludePath(
-          $filename
+        $pharFile = preg_match(
+            '/^phar:\/\/(?P<archive>.*\.phar)(?P<file>.*)$/i',
+            $filename,
+            $pharFileInfo
         );
+        if ($pharFile) {
+            $includePathFilename = PHPUnit_Util_Filesystem::fileExistsInIncludePath(
+                $pharFileInfo['archive']
+            );
+            $pharIncludePathFilename = 'phar://';
+            $pharIncludePathFilename .= $includePathFilename;
+            $pharIncludePathFilename .= $pharFileInfo['file'];
+            $includePathFilename = $pharIncludePathFilename;
+        } else {
+            $includePathFilename = PHPUnit_Util_Filesystem::fileExistsInIncludePath(
+                $filename
+            );
+        }
 
         if (!$includePathFilename || !is_readable($includePathFilename)) {
             throw new RuntimeException(


### PR DESCRIPTION
build
└─example.phar
········├─src(dir)
········│      └─exampleClass.php
········└─tests(dir)
················└─ exampleTest.php

Commandline:
project$ phpunit phar://build/example.phar/tests

stream_resolve_include_path() and realpath() in PHPUnit_Util_Filesystem::fileExistsInIncludePath() returns a empty string if a directory in a PHAR with PHAR stream wrapper is passed.
