### PR TITLE
Globales are defined too late in TestCaseMethod.tpl.dist

### DIFF
--- a/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
+++ b/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
@@ -38,9 +38,9 @@ function __phpunit_run_isolated_test()
     ob_start();
 }
 
+{globals}
 {constants}
 {included_files}
-{globals}
 
 if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
     require_once $GLOBALS['__PHPUNIT_BOOTSTRAP'];


### PR DESCRIPTION
Hi there,

I found out, that the 'TestCaseMethod.tpl.dist' file is first doing the includes and after that the globals are registered. This is bad, if you react on global variables (defined in the phpunit.xml config via <php><var /></php>) in the bootstrap; so they are not present, but they are without process-isolation!
The globals need to be defined first and after that the includes should be done, so the behaviour is like it is without process-isolation.

Kind regards,

Andy!
