### PR TITLE
Support git information in version display.

### DIFF
--- a/PHPUnit/Runner/Version.php
+++ b/PHPUnit/Runner/Version.php
@@ -57,6 +57,8 @@
  */
 class PHPUnit_Runner_Version
 {
+    const VERSION = '@package_version@';
+    
     /**
      * Returns the current version of PHPUnit.
      *
@@ -64,7 +66,7 @@ class PHPUnit_Runner_Version
      */
     public static function id()
     {
-        return '@package_version@';
+        return self::resolveVersionString();
     }
 
     /**
@@ -72,6 +74,35 @@ class PHPUnit_Runner_Version
      */
     public static function getVersionString()
     {
-        return 'PHPUnit @package_version@ by Sebastian Bergmann.';
+        return 'PHPUnit ' . self::resolveVersionString() . ' by Sebastian Bergmann.';
+    }
+    
+    /**
+     * Determine if version string has been set, or should be pulled from 
+     * git information.
+     * 
+     * @return string
+     */
+    public static function resolveVersionString()
+    {
+        if (self::VERSION != '@package_version@') {
+            // PEAR-installed
+            return self::VERSION;
+        }
+        
+        if (! is_dir(__DIR__ . '/../../.git')) {
+            // probably manually installed
+            return self::VERSION;
+        }
+        
+        $git = exec('which git');
+        if (empty($git)) {
+            // someone else's git repo left lying around
+            return self::VERSION;
+        }
+        
+        $cmd = escapeshellcmd("$git describe --tags");
+        $gitversion = exec($cmd);
+        return $gitversion;
     }
 }


### PR DESCRIPTION
As we discussed in #522 a few weeks ago, this patch allows display of the current git version in PHPUnit's version string.
- If installed via PEAR, the replaced `@package_version@` string will be used
- If running via git checkout, the current checkout will be displayed. For example, `PHPUnit 3.7.0-1-g47cb3be by Sebastian Bergmann.`
- If running via a composer installation, a tagged release will show the tag (same value as `@package_version@` from a PEAR install), and a "dev-master" checkout will show the git information.
- If `@package_version@` hasn't been replaced, but no git executable is found, use `@package_version@` anyway.

**still needed:** a `which git` equivalent for Windows platforms?
