### PR TITLE
Fix Typo (minor)

### DIFF
--- a/PHPUnit/Framework/Constraint.php
+++ b/PHPUnit/Framework/Constraint.php
@@ -151,7 +151,7 @@ abstract class PHPUnit_Framework_Constraint implements Countable, PHPUnit_Framew
     /**
      * Return additional failure description where needed
      *
-     * The function can be overritten to provide additional failure
+     * The function can be overridden to provide additional failure
      * information like a diff
      *
      * @param  mixed $other Evaluated value or object.


### PR DESCRIPTION
overritten -> overridden
