### PR TITLE
Use var_export for serialized data instead of addcslashes

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -717,11 +717,14 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $strict = 'FALSE';
             }
 
-            $data            = addcslashes(serialize($this->data), "'");
-            $dependencyInput = addcslashes(
-              serialize($this->dependencyInput), "'"
-            );
-            $includePath     = addslashes(get_include_path());
+            $data            = var_export(serialize($this->data), true);
+            $dependencyInput = var_export(serialize($this->dependencyInput), true);
+            $includePath     = var_export(get_include_path(), true);
+            // must do these fixes because TestCaseMethod.tpl has unserialize('{data}') in it, and we can't break BC
+            // the lines above used to use addcslashes() rather than var_export(), which breaks null byte escape sequences
+            $data            = "'." . $data . ".'";
+            $dependencyInput = "'." . $dependencyInput . ".'";
+            $includePath     = "'." . $includePath . ".'";
 
             $template->setVar(
               array(

--- a/PHPUnit/Util/PHP/Windows.php
+++ b/PHPUnit/Util/PHP/Windows.php
@@ -77,7 +77,7 @@ class PHPUnit_Util_PHP_Windows extends PHPUnit_Util_PHP
 
         fwrite(
           $pipe,
-          "<?php require_once '" . addcslashes($this->tempFile, "'") .  "'; ?>"
+          "<?php require_once " . var_export($this->tempFile, true) .  "; ?>"
         );
     }
 


### PR DESCRIPTION
When running tests in process isolation and data from a data provider contains null bytes, the `addcslashes()` call will screw up the serialized string and PHP will crash with a few lines of question marks and other garbage output.

Since it's a bad idea anyway to ever fiddle with the output of `serialize()`, I've replaced all the occurrences of `addcslashes()`, not just the one causing the crash, with `var_export()`.

I also put a fix in place that makes sure existing process isolation test case method templates will continue to work without breaking, as they contain stuff like

```
unserialize('{data}')
```

which means we need to generate an immediate closing single quote, a dot, then the `var_export()`ed value, then another dot and the opening single quote for the trailing single quote in the template.

I guess for 4.0 it'd be fine to change the templates accordingly and just get rid of the extra wrapping (that's why I've put them on separate lines even though it's less efficient, but in the grand scheme of things it doesn't even matter since process isolation itself is the much bigger overhead).

Tested to work fine.
