### PR TITLE
Fix data serialization when using process isolation (closes #614)

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -720,7 +720,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $strict = 'FALSE';
             }
 
-            $data            = addcslashes(serialize($this->data), "'");
+            $data            = addcslashes(serialize($this->data), "'\\");
             $dependencyInput = addcslashes(
               serialize($this->dependencyInput), "'"
             );


### PR DESCRIPTION
When setting process isolation to true, PHPUnit creates a script that is executed in another process. In the generated script, it serializes the data to be passed to the test method, and this is where there is an issue.

A simple PHP script that exhibits the same issue:

``` php
$a = '\\\\foo';
file_put_contents(__DIR__.'/test.php', sprintf('<?php echo unserialize(\'%s\');', serialize($a)));
exec('php '.__DIR__.'/test.php');
```

The output of the script is:

```
PHP Notice:  unserialize(): Error at offset 10 of 11 bytes in /Users/fabien/work/twig/test.php on line 1
```

The problem is that when a string contains two consecutive backslashes, it should be expanded to 4 to be correctly interpreted.
