### PR TITLE
Added function_exists('exec') in version detection

### DIFF
--- a/PHPUnit/Runner/Version.php
+++ b/PHPUnit/Runner/Version.php
@@ -69,7 +69,7 @@ class PHPUnit_Runner_Version
         if (self::$version === NULL) {
             self::$version = self::VERSION;
 
-            if (is_dir(dirname(dirname(__DIR__)) . '/.git')) {
+            if (is_dir(dirname(dirname(__DIR__)) . '/.git') && function_exists('exec')) {
                 $dir = getcwd();
                 chdir(__DIR__);
                 $version = exec('git describe --tags');


### PR DESCRIPTION
In some environments, exec() is disabled (disable_functions in php.ini), and then a warning is generated:

Warning: exec() has been disabled for security reasons in /data/phpunit/PHPUnit/Runner/Version.php on line 75
