### PR TITLE
assertInstanceOf does no longer trigger the autoloader

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -1165,7 +1165,7 @@ abstract class PHPUnit_Framework_Assert
     public static function assertInstanceOf($expected, $actual, $message = '')
     {
         if (is_string($expected)) {
-            if (class_exists($expected) || interface_exists($expected)) {
+            if (class_exists($expected, FALSE) || interface_exists($expected, FALSE)) {
                 $constraint = new PHPUnit_Framework_Constraint_IsInstanceOf(
                   $expected
                 );


### PR DESCRIPTION
assertInstanceOf caused side-effect of triggering the autoloader. this fix disables autoloading of classes and interfaces. 
