### PR TITLE
Allow to check identity for primitive type in `assertContains` and all assert that depends on `TraversableContains` class.

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -160,16 +160,18 @@ abstract class PHPUnit_Framework_Assert
      * @param  string  $message
      * @param  boolean $ignoreCase
      * @param  boolean $checkForObjectIdentity
+     * @param  boolean $checkForNonObjectIdentity
      * @since  Method available since Release 3.0.0
      */
-    public static function assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+    public static function assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
     {
         self::assertContains(
           $needle,
           self::readAttribute($haystackClassOrObject, $haystackAttributeName),
           $message,
           $ignoreCase,
-          $checkForObjectIdentity
+          $checkForObjectIdentity,
+          $checkForNonObjectIdentity
         );
     }
 
@@ -222,16 +224,18 @@ abstract class PHPUnit_Framework_Assert
      * @param  string  $message
      * @param  boolean $ignoreCase
      * @param  boolean $checkForObjectIdentity
+     * @param  boolean $checkForNonObjectIdentity
      * @since  Method available since Release 3.0.0
      */
-    public static function assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+    public static function assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
     {
         self::assertNotContains(
           $needle,
           self::readAttribute($haystackClassOrObject, $haystackAttributeName),
           $message,
           $ignoreCase,
-          $checkForObjectIdentity
+          $checkForObjectIdentity,
+          $checkForNonObjectIdentity
         );
     }
 

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -123,14 +123,15 @@ abstract class PHPUnit_Framework_Assert
      * @param  string  $message
      * @param  boolean $ignoreCase
      * @param  boolean $checkForObjectIdentity
+     * @param  boolean $checkForNonObjectIdentity
      * @since  Method available since Release 2.1.0
      */
-    public static function assertContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+    public static function assertContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
     {
         if (is_array($haystack) ||
             is_object($haystack) && $haystack instanceof Traversable) {
             $constraint = new PHPUnit_Framework_Constraint_TraversableContains(
-              $needle, $checkForObjectIdentity
+              $needle, $checkForObjectIdentity, $checkForNonObjectIdentity
             );
         }
 
@@ -180,15 +181,16 @@ abstract class PHPUnit_Framework_Assert
      * @param  string  $message
      * @param  boolean $ignoreCase
      * @param  boolean $checkForObjectIdentity
+     * @param  boolean $checkForNonObjectIdentity
      * @since  Method available since Release 2.1.0
      */
-    public static function assertNotContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+    public static function assertNotContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
     {
         if (is_array($haystack) ||
             is_object($haystack) && $haystack instanceof Traversable) {
             $constraint = new PHPUnit_Framework_Constraint_Not(
               new PHPUnit_Framework_Constraint_TraversableContains(
-                $needle, $checkForObjectIdentity
+                $needle, $checkForObjectIdentity, $checkForNonObjectIdentity
               )
             );
         }
@@ -2451,12 +2453,13 @@ abstract class PHPUnit_Framework_Assert
      *
      * @param  mixed   $value
      * @param  boolean $checkForObjectIdentity
+     * @param  boolean $checkForNonObjectIdentity
      * @return PHPUnit_Framework_Constraint_TraversableContains
      * @since  Method available since Release 3.0.0
      */
-    public static function contains($value, $checkForObjectIdentity = TRUE)
+    public static function contains($value, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
     {
-        return new PHPUnit_Framework_Constraint_TraversableContains($value, $checkForObjectIdentity);
+        return new PHPUnit_Framework_Constraint_TraversableContains($value, $checkForObjectIdentity, $checkForNonObjectIdentity);
     }
 
     /**

--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -114,11 +114,12 @@ function assertArrayNotHasKey($key, array $array, $message = '')
  * @param  string  $message
  * @param  boolean $ignoreCase
  * @param  boolean $checkForObjectIdentity
+ * @param  boolean $checkForNonObjectIdentity
  * @since  Method available since Release 3.0.0
  */
-function assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+function assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
 {
-    return PHPUnit_Framework_Assert::assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message, $ignoreCase, $checkForObjectIdentity);
+    return PHPUnit_Framework_Assert::assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
 }
 
 /**
@@ -277,11 +278,12 @@ function assertAttributeLessThanOrEqual($expected, $actualAttributeName, $actual
  * @param  string  $message
  * @param  boolean $ignoreCase
  * @param  boolean $checkForObjectIdentity
+ * @param  boolean $checkForNonObjectIdentity
  * @since  Method available since Release 3.0.0
  */
-function assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+function assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
 {
-    return PHPUnit_Framework_Assert::assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message, $ignoreCase, $checkForObjectIdentity);
+    return PHPUnit_Framework_Assert::assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
 }
 
 /**
@@ -463,11 +465,12 @@ function assertClassNotHasStaticAttribute($attributeName, $className, $message =
  * @param  string  $message
  * @param  boolean $ignoreCase
  * @param  boolean $checkForObjectIdentity
+ * @param  boolean $checkForNonObjectIdentity
  * @since  Method available since Release 2.1.0
  */
-function assertContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+function assertContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
 {
-    return PHPUnit_Framework_Assert::assertContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity);
+    return PHPUnit_Framework_Assert::assertContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
 }
 
 /**
@@ -771,11 +774,12 @@ function assertLessThanOrEqual($expected, $actual, $message = '')
  * @param  string  $message
  * @param  boolean $ignoreCase
  * @param  boolean $checkForObjectIdentity
+ * @param  boolean $checkForNonObjectIdentity
  * @since  Method available since Release 2.1.0
  */
-function assertNotContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE)
+function assertNotContains($needle, $haystack, $message = '', $ignoreCase = FALSE, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
 {
-    return PHPUnit_Framework_Assert::assertNotContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity);
+    return PHPUnit_Framework_Assert::assertNotContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
 }
 
 /**

--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -1541,12 +1541,13 @@ function classHasStaticAttribute($attributeName)
  *
  * @param  mixed   $value
  * @param  boolean $checkForObjectIdentity
+ * @param  boolean $checkForNonObjectIdentity
  * @return PHPUnit_Framework_Constraint_TraversableContains
  * @since  Method available since Release 3.0.0
  */
-function contains($value, $checkForObjectIdentity = TRUE)
+function contains($value, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
 {
-    return PHPUnit_Framework_Assert::contains($value, $checkForObjectIdentity);
+    return PHPUnit_Framework_Assert::contains($value, $checkForObjectIdentity, $checkForNonObjectIdentity);
 }
 
 /**

--- a/PHPUnit/Framework/Constraint/TraversableContains.php
+++ b/PHPUnit/Framework/Constraint/TraversableContains.php
@@ -65,16 +65,22 @@ class PHPUnit_Framework_Constraint_TraversableContains extends PHPUnit_Framework
     protected $checkForObjectIdentity;
 
     /**
+     * @var boolean
+     */
+    protected $checkForNonObjectIdentity;
+
+    /**
      * @var mixed
      */
     protected $value;
 
     /**
-     * @param  boolean $value
-     * @param  mixed   $checkForObjectIdentity
+     * @param  mixed $value
+     * @param  boolean $checkForObjectIdentity
+     * @param  boolean $checkForNonObjectIdentity
      * @throws PHPUnit_Framework_Exception
      */
-    public function __construct($value, $checkForObjectIdentity = TRUE)
+    public function __construct($value, $checkForObjectIdentity = TRUE, $checkForNonObjectIdentity = FALSE)
     {
         parent::__construct();
 
@@ -82,8 +88,13 @@ class PHPUnit_Framework_Constraint_TraversableContains extends PHPUnit_Framework
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'boolean');
         }
 
-        $this->checkForObjectIdentity = $checkForObjectIdentity;
-        $this->value                  = $value;
+        if (!is_bool($checkForNonObjectIdentity)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(3, 'boolean');
+        }
+
+        $this->checkForObjectIdentity    = $checkForObjectIdentity;
+        $this->checkForNonObjectIdentity = $checkForNonObjectIdentity;
+        $this->value                     = $value;
     }
 
     /**
@@ -110,7 +121,10 @@ class PHPUnit_Framework_Constraint_TraversableContains extends PHPUnit_Framework
             }
         } else {
             foreach ($other as $element) {
-                if ($element == $this->value) {
+                if (($this->checkForNonObjectIdentity &&
+                     $element === $this->value) ||
+                    (!$this->checkForNonObjectIdentity &&
+                     $element == $this->value)) {
                     return TRUE;
                 }
             }

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -152,6 +152,25 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         $this->fail();
     }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertContains
+     */
+    public function testAssertArrayContainsNonObject()
+    {
+        $this->assertContains('foo', array(TRUE));
+
+        try {
+            $this->assertContains('foo', array(TRUE), '', FALSE, TRUE, TRUE);
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
     /**
      * @covers PHPUnit_Framework_Assert::assertContainsOnlyInstancesOf
      */
@@ -434,6 +453,24 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertNotContains('foo', array('foo'));
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertNotContains
+     */
+    public function testAssertArrayNotContainsNonObject()
+    {
+        $this->assertNotContains('foo', array(TRUE), '', FALSE, TRUE, TRUE);
+
+        try {
+            $this->assertNotContains('foo', array(TRUE));
         }
 
         catch (PHPUnit_Framework_AssertionFailedError $e) {
@@ -1872,6 +1909,46 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertAttributeNotContains('baz', 'privateArray', $obj);
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertAttributeContains
+     */
+    public function testAssertAttributeContainsNonObject()
+    {
+        $obj = new ClassWithNonPublicAttributes;
+
+        $this->assertAttributeContains(TRUE, 'privateArray', $obj);
+
+        try {
+            $this->assertAttributeContains(TRUE, 'privateArray', $obj, '', FALSE, TRUE, TRUE);
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertAttributeNotContains
+     */
+    public function testAssertAttributeNotContainsNonObject()
+    {
+        $obj = new ClassWithNonPublicAttributes;
+
+        $this->assertAttributeNotContains(TRUE, 'privateArray', $obj, '', FALSE, TRUE, TRUE);
+
+        try {
+            $this->assertAttributeNotContains(TRUE, 'privateArray', $obj);
         }
 
         catch (PHPUnit_Framework_AssertionFailedError $e) {

--- a/Tests/Framework/ConstraintTest.php
+++ b/Tests/Framework/ConstraintTest.php
@@ -3073,6 +3073,24 @@ EOF
 
     /**
      * @covers PHPUnit_Framework_Constraint_TraversableContains
+     */
+    public function testConstraintArrayContainsCheckForObjectIdentity()
+    {
+        // Check for primitive type.
+        $constraint = new PHPUnit_Framework_Constraint_TraversableContains('foo', TRUE, TRUE);
+
+        $this->assertFalse($constraint->evaluate(array(0), '', TRUE));
+        $this->assertFalse($constraint->evaluate(array(TRUE), '', TRUE));
+
+        // Default case.
+        $constraint = new PHPUnit_Framework_Constraint_TraversableContains('foo');
+
+        $this->assertTrue($constraint->evaluate(array(0), '', TRUE));
+        $this->assertTrue($constraint->evaluate(array(TRUE), '', TRUE));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_TraversableContains
      * @covers PHPUnit_Framework_Constraint_Not
      * @covers PHPUnit_Framework_Assert::logicalNot
      * @covers PHPUnit_Framework_TestFailure::exceptionToString


### PR DESCRIPTION
This fixes #745. The correction is pretty basic. I just remove the `is_object` condition allowing now to use the `$checkForObjectIdentity` parameter whatever the type of the elements.
