### PR TITLE
Fixes error when E_NOTICE is set

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -699,7 +699,7 @@ class PHPUnit_Util_XML
             foreach ($nodes as $node) {
                 $parent = $node->parentNode;
 
-                while ($parent->nodeType != XML_HTML_DOCUMENT_NODE) {
+                while ($parent && $parent->nodeType != XML_HTML_DOCUMENT_NODE) {
                     if ($parent === $ancestorNode) {
                         $filtered[] = $node;
                     }


### PR DESCRIPTION
This breaks tests that use ancestor,
