### PR TITLE
Fix broken tests

### DIFF
--- a/Tests/TextUI/abstract-test-class.phpt
+++ b/Tests/TextUI/abstract-test-class.phpt
@@ -2,7 +2,6 @@
 phpunit AbstractTest ../_files/AbstractTest.php
 --FILE--
 <?php
-define('PHPUNIT_TESTSUITE', TRUE);
 
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = 'AbstractTest';

--- a/Tests/TextUI/fatal-isolation.phpt
+++ b/Tests/TextUI/fatal-isolation.phpt
@@ -21,14 +21,8 @@ Time: %i %s, Memory: %sMb
 There was 1 error:
 
 1) FatalTest::testFatalError
-PHPUnit_Framework_Exception: Fatal error: Call to undefined function non_existing_function() in %s
+PHPUnit_Framework_Exception: PHP Fatal error:  Call to undefined function non_existing_function() in %s
 
-%s:%i
-
-Caused by
-ErrorException: unserialize(): Error at offset %i of %i bytes
-
-%s:%i
 
 FAILURES!
 Tests: 1, Assertions: 0, Errors: 1.


### PR DESCRIPTION
I've worked on Issue #657, when found that 2 tests in 3.7 doesn't work (checked on ubuntu 32bit, php 5.3.10 & 5.4.6):

```
$ git branch
* 3.7
  master
$ ./run_tests
PHPUnit 3.7.10-4-ga0bccf3 by Sebastian Bergmann.

Configuration read from /home/ilya/projects/pu/phpunit.orig/phpunit.xml

[...progress cut...]

Time: 8 seconds, Memory: 18.50Mb

There were 2 failures:

1) /home/ilya/projects/pu/phpunit.orig/Tests/TextUI/abstract-test-class.phpt
--- Expected
+++ Actual
@@ @@
-PHPUnit %s by Sebastian Bergmann.
+PHPUnit 3.7.10-4-ga0bccf3 by Sebastian Bergmann.

 F

-Time: %i %s, Memory: %sMb
+Time: 0 seconds, Memory: 3.50Mb

@@ @@

+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/Assert.php:2744
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/Warning.php:103
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestCase.php:824
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestResult.php:648
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestCase.php:769
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:775
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:745
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/TestRunner.php:346
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:176
+/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:129

 FAILURES!
 Tests: 1, Assertions: 0, Failures: 1.

/home/ilya/projects/pu/phpunit.orig/PHPUnit/Extensions/PhptTestCase.php:209
/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:775
/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:745
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/TestRunner.php:346
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:176
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:129

2) /home/ilya/projects/pu/phpunit.orig/Tests/TextUI/fatal-isolation.phpt
--- Expected
+++ Actual
@@ @@
-PHPUnit %s by Sebastian Bergmann.
+PHPUnit 3.7.10-4-ga0bccf3 by Sebastian Bergmann.

 E

-Time: %i %s, Memory: %sMb
+Time: 0 seconds, Memory: 5.00Mb

 There was 1 error:

 1) FatalTest::testFatalError
-PHPUnit_Framework_Exception: Fatal error: Call to undefined function non_existing_function() in %s
+PHPUnit_Framework_Exception: PHP Fatal error:  Call to undefined function non_existing_function() in /home/ilya/projects/pu/phpunit.orig/Tests/_files/FatalTest.php on line 7
+PHP Stack trace:
+PHP   1. {main}() -:0
+PHP   2. __phpunit_run_isolated_test() -:82
+PHP   3. PHPUnit_Framework_TestCase->run() -:26
+PHP   4. PHPUnit_Framework_TestResult->run() /home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestCase.php:769
+PHP   5. PHPUnit_Framework_TestCase->runBare() /home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestResult.php:648
+PHP   6. PHPUnit_Framework_TestCase->runTest() /home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestCase.php:824
+PHP   7. ReflectionMethod->invokeArgs() /home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestCase.php:969
+PHP   8. FatalTest->testFatalError() /home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestCase.php:969

-%s:%i
-
-Caused by
-ErrorException: unserialize(): Error at offset %i of %i bytes
-
-%s:%i

 FAILURES!
 Tests: 1, Assertions: 0, Errors: 1.

/home/ilya/projects/pu/phpunit.orig/PHPUnit/Extensions/PhptTestCase.php:209
/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:775
/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:745
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/TestRunner.php:346
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:176
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:129

There was 1 skipped test:

1) /home/ilya/projects/pu/phpunit.orig/Tests/TextUI/log-json.phpt

/home/ilya/projects/pu/phpunit.orig/PHPUnit/Extensions/PhptTestCase.php:200
/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:775
/home/ilya/projects/pu/phpunit.orig/PHPUnit/Framework/TestSuite.php:745
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/TestRunner.php:346
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:176
/home/ilya/projects/pu/phpunit.orig/PHPUnit/TextUI/Command.php:129

FAILURES!
Tests: 938, Assertions: 1522, Failures: 2, Skipped: 1.
```

Please check my fix.
