### PR TITLE
Add value type information to InvalidArgumentException

### DIFF
--- a/PHPUnit/Util/InvalidArgumentHelper.php
+++ b/PHPUnit/Util/InvalidArgumentHelper.php
@@ -70,7 +70,7 @@ class PHPUnit_Util_InvalidArgumentHelper
           sprintf(
             'Argument #%d%sof %s::%s() must be a %s',
             $argument,
-            $value !== NULL ? ' (' . $value . ')' : ' ',
+            $value !== NULL ? ' (' . gettype($value) . '#' . $value . ')' : ' (No Value) ',
             $stack[1]['class'],
             $stack[1]['function'],
             $type


### PR DESCRIPTION
This would be slightly more useful when debugging certain issues, I could've identified unexpected issues easier if I was presented with this extra information.

The new exception message would look similar to this:

Argument #1 (valueType#value) of class::function() must be a type.

Or

Argument #1 (No Value) of class::function() must be a type.
