### PR TITLE
Don't use colors in output when output is not an interactive shell 

### DIFF
--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -133,7 +133,7 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
         }
 
         if (is_bool($colors)) {
-            $this->colors = $colors;
+            $this->colors = $colors && (!function_exists('posix_isatty') || posix_isatty(STDOUT));
         } else {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(3, 'boolean');
         }


### PR DESCRIPTION
When piping phpunit output to less or some other program, the ANSI codes for colors show up as literals instead of changing the colors out the output.

Ignore the --colors option when the stdout is not a tty.

If it cannot be determined if stdout is a tty (e.g. the POSIX extension is not installed), then the --colors option will be honored.
