### PR TITLE
Added --testsuite argument, allowing to filter files/directory by parent testsuite name attribute

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -86,6 +86,7 @@ class PHPUnit_TextUI_Command
       'debug' => NULL,
       'exclude-group=' => NULL,
       'filter=' => NULL,
+      'testsuite=' => NULL,
       'group=' => NULL,
       'help' => NULL,
       'include-path=' => NULL,
@@ -360,6 +361,11 @@ class PHPUnit_TextUI_Command
 
                 case '--filter': {
                     $this->arguments['filter'] = $option[1];
+                }
+                break;
+
+                case '--testsuite': {
+                    $this->arguments['testsuite'] = $option[1];
                 }
                 break;
 
@@ -668,7 +674,7 @@ class PHPUnit_TextUI_Command
             }
 
             if (!isset($this->arguments['test'])) {
-                $testSuite = $configuration->getTestSuiteConfiguration();
+                $testSuite = $configuration->getTestSuiteConfiguration(isset($this->arguments['testsuite']) ? $this->arguments['testsuite'] : null);
 
                 if ($testSuite !== NULL) {
                     $this->arguments['test'] = $testSuite;

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -756,7 +756,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.2.1
      */
-    public function getTestSuiteConfiguration()
+    public function getTestSuiteConfiguration($testSuiteName=null)
     {
         $testSuiteNodes = $this->xpath->query('testsuites/testsuite');
 
@@ -765,7 +765,7 @@ class PHPUnit_Util_Configuration
         }
 
         if ($testSuiteNodes->length == 1) {
-            return $this->getTestSuite($testSuiteNodes->item(0));
+            return $this->getTestSuite($testSuiteNodes->item(0), $testSuiteName);
         }
 
         if ($testSuiteNodes->length > 1) {
@@ -773,7 +773,7 @@ class PHPUnit_Util_Configuration
 
             foreach ($testSuiteNodes as $testSuiteNode) {
                 $suite->addTestSuite(
-                  $this->getTestSuite($testSuiteNode)
+                  $this->getTestSuite($testSuiteNode, $testSuiteName)
                 );
             }
 
@@ -786,7 +786,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.4.0
      */
-    protected function getTestSuite(DOMElement $testSuiteNode)
+    protected function getTestSuite(DOMElement $testSuiteNode, $testSuiteName=null)
     {
         if ($testSuiteNode->hasAttribute('name')) {
             $suite = new PHPUnit_Framework_TestSuite(
@@ -805,6 +805,10 @@ class PHPUnit_Util_Configuration
         $fileIteratorFacade = new File_Iterator_Facade;
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
+            if ($testSuiteName && $directoryNode->parentNode->getAttribute('name') != $testSuiteName) {
+                continue;
+            }
+            
             $directory = (string)$directoryNode->nodeValue;
 
             if (empty($directory)) {
@@ -849,6 +853,10 @@ class PHPUnit_Util_Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
+            if ($testSuiteName && $fileNode->parentNode->getAttribute('name') != $testSuiteName) {
+                continue;
+            }
+            
             $file = (string)$fileNode->nodeValue;
 
             if (empty($file)) {


### PR DESCRIPTION
Before, we could run the test suite of a component as such: UnitTest/src/runtests.php Database

But the new test runner does not allow this. For example, consider this phpunit.xml.dist: https://fisheye6.atlassian.com/browse/zetacomponents/trunk/phpunit.xml.dist?hb=true

Phpunit --filter Database will not behave as expected in two ways:

0) test cases without Database in the class name will be omited (ie. ezcQueryExpressionTest from Database/tests/sqlabstraction/expression_test.php)
1) test cases with Database in the class name from other components will be included (ezcDatabaseSchemaGenericTest from DatabaseSchema/tests/generic_test.php)

As a more alarming example: --filter MvcTools runs 124 tests, wheras --testsuite MvcTools runs 168.

Credit to Derick Rethans who participated in this little task. Long live the Components !
