### PR TITLE
Fix PHPUnit_Util_PHP::getPhpBinary() to work as documented and change lookup order

### DIFF
--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -93,15 +93,18 @@ abstract class PHPUnit_Util_PHP
     protected function getPhpBinary()
     {
         if ($this->phpBinary === NULL) {
-            if (PHP_SAPI == 'cli' && isset($_SERVER['_']) &&
-                     strpos($_SERVER['_'], 'phpunit') !== FALSE) {
-                $file = file($_SERVER['_']);
+            if (PHP_SAPI == 'cli' && isset($_SERVER['_'])) {
+                if(strpos($_SERVER['_'], 'phpunit') !== FALSE) {
+                    $file = file($_SERVER['_']);
 
-                if (strpos($file[0], ' ') !== FALSE) {
-                    $tmp = explode(' ', $file[0]);
-                    $this->phpBinary = trim($tmp[1]);
+                    if (strpos($file[0], ' ') !== FALSE) {
+                        $tmp = explode(' ', $file[0]);
+                        $this->phpBinary = trim($tmp[1]);
+                    } else {
+                        $this->phpBinary = ltrim(trim($file[0]), '#!');
+                    }
                 } else {
-                    $this->phpBinary = ltrim(trim($file[0]), '#!');
+                    $this->phpBinary = $_SERVER['_'];
                 }
             } else if (is_readable('@php_bin@')) {
                 $this->phpBinary = '@php_bin@';

--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -70,20 +70,20 @@ abstract class PHPUnit_Util_PHP
      *
      * When not set, the following assumptions will be made:
      *
-     *   1. When the PHP CLI/CGI binary configured with the PEAR Installer
-     *      (php_bin configuration value) is readable, it will be used.
-     *
-     *   2. When PHPUnit is run using the CLI SAPI and the $_SERVER['_']
+     *   1. When PHPUnit is run using the CLI SAPI and the $_SERVER['_']
      *      variable does not contain the string "PHPUnit", $_SERVER['_']
      *      is assumed to contain the path to the current PHP interpreter
      *      and that will be used.
      *
-     *   3. When PHPUnit is run using the CLI SAPI and the $_SERVER['_']
+     *   2. When PHPUnit is run using the CLI SAPI and the $_SERVER['_']
      *      variable contains the string "PHPUnit", the file that $_SERVER['_']
      *      points to is assumed to be the PHPUnit TextUI CLI wrapper script
      *      "phpunit" and the binary set up using #! on that file's first
      *      line of code is assumed to contain the path to the current PHP
      *      interpreter and that will be used.
+     *
+     *   3. When the PHP CLI/CGI binary configured with the PEAR Installer
+     *      (php_bin configuration value) is readable, it will be used.
      *
      *   4. The current PHP interpreter is assumed to be in the $PATH and
      *      to be invokable through "php".
@@ -93,11 +93,7 @@ abstract class PHPUnit_Util_PHP
     protected function getPhpBinary()
     {
         if ($this->phpBinary === NULL) {
-            if (is_readable('@php_bin@')) {
-                $this->phpBinary = '@php_bin@';
-            }
-
-            else if (PHP_SAPI == 'cli' && isset($_SERVER['_']) &&
+            if (PHP_SAPI == 'cli' && isset($_SERVER['_']) &&
                      strpos($_SERVER['_'], 'phpunit') !== FALSE) {
                 $file = file($_SERVER['_']);
 
@@ -107,6 +103,8 @@ abstract class PHPUnit_Util_PHP
                 } else {
                     $this->phpBinary = ltrim(trim($file[0]), '#!');
                 }
+            } else if (is_readable('@php_bin@')) {
+                $this->phpBinary = '@php_bin@';
             }
 
             if (!is_readable($this->phpBinary)) {


### PR DESCRIPTION
First change makes sure `$_SERVER["_"]` is preferred over `@php_bin@`, since that likely makes a lot more sense in almost all cases (very useful e.g. when running tests using different PHP versions).

Second change makes sure that this actually works :) Contrary to what the docs say, `$_SERVER["_"]` was never used if it did not contain the string "phpunit".
