### PR TITLE
Update PHPUnit/Framework/TestSuite.php

### DIFF
--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -650,6 +650,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             $this->setUp();
 
             if ($this->testCase &&
+                is_callable($this->name) &&
                 method_exists($this->name, 'setUpBeforeClass')) {
                 call_user_func(array($this->name, 'setUpBeforeClass'));
             }
@@ -736,6 +737,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         }
 
         if ($this->testCase &&
+            is_callable($this->name) &&
             method_exists($this->name, 'tearDownAfterClass')) {
             call_user_func(array($this->name, 'tearDownAfterClass'));
         }


### PR DESCRIPTION
Fixing this so that the PHP will not display Warnings when running tests. Example warning:

Warning: include(MenuEditorTest: .php): failed to open stream: No such file or directory in /usr/share/php/yii-1.1.10/framework/YiiBase.php on line 418

Call Stack:
    0.0012     329104   1. {main}() /Applications/XAMPP/xamppfiles/bin/phpunit:0
    0.0084     716348   2. PHPUnit_TextUI_Command::main() /Applications/XAMPP/xamppfiles/bin/phpunit:46
    0.0084     716748   3. PHPUnit_TextUI_Command->run() /Applications/XAMPP/xamppfiles/lib/php/pear/PHPUnit/TextUI/Command.php:130
    0.1605    6161068   4. PHPUnit_TextUI_TestRunner->doRun() /Applications/XAMPP/xamppfiles/lib/php/pear/PHPUnit/TextUI/Command.php:192
    0.1663    6472564   5. PHPUnit_Framework_TestSuite->run() /Applications/XAMPP/xamppfiles/lib/php/pear/PHPUnit/TextUI/TestRunner.php:325
    0.1665    6472836   6. PHPUnit_Framework_TestSuite->run() /Applications/XAMPP/xamppfiles/lib/php/pear/PHPUnit/Framework/TestSuite.php:705
   59.7726   12996444   7. method_exists() /Applications/XAMPP/xamppfiles/lib/php/pear/PHPUnit/Framework/TestSuite.php:752
   59.7730   12996660   8. YiiBase::autoload() /Applications/XAMPP/xamppfiles/lib/php/pear/PHPUnit/Framework/TestSuite.php:0
