### PR TITLE
Fix wrong output message when invoking with --coverage-text switch

### DIFF
--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -370,9 +370,15 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             }
 
             if (isset($arguments['reportDirectory'])) {
-                $this->printer->write(
-                  "\nGenerating code coverage report in HTML format ..."
-                );
+                if (isset($arguments['coverageText'])) {
+                    $this->printer->write(
+                      "\nGenerating code coverage report in Text format ..."
+                    );
+                } else {
+                    $this->printer->write(
+                      "\nGenerating code coverage report in HTML format ..."
+                    );
+                }
 
                 $writer = new PHP_CodeCoverage_Report_HTML(
                   $arguments['reportCharset'],


### PR DESCRIPTION
When invoking `phpunit --coverage-text`, following output is shown:

```
...
Generating code coverage report in HTML format ... done
...
```

This commit modifies message to:

```
...
Generating code coverage report in Text format ... done
...
```

Fix could be optimized, but since I haven't found an official coding standards, I went with a safe approach :)
