### PR TITLE
Remove duplicate description of --debug flag

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -971,8 +971,6 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
 
-  --debug                   Output debugging information.
-
 EOT;
     }
 

--- a/Tests/TextUI/help.phpt
+++ b/Tests/TextUI/help.phpt
@@ -62,5 +62,3 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
 
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
-
-  --debug                   Output debugging information.

--- a/Tests/TextUI/help2.phpt
+++ b/Tests/TextUI/help2.phpt
@@ -63,5 +63,3 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
 
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
-
-  --debug                   Output debugging information.


### PR DESCRIPTION
ebdcfc40fb85 for #442 added a description for the --debug flag to the help output even though one already existed from 056ae02abd5
