### PR TITLE
Earlier declaration of $time in Util/PHP.php.

### DIFF
--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -222,8 +222,9 @@ abstract class PHPUnit_Util_PHP
      */
     protected function processChildResult(PHPUnit_Framework_Test $test, PHPUnit_Framework_TestResult $result, $stdout, $stderr)
     {
+        $time = 0;
+
         if (!empty($stderr)) {
-            $time = 0;
             $result->addError(
               $test,
               new PHPUnit_Framework_Exception(trim($stderr)), $time
@@ -239,7 +240,6 @@ abstract class PHPUnit_Util_PHP
                 restore_error_handler();
                 $childResult = FALSE;
 
-                $time = 0;
                 $result->addError(
                   $test, new PHPUnit_Framework_Exception(trim($stdout), 0, $e), $time
                 );


### PR DESCRIPTION
When running tests in strict mode, PHP complains about an undeclared `$time` variable at the end of the `processChildResult` function. Moving the `$time` initialisation at the top of the function fixes it.
