### PR TITLE
added coverage-text argument "showOnlySummary"

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -308,6 +308,7 @@ class PHPUnit_TextUI_Command
 
                             $this->arguments['coverageText'] = $option[1];
                             $this->arguments['coverageTextShowUncoveredFiles'] = FALSE;
+                            $this->arguments['coverageTextShowOnlySummary'] = FALSE;
                         }
                         break;
                     }

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -412,7 +412,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                   $outputStream,
                   $arguments['reportLowUpperBound'],
                   $arguments['reportHighLowerBound'],
-                  $arguments['coverageTextShowUncoveredFiles']
+                  $arguments['coverageTextShowUncoveredFiles'],
+                  $arguments['coverageTextShowOnlySummary']
                 );
 
                 $writer->process($codeCoverage, $colors);
@@ -683,6 +684,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     $arguments['coverageTextShowUncoveredFiles'] = $loggingConfiguration['coverageTextShowUncoveredFiles'];
                 } else {
                     $arguments['coverageTextShowUncoveredFiles'] = FALSE;
+                }
+                if (isset($loggingConfiguration['coverageTextShowOnlySummary'])) {
+                    $arguments['coverageTextShowOnlySummary'] = $loggingConfiguration['coverageTextShowOnlySummary'];
+                } else {
+                    $arguments['coverageTextShowOnlySummary'] = FALSE;
                 }
             }
 


### PR DESCRIPTION
This adds a new attribute "showOnlySummary" for usage in phpunit.xml, like so
`<log type="coverage-text"   target="php://stdout" showOnlySummary="true" />`

If true, only the 3-line summary is displayed and the detailed report is skipped.
If false (default), the full report is displayed.

This is inspired by http://ocramius.github.com/blog/automated-code-coverage-check-for-github-pull-requests-with-travis/

Maybe someone else finds the time to add colors to the summary indicating whether the coverage is at the accepted percentage (green) or below (red).

This is related to https://github.com/sebastianbergmann/php-code-coverage/pull/135
