### PR TITLE
Handle reflected param names for variable length arguments

### DIFF
--- a/PHPUnit/Util/Class.php
+++ b/PHPUnit/Util/Class.php
@@ -138,8 +138,11 @@ class PHPUnit_Util_Class
         foreach ($method->getParameters() as $i => $parameter) {
             $name = '$' . $parameter->getName();
 
-            if ($name === '$') {
-                $name .= 'arg' . $i;
+            /* Note: PHP extensions may use empty names for reference arguments
+             * or "..." for methods taking a variable number of arguments.
+             */
+            if ($name === '$' || $name === '$...') {
+                $name = '$arg' . $i;
             }
 
             $default   = '';


### PR DESCRIPTION
The existing code handled cases where a PHP extension declared an argument for the reflection API without providing a name (typically done for referenced arguments). Also handle the case where the name it provides is "..." (i.e. variable arguments), as that would break mock object generation.

See: http://php.net/manual/en/language.pseudo-types.php

---

This came up as I was attempting to Mock the [MongoCollection::aggregate()](http://php.net/manual/en/mongocollection.aggregate.php) method, which uses the convention for defining variable length arguments. I'm aware the docs currently use `$..` as the name instead of the `$...` convention -- that was an oversight, which is being changed.
