### PR TITLE
Add excluded groups to TestListener

### DIFF
--- a/PHPUnit/Extensions/TicketListener.php
+++ b/PHPUnit/Extensions/TicketListener.php
@@ -116,6 +116,15 @@ abstract class PHPUnit_Extensions_TicketListener implements PHPUnit_Framework_Te
     }
 
     /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+    }
+
+    /**
      * A test suite started.
      *
      * @param  PHPUnit_Framework_TestSuite $suite

--- a/PHPUnit/Framework/TestExclude.php
+++ b/PHPUnit/Framework/TestExclude.php
@@ -44,91 +44,56 @@
  */
 
 /**
- * A Listener for test progress.
+ * A TestExclude collects an exclude test.
  *
  * @package    PHPUnit
  * @subpackage Framework
  * @author     Sebastian Bergmann <sebastian@phpunit.de>
  * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
- * @version    Release: @package_version@
+ * @version    Release: 3.6.10
  * @link       http://www.phpunit.de/
- * @since      Interface available since Release 2.0.0
+ * @since      Class available since Release 2.0.0
  */
-interface PHPUnit_Framework_TestListener
+class PHPUnit_Framework_TestExclude
 {
     /**
-     * An error occurred.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
+     * @var    PHPUnit_Framework_Test
      */
-    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time);
+    protected $excludedTest;
 
     /**
-     * A failure occurred.
+     * Constructs a TestExclude with the given test and exception.
      *
-     * @param  PHPUnit_Framework_Test                 $test
-     * @param  PHPUnit_Framework_AssertionFailedError $e
-     * @param  float                                  $time
+     * @param  PHPUnit_Framework_Test $excludedTest
+     * @param  Exception               $thrownException
      */
-    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time);
+    public function __construct(PHPUnit_Framework_Test $excludedTest)
+    {
+        $this->excludedTest    = $excludedTest;
+    }
 
     /**
-     * Incomplete test.
+     * Returns a short description of the exclude.
      *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
+     * @return string
      */
-    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time);
+    public function toString()
+    {
+        return sprintf(
+          '%s',
+
+          $this->failedTest
+        );
+    }
 
     /**
-     * Skipped test.
+     * Gets the excluded test.
      *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  Exception              $e
-     * @param  float                  $time
-     * @since  Method available since Release 3.0.0
+     * @return Test
      */
-    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time);
-
-    /**
-     * Excluded test.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     */
-    public function addExcludedTest(PHPUnit_Framework_Test $test);
-
-    /**
-     * A test suite started.
-     *
-     * @param  PHPUnit_Framework_TestSuite $suite
-     * @since  Method available since Release 2.2.0
-     */
-    public function startTestSuite(PHPUnit_Framework_TestSuite $suite);
-
-    /**
-     * A test suite ended.
-     *
-     * @param  PHPUnit_Framework_TestSuite $suite
-     * @since  Method available since Release 2.2.0
-     */
-    public function endTestSuite(PHPUnit_Framework_TestSuite $suite);
-
-    /**
-     * A test started.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     */
-    public function startTest(PHPUnit_Framework_Test $test);
-
-    /**
-     * A test ended.
-     *
-     * @param  PHPUnit_Framework_Test $test
-     * @param  float                  $time
-     */
-    public function endTest(PHPUnit_Framework_Test $test, $time);
+    public function excludedTest()
+    {
+        return $this->excludedTest;
+    }
 }

--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -100,6 +100,11 @@ class PHPUnit_Framework_TestResult implements Countable
     /**
      * @var array
      */
+    protected $excluded = array();
+
+    /**
+     * @var array
+     */
     protected $listeners = array();
 
     /**
@@ -313,6 +318,21 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
+     * Adds an exclude to the list of excludes.
+     *
+     * @param  PHPUnit_Framework_Test                 $test
+     */
+    public function addExclude(PHPUnit_Framework_Test $test)
+    {
+        $this->excluded[] = new PHPUnit_Framework_TestExclude($test);
+        $notifyMethod     = 'addExcludedTest';
+
+        foreach ($this->listeners as $listener) {
+            $listener->$notifyMethod($test);
+        }
+    }
+
+    /**
      * Adds a deprecated feature notice to the list of deprecated features used during run
      *
      * @param PHPUnit_Util_DeprecatedFeature $deprecatedFeature
@@ -447,6 +467,16 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
+     * Gets the number of excluded tests.
+     *
+     * @return integer
+     */
+    public function excludedCount()
+    {
+        return count($this->excluded);
+    }
+
+    /**
      * Returns an Enumeration for the skipped tests.
      *
      * @return array
@@ -455,6 +485,16 @@ class PHPUnit_Framework_TestResult implements Countable
     public function skipped()
     {
         return $this->skipped;
+    }
+
+    /**
+     * Returns an Enumeration for the excluded tests.
+     *
+     * @return array
+     */
+    public function excluded()
+    {
+        return $this->excluded;
     }
 
     /**

--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -741,6 +741,8 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
                     }
 
                     $this->runTest($test, $result);
+                } else {
+                    $result->addExclude($test);
                 }
             }
         }

--- a/PHPUnit/Runner/BaseTestRunner.php
+++ b/PHPUnit/Runner/BaseTestRunner.php
@@ -62,6 +62,7 @@ abstract class PHPUnit_Runner_BaseTestRunner
     const STATUS_INCOMPLETE = 2;
     const STATUS_FAILURE    = 3;
     const STATUS_ERROR      = 4;
+    const STATUS_EXCLUDED   = 5;
     const SUITE_METHODNAME  = 'suite';
 
     /**

--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -370,7 +370,7 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
               sprintf(
                 "Tests: %d, Assertions: %d%s%s.\n",
 
-                count($result),
+                count($result) + $result->excludedCount(),
                 $this->numAssertions,
                 $this->getCountString(
                   $result->notImplementedCount(), 'Incomplete'
@@ -534,6 +534,20 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
         }
 
         $this->lastTestFailed = TRUE;
+    }
+
+    /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+        if ($this->colors) {
+            $this->writeProgress("_");
+        } else {
+            $this->writeProgress('_');
+        }
     }
 
     /**

--- a/PHPUnit/Util/DeprecatedFeature/Logger.php
+++ b/PHPUnit/Util/DeprecatedFeature/Logger.php
@@ -160,6 +160,15 @@ class PHPUnit_Util_DeprecatedFeature_Logger implements PHPUnit_Framework_TestLis
     }
 
     /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+    }
+
+    /**
      * A test suite started.
      *
      * @param  PHPUnit_Framework_TestSuite $suite

--- a/PHPUnit/Util/Log/JSON.php
+++ b/PHPUnit/Util/Log/JSON.php
@@ -154,6 +154,15 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
     }
 
     /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+    }
+
+    /**
      * A testsuite started.
      *
      * @param  PHPUnit_Framework_TestSuite $suite

--- a/PHPUnit/Util/Log/JUnit.php
+++ b/PHPUnit/Util/Log/JUnit.php
@@ -280,6 +280,15 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
     }
 
     /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+    }
+
+    /**
      * A testsuite started.
      *
      * @param  PHPUnit_Framework_TestSuite $suite

--- a/PHPUnit/Util/Log/TAP.php
+++ b/PHPUnit/Util/Log/TAP.php
@@ -178,6 +178,15 @@ class PHPUnit_Util_Log_TAP extends PHPUnit_Util_Printer implements PHPUnit_Frame
     }
 
     /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+    }
+
+    /**
      * A testsuite started.
      *
      * @param  PHPUnit_Framework_TestSuite $suite

--- a/PHPUnit/Util/TestDox/ResultPrinter.php
+++ b/PHPUnit/Util/TestDox/ResultPrinter.php
@@ -95,6 +95,11 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
     /**
      * @var integer
      */
+    protected $excluded = 0;
+
+    /**
+     * @var integer
+     */
     protected $incomplete = 0;
 
     /**
@@ -195,6 +200,19 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
         if ($test instanceof $this->testTypeOfInterest) {
             $this->testStatus = PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED;
             $this->skipped++;
+        }
+    }
+
+    /**
+     * Excluded test.
+     *
+     * @param  PHPUnit_Framework_Test $test
+     */
+    public function addExcludedTest(PHPUnit_Framework_Test $test)
+    {
+        if ($test instanceof $this->testTypeOfInterest) {
+            $this->testStatus = PHPUnit_Runner_BaseTestRunner::STATUS_EXCLUDED;
+            $this->excluded++;
         }
     }
 


### PR DESCRIPTION
When run tests, our default excludes a couple of groups of test causing the output to appear like it is missing test cases. This is a quick fix to let the TestListeners know whenever a test is excluded, since the exclusion isn't calculated until after we start looping test cases.

This is for issue [#541]

This is also a re-issue of Pull Request [#546].
