### PR TITLE
Improvement of filtering test suites

### DIFF
--- a/PHPUnit/Extensions/RepeatedTest.php
+++ b/PHPUnit/Extensions/RepeatedTest.php
@@ -81,6 +81,11 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
     protected $timesRepeat = 1;
 
     /**
+     * @var mixed
+     */
+    protected $filterTestsuite = FALSE;
+
+    /**
      * Constructor.
      *
      * @param  PHPUnit_Framework_Test $test
@@ -144,7 +149,8 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
                   $this->filter,
                   $this->groups,
                   $this->excludeGroups,
-                  $this->processIsolation
+                  $this->processIsolation,
+                  $this->filterTestsuite
                 );
             } else {
                 $this->test->run($result);
@@ -152,5 +158,28 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
         }
 
         return $result;
+    }
+
+    /**
+     * getter for $filterTestsuite
+     * @return  mixed
+     */
+    public function getFilterTestsuite() {
+        return $this->filterTestsuite;
+    }
+
+    /**
+     * setter for $filterTestsuite
+     * @param   mixed   $value
+     * @return  null
+     */
+    public function setFilterTestsuite($value) {
+        // check it's valid regex. if FALSE it means it did not set
+        if ($value!==FALSE && (!is_string($value) || preg_match($value, 'a')===FALSE)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+              1, 'regex string'
+            );
+        }
+        $this->filterTestsuite = $value;
     }
 }

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -663,7 +663,7 @@ class PHPUnit_TextUI_Command
             }
 
             if (!isset($this->arguments['test'])) {
-                $testSuite = $configuration->getTestSuiteConfiguration(isset($this->arguments['testsuite']) ? $this->arguments['testsuite'] : null);
+                $testSuite = $configuration->getTestSuiteConfiguration();
 
                 if ($testSuite !== NULL) {
                     $this->arguments['test'] = $testSuite;

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -857,7 +857,8 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --testdox-text <file>     Write agile documentation in Text format to file.
 
   --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
+  --testsuite <pattern>     Filter which test suite to run. Child test suites
+                            could be separated by "::". E.g.: "ParentSuite::ChildSuite".
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -160,6 +160,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
               $arguments['excludeGroups'],
               $arguments['processIsolation']
             );
+            $suite->setFilterTestsuite($arguments['testsuite']);
         }
 
         $result = $this->createTestResult();
@@ -321,7 +322,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
           $arguments['filter'],
           $arguments['groups'],
           $arguments['excludeGroups'],
-          $arguments['processIsolation']
+          $arguments['processIsolation'],
+          $arguments['testsuite']
         );
 
         unset($suite);
@@ -502,6 +504,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
         $arguments['debug']     = isset($arguments['debug'])     ? $arguments['debug']     : FALSE;
         $arguments['filter']    = isset($arguments['filter'])    ? $arguments['filter']    : FALSE;
+        $arguments['testsuite'] = isset($arguments['testsuite']) ? $arguments['testsuite'] : FALSE;
         $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
         if (isset($arguments['configuration'])) {
@@ -797,13 +800,16 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['strict']                             = isset($arguments['strict'])                             ? $arguments['strict']                             : FALSE;
         $arguments['verbose']                            = isset($arguments['verbose'])                            ? $arguments['verbose']                            : FALSE;
 
-        if ($arguments['filter'] !== FALSE &&
-            preg_match('/^[a-zA-Z0-9_]/', $arguments['filter'])) {
-            // Escape delimiters in regular expression. Do NOT use preg_quote,
-            // to keep magic characters.
-            $arguments['filter'] = '/' . str_replace(
-              '/', '\\/', $arguments['filter']
-            ) . '/';
+        // escape regex arguments
+        foreach (array('filter', 'testsuite') as $argToEscape) {
+            if ($arguments[$argToEscape] !== FALSE &&
+                preg_match('/^[a-zA-Z0-9_]/', $arguments[$argToEscape])) {
+                // Escape delimiters in regular expression. Do NOT use preg_quote,
+                // to keep magic characters.
+                $arguments[$argToEscape] = '/' . str_replace(
+                  '/', '\\/', $arguments[$argToEscape]
+                ) . '/';
+            }
         }
     }
 }

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -758,7 +758,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.2.1
      */
-    public function getTestSuiteConfiguration($testSuiteFilter=null)
+    public function getTestSuiteConfiguration()
     {
         $testSuiteNodes = $this->xpath->query('testsuites/testsuite');
 
@@ -767,7 +767,7 @@ class PHPUnit_Util_Configuration
         }
 
         if ($testSuiteNodes->length == 1) {
-            return $this->getTestSuite($testSuiteNodes->item(0), $testSuiteFilter);
+            return $this->getTestSuite($testSuiteNodes->item(0));
         }
 
         if ($testSuiteNodes->length > 1) {
@@ -775,7 +775,7 @@ class PHPUnit_Util_Configuration
 
             foreach ($testSuiteNodes as $testSuiteNode) {
                 $suite->addTestSuite(
-                  $this->getTestSuite($testSuiteNode, $testSuiteFilter)
+                  $this->getTestSuite($testSuiteNode)
                 );
             }
 
@@ -788,7 +788,7 @@ class PHPUnit_Util_Configuration
      * @return PHPUnit_Framework_TestSuite
      * @since  Method available since Release 3.4.0
      */
-    protected function getTestSuite(DOMElement $testSuiteNode, $testSuiteFilter=null)
+    protected function getTestSuite(DOMElement $testSuiteNode)
     {
         if ($testSuiteNode->hasAttribute('name')) {
             $suite = new PHPUnit_Framework_TestSuite(
@@ -807,10 +807,6 @@ class PHPUnit_Util_Configuration
         $fileIteratorFacade = new File_Iterator_Facade;
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
-            if ($testSuiteFilter && $directoryNode->parentNode->getAttribute('name') != $testSuiteFilter) {
-                continue;
-            }
-            
             $directory = (string)$directoryNode->nodeValue;
 
             if (empty($directory)) {
@@ -855,10 +851,6 @@ class PHPUnit_Util_Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
-            if ($testSuiteFilter && $fileNode->parentNode->getAttribute('name') != $testSuiteFilter) {
-                continue;
-            }
-            
             $file = (string)$fileNode->nodeValue;
 
             if (empty($file)) {

--- a/Tests/TextUI/help.phpt
+++ b/Tests/TextUI/help.phpt
@@ -29,6 +29,8 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --testdox-text <file>     Write agile documentation in Text format to file.
 
   --filter <pattern>        Filter which tests to run.
+  --testsuite <pattern>     Filter which test suite to run. Child test suites
+                            could be separated by "::". E.g.: "ParentSuite::ChildSuite".
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.

--- a/Tests/TextUI/help2.phpt
+++ b/Tests/TextUI/help2.phpt
@@ -30,6 +30,8 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --testdox-text <file>     Write agile documentation in Text format to file.
 
   --filter <pattern>        Filter which tests to run.
+  --testsuite <pattern>     Filter which test suite to run. Child test suites
+                            could be separated by "::". E.g.: "ParentSuite::ChildSuite".
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.

--- a/Tests/TextUI/testsuite-filter.phpt
+++ b/Tests/TextUI/testsuite-filter.phpt
@@ -1,0 +1,31 @@
+--TEST--
+phpunit --testsuite Parent::Child1 ParentSuite ../_files/ParentSuite.php
+--FILE--
+<?php
+
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testsuite';
+$_SERVER['argv'][] = 'Parent::Child1';
+$_SERVER['argv'][] = 'ParentSuite';
+$_SERVER['argv'][] = dirname(__FILE__).'/../_files/ParentSuite.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit @package_version@ by Sebastian Bergmann.
+
+F
+
+Time: 0 seconds, Memory: 4.50Mb
+
+There was 1 failure:
+
+1) OneTest::testSomething
+Failed asserting that false is true.
+
+%s/OneTest.php:%i
+%s/testsuite-filter.php:%i
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/Tests/_files/Child1Suite.php
+++ b/Tests/_files/Child1Suite.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'OneTest.php';
+
+class Child1Suite
+{
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('Child1');
+        $suite->addTestSuite('OneTest');
+
+        return $suite;
+    }
+}

--- a/Tests/_files/Child2Suite.php
+++ b/Tests/_files/Child2Suite.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'OneTest.php';
+
+class Child2Suite
+{
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('Child2');
+        $suite->addTestSuite('OneTest');
+
+        return $suite;
+    }
+}

--- a/Tests/_files/OneTest.php
+++ b/Tests/_files/OneTest.php
@@ -1,0 +1,9 @@
+<?php
+class OneTest extends PHPUnit_Framework_TestCase
+{
+    public function testSomething()
+    {
+        $this->assertTrue(false);
+    }
+}
+

--- a/Tests/_files/ParentSuite.php
+++ b/Tests/_files/ParentSuite.php
@@ -1,0 +1,15 @@
+<?php
+require_once 'Child1Suite.php';
+require_once 'Child2Suite.php';
+
+class ParentSuite
+{
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('Parent');
+        $suite->addTestSuite(Child1Suite::suite());
+        $suite->addTestSuite(Child2Suite::suite());
+
+        return $suite;
+    }
+}


### PR DESCRIPTION
This is improvement of #495.
It allows to filter any kind of test suites (not only that set in XML configuration). The --testsuite option made similar to --filter option: it accepts regex and all the filtering code are made alike.
Also I introduced storing parent-child suites relationship. It's used for filtering hierarchal suites (symbols "::" used for indication of the parent-child relation).