### PR TITLE
more verbose expectedException + directory seperator fix

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -955,15 +955,17 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
 
             if ($checkException) {
+                $checkExceptionMessage = is_string($this->expectedExceptionMessage) && !empty($this->expectedExceptionMessage);
+              
                 $this->assertThat(
                   $e,
                   new PHPUnit_Framework_Constraint_Exception(
                     $this->expectedException
-                  )
+                  ),
+                  (!$checkExceptionMessage ? $e->getMessage() : '')
                 );
 
-                if (is_string($this->expectedExceptionMessage) &&
-                    !empty($this->expectedExceptionMessage)) {
+                if ($checkExceptionMessage) {
                     $this->assertThat(
                       $e,
                       new PHPUnit_Framework_Constraint_ExceptionMessage(

--- a/Tests/Util/ConfigurationTest.php
+++ b/Tests/Util/ConfigurationTest.php
@@ -243,7 +243,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
           array(
             'include_path' =>
             array(
-              dirname(__DIR__) . '/_files/.',
+              dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.',
               '/path/to/lib'
             ),
             'ini'=> array('foo' => 'bar'),
@@ -268,7 +268,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->configuration->handlePHPConfiguration();
 
-        $path = dirname(__DIR__) . '/_files/.' . PATH_SEPARATOR . '/path/to/lib';
+        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.' . PATH_SEPARATOR . '/path/to/lib';
         $this->assertStringStartsWith($path, ini_get('include_path'));
         $this->assertEquals(FALSE, FOO);
         $this->assertEquals(TRUE, BAR);


### PR DESCRIPTION
I added a more verbose description for testing if an exception was thrown (expectedException). When the exception thrown mismatches the expected it's often very useful to see what goes actually wrong (for example if errorexception is raised)

When the expectedExceptionmessage is not set (otherwise you would see the message anyways) its added to the assertThat
