### PR TITLE
Not automatically using the autoloader in GlobalState.php during class_exists

### DIFF
--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -406,7 +406,7 @@ class PHPUnit_Util_GlobalState
      */
     protected static function addDirectoryContainingClassToPHPUnitFilesList($className, $parent = 1)
     {
-        if (!class_exists($className)) {
+        if (!class_exists($className, false)) {
             return;
         }
 


### PR DESCRIPTION
We found this need because:
1. We do not have PHP_Invoker installed.
2. We have multiple autoloaders registered
3. When the class_exists was checking for "PHP_Invoker" it was
automatically trying to autoload it and failing in a way that fatally
ended our phpunit tests.
