### PR TITLE
Printing cause of exception when present

### DIFF
--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -274,6 +274,20 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
             $defect->thrownException()
           )
         );
+        
+        $e = $defect->thrownException();
+        if (method_exists($e, 'getPrevious')) {
+            //php >= 5.3, exceptions may have a previous cause
+            $e = $e->getPrevious();
+            while ($e) {
+                $this->write(
+                    "\nCaused by\n" .
+                    PHPUnit_Util_Filter::getFilteredStacktrace($e)
+                );
+                $e = $e->getPrevious();
+            }
+        }
+        
     }
 
     /**


### PR DESCRIPTION
On php >= 5.3, exceptions may have a previous cause. This allows exception chaining, by catching, modifying and throwing a (new) exception.

This is usefull in tests where you can write a TestCase base class for a set of tests, override onNotSuccessfulTest() to do some additional processing (throwing a new exception at the end) and at the UI you can see the stack trace of both the new processed exception and the original one.

Hope this makes it clear enough the purpose of this change (it's my first ever pull request on github!).
