### PR TITLE
Fix misbehaviour of junit logger if logIncompleteSkipped is set to true

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -1567,6 +1567,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 }
 
                 if (!isset($passedKeys[$dependency])) {
+                    $this->result->startTest($this);
                     $this->result->addError(
                       $this,
                       new PHPUnit_Framework_SkippedTestError(
@@ -1576,6 +1577,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                       ),
                       0
                     );
+                    $this->result->endTest($this, 0);
 
                     return FALSE;
                 }


### PR DESCRIPTION
Skipped tests were not logged by the junit logger evene if logIncompleteSkipped was set to true because the logger was not notified that the test has been started or ended when sending the 'incomplete' notify.