### PR TITLE
Time Threshold Annotation

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -604,8 +604,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
     /**
      * Initializes Thresholds from Annotations
-     * 
-     * @since Method available since Release 3.7.0
      */
     protected function setThresholdsFromAnnotation()
     {
@@ -621,8 +619,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
     /**
      * Starts Timers for Thresholds
-     * 
-     * @since  Method available since Release 3.6.0
      */
     protected function setUpThresholds() 
     {
@@ -634,8 +630,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
     /**
      * Asserts if Thresholds have exceeded
-     * 
-     * @since Method available since Release 3.6.1
      */
     protected function assertThresholds() 
     {

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -202,6 +202,16 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     );
 
     /**
+     * The time thresholds for a test.
+     *
+     * @var array
+     */
+    private $threshold = array(
+        'class' => 0,
+        'method' => 0
+    );
+
+    /**
      * The name of the test case.
      *
      * @var string
@@ -287,6 +297,20 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * @var boolean
      */
     private $outputBufferingActive = FALSE;
+
+    /**
+     * Time method test started
+     * 
+     * @var float
+     */
+    private $startTimeMethod;
+
+    /**
+     * Time class test started
+     *
+     * @var float
+     */
+    private static $startTimeClass;
 
     /**
      * Constructs a test case with the given name.
@@ -579,6 +603,59 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * Initializes Thresholds from Annotations
+     * 
+     * @since Method available since Release 3.7.0
+     */
+    protected function setThresholdsFromAnnotation()
+    {
+        try {
+            $this->thresholds = PHPUnit_Util_Test::getThresholds(
+              get_class($this), $this->name
+            );
+        }
+
+        catch (ReflectionException $e) {
+        }
+    }
+
+    /**
+     * Starts Timers for Thresholds
+     * 
+     * @since  Method available since Release 3.6.0
+     */
+    protected function setUpThresholds() 
+    {
+        if (!isset(self::$startTimeClass)) {
+            self::$startTimeClass = microtime(true);
+        }
+        $this->startTimeMethod = microtime(true);
+    }
+
+    /**
+     * Asserts if Thresholds have exceeded
+     * 
+     * @since Method available since Release 3.6.1
+     */
+    protected function assertThresholds() 
+    {
+        $this->setThresholdsFromAnnotation();
+        
+        $endTime = microtime(true);
+     
+        $elapsedTimeMethod = $endTime - $this->startTimeMethod;
+        $elapsedTimeClass = $endTime - self::$startTimeClass;
+        
+        if ($this->thresholds['class'] > 0) {
+            $this->assertLessThan($this->thresholds['class'], $elapsedTimeClass, 'Class Time Threshold Exceeded');
+        }
+
+        if ($this->thresholds['method'] > 0) {
+            $this->assertLessThan($this->thresholds['method'], $elapsedTimeMethod, 'Method Time Threshold Exceeded');
+        }
+    }
+
+    /**
      * @since Method available since Release 3.6.0
      */
     protected function checkRequirements()
@@ -822,7 +899,9 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $this->setUp();
             $this->checkRequirements();
             $this->assertPreConditions();
+            $this->setUpThresholds();
             $this->testResult = $this->runTest();
+            $this->assertThresholds();
             $this->verifyMockObjects();
             $this->assertPostConditions();
             $this->status = PHPUnit_Runner_BaseTestRunner::STATUS_PASSED;

--- a/PHPUnit/Util/Test.php
+++ b/PHPUnit/Util/Test.php
@@ -355,6 +355,37 @@ class PHPUnit_Util_Test
     }
 
     /**
+     * Returns the thresholds for a test class and method.
+     *
+     * @param  string $className
+     * @param  string $methodName
+     * @return array
+     * @since  Method available since Release 3.7.0
+     */
+    public static function getThresholds($className, $methodName)
+    {
+        $annotations = self::parseTestMethodAnnotations(
+          $className, $methodName
+        );
+
+        $thresholds = array(
+            'class' => 0,
+            'method' => 0
+        );
+        
+        // @note By using array_sum, we convert any non-numeric numbers into 0
+        if (isset($annotations['class']['threshold'])) {
+            $thresholds['class'] = array_sum($annotations['class']['threshold']);
+        }
+
+        if (isset($annotations['method']['threshold'])) {
+            $thresholds['method'] = array_sum($annotations['method']['threshold']);
+        }
+
+        return $thresholds;
+    }
+
+    /**
      * Returns the dependencies for a test class or method.
      *
      * @param  string $className

--- a/PHPUnit/Util/Test.php
+++ b/PHPUnit/Util/Test.php
@@ -360,7 +360,6 @@ class PHPUnit_Util_Test
      * @param  string $className
      * @param  string $methodName
      * @return array
-     * @since  Method available since Release 3.7.0
      */
     public static function getThresholds($className, $methodName)
     {

--- a/Tests/Framework/TestCaseTest.php
+++ b/Tests/Framework/TestCaseTest.php
@@ -58,6 +58,8 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ThrowNoExceptionTestCase.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'WasRun.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ChangeCurrentWorkingDirectoryTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ThresholdClassTestCase.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ThresholdMethodTestCase.php';
 
 $GLOBALS['a']  = 'a';
 $_ENV['b']     = 'b';
@@ -233,6 +235,28 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, $result->failureCount());
         $this->assertEquals(1, count($result));
+    }
+
+    public function testMethodThreshold()
+    {
+        $test = new ThresholdMethodTestCase('test');
+        $result = $test->run();
+        
+        $this->assertEquals(1, count($result->failures()));
+        $failure = reset($result->failures());
+
+        $this->assertRegExp('/Method Time Threshold Exceeded\nFailed asserting that [\d.]+ is less than 0\.0001\./', $failure->exceptionMessage());
+    }
+
+    public function testClassThreshold()
+    {
+        $test = new ThresholdClassTestCase('test');
+        $result = $test->run();
+        
+        $this->assertEquals(1, count($result->failures()));
+        $failure = reset($result->failures());
+
+        $this->assertRegExp('/Class Time Threshold Exceeded\nFailed asserting that [\d.]+ is less than 0\.0001\./', $failure->exceptionMessage());
     }
 
     /**

--- a/Tests/Util/TestTest.php
+++ b/Tests/Util/TestTest.php
@@ -57,6 +57,7 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
  * @version    Release: @package_version@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release 3.3.6
+ * @threshold  42
  */
 class Util_TestTest extends PHPUnit_Framework_TestCase
 {
@@ -214,9 +215,18 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testParseThreshold()
+    {
+        $this->assertEquals(
+          array('class' => 42, 'method' => 15),
+          PHPUnit_Util_Test::getThresholds(get_class($this), 'methodForTestParseAnnotation')
+        );
+    }
+
     /**
      * @depends Foo
      * @depends ほげ
+     * @threshold 15
      */
     public function methodForTestParseAnnotation()
     {

--- a/Tests/_files/ThresholdClassTestCase.php
+++ b/Tests/_files/ThresholdClassTestCase.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @threshold 0.0001
+ */ 
+class ThresholdClassTestCase extends PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        usleep(2000);
+    }
+}

--- a/Tests/_files/ThresholdMethodTestCase.php
+++ b/Tests/_files/ThresholdMethodTestCase.php
@@ -1,0 +1,11 @@
+<?php
+class ThresholdMethodTestCase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @threshold 0.0001
+     */
+    public function test()
+    {
+        usleep(2000);
+    }
+}


### PR DESCRIPTION
Howdy!

Just looking to add method / class level time thresholds as an annotation.  

By this I mean being able to specify the maximum amount of time before a test is considered a failure.  We can use this to monitor when new changes cause drops in efficiency for time/speed sensitive applications.

``` php
/**
 * Some sort of test
 * @threshold 10
 */
public function longTest() {
  sleep(15);
}
```

Expected Exception:

> Method Time Threshold Exceeded
> Failed asserting that 15.02023 is less than 10.

I wasn't sure if this should be added at the `TestResult` layer (since time is already being stored and there is a generic timeout engine for s/m/l tests).  But I felt it would be more appropriate in the `TestCase` class as most annotation checks are done there. 

Let me know if you have any feedback.
