### PR TITLE
Handle recursive and repeated arrays more gracefully when exporting

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -175,6 +175,7 @@ spl_autoload_register(
             'phpunit_util_testdox_resultprinter_text' => '/Util/TestDox/ResultPrinter/Text.php',
             'phpunit_util_testsuiteiterator' => '/Util/TestSuiteIterator.php',
             'phpunit_util_type' => '/Util/Type.php',
+            'phpunit_util_type_exportcontext' => '/Util/Type/ExportContext.php',
             'phpunit_util_xml' => '/Util/XML.php'
           );
 

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -136,6 +136,10 @@ class PHPUnit_Util_Type
             if (preg_match('/[^\x09-\x0d\x20-\xff]/', $value)) {
                 return 'Binary String: 0x' . bin2hex($value);
             }
+
+            return "'" .
+                   str_replace(array("\r\n", "\n\r", "\r"), array("\n", "\n", "\n"), $value) .
+                   "'";
         }
 
         $whitespace = str_repeat(' ', 4 * $indentation);

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -150,9 +150,9 @@ class PHPUnit_Util_Type
             }
 
             $key = $processed->add($value);
-            $output = "\n{$whitespace}Array &$key\n$whitespace(\n";
+            $output = "Array &$key (\n";
             foreach ($value as $k => $v) {
-                $output .= "$whitespace    [$k] => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+                $output .= "$whitespace    '$k' => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
             return "$output$whitespace)\n";
         }
@@ -165,7 +165,7 @@ class PHPUnit_Util_Type
             }
 
             $hash = $processed->add($value);
-            $output = "\n$whitespace$class Object &$hash\n$whitespace(\n";
+            $output = "$class Object &$hash (\n";
             foreach (self::toArray($value) as $k => $v) {
                 $output .= "$whitespace    [$k] => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -156,7 +156,8 @@ class PHPUnit_Util_Type
             $key = $processed->add($value);
             $output = "Array &$key (\n";
             foreach ($value as $k => $v) {
-                $output .= "$whitespace    '$k' => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+                $k = self::export($k);
+                $output .= "$whitespace    $k => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
             return "$output$whitespace)";
         }
@@ -171,7 +172,8 @@ class PHPUnit_Util_Type
             $hash = $processed->add($value);
             $output = "$class Object &$hash (\n";
             foreach (self::toArray($value) as $k => $v) {
-                $output .= "$whitespace    '$k' => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+                $k = self::export($k);
+                $output .= "$whitespace    $k => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
 
             return "$output$whitespace)";

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -154,12 +154,18 @@ class PHPUnit_Util_Type
             }
 
             $key = $processed->add($value);
-            $output = "Array &$key (\n";
-            foreach ($value as $k => $v) {
-                $k = self::export($k);
-                $output .= "$whitespace    $k => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+            if (count($value) > 0) {
+                $output = "Array &$key (\n";
+
+                foreach ($value as $k => $v) {
+                    $k = self::export($k);
+                    $output .= "$whitespace    $k => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+                }
+
+                return "$output$whitespace)";
+            } else {
+                return "Array &$key ()";
             }
-            return "$output$whitespace)";
         }
 
         if (is_object($value)) {
@@ -170,13 +176,20 @@ class PHPUnit_Util_Type
             }
 
             $hash = $processed->add($value);
-            $output = "$class Object &$hash (\n";
-            foreach (self::toArray($value) as $k => $v) {
-                $k = self::export($k);
-                $output .= "$whitespace    $k => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+            $array = self::toArray($value);
+            if (count($array) > 0) {
+                $output = "$class Object &$hash (\n";
+
+                foreach ($array as $k => $v) {
+                    $k = self::export($k);
+                    $output .= "$whitespace    $k => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+                }
+
+                return "$output$whitespace)";
+            } else {
+                return "$class Object &$hash ()";
             }
 
-            return "$output$whitespace)";
         }
 
         return var_export($value, true);

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -171,7 +171,7 @@ class PHPUnit_Util_Type
             $hash = $processed->add($value);
             $output = "$class Object &$hash (\n";
             foreach (self::toArray($value) as $k => $v) {
-                $output .= "$whitespace    [$k] => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
+                $output .= "$whitespace    '$k' => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
 
             return "$output$whitespace)";

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -164,25 +164,10 @@ class PHPUnit_Util_Type
                 return "$class Object &$hash";
             }
 
-            $refl = new ReflectionObject($value);
-
             $hash = $processed->add($value);
             $output = "\n$whitespace$class Object &$hash\n$whitespace(\n";
-            foreach ($refl->getProperties() as $prop) {
-                $prop->setAccessible(true);
-                $key = $prop->getName();
-                if ($prop->isProtected()) {
-                    $key .= ':protected';
-                } elseif ($prop->isPrivate()) {
-                    $key .= ':private';
-                }
-
-                $propValue = $prop->getValue($value);
-                $output .= "$whitespace    [$key] => ".self::recursiveExport($propValue, $indentation + 1, $processed)."\n";
-
-                if (!$prop->isPublic()) {
-                    $prop->setAccessible(false);
-                }
+            foreach (self::toArray($value) as $k => $v) {
+                $output .= "$whitespace    [$k] => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
 
             return "$output$whitespace)\n";

--- a/PHPUnit/Util/Type.php
+++ b/PHPUnit/Util/Type.php
@@ -158,7 +158,7 @@ class PHPUnit_Util_Type
             foreach ($value as $k => $v) {
                 $output .= "$whitespace    '$k' => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
-            return "$output$whitespace)\n";
+            return "$output$whitespace)";
         }
 
         if (is_object($value)) {
@@ -174,7 +174,7 @@ class PHPUnit_Util_Type
                 $output .= "$whitespace    [$k] => ".self::recursiveExport($v, $indentation + 1, $processed)."\n";
             }
 
-            return "$output$whitespace)\n";
+            return "$output$whitespace)";
         }
 
         return var_export($value, true);

--- a/PHPUnit/Util/Type/ExportContext.php
+++ b/PHPUnit/Util/Type/ExportContext.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2012, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Util
+ * @author     Adam Harvey <aharvey@php.net>
+ * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.9.0
+ */
+
+/**
+ * A context containing previously rendered arrays and objects when recursively
+ * exporting a value.
+ *
+ * @package    PHPUnit
+ * @subpackage Util
+ * @author     Adam Harvey <aharvey@php.net>
+ * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.9.0
+ */
+class PHPUnit_Util_Type_ExportContext {
+    /**
+     * Previously seen arrays.
+     *
+     * @var array[] $arrays
+     */
+    protected $arrays;
+
+    /**
+     * Previously seen objects.
+     *
+     * @var SplObjectStorage $objects
+     */
+    protected $objects;
+
+    /** Initialises the context. */
+    public function __construct()
+    {
+        $this->arrays = [];
+        $this->objects = new SplObjectStorage;
+    }
+
+    /**
+     * Adds a value to the export context.
+     *
+     * @param mixed $value The value to add.
+     * @return mixed The ID of the stored value, either as a string or integer.
+     * @throws PHPUnit_Framework_Exception Thrown if $value is not an array or
+     *                                     object.
+     */
+    public function add(&$value)
+    {
+        if (is_array($value)) {
+            return $this->addArray($value);
+        } elseif (is_object($value)) {
+            return $this->addObject($value);
+        }
+
+        throw new PHPUnit_Framework_Exception('Only arrays and objects are supported');
+    }
+
+    /**
+     * Checks if the given value exists within the context.
+     *
+     * @param mixed $value The value to check.
+     * @return mixed The string or integer ID of the stored value if it has
+     *               already been seen, or boolean false if the value is not
+     *               stored.
+     * @throws PHPUnit_Framework_Exception Thrown if $value is not an array or
+     *                                     object.
+     */
+    public function contains(&$value)
+    {
+        if (is_array($value)) {
+            return $this->containsArray($value);
+        } elseif (is_object($value)) {
+            return $this->containsObject($value);
+        }
+
+        throw new PHPUnit_Framework_Exception('Only arrays and objects are supported');
+    }
+
+    /**
+     * Stores an array within the context.
+     *
+     * @param array $value The value to store.
+     * @return integer The internal ID of the array.
+     */
+    protected function addArray(array &$value)
+    {
+        if (($key = $this->containsArray($value)) !== false) {
+            return $key;
+        }
+
+        $this->arrays[] = &$value;
+        return count($this->arrays) - 1;
+    }
+
+    /**
+     * Stores an object within the context.
+     *
+     * @param object $value
+     * @return string The ID of the object.
+     */
+    protected function addObject($value)
+    {
+        if (!$this->objects->contains($value)) {
+            $this->objects->attach($value);
+        }
+
+        return spl_object_hash($value);
+    }
+
+    /**
+     * Checks if the given array exists within the context.
+     *
+     * @param array $value The array to check.
+     * @return mixed The integer ID of the array if it exists, or boolean false
+     *               otherwise.
+     */
+    protected function containsArray(array &$value)
+    {
+        $keys = array_keys($this->arrays, $value, true);
+        $gen = '_PHPUnit_Test_Key_'.hash('sha512', microtime(true));
+        foreach ($keys as $key) {
+            $this->arrays[$key][$gen] = $gen;
+            if (isset($value[$gen]) && $value[$gen] === $gen) {
+                unset($this->arrays[$key][$gen]);
+                return $key;
+            }
+            unset($this->arrays[$key][$gen]);
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the given object exists within the context.
+     *
+     * @param object $value The object to check.
+     * @return mixed The string ID of the object if it exists, or boolean false
+     *               otherwise.
+     */
+    protected function containsObject($value)
+    {
+        if ($this->objects->contains($value)) {
+            return spl_object_hash($value);
+        }
+
+        return false;
+    }
+}

--- a/PHPUnit/Util/Type/ExportContext.php
+++ b/PHPUnit/Util/Type/ExportContext.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit
  *
- * Copyright (c) 2001-2012, Sebastian Bergmann <sebastian@phpunit.de>.
+ * Copyright (c) 2001-2013, Sebastian Bergmann <sebastian@phpunit.de>.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -37,10 +37,10 @@
  * @package    PHPUnit
  * @subpackage Util
  * @author     Adam Harvey <aharvey@php.net>
- * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://www.phpunit.de/
- * @since      File available since Release 3.9.0
+ * @since      File available since Release 3.8.0
  */
 
 /**
@@ -50,10 +50,10 @@
  * @package    PHPUnit
  * @subpackage Util
  * @author     Adam Harvey <aharvey@php.net>
- * @copyright  2001-2012 Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://www.phpunit.de/
- * @since      Class available since Release 3.9.0
+ * @since      Class available since Release 3.8.0
  */
 class PHPUnit_Util_Type_ExportContext {
     /**

--- a/Tests/Framework/ConstraintTest.php
+++ b/Tests/Framework/ConstraintTest.php
@@ -737,6 +737,8 @@ EOF
         $storage1->attach($b);
         $storage2 = new SplObjectStorage;
         $storage2->attach($b);
+        $storage1hash = spl_object_hash($storage1);
+        $storage2hash = spl_object_hash($storage2);
 
         $dom1 = new DOMDocument;
         $dom1->preserveWhiteSpace = FALSE;
@@ -892,17 +894,17 @@ Failed asserting that two objects are equal.
 --- Expected
 +++ Actual
 @@ @@
- SplObjectStorage Object (
--    '$ahash' => Array (
--        'obj' => stdClass Object (
+-SplObjectStorage Object &$storage1hash (
+-    '$ahash' => Array &0 (
+-        'obj' => stdClass Object &$ahash (
 -            'foo' => 'bar'
 -        )
--        'inf' => null
--    )
-     '$bhash' => Array (
-         'obj' => stdClass Object ()
++SplObjectStorage Object &$storage2hash (
++    '$bhash' => Array &0 (
++        'obj' => stdClass Object &$bhash ()
          'inf' => null
      )
+-    '$bhash' => Array &0
  )
 
 EOF
@@ -1387,8 +1389,8 @@ EOF
         }
 
         catch (PHPUnit_Framework_ExpectationFailedException $e) {
-            $this->assertEquals(<<<EOF
-Failed asserting that stdClass Object () is of type "string".
+            $this->assertStringMatchesFormat(<<<EOF
+Failed asserting that stdClass Object &%x () is of type "string".
 
 EOF
               ,
@@ -1415,9 +1417,9 @@ EOF
         }
 
         catch (PHPUnit_Framework_ExpectationFailedException $e) {
-            $this->assertEquals(<<<EOF
+            $this->assertStringMatchesFormat(<<<EOF
 custom message
-Failed asserting that stdClass Object () is of type "string".
+Failed asserting that stdClass Object &%x () is of type "string".
 
 EOF
               ,
@@ -3193,7 +3195,7 @@ EOF
     {
         $object     = new StdClass;
         $constraint = new PHPUnit_Framework_Constraint_TraversableContains($object);
-        $this->assertEquals("contains stdClass Object ()", $constraint->toString());
+        $this->assertStringMatchesFormat("contains stdClass Object &%s ()", $constraint->toString());
 
         $storage = new SplObjectStorage;
         $this->assertFalse($constraint->evaluate($storage, '', TRUE));
@@ -3206,9 +3208,9 @@ EOF
         }
 
         catch (PHPUnit_Framework_ExpectationFailedException $e) {
-            $this->assertEquals(
+            $this->assertStringMatchesFormat(
               <<<EOF
-Failed asserting that an iterator contains stdClass Object ().
+Failed asserting that an iterator contains stdClass Object &%x ().
 
 EOF
               ,
@@ -3235,10 +3237,10 @@ EOF
         }
 
         catch (PHPUnit_Framework_ExpectationFailedException $e) {
-            $this->assertEquals(
+            $this->assertStringMatchesFormat(
               <<<EOF
 custom message
-Failed asserting that an iterator contains stdClass Object ().
+Failed asserting that an iterator contains stdClass Object &%x ().
 
 EOF
               ,

--- a/Tests/Util/TypeTest.php
+++ b/Tests/Util/TypeTest.php
@@ -126,10 +126,10 @@ long
 text'
 EOF
             ),
-            array(new stdClass, 'stdClass Object ()'),
+            array(new stdClass, 'stdClass Object &%x ()'),
             array($obj,
 <<<EOF
-stdClass Object (
+stdClass Object &%x (
     'null' => null
     'boolean' => true
     'integer' => 1
@@ -146,21 +146,21 @@ very
 very
 long
 text'
-    'object' => stdClass Object (
+    'object' => stdClass Object &%x (
         'foo' => 'bar'
     )
-    'objectagain' => stdClass Object (*RECURSION*)
-    'array' => Array (
+    'objectagain' => stdClass Object &%x
+    'array' => Array &%d (
         'foo' => 'bar'
     )
-    'self' => stdClass Object (*RECURSION*)
+    'self' => stdClass Object &%x
 )
 EOF
             ),
-            array(array(), 'Array ()'),
+            array(array(), 'Array &%d ()'),
             array($array,
 <<<EOF
-Array (
+Array &%d (
     0 => 0
     'null' => null
     'boolean' => true
@@ -178,14 +178,14 @@ very
 very
 long
 text'
-    'object' => stdClass Object (
+    'object' => stdClass Object &%x (
         'foo' => 'bar'
     )
-    'objectagain' => stdClass Object (*RECURSION*)
-    'array' => Array (
+    'objectagain' => stdClass Object &%x
+    'array' => Array &%d (
         'foo' => 'bar'
     )
-    'self' => Array (*RECURSION*)
+    'self' => Array &%d
 )
 EOF
             ),
@@ -213,7 +213,7 @@ EOF
      */
     public function testExport($value, $expected)
     {
-        $this->assertSame($expected, self::trimnl(PHPUnit_Util_Type::export($value)));
+        $this->assertStringMatchesFormat($expected, self::trimnl(PHPUnit_Util_Type::export($value)));
     }
 
     public function shortenedExportProvider()

--- a/package.xml
+++ b/package.xml
@@ -170,6 +170,9 @@
       <file baseinstalldir="/" name="NamePrettifier.php" role="php" />
       <file baseinstalldir="/" name="ResultPrinter.php" role="php" />
      </dir>
+     <dir name="Type">
+      <file baseinstalldir="/" name="ExportContext.php" role="php" />
+     </dir>
      <file baseinstalldir="/" name="Configuration.php" role="php" />
      <file baseinstalldir="/" name="DeprecatedFeature.php" role="php" />
      <file baseinstalldir="/" name="Diff.php" role="php" />


### PR DESCRIPTION
This PR largely replaces `PHPUnit_Util_Type::recursiveExport()` with a more robust implementation that doesn't rely on `print_r()` to detect array recursion.

Test suites that have heavily nested arrays don't seem to have recursion picked up completely reliably — this seems to particularly manifest itself when dealing with codebases that use Symfony 2 and Doctrine ORM, where the proxied entity objects often include recursed and repeated arrays. As a result, when an assertion fails and the data structure has to be exported, PHP typically runs out of memory while looping infinitely. (For example, my memory_limit is set to 8G. At the risk of invoking Bill Gates, that should be enough for anyone.)

This implementation uses a completely userland approach to detect array recursion, and keeps the list of previously seen arrays and objects in a new context object (which also uses SplObjectStorage for more efficient storage of the seen object set).

The output format of `recursiveExport()` has changed in this PR: arrays now include a numeric ID, and objects now include a hexadecimal hash from `spl_object_hash()`. The initial reference to an array or object will dump the entire array or object as it does now, while subsequent references will simply show the ID/hash.
