### PR TITLE
Added --testsuite argument, allowing to filter files/directory by parent testsuite name attribute

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -86,6 +86,7 @@ class PHPUnit_TextUI_Command
       'debug' => NULL,
       'exclude-group=' => NULL,
       'filter=' => NULL,
+      'testsuite=' => NULL,
       'group=' => NULL,
       'help' => NULL,
       'include-path=' => NULL,
@@ -339,6 +340,11 @@ class PHPUnit_TextUI_Command
 
                 case '--filter': {
                     $this->arguments['filter'] = $option[1];
+                }
+                break;
+
+                case '--testsuite': {
+                    $this->arguments['testsuite'] = $option[1];
                 }
                 break;
 
@@ -644,7 +650,7 @@ class PHPUnit_TextUI_Command
             }
 
             if (!isset($this->arguments['test'])) {
-                $testSuite = $configuration->getTestSuiteConfiguration();
+                $testSuite = $configuration->getTestSuiteConfiguration(isset($this->arguments['testsuite']) ? $this->arguments['testsuite'] : null);
 
                 if ($testSuite !== NULL) {
                     $this->arguments['test'] = $testSuite;

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -844,6 +844,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --testdox-text <file>     Write agile documentation in Text format to file.
 
   --filter <pattern>        Filter which tests to run.
+  --testsuite <pattern>     Filter which testsuite to run.
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -758,7 +758,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.2.1
      */
-    public function getTestSuiteConfiguration($testSuiteName=null)
+    public function getTestSuiteConfiguration($testSuiteFilter=null)
     {
         $testSuiteNodes = $this->xpath->query('testsuites/testsuite');
 
@@ -767,7 +767,7 @@ class PHPUnit_Util_Configuration
         }
 
         if ($testSuiteNodes->length == 1) {
-            return $this->getTestSuite($testSuiteNodes->item(0), $testSuiteName);
+            return $this->getTestSuite($testSuiteNodes->item(0), $testSuiteFilter);
         }
 
         if ($testSuiteNodes->length > 1) {
@@ -775,7 +775,7 @@ class PHPUnit_Util_Configuration
 
             foreach ($testSuiteNodes as $testSuiteNode) {
                 $suite->addTestSuite(
-                  $this->getTestSuite($testSuiteNode, $testSuiteName)
+                  $this->getTestSuite($testSuiteNode, $testSuiteFilter)
                 );
             }
 
@@ -788,7 +788,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.4.0
      */
-    protected function getTestSuite(DOMElement $testSuiteNode, $testSuiteName=null)
+    protected function getTestSuite(DOMElement $testSuiteNode, $testSuiteFilter=null)
     {
         if ($testSuiteNode->hasAttribute('name')) {
             $suite = new PHPUnit_Framework_TestSuite(
@@ -807,7 +807,7 @@ class PHPUnit_Util_Configuration
         $fileIteratorFacade = new File_Iterator_Facade;
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
-            if ($testSuiteName && $directoryNode->parentNode->getAttribute('name') != $testSuiteName) {
+            if ($testSuiteFilter && $directoryNode->parentNode->getAttribute('name') != $testSuiteFilter) {
                 continue;
             }
             
@@ -855,7 +855,7 @@ class PHPUnit_Util_Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
-            if ($testSuiteName && $fileNode->parentNode->getAttribute('name') != $testSuiteName) {
+            if ($testSuiteFilter && $fileNode->parentNode->getAttribute('name') != $testSuiteFilter) {
                 continue;
             }
             

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -758,7 +758,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.2.1
      */
-    public function getTestSuiteConfiguration()
+    public function getTestSuiteConfiguration($testSuiteName=null)
     {
         $testSuiteNodes = $this->xpath->query('testsuites/testsuite');
 
@@ -767,7 +767,7 @@ class PHPUnit_Util_Configuration
         }
 
         if ($testSuiteNodes->length == 1) {
-            return $this->getTestSuite($testSuiteNodes->item(0));
+            return $this->getTestSuite($testSuiteNodes->item(0), $testSuiteName);
         }
 
         if ($testSuiteNodes->length > 1) {
@@ -775,7 +775,7 @@ class PHPUnit_Util_Configuration
 
             foreach ($testSuiteNodes as $testSuiteNode) {
                 $suite->addTestSuite(
-                  $this->getTestSuite($testSuiteNode)
+                  $this->getTestSuite($testSuiteNode, $testSuiteName)
                 );
             }
 
@@ -788,7 +788,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.4.0
      */
-    protected function getTestSuite(DOMElement $testSuiteNode)
+    protected function getTestSuite(DOMElement $testSuiteNode, $testSuiteName=null)
     {
         if ($testSuiteNode->hasAttribute('name')) {
             $suite = new PHPUnit_Framework_TestSuite(
@@ -807,6 +807,10 @@ class PHPUnit_Util_Configuration
         $fileIteratorFacade = new File_Iterator_Facade;
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
+            if ($testSuiteName && $directoryNode->parentNode->getAttribute('name') != $testSuiteName) {
+                continue;
+            }
+            
             $directory = (string)$directoryNode->nodeValue;
 
             if (empty($directory)) {
@@ -851,6 +855,10 @@ class PHPUnit_Util_Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
+            if ($testSuiteName && $fileNode->parentNode->getAttribute('name') != $testSuiteName) {
+                continue;
+            }
+            
             $file = (string)$fileNode->nodeValue;
 
             if (empty($file)) {


### PR DESCRIPTION
Before, we could run the test suite of a component as such: UnitTest/src/runtests.php Database

But the new test runner does not allow this. For example, consider this phpunit.xml.dist: https://fisheye6.atlassian.com/browse/zetacomponents/trunk/phpunit.xml.dist?hb=true

Phpunit --filter Database will not behave as expected in two ways:

0) test cases without Database in the class name will be omited (ie. ezcQueryExpressionTest from Database/tests/sqlabstraction/expression_test.php)
1) test cases with Database in the class name from other components will be included (ezcDatabaseSchemaGenericTest from DatabaseSchema/tests/generic_test.php)

As a more alarming example: --filter MvcTools runs 124 tests, wheras --testsuite MvcTools runs 168.

Credit to Derick Rethans who participated in this little task. Long live the Components !

(this is a follow up to: https://github.com/sebastianbergmann/phpunit/pull/494)
