### PR TITLE
Support empty content in tag matcher

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -622,6 +622,13 @@ class PHPUnit_Util_XML
                     }
                 }
 
+                // match empty string
+                else if ($options['content'] === '') {
+                    if (self::getNodeText($node) !== '') {
+                        $invalid = TRUE;
+                    }
+                }
+
                 // match by exact string
                 else if (strstr(self::getNodeText($node), $options['content']) === FALSE) {
                     $invalid = TRUE;


### PR DESCRIPTION
Without this, we get the PHP error "strstr(): Empty delimiter" when $needle == ''.
