### PR TITLE
Refactored PHPUnit_Util_Diff::diff to allow the util to return the result as array

### DIFF
--- a/PHPUnit/Util/Diff.php
+++ b/PHPUnit/Util/Diff.php
@@ -76,7 +76,7 @@ class PHPUnit_Util_Diff
         $old   = array();
 
         foreach ($diff as $line) {
-            if ($line[1] === 0 /* OLD */) {
+            if ($line[1] ===  0 /* OLD */) {
                 if ($inOld === FALSE) {
                     $inOld = $i;
                 }
@@ -136,11 +136,11 @@ class PHPUnit_Util_Diff
      *
      * every array-entry containts two elements:
      *   - [0] => string $token
-     *   - [1] => self::ADDED|self::REMOVED|self::OLD
-     * 
-     * - ADDED: $token was added to $from
-     * - REMOVED: $token was removed from $from
-     * - OLD: $token is not changed in $to
+     *   - [1] => 2|1|0
+     *
+     * - 2: REMOVED: $token was removed from $from
+     * - 1: ADDED: $token was added to $from
+     * - 0: OLD: $token is not changed in $to
      * 
      * @param  array|string $from
      * @param  array|string $to

--- a/PHPUnit/Util/Diff.php
+++ b/PHPUnit/Util/Diff.php
@@ -59,11 +59,6 @@
  */
 class PHPUnit_Util_Diff
 {
-  
-    const REMOVED = 2;
-    const ADDED = 1;
-    const OLD = 0;
-    
     /**
      * Returns the diff between two arrays or strings as string.
      *
@@ -81,7 +76,7 @@ class PHPUnit_Util_Diff
         $old   = array();
 
         foreach ($diff as $line) {
-            if ($line[1] === self::OLD) {
+            if ($line[1] === 0 /* OLD */) {
                 if ($inOld === FALSE) {
                     $inOld = $i;
                 }
@@ -120,11 +115,11 @@ class PHPUnit_Util_Diff
                 $newChunk = FALSE;
             }
 
-            if ($diff[$i][1] === self::ADDED) {
+            if ($diff[$i][1] === 1 /* ADDED */) {
                 $buffer .= '+' . $diff[$i][0] . "\n";
             }
 
-            else if ($diff[$i][1] === self::REMOVED) {
+            else if ($diff[$i][1] === 2 /* REMOVED */) {
                 $buffer .= '-' . $diff[$i][0] . "\n";
             }
 
@@ -195,7 +190,7 @@ class PHPUnit_Util_Diff
         $line = 0;
 
         foreach ($start as $token) {
-            $diff[] = array($token, self::OLD);
+            $diff[] = array($token, 0 /* OLD */);
         }
 
         reset($from);
@@ -203,29 +198,29 @@ class PHPUnit_Util_Diff
 
         foreach ($common as $token) {
             while ((($fromToken = reset($from)) !== $token)) {
-                $diff[] = array(array_shift($from), self::REMOVED);
+                $diff[] = array(array_shift($from), 2 /* REMOVED */);
             }
 
             while ((($toToken = reset($to)) !== $token)) {
-                $diff[] = array(array_shift($to), self::ADDED);
+                $diff[] = array(array_shift($to), 1 /* ADDED */);
             }
 
-            $diff[] = array($token, self::OLD);
+            $diff[] = array($token, 0 /* OLD */);
 
             array_shift($from);
             array_shift($to);
         }
 
         while (($token = array_shift($from)) !== NULL) {
-            $diff[] = array($token, self::REMOVED);
+            $diff[] = array($token, 2 /* REMOVED */);
         }
 
         while (($token = array_shift($to)) !== NULL) {
-            $diff[] = array($token, self::ADDED);
+            $diff[] = array($token, 1 /* ADDED */);
         }
 
         foreach ($end as $token) {
-            $diff[] = array($token, self::OLD);
+            $diff[] = array($token, 0 /* OLD */);
         }
         
         return $diff;

--- a/Tests/Util/DiffTest.php
+++ b/Tests/Util/DiffTest.php
@@ -67,6 +67,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorMessage_toArray()
+    {
+        $diff = array();
+        $diff[] = array('a', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('b', PHPUnit_Util_DIFF::ADDED);
+        
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('a', 'b')
+        );
+    }
+
+    /**
      * @covers PHPUnit_Util_Diff::diff
      */
     public function testComparisonErrorStartSame()
@@ -74,6 +89,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
           "--- Expected\n+++ Actual\n@@ @@\n-ba\n+bc\n",
           PHPUnit_Util_Diff::diff('ba', 'bc')
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorStartSame_toArray()
+    {
+        $diff = array();
+        $diff[] = array('ba', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('bc', PHPUnit_Util_DIFF::ADDED);
+        
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('ba', 'bc')
         );
     }
 
@@ -89,6 +119,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorEndSame_toArray()
+    {
+        $diff = array();
+        $diff[] = array('ab', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('cb', PHPUnit_Util_DIFF::ADDED);
+        
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('ab', 'cb')
+        );
+    }
+
+    /**
      * @covers PHPUnit_Util_Diff::diff
      */
     public function testComparisonErrorStartAndEndSame()
@@ -96,6 +141,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
           "--- Expected\n+++ Actual\n@@ @@\n-abc\n+adc\n",
           PHPUnit_Util_Diff::diff('abc', 'adc')
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorStartAndEndSame_toArray()
+    {
+        $diff = array();
+        $diff[] = array('abc', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('adc', PHPUnit_Util_DIFF::ADDED);
+        
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('abc', 'adc')
         );
     }
 
@@ -111,6 +171,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorStartSameComplete_toArray()
+    {
+        $diff = array();
+        $diff[] = array('ab', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('abc', PHPUnit_Util_DIFF::ADDED);
+      
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('ab', 'abc')
+        );
+    }
+
+    /**
      * @covers PHPUnit_Util_Diff::diff
      */
     public function testComparisonErrorEndSameComplete()
@@ -118,6 +193,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
           "--- Expected\n+++ Actual\n@@ @@\n-bc\n+abc\n",
           PHPUnit_Util_Diff::diff('bc', 'abc')
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorEndSameComplete_toArray()
+    {
+        $diff = array();
+        $diff[] = array('bc', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('abc', PHPUnit_Util_DIFF::ADDED);
+        
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('bc', 'abc')
         );
     }
 
@@ -133,6 +223,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorOverlapingMatches_toArray()
+    {
+        $diff = array();
+        $diff[] = array('abc', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('abbc', PHPUnit_Util_DIFF::ADDED);
+
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('abc', 'abbc')
+        );
+    }
+
+    /**
      * @covers PHPUnit_Util_Diff::diff
      */
     public function testComparisonErrorOverlapingMatches2()
@@ -140,6 +245,21 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
           "--- Expected\n+++ Actual\n@@ @@\n-abcdde\n+abcde\n",
           PHPUnit_Util_Diff::diff('abcdde', 'abcde')
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Util_Diff::diffToArray
+     */
+    public function testComparisonErrorOverlapingMatches2_toArray()
+    {
+        $diff = array();
+        $diff[] = array('abcdde', PHPUnit_Util_DIFF::REMOVED);
+        $diff[] = array('abcde', PHPUnit_Util_DIFF::ADDED);
+
+        $this->assertEquals(
+          $diff,
+          PHPUnit_Util_Diff::diffToArray('abcdde', 'abcde')
         );
     }
 }

--- a/Tests/Util/DiffTest.php
+++ b/Tests/Util/DiffTest.php
@@ -55,6 +55,11 @@
  */
 class Util_DiffTest extends PHPUnit_Framework_TestCase
 {
+  
+   const REMOVED = 2;
+   const ADDED = 1;
+   const OLD = 0;
+   
     /**
      * @covers PHPUnit_Util_Diff::diff
      */
@@ -72,8 +77,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorMessage_toArray()
     {
         $diff = array();
-        $diff[] = array('a', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('b', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('a', self::REMOVED);
+        $diff[] = array('b', self::ADDED);
         
         $this->assertEquals(
           $diff,
@@ -98,8 +103,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorStartSame_toArray()
     {
         $diff = array();
-        $diff[] = array('ba', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('bc', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('ba', self::REMOVED);
+        $diff[] = array('bc', self::ADDED);
         
         $this->assertEquals(
           $diff,
@@ -124,8 +129,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorEndSame_toArray()
     {
         $diff = array();
-        $diff[] = array('ab', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('cb', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('ab', self::REMOVED);
+        $diff[] = array('cb', self::ADDED);
         
         $this->assertEquals(
           $diff,
@@ -150,8 +155,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorStartAndEndSame_toArray()
     {
         $diff = array();
-        $diff[] = array('abc', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('adc', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('abc', self::REMOVED);
+        $diff[] = array('adc', self::ADDED);
         
         $this->assertEquals(
           $diff,
@@ -176,8 +181,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorStartSameComplete_toArray()
     {
         $diff = array();
-        $diff[] = array('ab', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('abc', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('ab', self::REMOVED);
+        $diff[] = array('abc', self::ADDED);
       
         $this->assertEquals(
           $diff,
@@ -202,8 +207,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorEndSameComplete_toArray()
     {
         $diff = array();
-        $diff[] = array('bc', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('abc', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('bc', self::REMOVED);
+        $diff[] = array('abc', self::ADDED);
         
         $this->assertEquals(
           $diff,
@@ -228,8 +233,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorOverlapingMatches_toArray()
     {
         $diff = array();
-        $diff[] = array('abc', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('abbc', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('abc', self::REMOVED);
+        $diff[] = array('abbc', self::ADDED);
 
         $this->assertEquals(
           $diff,
@@ -254,8 +259,8 @@ class Util_DiffTest extends PHPUnit_Framework_TestCase
     public function testComparisonErrorOverlapingMatches2_toArray()
     {
         $diff = array();
-        $diff[] = array('abcdde', PHPUnit_Util_DIFF::REMOVED);
-        $diff[] = array('abcde', PHPUnit_Util_DIFF::ADDED);
+        $diff[] = array('abcdde', self::REMOVED);
+        $diff[] = array('abcde', self::ADDED);
 
         $this->assertEquals(
           $diff,


### PR DESCRIPTION
I hope my Indenting and CodeStyle is correct.
I added some dumb tests to it, too.

I think it would be nice to have this array output to create better custom assertions for other libraries. I often like to use the diff for arrays or strings and evaluate the output. This is easier accomplished when the util would return arrays.

best regards
psc
