### PR TITLE
Support CSS attribute existence selector

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -402,8 +402,14 @@ class PHPUnit_Util_XML
                         }
 
                         // exact match
-                        else {
+                        else if (strstr($attribute, '=')) {
                             list($key, $value) = explode('=', $attribute);
+                        }
+
+                        // existence
+                        else {
+                            $key               = $attribute;
+                            $value             = "regexp:/.+/";
                         }
 
                         $attrs[$key] = $value;


### PR DESCRIPTION
Support CSS attribute existence selector, e.g., img[alt] to select images with an alt attribute.

Known issue: requires attribute to be set to a non-empty string.
