### PR TITLE
Implements XInclude support for phpunit.xml

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -188,7 +188,7 @@ class PHPUnit_Util_Configuration
     protected function __construct($filename)
     {
         $this->filename = $filename;
-        $this->document = PHPUnit_Util_XML::loadFile($filename);
+        $this->document = PHPUnit_Util_XML::loadFile($filename, FALSE, TRUE);
         $this->xpath    = new DOMXPath($this->document);
     }
 

--- a/Tests/Util/ConfigurationTest.php
+++ b/Tests/Util/ConfigurationTest.php
@@ -331,4 +331,59 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
           $this->configuration->getSeleniumBrowserConfiguration()
         );
     }
+
+    public function testXincludeInConfiguration()
+    {
+        $configurationWithXinclude = PHPUnit_Util_Configuration::getInstance(
+          dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration_xinclude.xml'
+        );
+
+        $this->assertConfigurationEquals(
+            $this->configuration,
+            $configurationWithXinclude
+        );
+    }
+
+    /**
+     * Asserts that the values in $actualConfiguration equal $expectedConfiguration.
+     *
+     * @param PHPUnit_Util_Configuration $expectedConfiguration
+     * @param PHPUnit_Util_Configuration $actualConfiguration
+     * @return void
+     */
+    protected function assertConfigurationEquals( PHPUnit_Util_Configuration $expectedConfiguration, PHPUnit_Util_Configuration $actualConfiguration )
+    {
+        $this->assertEquals(
+            $expectedConfiguration->getFilterConfiguration(),
+            $actualConfiguration->getFilterConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getGroupConfiguration(),
+            $actualConfiguration->getGroupConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getListenerConfiguration(),
+            $actualConfiguration->getListenerConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getLoggingConfiguration(),
+            $actualConfiguration->getLoggingConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getPHPConfiguration(),
+            $actualConfiguration->getPHPConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getPHPUnitConfiguration(),
+            $actualConfiguration->getPHPUnitConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getSeleniumBrowserConfiguration(),
+            $actualConfiguration->getSeleniumBrowserConfiguration()
+        );
+        $this->assertEquals(
+            $expectedConfiguration->getTestSuiteConfiguration(),
+            $actualConfiguration->getTestSuiteConfiguration()
+        );
+    }
 }

--- a/Tests/_files/configuration_xinclude.xml
+++ b/Tests/_files/configuration_xinclude.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<phpunit backupGlobals="true"
+         backupStaticAttributes="false"
+         bootstrap="/path/to/bootstrap.php"
+         cacheTokens="true"
+         colors="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         mapTestClassNameToCoveredClassName="false"
+         printerClass="PHPUnit_TextUI_ResultPrinter"
+         stopOnFailure="false"
+         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+         timeoutForSmallTests="1"
+         timeoutForMediumTests="10"
+         timeoutForLargeTests="60"
+         strict="false"
+		 verbose="false">
+		 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+			 href="configuration.xml"
+			 parse="xml"
+			 xpointer="xpointer(/phpunit/testsuites)" />
+
+  <groups>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+	  	href="configuration.xml"
+		parse="xml"
+		xpointer="xpointer(/phpunit/groups/*)" />
+  </groups>
+
+
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+	  href="configuration.xml"
+	  parse="xml"
+	  xpointer="xpointer(/phpunit/filter)" />
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+	  href="configuration.xml"
+	  parse="xml"
+	  xpointer="xpointer(/phpunit/listeners)" />
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+	  href="configuration.xml"
+	  parse="xml"
+	  xpointer="xpointer(/phpunit/logging)" />
+
+  <php>
+    <includePath>.</includePath>
+    <includePath>/path/to/lib</includePath>
+    <ini name="foo" value="bar"/>
+    <const name="FOO" value="false"/>
+    <const name="BAR" value="true"/>
+    <var name="foo" value="false"/>
+    <env name="foo" value="true"/>
+    <post name="foo" value="bar"/>
+    <get name="foo" value="bar"/>
+    <cookie name="foo" value="bar"/>
+    <server name="foo" value="bar"/>
+    <files name="foo" value="bar"/>
+    <request name="foo" value="bar"/>
+  </php>
+
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+	  href="configuration.xml"
+	  parse="xml"
+	  xpointer="xpointer(/phpunit/selenium)" />
+</phpunit>
+


### PR DESCRIPTION
Implements the possibility of using XInclude in phpunit.xml (see test fixture for usage). This can be especially useful, if you need to maintain multiple different test setups (e.g. against different databases, OS's, etc.) but want to have common parts of the configuration in a central place.
