### PR TITLE
It's `phpunit-skelgen`, not `phpunit-skel` 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,6 +44,6 @@ PHPUnit 3.7.0
 * If no tests where executed, for example because of a `--filter`, PHPUnit now prints a "No tests executed" warning instead of "OK (0 tests...)".
 * It is possible again to expect the generic `Exception` class.
 * Removed `addUncoveredFilesFromWhitelist` configuration setting.
-* Removed deprecated `--skeleton-class` and `--skeleton-test` switches. The functionality is now provided by the `phpunit-skel` command of the `PHPUnit_SkeletonGenerator` package.
+* Removed deprecated `--skeleton-class` and `--skeleton-test` switches. The functionality is now provided by the `phpunit-skelgen` command of the `PHPUnit_SkeletonGenerator` package.
 * Removed deprecated `PHPUnit_Extensions_OutputTestCase` class.
 


### PR DESCRIPTION
This is a trivial update, but it might help prevent  someone in the world scratching their head. 

There is no `phpunit-skel` command, it is called `phpunit-skelgen`. I just installed from PEAR and here is a copy of my command-line output:

phpunit-skelgen --help
PHPUnit Skeleton Generator 1.1.0 by Sebastian Bergmann.

Usage: phpunit-skelgen --class ClassTest
...
