### PR TITLE
Fixed the way PHPUnit_Util_Configuration parses listener constructor arguments

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -344,9 +344,9 @@ class PHPUnit_Util_Configuration
                 );
             }
 
-            if ($listener->childNodes->item(1) instanceof DOMElement &&
-                $listener->childNodes->item(1)->tagName == 'arguments') {
-                foreach ($listener->childNodes->item(1)->childNodes as $argument) {
+            foreach ($listener->childNodes as $node) {
+              if ($node instanceof DOMElement && $node->tagName == 'arguments') {
+                foreach ($node->childNodes as $argument) {
                     if ($argument instanceof DOMElement) {
                         if ($argument->tagName == 'file' ||
                             $argument->tagName == 'directory') {
@@ -356,6 +356,7 @@ class PHPUnit_Util_Configuration
                         }
                     }
                 }
+              }
             }
 
             $result[] = array(

--- a/Tests/Util/ConfigurationTest.php
+++ b/Tests/Util/ConfigurationTest.php
@@ -205,7 +205,15 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
               'class' => 'IncludePathListener',
               'file' => __FILE__,
               'arguments' => array()
-            )
+            ),
+            array(
+              'class' => 'CompactArgumentsListener',
+              'file' => '/CompactArgumentsListener.php',
+              'arguments' =>
+              array(
+                0 => 42
+              ),
+            ),
           ),
           $this->configuration->getListenerConfiguration()
         );

--- a/Tests/_files/configuration.xml
+++ b/Tests/_files/configuration.xml
@@ -71,6 +71,7 @@
       </arguments>
     </listener>
     <listener class="IncludePathListener" file="ConfigurationTest.php" />
+    <listener class="CompactArgumentsListener" file="/CompactArgumentsListener.php"><arguments><integer>42</integer></arguments></listener>
   </listeners>
 
   <logging>


### PR DESCRIPTION
Previously, getListenerConfiguration assumed the <arguments> element
would always be the second element (index 1) because nicely formatted
XML has a DOMText node containing a newline and some space before the
arguments node. Computer-generated XML places the arguments element
immediately after the listener element, so the node would be at index 0,
causing the arguments node to not be found.

Instead, it now searches the entire listener node for argument nodes.
