### PR TITLE
Composer fixes: include path and branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,6 @@
             "role": "lead"
         }
     ],
-    "version": "3.7.0RC5",
-    "time": "2012-09-17",
     "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "irc": "irc://irc.freenode.net/phpunit"
@@ -42,8 +40,7 @@
         "ext-tokenizer": "*"
     },
     "bin": [
-        "composer/bin/phpunit",
-        "phpunit.bat"
+        "composer/bin/phpunit"
     ],
     "config": {
         "bin-dir": "bin"
@@ -53,7 +50,13 @@
             "PHPUnit/Autoload.php"
         ]
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.7.x-dev"
+        }
+    },
     "include-path": [
-        ""
+        "",
+        "../../symfony/yaml/"
     ]
 }

--- a/package-composer.json
+++ b/package-composer.json
@@ -19,10 +19,15 @@
         "files": [ "PHPUnit/Autoload.php" ]
     },
     "include_path": [
-        ""
+        "",
+        "../../symfony/yaml/"
     ],
     "bin": [
-        "composer/bin/phpunit",
-        "phpunit.bat"
-    ]
+        "composer/bin/phpunit"
+    ],
+    "branch-alias": {
+        "dev-master": "3.7.x-dev"
+    },
+    "version": false,
+    "time": false
 }


### PR DESCRIPTION
Updated the `package2composer` config file to reflect options in Conductor 1.0.4 (branch-alias, relying on Git for version and release date). Also added necessary include-path for local YAML, which I erroneously removed in the switch from Symfony1 YAML to Symfony2 YAML.
