### PR TITLE
Fixes #710

### DIFF
--- a/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
+++ b/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
@@ -1,4 +1,5 @@
 <?php
+ini_set('display_errors', 1);
 set_include_path('{include_path}');
 require 'PHPUnit/Autoload.php';
 ob_start();


### PR DESCRIPTION
Ensure isolation tests display errors so they can be handled by the test runner.

To expand on the issue a little: one of the reasons to run tests in isolation is to test fatal errors (see [Tests/TextUI/fatal-isolation.phpt](https://github.com/sebastianbergmann/phpunit/blob/00f34086f6cdd9d9d5b1c6a3009c59dce783e4dc/Tests/TextUI/fatal-isolation.phpt)). Unfortunately, error printing can be disabled in `php.ini` which will hide the errors from the test runner (see #710). 

A pull request (#778) was accepted today that hides the notice described in #710, but it doesn't solve the underlying problem. In fact, your tests will appear to pass when they should fail (albeit for a different reason). If you set `display_errors=Off` in your `php.ini` and run [Tests/TextUI/fatal-isolation.phpt](https://github.com/sebastianbergmann/phpunit/blob/00f34086f6cdd9d9d5b1c6a3009c59dce783e4dc/Tests/TextUI/fatal-isolation.phpt), you can see this in action.

This PR should fix the problem.
