### PR TITLE
Fix the fatal-isolation test on my environment.

### DIFF
--- a/Tests/TextUI/fatal-isolation.phpt
+++ b/Tests/TextUI/fatal-isolation.phpt
@@ -29,9 +29,6 @@ There was 1 error:
 1) FatalTest::testFatalError
 PHPUnit_Framework_Exception: %s error: Call to undefined function non_existing_function() in %s
 
-%s
-
-
 
 Caused by
 ErrorException: unserialize(): Error at offset %i of %i bytes


### PR DESCRIPTION
I'm not sure this is actually right, but the fatal-isolation test fails for me in PHP 5.5 with and without xdebug.

This seems to fix the issue, but I presume that %s was there for a reason.
