### PR TITLE
Tests freeze if fail is called with an Exception object

### DIFF
--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -299,6 +299,14 @@ class PHPUnit_Util_Type
             }
         }
 
+        // Exception trace can contain some recursive variables that cause
+        // infinite loop in print_r(). It always happens when using TestCase.
+        // To avoid the issue, simply removing the stack trace from the
+        // exception
+        if ($object instanceof Exception) {
+            unset($array['trace']);
+        }
+
         return $array;
     }
 }

--- a/Tests/Util/TypeTest.php
+++ b/Tests/Util/TypeTest.php
@@ -188,6 +188,16 @@ text'
 )
 EOF
             ),
+            array(new Exception('Error message'),
+"Exception Object (
+    'message' => 'Error message'
+    'string' => ''
+    'code' => 0
+    'file' => '" . __FILE__ . "'
+    'line' => " . (__LINE__ - 6) . "
+    'previous' => null
+)"
+            ),
             array(
                 chr(0) . chr(1) . chr(2) . chr(3) . chr(4) . chr(5),
                 'Binary String: 0x000102030405'


### PR DESCRIPTION
If you create a test case and the assert use an Exception (or child) object, it freeze the code trying to allocate all the memory available for PHP.

Debugging the code I saw the problem is caused by the `print_r` in `PHPUnit_Util_Type::recursiveExport`.

It seems a PHP bug, but maybe PHPUnit can use a different approach for Exception classes to avoid it. The easiest way was removing the trace, once it is not very important on tests dumps.

Thanks for @cjsaylor in help figure this out.
