### PR TITLE
Allow autoloading of listeners and warn if loading fails

### DIFF
--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -612,7 +612,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     require_once $listener['file'];
                 }
 
-                if (class_exists($listener['class'], FALSE)) {
+                if (class_exists($listener['class'])) {
                     if (count($listener['arguments']) == 0) {
                         $listener = new $listener['class'];
                     } else {


### PR DESCRIPTION
It turned out to be because the listener class wasn't loaded using the autoloader, which looks like it was done on purpose, but I couldn't see why. The attached patch enables autoloading for test listener classes.

The issue was very hard to spot or debug, as there's no error or warning raised by the test runner when the listener fails to load. I would have included this in the patch, but I couldn't see how to print to standard error easily from this part of the code.
