### PR TITLE
make class of a test suite customizable

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -663,7 +663,7 @@ class PHPUnit_TextUI_Command
             }
 
             if (!isset($this->arguments['test'])) {
-                $testSuite = $configuration->getTestSuiteConfiguration();
+                $testSuite = $configuration->getTestSuiteConfiguration($this->arguments['loader'] ?: NULL);
 
                 if ($testSuite !== NULL) {
                     $this->arguments['test'] = $testSuite;

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -663,7 +663,7 @@ class PHPUnit_TextUI_Command
             }
 
             if (!isset($this->arguments['test'])) {
-                $testSuite = $configuration->getTestSuiteConfiguration($this->arguments['loader'] ?: NULL);
+                $testSuite = $configuration->getTestSuiteConfiguration(isset($this->arguments['loader']) ? $this->arguments['loader'] : NULL);
 
                 if ($testSuite !== NULL) {
                     $this->arguments['test'] = $testSuite;


### PR DESCRIPTION
When using phpunit with an XML configuration file, every testsuite element is by default mapped to an instance of class PHPUnit_Framework_TestSuite.

If the testsuite element contains a @class attribute, the actual class can be overridden.

Example:

``` xml
<phpunit>
    <testsuites>
        <testsuite name="My Tests" class="MyTestSuite">
            <directory>tests</directory>
        </testsuite>
    </testsuites>
</phpunit>
```

---

Edit by  @edorian: fixed markup
