### PR TITLE
added a --no-colors option to the TextUI

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -76,6 +76,7 @@ class PHPUnit_TextUI_Command
      */
     protected $longOptions = array(
       'colors' => NULL,
+      'no-colors' => NULL,
       'bootstrap=' => NULL,
       'configuration=' => NULL,
       'coverage-html=' => NULL,
@@ -251,6 +252,11 @@ class PHPUnit_TextUI_Command
             switch ($option[0]) {
                 case '--colors': {
                     $this->arguments['colors'] = TRUE;
+                }
+                break;
+                
+                case '--no-colors': {
+                    $this->arguments['colors'] = FALSE;
                 }
                 break;
 
@@ -863,6 +869,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --testdox                 Report test execution progress in TestDox format.
 
   --colors                  Use colors in output.
+  --no-colors               Do not use colors in output.
   --stderr                  Write to STDERR instead of STDOUT.
   --stop-on-error           Stop execution upon first error.
   --stop-on-failure         Stop execution upon first error or failure.


### PR DESCRIPTION
i have the case, that my IDE is to stupid to see colored text. But my console is. So that i have in the phpunit.xml colors=true
but i want to temporarly disable it for the IDE.

In this case --no-colors for the call from the ide makes sense.

I had problems finding the test-cases for the configuration / arguments parsing. Maybe it helps anyways.

best regards
