### PR TITLE
Fixes GH-765

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -692,7 +692,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $result->convertErrorsToExceptions($this->useErrorHandler);
         }
 
-        if (!$this->handleDependencies()) {
+        if (!$this instanceof PHPUnit_Framework_Warning && !$this->handleDependencies()) {
             return;
         }
 

--- a/Tests/Regression/GitHub/765.phpt
+++ b/Tests/Regression/GitHub/765.phpt
@@ -1,0 +1,28 @@
+--TEST--
+GH-765: Fatal error triggered in PHPUnit when exception is thrown in data provider of a test with a dependency
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue765Test';
+$_SERVER['argv'][3] = dirname(__FILE__).'/765/Issue765Test.php';
+
+require_once dirname(dirname(dirname(dirname(__FILE__)))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.F
+
+Time: %i %s, Memory: %sMb
+
+There was 1 failure:
+
+1) Warning
+The data provider specified for Issue765Test::testDependent is invalid.
+
+
+FAILURES!
+Tests: 2, Assertions: 1, Failures: 1.
+

--- a/Tests/Regression/GitHub/765/Issue765Test.php
+++ b/Tests/Regression/GitHub/765/Issue765Test.php
@@ -1,0 +1,22 @@
+<?php
+class Issue765Test extends PHPUnit_Framework_TestCase
+{
+    public function testDependee()
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @depends testDependee
+     * @dataProvider dependentProvider
+     */
+    public function testDependent($a)
+    {
+        $this->assertTrue(true);
+    }
+
+    public function dependentProvider()
+    {
+        throw new Exception;
+    }
+}


### PR DESCRIPTION
Fixed fatal error triggered in PHPUnit when exception is thrown in data provider of a test with a dependency.
