### PR TITLE
Add a specific memory limit when executing coverage-html

### DIFF
--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -361,7 +361,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 );
                 
                 if (isset($arguments['reportMemoryLimit'])) {
-                    $defaultMemoryLimit = ini_get('memory_limit');
+					//ini_set return the old value
                     $defaultMemoryLimit = ini_set('memory_limit', $arguments['reportMemoryLimit']);
                 }
 

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -361,7 +361,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 );
                 
                 if (isset($arguments['reportMemoryLimit'])) {
-					//ini_set return the old value
+                    //ini_set return the old value
                     $defaultMemoryLimit = ini_set('memory_limit', $arguments['reportMemoryLimit']);
                 }
 

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -359,6 +359,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $this->printer->write(
                   "\nGenerating code coverage report, this may take a moment."
                 );
+                
+                if (isset($arguments['reportMemoryLimit'])) {
+                    $defaultMemoryLimit = ini_get('memory_limit');
+                    $defaultMemoryLimit = ini_set('memory_limit', $arguments['reportMemoryLimit']);
+                }
 
                 $writer = new PHP_CodeCoverage_Report_HTML(
                   $title,
@@ -374,6 +379,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
                 $this->printer->write("\n");
                 unset($writer);
+
+                if (isset($arguments['reportMemoryLimit'])) {
+                    //Restore the default memory limit
+                    ini_set('memory_limit', $defaultMemoryLimit);
+                }
             }
 
             if (isset($arguments['coveragePHP'])) {
@@ -659,6 +669,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     $arguments['reportHighLowerBound'] = $loggingConfiguration['highLowerBound'];
                 }
 
+                if (isset($loggingConfiguration['memoryLimit']) &&
+                    !isset($arguments['reportMemoryLimit'])) {
+                    $arguments['reportMemoryLimit'] = $loggingConfiguration['memoryLimit'];
+                }
+
                 $arguments['reportDirectory'] = $loggingConfiguration['coverage-html'];
             }
 
@@ -786,6 +801,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['reportHighlight']                = isset($arguments['reportHighlight'])                ? $arguments['reportHighlight']                : FALSE;
         $arguments['reportHighLowerBound']           = isset($arguments['reportHighLowerBound'])           ? $arguments['reportHighLowerBound']           : 70;
         $arguments['reportLowUpperBound']            = isset($arguments['reportLowUpperBound'])            ? $arguments['reportLowUpperBound']            : 35;
+        $arguments['reportMemoryLimit']              = isset($arguments['reportMemoryLimit'])              ? $arguments['reportMemoryLimit']              : NULL;
         $arguments['reportYUI']                      = isset($arguments['reportYUI'])                      ? $arguments['reportYUI']                      : TRUE;
         $arguments['stopOnError']                    = isset($arguments['stopOnError'])                    ? $arguments['stopOnError']                    : FALSE;
         $arguments['stopOnFailure']                  = isset($arguments['stopOnFailure'])                  ? $arguments['stopOnFailure']                  : FALSE;

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -130,7 +130,7 @@
  *   <logging>
  *     <log type="coverage-html" target="/tmp/report" title="My Project"
             charset="UTF-8" yui="true" highlight="false"
- *          lowUpperBound="35" highLowerBound="70"/>
+ *          lowUpperBound="35" highLowerBound="70" memoryLimit="256M"/>
  *     <log type="coverage-clover" target="/tmp/clover.xml"/>
  *     <log type="json" target="/tmp/logfile.json"/>
  *     <log type="plain" target="/tmp/logfile.txt"/>
@@ -413,6 +413,10 @@ class PHPUnit_Util_Configuration
                       (string)$log->getAttribute('highlight'),
                       FALSE
                     );
+                }
+
+                if ($log->hasAttribute('memoryLimit')) {
+                    $result['memoryLimit'] = (string)$log->getAttribute('memoryLimit');
                 }
             }
 

--- a/Tests/Util/ConfigurationTest.php
+++ b/Tests/Util/ConfigurationTest.php
@@ -232,6 +232,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'junit' => '/tmp/logfile.xml',
             'testdox-html' => '/tmp/testdox.html',
             'testdox-text' => '/tmp/testdox.txt',
+			'memoryLimit' => '256M',
           ),
           $this->configuration->getLoggingConfiguration()
         );

--- a/Tests/Util/ConfigurationTest.php
+++ b/Tests/Util/ConfigurationTest.php
@@ -232,7 +232,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'junit' => '/tmp/logfile.xml',
             'testdox-html' => '/tmp/testdox.html',
             'testdox-text' => '/tmp/testdox.txt',
-			'memoryLimit' => '256M',
+            'memoryLimit' => '256M',
           ),
           $this->configuration->getLoggingConfiguration()
         );

--- a/Tests/_files/configuration.xml
+++ b/Tests/_files/configuration.xml
@@ -76,7 +76,7 @@
   <logging>
     <log type="coverage-html" target="/tmp/report" title="My Project"
          charset="UTF-8" yui="true" highlight="false"
-         lowUpperBound="35" highLowerBound="70"/>
+         lowUpperBound="35" highLowerBound="70" memoryLimit="256M"/>
     <log type="coverage-clover" target="/tmp/clover.xml"/>
     <log type="json" target="/tmp/logfile.json"/>
     <log type="plain" target="/tmp/logfile.txt"/>


### PR DESCRIPTION
Hi,
I would like to propose to have a specific memory-limit for the execution of coverage-html, I would like to keep the memory limit as configured by php during the execution and having the possibility to have an higher value at the execution coverage-html when working with a large code base.
