### PR TITLE
Fixes sebastianbergmann/phpunit-mock-objects#81.

### DIFF
--- a/PHPUnit/Util/Class.php
+++ b/PHPUnit/Util/Class.php
@@ -180,10 +180,10 @@ class PHPUnit_Util_Class
                 else if ($parameter->isOptional()) {
                     $default = ' = null';
                 }
+            }
 
-                if ($parameter->isPassedByReference()) {
-                    $reference = '&';
-                }
+            if ($parameter->isPassedByReference()) {
+                $reference = '&';
             }
 
             $parameters[] = $typeHint . $reference . $name . $default;


### PR DESCRIPTION
- Ensure that mock methods preserve pass-by-reference.
