### PR TITLE
PHPunit can fail to find testsuite files pointed by relative paths in c...

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -856,7 +856,7 @@ class PHPUnit_Util_Configuration
             }
 
             // Get the absolute path to the file
-            $file = $fileIteratorFacade->getFilesAsArray($file);
+            $file = $fileIteratorFacade->getFilesAsArray($this->toAbsolutePath($file));
             $file = $file[0];
 
             if ($fileNode->hasAttribute('phpVersion')) {


### PR DESCRIPTION
...onfiguration XML file. Fixed a difference of path processing between "directory" and "file" tag in Configuration.php.
