### PR TITLE
ClassExists - constraint for testing if a string is a registered class

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -84,6 +84,7 @@ spl_autoload_register(
             'phpunit_framework_constraint_arrayhaskey' => '/Framework/Constraint/ArrayHasKey.php',
             'phpunit_framework_constraint_attribute' => '/Framework/Constraint/Attribute.php',
             'phpunit_framework_constraint_callback' => '/Framework/Constraint/Callback.php',
+            'phpunit_framework_constraint_classexists' => '/Framework/Constraint/ClassExists.php',
             'phpunit_framework_constraint_classhasattribute' => '/Framework/Constraint/ClassHasAttribute.php',
             'phpunit_framework_constraint_classhasstaticattribute' => '/Framework/Constraint/ClassHasStaticAttribute.php',
             'phpunit_framework_constraint_composite' => '/Framework/Constraint/Composite.php',

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -923,6 +923,23 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts that a class exists in current scope
+     *
+     * @param  string $className
+     * @param  string $message
+     */
+    public static function assertClassExists($className, $message = '')
+    {
+        if (!is_string($className)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_ClassExists();
+
+        self::assertThat($className, $constraint, $message);
+    }
+
+    /**
      * Asserts that a class has a specified attribute.
      *
      * @param  string $attributeName
@@ -2561,6 +2578,16 @@ abstract class PHPUnit_Framework_Assert
           new PHPUnit_Framework_Constraint_IsEqual($value),
           new PHPUnit_Framework_Constraint_GreaterThan($value)
         );
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_ClassExists matcher object.
+     *
+     * @return PHPUnit_Framework_Constraint_ClassExists
+     */
+    public static function classExists()
+    {
+        return new PHPUnit_Framework_Constraint_ClassExists();
     }
 
     /**

--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -404,6 +404,17 @@ function assertAttributeSame($expected, $actualAttributeName, $actualClassOrObje
 }
 
 /**
+ * Asserts that a class exists in given scope
+ *
+ * @param string $className
+ * @param string $message
+ */
+function assertClassExists($className, $message = '')
+{
+    return PHPUnit_Framework_Assert::assertClassExists($className, $message);
+}
+
+/**
  * Asserts that a class has a specified attribute.
  *
  * @param  string $attributeName

--- a/PHPUnit/Framework/Constraint/ClassExists.php
+++ b/PHPUnit/Framework/Constraint/ClassExists.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2012, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Bernhard Schussek <bschussek@2bepublished.at>
+ * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.0.0
+ */
+
+/**
+ * Constraint that checks if a given classname exists
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Marek Kalnik <marekk@theodo.fr>
+ * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.0.0
+ */
+class PHPUnit_Framework_Constraint_ClassExists extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Evaluates the constraint for parameter $other. Returns TRUE if the
+     * constraint is met, FALSE otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return class_exists($other);
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'is a registered class in current scope';
+    }
+}

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -2127,6 +2127,24 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers            PHPUnit_Framework_Assert::assertClassExists
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertClassExistsThrowsException()
+    {
+        $this->assertClassExists(NULL);
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertClassExists
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertClassExistsThrowsException2()
+    {
+        $this->assertClassExists('foo');
+    }
+
+    /**
      * @covers            PHPUnit_Framework_Assert::assertClassHasAttribute
      * @expectedException PHPUnit_Framework_Exception
      */
@@ -2232,6 +2250,24 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     public function testAssertObjectNotHasAttributeThrowsException2()
     {
         $this->assertObjectNotHasAttribute('foo', NULL);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertClassExists
+     */
+    public function testClassExists()
+    {
+        $this->assertClassExists('stdClass');
+
+        try {
+            $this->assertClassExists('foo');
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
     }
 
     /**

--- a/Tests/Framework/ConstraintTest.php
+++ b/Tests/Framework/ConstraintTest.php
@@ -2022,6 +2022,64 @@ EOF
     }
 
     /**
+     * @covers PHPUnit_Framework_Constraint_ClassExists
+     * @covers PHPUnit_Framework_Assert::classExists
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintClassExists()
+    {
+        $constraint = PHPUnit_Framework_Assert::classExists();
+
+        $this->assertTrue($constraint->evaluate('stdClass', '', TRUE));
+        $this->assertFalse($constraint->evaluate('foo', '', TRUE));
+        $this->assertEquals('is a registered class in current scope', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('foo');
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+              <<<EOF
+Failed asserting that 'foo' is a registered class in current scope.
+
+EOF
+              ,
+              PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+        }
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_ClassExists
+     * @covers PHPUnit_Framework_Assert::classExists
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintClassExists2()
+    {
+        $constraint = PHPUnit_Framework_Assert::classExists();
+
+        try {
+            $constraint->evaluate('foo', 'custom message');
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+              <<<EOF
+custom message
+Failed asserting that 'foo' is a registered class in current scope.
+
+EOF
+              ,
+              PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+        }
+    }
+
+    /**
      * @covers PHPUnit_Framework_Constraint_ClassHasAttribute
      * @covers PHPUnit_Framework_Assert::classHasAttribute
      * @covers PHPUnit_Framework_Constraint::count


### PR DESCRIPTION
Mentionned in #716.

In some cases you need to check if a method returns a string that is a valid classname. One of these examples is a data_class option in Symfony2 forms.

It is possible to do it with a callback or constraints, but this would provide a shorthand method with a default error message and all other pros of real constraints.
