### PR TITLE
Show stack trace for unexpected exceptions

### DIFF
--- a/PHPUnit/Framework/Constraint/Exception.php
+++ b/PHPUnit/Framework/Constraint/Exception.php
@@ -95,7 +95,8 @@ class PHPUnit_Framework_Constraint_Exception extends PHPUnit_Framework_Constrain
         if ($other !== NULL) {
             $message = '';
             if ($other instanceof Exception && $other->getMessage()) {
-                $message = '. Message was: "' . $other->getMessage() . '"';
+                $message = '. Message was: "' . $other->getMessage() . '" at'
+                        . "\n" . $other->getTraceAsString();
             }
             return sprintf(
               'exception of type "%s" matches expected exception "%s"%s',

--- a/PHPUnit/Framework/Constraint/Exception.php
+++ b/PHPUnit/Framework/Constraint/Exception.php
@@ -94,7 +94,7 @@ class PHPUnit_Framework_Constraint_Exception extends PHPUnit_Framework_Constrain
     {
         if ($other !== NULL) {
             $message = '';
-            if ($other instanceof Exception && $other->getMessage()) {
+            if ($other instanceof Exception) {
                 $message = '. Message was: "' . $other->getMessage() . '" at'
                         . "\n" . $other->getTraceAsString();
             }

--- a/Tests/Framework/ConstraintTest.php
+++ b/Tests/Framework/ConstraintTest.php
@@ -45,6 +45,7 @@
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ClassWithNonPublicAttributes.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'TestIterator.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DummyException.php';
 
 /**
  *
@@ -3544,6 +3545,37 @@ Failed asserting that actual size 2 does not match expected size 2.
 EOF
               ,
               PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_Exception
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintException()
+    {
+        $constraint = new PHPUnit_Framework_Constraint_Exception('FoobarException');
+        $exception = new DummyException('Test');
+        $stackTrace = $exception->getTraceAsString();
+
+        try {
+            $constraint->evaluate($exception);
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+              <<<EOF
+Failed asserting that exception of type "DummyException" matches expected exception "FoobarException". Message was: "Test" at
+$stackTrace.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
             );
 
             return;

--- a/Tests/_files/DummyException.php
+++ b/Tests/_files/DummyException.php
@@ -1,0 +1,5 @@
+<?php
+
+class DummyException extends Exception
+{
+}


### PR DESCRIPTION
One thing that always bugged me when using the @expectedException annotation was that if an exception occurs that is not matched by the annotation, no detailed information about that exception is passed out. While @edorian recently added the exception message to the output, I think having an actual stack trace is still better than that, so here's my proposal to improve it.
