### PR TITLE
$time was being passed into endTest() but not being displayed in debug mode

### DIFF
--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -589,6 +589,14 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
             $this->writeProgress('.');
         }
 
+        if ($this->debug) {
+            $this->write(
+                sprintf(
+                    "\nTest execution time '%s seconds'.\n", $time
+                )
+            );
+        }
+
         if ($test instanceof PHPUnit_Framework_TestCase) {
             $this->numAssertions += $test->getNumAssertions();
         }


### PR DESCRIPTION
Hi,

I made a small addition to the endTest() function within PHPUnit/TextUI/ResultPrinter.php because I needed to know the execution time for my tests in debug mode.

The value was already passed to the function, so all I needed to add was the call to write().

Regards,
Carl.
