### PR TITLE
Initial support of CSV coverage format.

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -79,6 +79,7 @@ class PHPUnit_TextUI_Command
       'bootstrap=' => NULL,
       'configuration=' => NULL,
       'coverage-html=' => NULL,
+      'coverage-csv=' => NULL,
       'coverage-clover=' => NULL,
       'coverage-php=' => NULL,
       'coverage-text==' => NULL,
@@ -265,6 +266,7 @@ class PHPUnit_TextUI_Command
                 }
                 break;
 
+                case '--coverage-csv':
                 case '--coverage-clover':
                 case '--coverage-html':
                 case '--coverage-php':
@@ -288,6 +290,11 @@ class PHPUnit_TextUI_Command
                     switch ($option[0]) {
                         case '--coverage-clover': {
                             $this->arguments['coverageClover'] = $option[1];
+                        }
+                        break;
+
+                        case '--coverage-csv': {
+                            $this->arguments['coverageCSV'] = $option[1];
                         }
                         break;
 
@@ -632,7 +639,7 @@ class PHPUnit_TextUI_Command
 
             $logging = $configuration->getLoggingConfiguration();
 
-            if (isset($logging['coverage-html']) || isset($logging['coverage-clover']) || isset($logging['coverage-text']) ) {
+            if (isset($logging['coverage-csv']) || isset($logging['coverage-html']) || isset($logging['coverage-clover']) || isset($logging['coverage-text']) ) {
                 if (!extension_loaded('tokenizer')) {
                     $this->showExtensionNotLoadedMessage(
                       'tokenizer', 'No code coverage will be generated.'
@@ -838,6 +845,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --log-tap <file>          Log test execution in TAP format to file.
   --log-json <file>         Log test execution in JSON format.
 
+  --coverage-csv <file>     Generate code coverage report in CSV format.
   --coverage-clover <file>  Generate code coverage report in Clover XML format.
   --coverage-html <dir>     Generate code coverage report in HTML format.
   --coverage-php <file>     Serialize PHP_CodeCoverage object to file.

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -265,6 +265,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($arguments['coverageText'])) {
                 $codeCoverageReports++;
             }
+
+            if (isset($arguments['coverageCSV'])) {
+                $codeCoverageReports++;
+            }
         }
 
         if ($codeCoverageReports > 0) {
@@ -416,6 +420,18 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 );
 
                 $writer->process($codeCoverage, $colors);
+            }
+
+            if (isset($arguments['coverageCSV'])) {
+                $this->printer->write(
+                    "\nGenerating code coverage report in CSV format ..."
+                );
+
+                $writer = new PHP_CodeCoverage_Report_CSV();
+                $writer->process($codeCoverage, $arguments['coverageCSV']);
+
+                $this->printer->write(" done\n");
+                unset($writer);
             }
         }
 
@@ -671,6 +687,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $arguments['coverageClover'] = $loggingConfiguration['coverage-clover'];
             }
 
+            if (isset($loggingConfiguration['coverage-csv']) &&
+                !isset($arguments['coverageCSV'])) {
+                $arguments['coverageCSV'] = $loggingConfiguration['coverage-csv'];
+            }
+
             if (isset($loggingConfiguration['coverage-php']) &&
                 !isset($arguments['coveragePHP'])) {
                 $arguments['coveragePHP'] = $loggingConfiguration['coverage-php'];
@@ -723,6 +744,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             }
 
             if ((isset($arguments['coverageClover']) ||
+                isset($arguments['coverageCSV']) ||
                 isset($arguments['reportDirectory']) ||
                 isset($arguments['coveragePHP']) ||
                 isset($arguments['coverageText'])) &&


### PR DESCRIPTION
Added support of `--coverage-csv` based on badoo/php-code-coverage@1d593c3c47f95d1e22d3773404a9164c0ffb8846
