### PR TITLE
Replace deprecated preg_replace() with /e with preg_replace_callback()

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -64,9 +64,12 @@ class PHPUnit_Util_XML
      */
     public static function prepareString($string)
     {
-        return preg_replace(
-          '([\\x00-\\x04\\x0b\\x0c\\x0e-\\x1f\\x7f])e',
-          'sprintf( "&#x%02x;", ord( "\\1" ) )',
+        return preg_replace_callback(
+          '([\\x00-\\x04\\x0b\\x0c\\x0e-\\x1f\\x7f])',
+          function ($matches)
+          {
+              return sprintf('&#x%02x;', ord($matches[1]));
+          },
           htmlspecialchars(
             PHPUnit_Util_String::convertToUtf8($string), ENT_COMPAT, 'UTF-8'
           )


### PR DESCRIPTION
PHP 5.5 generates an E_DEPRECATED when the /e modifier is used in a preg_replace() call. Since PHPUnit master requires PHP 5.4+ anyway, this can replaced with an anonymous function and preg_replace_callback().
