### PR TITLE
make InvalidArgumentException of PHPUnit_Framework_TestSuite more inform...

### DIFF
--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -182,7 +182,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
 
         if (!$theClass->isSubclassOf('PHPUnit_Framework_TestCase')) {
             throw new InvalidArgumentException(
-              'Class does not extend PHPUnit_Framework_TestCase.'
+              'Class "'.$theClass->name.'" does not extend PHPUnit_Framework_TestCase.'
             );
         }
 


### PR DESCRIPTION
...ativ

For example in some old code which relies heavily on TestSuites it happens, that there got interpreted as Tests and cause this error. This patch will make it lot easier to find the cause for such an exception.
