### PR TITLE
fixes #422

### DIFF
--- a/PHPUnit/Util/Test.php
+++ b/PHPUnit/Util/Test.php
@@ -424,9 +424,9 @@ class PHPUnit_Util_Test
         $size   = self::SMALL;
         $class  = new ReflectionClass($className);
 
-        if ((class_exists('PHPUnit_Extensions_Database_TestCase') &&
+        if ((class_exists('PHPUnit_Extensions_Database_TestCase', FALSE) &&
              $class->isSubclassOf('PHPUnit_Extensions_Database_TestCase')) ||
-            (class_exists('PHPUnit_Extensions_SeleniumTestCase') &&
+            (class_exists('PHPUnit_Extensions_SeleniumTestCase', FALSE) &&
              $class->isSubclassOf('PHPUnit_Extensions_SeleniumTestCase'))) {
             $size = self::LARGE;
         }


### PR DESCRIPTION
class_exists hits the autoloader by default, this patch sets autoload to FALSE for class_exists for the Selenium and DBUnit dependency problem rasied in Util/Test.php::getSize(), as $class->isSubclassOf() already implies the prior loading of $class and its Selenium or DBUnit inheritance chain.
