### PR TITLE
Fix wrong parameter exceptionFixed

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -78,7 +78,7 @@ abstract class PHPUnit_Framework_Assert
         }
         if (!(is_array($array) || $array instanceof ArrayAccess)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
-              1, 'array or ArrayAccess'
+              2, 'array or ArrayAccess'
             );
         }
 
@@ -104,7 +104,7 @@ abstract class PHPUnit_Framework_Assert
         }
         if (!(is_array($array) || $array instanceof ArrayAccess)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
-              1, 'array or ArrayAccess'
+              2, 'array or ArrayAccess'
             );
         }
 


### PR DESCRIPTION
Code was reporting wrong parameter position. Second parameter was reported as first.
