### PR TITLE
callback() function does not pass $callback parameter

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -2376,6 +2376,7 @@ abstract class PHPUnit_Framework_Assert
     /**
      * Returns a PHPUnit_Framework_Constraint_Callback matcher object.
      *
+     * @param callable $callback
      * @return PHPUnit_Framework_Constraint_Callback
      */
     public static function callback($callback)

--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -1699,11 +1699,12 @@ function isTrue()
 /**
  * Returns a PHPUnit_Framework_Constraint_Callback matcher object.
  *
+ * @param callable $callback
  * @return PHPUnit_Framework_Constraint_Callback
  */
-function callback()
+function callback($callback)
 {
-    return PHPUnit_Framework_Assert::callback();
+    return PHPUnit_Framework_Assert::callback($callback);
 }
 
 /**

--- a/PHPUnit/Framework/Constraint/Callback.php
+++ b/PHPUnit/Framework/Constraint/Callback.php
@@ -58,7 +58,7 @@ class PHPUnit_Framework_Constraint_Callback extends PHPUnit_Framework_Constraint
     private $callback;
 
     /**
-     * @param callable $value
+     * @param callable $callback
      * @throws InvalidArgumentException
      */
     public function __construct($callback)


### PR DESCRIPTION
If you use the callback() function from PHPUnit/Framework/Functions.php as shortcut for PHPUnit_Framework_Assert::callback(), the test will fail with an error:

PHPUnit_Framework_Error_Warning : Missing argument 1 for PHPUnit_Framework_Assert::callback(), called in /path/to/phpunit/PHPUnit/Framework/Assert/Functions.php on line 1706

The problem is that this function simply does not pass the parameter. This pull request fixes this issue.
