### PR TITLE
Added support for nested exceptions

### DIFF
--- a/PHPUnit/Framework/Error.php
+++ b/PHPUnit/Framework/Error.php
@@ -60,18 +60,17 @@ class PHPUnit_Framework_Error extends Exception
     /**
      * Constructor.
      *
-     * @param  string  $message
-     * @param  integer $code
-     * @param  string  $file
-     * @param  integer $line
-     * @param  array   $trace
+     * @param  string     $message
+     * @param  integer    $code
+     * @param  string     $file
+     * @param  integer    $line
+     * @param  Exception  $previous
      */
-    public function __construct($message, $code, $file, $line, $trace)
+    public function __construct($message, $code, $file, $line, Exception $previous = NULL)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
 
         $this->file  = $file;
         $this->line  = $line;
-        $this->trace = $trace;
     }
 }

--- a/PHPUnit/Framework/ExpectationFailedException.php
+++ b/PHPUnit/Framework/ExpectationFailedException.php
@@ -66,11 +66,11 @@ class PHPUnit_Framework_ExpectationFailedException extends PHPUnit_Framework_Ass
      */
     protected $comparisonFailure;
 
-    public function __construct($message, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+    public function __construct($message, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL, Exception $previous = NULL)
     {
         $this->comparisonFailure = $comparisonFailure;
 
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 
     /**

--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -128,6 +128,6 @@ class PHPUnit_Util_ErrorHandler
             $exception = 'PHPUnit_Framework_Error';
         }
 
-        throw new $exception($errstr, $errno, $errfile, $errline, $trace);
+        throw new $exception($errstr, $errno, $errfile, $errline);
     }
 }

--- a/PHPUnit/Util/Filter.php
+++ b/PHPUnit/Util/Filter.php
@@ -83,7 +83,11 @@ class PHPUnit_Util_Filter
             $eFile  = $e->getSyntheticFile();
             $eLine  = $e->getSyntheticLine();
         } else {
-            $eTrace = $e->getTrace();
+            if ($e->getPrevious()) {
+                $eTrace = $e->getPrevious()->getTrace();
+            } else {
+                $eTrace = $e->getTrace();
+            }
             $eFile  = $e->getFile();
             $eLine  = $e->getLine();
         }


### PR DESCRIPTION
This commit fixes the bug in PHPUnit_Framework_Error and allows throwing a new Exception (with a modified message, which is necessary for taking screenshots in phpunit-selenium) while keeping the initial trace (by means of the nested exception). Please check the issues below for more information. As I wrote in there I am willing to adjust the code to work with PHP < 5.3.

This pull request is connected with issues:
#471
#470

https://github.com/sebastianbergmann/phpunit-selenium/issues/84
