### PR TITLE
Incompatibility with PHP_CodeCoverage 1.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -525,6 +525,8 @@
     <name>PHP_CodeCoverage</name>
     <channel>pear.phpunit.de</channel>
     <min>1.0.2</min>
+    <max>1.1.0</max>
+    <exclude>1.1.0</exclude>
    </package>
    <package>
     <name>PHP_Timer</name>


### PR DESCRIPTION
Using PHPUnit 3.5 with PHP_CodeCoverage 1.1 fails with the following error:

```
PHP Fatal error:  Call to undefined method PHP_CodeCoverage_Filter::getInstance() in /usr/bin/phpunit on line 39
```

Using a version less than 1.1 fixes this.
