### PR TITLE
Use psr0 autoloading instead of requiring a bunch of phpunit files at every request

### DIFF
--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -373,6 +373,29 @@ class PHPUnit_Util_GlobalState
     public static function phpunitFiles()
     {
         if (self::$phpunitFiles === NULL) {
+            if (file_exists(dirname(__FILE__).'/../../../../autoload.php')) {
+                self::$phpunitFiles = array();
+                $prefixes = array(
+                    'PHPUnit_',
+                    'File_Iterator',
+                    'PHP_CodeCoverage',
+                    'PHP_Text',
+                    'PHP_Timer',
+                    'PHP_Token',
+                );
+
+                foreach (get_declared_classes() as $class) {
+                    foreach ($prefixes as $prefix) {
+                        if (0 === strpos($class, $prefix)) {
+                            $reflClass = new ReflectionClass($class);
+                            self::$phpunitFiles[] = $reflClass->getFileName();
+                        }
+                    }
+                }
+
+                return self::$phpunitFiles;
+            }
+
             self::$phpunitFiles = phpunit_autoload();
 
             if (function_exists('phpunit_mockobject_autoload')) {

--- a/composer.json
+++ b/composer.json
@@ -49,9 +49,9 @@
         "bin-dir": "bin"
     },
     "autoload": {
-        "files": [
-            "PHPUnit/Autoload.php"
-        ]
+        "psr-0": {
+            "PHPUnit_": ""
+        }
     },
     "include-path": [
         ""

--- a/package-composer.json
+++ b/package-composer.json
@@ -16,7 +16,9 @@
         "irc": "irc://irc.freenode.net/phpunit"
     },
     "autoload": {
-        "files": [ "PHPUnit/Autoload.php" ]
+        "psr-0": {
+            "PHPUnit_": ""
+        }
     },
     "include_path": [
         ""


### PR DESCRIPTION
This one is slightly problematic. 

Basically force-including PHPUnit/Autoload.php and similar files in satellite projects is not a good thing, because those register a lot of autoloaders, and require a few files already, which means if you have phpunit installed in your project, whenever you include the composer autoloader you end up loading a bunch of PHPUnit files you'll most likely not need.

So the solution is to switch to PSR-0 autoloading, which seems to work fine apart from PHPUnit_Util_GlobalState that calls phpunit_autoload() which fails obviously. So I attempted to workaround the issue by just returning phpunit files from the declared classes. I'm not sure however whether this is complete nor if it is an acceptable workaround since I'm not sure in which contexts this method is used. That said I don't see a better way to fix it apart from reworking the code a bit more so that the classmap used in phpunit_autoload() is available separately/individually in another file of the project.

If this solution should be accepted, the same change to composer.json should be applied to all satellite projects with their respective PSR-0 prefixes.
