### PR TITLE
Targeting also the new autoloader. For BC, fallback to the old one

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -214,7 +214,9 @@ if (PHPUnit_Util_Filesystem::fileExistsInIncludePath('PHPUnit/Extensions/Databas
     require_once 'PHPUnit/Extensions/Database/Autoload.php';
 }
 
-if (PHPUnit_Util_Filesystem::fileExistsInIncludePath('PHPUnit/Extensions/SeleniumTestCase/Autoload.php')) {
+if (PHPUnit_Util_Filesystem::fileExistsInIncludePath('PHPUnit/Extensions/SeleniumCommon/Autoload.php')) {
+    require_once 'PHPUnit/Extensions/SeleniumCommon/Autoload.php';
+} else if (PHPUnit_Util_Filesystem::fileExistsInIncludePath('PHPUnit/Extensions/SeleniumTestCase/Autoload.php')) {
     require_once 'PHPUnit/Extensions/SeleniumTestCase/Autoload.php';
 }
 


### PR DESCRIPTION
I am changing the location of PHPUnit_Selenium autoloader to reflect the fact that there are now two implementations (for the Selenium 1 and Selenium 2 APIs) and some common files.
With this change, in the future I will be able to remove the old autoloader by depending on the next release of PHPUnit.
