### PR TITLE
Mimic Composer's formula for locating autoload.php

### DIFF
--- a/composer/bin/phpunit
+++ b/composer/bin/phpunit
@@ -36,7 +36,17 @@
  */
 define('PHPUnit_MAIN_METHOD', 'PHPUnit_TextUI_Command::main');
 
-// pull in vendor/autoload.php as defined by composer
-require __DIR__ .'/../../../../autoload.php';
+function includeIfExists($file)
+{
+    if (file_exists($file)) {
+        return include $file;
+    }
+}
+
+if ((!$loader = includeIfExists(__DIR__.'/../../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../../autoload.php'))) {
+    die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
+        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+        'php composer.phar install'.PHP_EOL);
+}
 
 PHPUnit_TextUI_Command::main();


### PR DESCRIPTION
The Composer bin's setup was only allowing the Composer bin to be run when it was installed as a dependency. This change will allow for someone to execute `composer/bin/phpunit` from a development version of phpunit in addition to it being installed as a dependency.

My preferred way to install phpunit via composer would be something like this:

```
composer create-project phpunit/phpunit ~/phpunit-3.7.1 '3.7.1'
```

This creates a fresh version of phpunit at version 3.7.1 and will allow me to create a symlink from `~/bin/phpunit-3.7.1` to `~/phpunit-3.7.1/composer/bin/phpunit`. This was not working prior to this fix.

There are of course many ways to do this. If there are objections to this exact implementation I'd be happy to take suggestions on how to change this so that it would be acceptable.

Super happy for the official support of Composer by phpunit. :)
