### PR TITLE
Mark skipped cases as "skipped" in jUnit report.

### DIFF
--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -295,7 +295,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         if (isset($arguments['junitLogfile'])) {
             $result->addListener(
               new PHPUnit_Util_Log_JUnit(
-                $arguments['junitLogfile'], $arguments['logIncompleteSkipped']
+                $arguments['junitLogfile'], $arguments['logIncompleteSkipped'], $arguments['logIncompleteAsSkipped'], $arguments['logSkippedAsSkipped']
               )
             );
         }
@@ -705,6 +705,16 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     !isset($arguments['logIncompleteSkipped'])) {
                     $arguments['logIncompleteSkipped'] = $loggingConfiguration['logIncompleteSkipped'];
                 }
+                
+                if (isset($loggingConfiguration['logIncompleteAsSkipped']) &&
+                    !isset($arguments['logIncompleteAsSkipped'])) {
+                    $arguments['logIncompleteAsSkipped'] = $loggingConfiguration['logIncompleteAsSkipped'];
+                }
+                
+    			if (isset($loggingConfiguration['logSkippedAsSkipped']) &&
+                    !isset($arguments['logSkippedAsSkipped'])) {
+                    $arguments['logSkippedAsSkipped'] = $loggingConfiguration['logSkippedAsSkipped'];
+                }
             }
 
             if (isset($loggingConfiguration['testdox-html']) &&
@@ -779,6 +789,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['excludeGroups']                  = isset($arguments['excludeGroups'])                  ? $arguments['excludeGroups']                  : array();
         $arguments['groups']                         = isset($arguments['groups'])                         ? $arguments['groups']                         : array();
         $arguments['logIncompleteSkipped']           = isset($arguments['logIncompleteSkipped'])           ? $arguments['logIncompleteSkipped']           : FALSE;
+        $arguments['logIncompleteAsSkipped']         = isset($arguments['logIncompleteAsSkipped'])         ? $arguments['logIncompleteAsSkipped']         : FALSE;
+        $arguments['logSkippedAsSkipped']            = isset($arguments['logSkippedAsSkipped'])            ? $arguments['logSkippedAsSkipped']            : FALSE;
         $arguments['processIsolation']               = isset($arguments['processIsolation'])               ? $arguments['processIsolation']               : FALSE;
         $arguments['repeat']                         = isset($arguments['repeat'])                         ? $arguments['repeat']                         : FALSE;
         $arguments['reportCharset']                  = isset($arguments['reportCharset'])                  ? $arguments['reportCharset']                  : 'UTF-8';

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -135,7 +135,7 @@
  *     <log type="json" target="/tmp/logfile.json"/>
  *     <log type="plain" target="/tmp/logfile.txt"/>
  *     <log type="tap" target="/tmp/logfile.tap"/>
- *     <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+ *     <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false" logIncompleteAsSkipped="false" logSkippedAsSkipped="false"/>
  *     <log type="testdox-html" target="/tmp/testdox.html"/>
  *     <log type="testdox-text" target="/tmp/testdox.txt"/>
  *   </logging>

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -423,6 +423,20 @@ class PHPUnit_Util_Configuration
                       FALSE
                     );
                 }
+                
+                if ($log->hasAttribute('logIncompleteAsSkipped')) {
+                    $result['logIncompleteAsSkipped'] = $this->getBoolean(
+                      (string)$log->getAttribute('logIncompleteAsSkipped'),
+                      FALSE
+                    );
+                }
+                
+                if ($log->hasAttribute('logSkippedAsSkipped')) {
+                    $result['logSkippedAsSkipped'] = $this->getBoolean(
+                      (string)$log->getAttribute('logSkippedAsSkipped'),
+                      FALSE
+                    );
+                }
             }
 
             else if ($type == 'coverage-text') {

--- a/PHPUnit/Util/Log/JUnit.php
+++ b/PHPUnit/Util/Log/JUnit.php
@@ -73,7 +73,17 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
      * @var    boolean
      */
     protected $logIncompleteSkipped = FALSE;
-
+    
+    /**
+     * @var    boolean
+     */
+    protected $logSkippedAsSkipped = FALSE;
+	
+	/**
+     * @var    boolean
+     */
+    protected $logIncompleteAsSkipped = FALSE;
+    
     /**
      * @var    boolean
      */
@@ -130,7 +140,7 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
      * @param  mixed   $out
      * @param  boolean $logIncompleteSkipped
      */
-    public function __construct($out = NULL, $logIncompleteSkipped = FALSE)
+    public function __construct($out = NULL, $logIncompleteSkipped = FALSE, $logSkippedAsSkipped = FALSE, $logIncompleteAsSkipped = FALSE)
     {
         $this->document = new DOMDocument('1.0', 'UTF-8');
         $this->document->formatOutput = TRUE;
@@ -141,6 +151,8 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
         parent::__construct($out);
 
         $this->logIncompleteSkipped = $logIncompleteSkipped;
+    	$this->logSkippedAsSkipped = $logSkippedAsSkipped;
+		$this->logIncompleteAsSkipped = $logIncompleteAsSkipped;
     }
 
     /**
@@ -232,6 +244,11 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
     public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         if ($this->logIncompleteSkipped && $this->currentTestCase !== NULL) {
+            if($this->logIncompleteAsSkipped) {
+				$skipped = $this->document->createElement('skipped');
+				$this->currentTestCase->appendChild($skipped);
+			}
+            
             $error = $this->document->createElement(
               'error',
               PHPUnit_Util_XML::prepareString(
@@ -261,6 +278,11 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         if ($this->logIncompleteSkipped && $this->currentTestCase !== NULL) {
+            if($this->logSkippedAsSkipped) {
+				$skipped = $this->document->createElement('skipped');
+				$this->currentTestCase->appendChild($skipped);
+			}
+            
             $error = $this->document->createElement(
               'error',
               PHPUnit_Util_XML::prepareString(


### PR DESCRIPTION
These changes are adding ability to mark incomplete and/or skipped cases as "skipped" in jUnit report.