### PR TITLE
Deferred error handling

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -469,6 +469,17 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @param  mixed   $exceptionName
+     * @param  string  $exceptionMessage
+     * @param  integer $exceptionCode
+     */
+    public function setExpectedExceptionDeferred($exceptionName, $exceptionMessage = '', $exceptionCode = NULL)
+    {
+        $this->setExpectedException($exceptionName, $exceptionMessage, $exceptionCode);
+        PHPUnit_Util_ErrorHandler::setDeferred();
+    }
+
+    /**
      * @since  Method available since Release 3.4.0
      */
     protected function setExpectedExceptionFromAnnotation()
@@ -961,6 +972,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $this->fail($e->getMessage());
         }
 
+        $e = null;
         try {
             $testResult = $method->invokeArgs(
               $this, array_merge($this->data, $this->dependencyInput)
@@ -968,6 +980,14 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         }
 
         catch (Exception $e) {
+        }
+        if (!$e) {
+            $exceptionStack = PHPUnit_Util_ErrorHandler::getExceptionStack();
+            $e = reset($exceptionStack);
+        }
+        PHPUnit_Util_ErrorHandler::freeExceptionStack();
+        PHPUnit_Util_ErrorHandler::setDeferred(false);
+        if ($e) {
             $checkException = FALSE;
 
             if (is_string($this->expectedException)) {

--- a/PHPUnit/Util/ErrorHandler.php
+++ b/PHPUnit/Util/ErrorHandler.php
@@ -65,6 +65,8 @@ require_once 'PHPUnit/Framework/Error/Deprecated.php';
 class PHPUnit_Util_ErrorHandler
 {
     protected static $errorStack = array();
+    protected static $exceptionStack = array();
+    protected static $deferred = FALSE;
 
     /**
      * Returns the error stack.
@@ -74,6 +76,36 @@ class PHPUnit_Util_ErrorHandler
     public static function getErrorStack()
     {
         return self::$errorStack;
+    }
+
+    /**
+     * Returns the exception stack
+     *
+     * @return array
+     */
+    public static function getExceptionStack()
+    {
+        return self::$exceptionStack;
+    }
+
+    /**
+     * Frees the exception stack
+     *
+     * @return array
+     */
+    public static function freeExceptionStack()
+    {
+        self::$exceptionStack = array();
+    }
+
+    /**
+     * Defers throwing resulting exceptions
+     *
+     * @param bool $deferred
+     */
+    public static function setDeferred($deferred = TRUE)
+    {
+        self::$deferred = $deferred;
     }
 
     /**
@@ -128,6 +160,14 @@ class PHPUnit_Util_ErrorHandler
             $exception = 'PHPUnit_Framework_Error';
         }
 
-        throw new $exception($errstr, $errno, $errfile, $errline);
+        $Exception = new $exception($errstr, $errno, $errfile, $errline);
+        if (self::$deferred) {
+            self::$exceptionStack[] = $Exception;
+            return TRUE;
+        }
+
+        else {
+            throw $Exception;
+        }
     }
 }


### PR DESCRIPTION
When you write a functional test on a method that acquires a resource, does something that leads to a trigger_error(), and then releases the resource, PHPUnit_Util_ErrorHandler will convert the error to exception and throw it right where it happened, so the resource won't be released. If you want to assert whether error was triggered, you use setExpectedException(). But in this case the resource won't be released and test won't be isolated enough. 

I've implemented setExpectedExceptionDeferred() to continue execution in case of trigger_error(). 
