### PR TITLE
PHP error type included in reports

### DIFF
--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -106,6 +106,12 @@ class PHPUnit_Util_ErrorHandler
             }
 
             $exception = 'PHPUnit_Framework_Error_Notice';
+            $prefix = ($errno === E_STRICT)
+                ? 'Strict Standards: '
+                : 'Notice: '
+            ;
+
+            $errstr = $prefix . $errstr;
         }
 
         else if ($errno == E_WARNING || $errno == E_USER_WARNING) {
@@ -114,6 +120,7 @@ class PHPUnit_Util_ErrorHandler
             }
 
             $exception = 'PHPUnit_Framework_Error_Warning';
+            $errstr = 'Warning: ' . $errstr;
         }
 
         else if (version_compare(PHP_VERSION, '5.3', '>=') && ($errno == E_DEPRECATED || $errno == E_USER_DEPRECATED)) {
@@ -122,10 +129,12 @@ class PHPUnit_Util_ErrorHandler
             }
 
             $exception = 'PHPUnit_Framework_Error_Deprecated';
+            $errstr = 'Deprecated: ' . $errstr;
         }
 
         else {
             $exception = 'PHPUnit_Framework_Error';
+            $errstr = 'PHP Error: ' . $errstr;
         }
 
         throw new $exception($errstr, $errno, $errfile, $errline, $trace);

--- a/Tests/Regression/578.phpt
+++ b/Tests/Regression/578.phpt
@@ -19,12 +19,12 @@ Time: %i %s, Memory: %sMb
 There were 3 errors:
 
 1) Issue578Test::testNoticesDoublePrintStackTrace
-Invalid error type specified
+Warning: Invalid error type specified
 %s/Issue578Test.php:%i
 %s/578.php:%i
 
 2) Issue578Test::testWarningsDoublePrintStackTrace
-Invalid error type specified
+Warning: Invalid error type specified
 %s/Issue578Test.php:%i
 %s/578.php:%i
 

--- a/Tests/TextUI/php-error.phpt
+++ b/Tests/TextUI/php-error.phpt
@@ -1,0 +1,44 @@
+--TEST--
+phpunit PhpError ../_files/PhpError.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'PhpError';
+$_SERVER['argv'][3] = dirname(__FILE__).'/../_files/PhpError.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+EEEE
+
+Time: %i %s, Memory: %sMb
+
+There were 4 errors:
+
+1) PhpErrorTestCase::testError
+PHP Error: Error message
+
+%s:%i
+
+2) PhpErrorTestCase::testNotice
+Notice: Notice message
+
+%s:%i
+
+3) PhpErrorTestCase::testDeprecated
+Deprecated: Deprecated message
+
+%s:%i
+
+4) PhpErrorTestCase::testWarning
+Warning: Warning message
+
+%s:%i
+
+FAILURES!
+Tests: 4, Assertions: 0, Errors: 4.

--- a/Tests/_files/PhpError.php
+++ b/Tests/_files/PhpError.php
@@ -1,0 +1,24 @@
+<?php
+
+class PhpErrorTestCase extends PHPUnit_Framework_TestCase {
+
+  public function testError () {
+
+    trigger_error ( 'Error message', E_USER_ERROR );
+  }
+
+  public function testNotice () {
+
+    trigger_error ( 'Notice message', E_USER_NOTICE );
+  }
+
+  public function testDeprecated () {
+
+    trigger_error ( 'Deprecated message', E_USER_DEPRECATED );
+  }
+
+  public function testWarning () {
+
+    trigger_error ( 'Warning message', E_USER_WARNING );
+  }
+}


### PR DESCRIPTION
This change identifies PHP error type on output. It gives:

```
Warning: fopen() expects at least 2 parameters, 0 given
```

instead of just:

```
 fopen() expects at least 2 parameters, 0 given
```

Uncaught  exceptions are prefixed by the type so it is a bit odd that errors aren't.
