### PR TITLE
Exclude directories - Use AbsolutePath

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -845,7 +845,7 @@ class PHPUnit_Util_Configuration
               $this->toAbsolutePath($directory),
               $suffix,
               $prefix,
-              $exclude
+              array_map(array($this, 'toAbsolutePath'), $exclude)
             );
             $suite->addTestFiles($files);
         }


### PR DESCRIPTION
When you run phpunit using a configuration file where the current working directory does not match the configuration's directory, phpunit will fail to exclude paths in testsuites correctly.

Sample configuration:

``` <testsuites>
  <testsuite name="Normal Test Suite">
    <directory>.</directory>
    <exclude>LongTests</exclude>
    <exclude>FlakyTests</exclude>
  </testsuite>
```

If you run that configuration from any other directory, the <directory>.</directory> will go to the absolute path of the configuration, while the excludes will only exclude from your current working directory (which won't match the . directory).
