### PR TITLE
required PHPUnit_Utils_Filesystem in Autoload

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -46,6 +46,7 @@ require_once 'File/Iterator/Autoload.php';
 require_once 'PHP/CodeCoverage/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';
 require_once 'PHPUnit/Framework/MockObject/Autoload.php';
+require_once 'PHPUnit/Util/Filesystem.php';
 require_once 'Text/Template/Autoload.php';
 
 function phpunit_autoload($class = NULL)


### PR DESCRIPTION
added this line because this file is using the class and there might be
an autoloader that tries to include it before phpunit can do it.
workarounds are not possible outside of this file though.
