### PR TITLE
#487 Removed check for __toString in ErrorHandler

### DIFF
--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -94,12 +94,6 @@ class PHPUnit_Util_ErrorHandler
         $trace = debug_backtrace(FALSE);
         array_shift($trace);
 
-        foreach ($trace as $frame) {
-            if ($frame['function'] == '__toString') {
-                return FALSE;
-            }
-        }
-
         if ($errno == E_NOTICE || $errno == E_USER_NOTICE || $errno == E_STRICT) {
             if (PHPUnit_Framework_Error_Notice::$enabled !== TRUE) {
                 return FALSE;

--- a/Tests/Regression/GitHub/487/Issue487Test.php
+++ b/Tests/Regression/GitHub/487/Issue487Test.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @package    PHPUnit
+ * @author     Andrew Lawson <http://adlawson.com>
+ * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @version    Release: @package_version@
+ * @link       http://www.phpunit.de/
+ */
+class Issue487Test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test render method (worked fine before)
+     * @expectedException PHPUnit_Framework_Error_Warning
+     * @return void
+     */
+    public function testRender()
+    {
+        $renderer = new Issue487TestRenderer;
+        $renderer->render();
+    }
+
+    /**
+     * Test __toString method (didn't work before this patch)
+     * @expectedException PHPUnit_Framework_Error_Warning
+     * @return void
+     */
+    public function testToString()
+    {
+        $renderer = new Issue487TestRenderer;
+        $renderer->__toString();
+    }
+}
+
+/**
+ * Mock renderer
+ */
+class Issue487TestRenderer
+{
+    public function render()
+    {
+        trigger_error('User error: Replace user.', E_USER_WARNING);
+    }
+
+    public function __toString()
+    {
+        trigger_error('User error: Replace user.', E_USER_WARNING);
+    }
+}


### PR DESCRIPTION
Fulfils request made in issue #487 to allow error handling for __toString methods
