### PR TITLE
Refactor bootstrap running test in separate process

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ PHPUnit 3.8.0
 * Implemented #758: Show a proper stack trace when @expectedException fails due to a unexcepted exception being thrown.
 * Implemented #711: `coverage-text` now has an XML `showOnlySummary` option.
 * Implemented #719: The `--stderr` flag now respects `--colors` and `--debug`.
+* Implemented #382: Added the `$options` parameter to `PHPUnit_Framework_TestCase::getMockFromWsdl()` for configuring the `SoapClient`.
 * A test will now fail in strict mode when it uses the `@covers` annotation and code that is not expected to be covered is executed.
 * Fixed #240: XML strings are escaped by removing invalid characters.
 * Fixed #261: `setUp()` and `setUpBeforeClass()` are run before filters are applied.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ This is the list of changes for the PHPUnit 3.8 release series.
 PHPUnit 3.8.0
 -------------
 
+* Implemented #838: Added a base test listener.
 * Implemented #835: Printers that extend `PHPUnit_TextUI_ResultPrinter` should have similar construction
 * Implemented #834: Added the `@requires OS` annotation.
 * Implemented #773: Recursive and repeated arrays are more gracefully when comparison differences are exported.

--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -88,6 +88,7 @@ spl_autoload_register(
             'phpunit_extensions_ticketlistener' => '/Extensions/TicketListener.php',
             'phpunit_framework_assert' => '/Framework/Assert.php',
             'phpunit_framework_assertionfailederror' => '/Framework/AssertionFailedError.php',
+            'phpunit_framework_basetestlistener' => '/Framework/BaseTestListener.php',
             'phpunit_framework_comparator' => '/Framework/Comparator.php',
             'phpunit_framework_comparator_array' => '/Framework/Comparator/Array.php',
             'phpunit_framework_comparator_domdocument' => '/Framework/Comparator/DOMDocument.php',

--- a/PHPUnit/Framework/BaseTestListener.php
+++ b/PHPUnit/Framework/BaseTestListener.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2013, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Giorgio Sironi <info@giorgiosironi.com>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.8.0
+ */
+
+/**
+ * An empty Listener that can be extended to implement TestListener
+ * with just a few lines of code.
+ * @see PHPUnit_Framework_TestListener for documentation on the API methods.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Giorgio Sironi<info@giorgiosironi.com>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.8.0
+ */
+class PHPUnit_Framework_BaseTestListener implements PHPUnit_Framework_TestListener
+{
+    public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+
+    public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time) {}
+
+    public function addIncompleteTest(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+
+    public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {}
+
+    public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {}
+
+    public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {}
+
+    public function startTest(PHPUnit_Framework_Test $test) {}
+
+    public function endTest(PHPUnit_Framework_Test $test, $time) {}
+}

--- a/PHPUnit/Framework/BaseTestListener.php
+++ b/PHPUnit/Framework/BaseTestListener.php
@@ -56,7 +56,7 @@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release 3.8.0
  */
-class PHPUnit_Framework_BaseTestListener implements PHPUnit_Framework_TestListener
+abstract class PHPUnit_Framework_BaseTestListener implements PHPUnit_Framework_TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time) {}
 

--- a/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
+++ b/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist
@@ -51,9 +51,9 @@ function __phpunit_run_isolated_test()
 {included_files}
 {globals}
 
-if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
-    require_once $GLOBALS['__PHPUNIT_BOOTSTRAP'];
-    unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
+$bootstrap = '{bootstrapPath}';
+if (!empty($bootstrap)) {
+    require_once $bootstrap;
 }
 
 __phpunit_run_isolated_test();

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -428,6 +428,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     /**
      * @param string $expectedRegex
      * @since Method available since Release 3.6.0
+     * @throws PHPUnit_Framework_Exception
      */
     public function expectOutputRegex($expectedRegex)
     {
@@ -992,6 +993,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * Override to run the test and assert its state.
      *
      * @return mixed
+     * @throws Exception|PHPUnit_Framework_Exception
      * @throws PHPUnit_Framework_Exception
      */
     protected function runTest()
@@ -1724,8 +1726,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     *
-     *
      * @param  mixed $value, ...
      * @return PHPUnit_Framework_MockObject_Stub_ConsecutiveCalls
      * @since  Method available since Release 3.0.0
@@ -1954,6 +1954,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      *
      * @param Exception $e
      * @since Method available since Release 3.4.0
+     * @throws Exception
      */
     protected function onNotSuccessfulTest(Exception $e)
     {

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -148,6 +148,18 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     private $inIsolation = FALSE;
 
     /**
+     * Whether or not the test running in a separate process should include the
+     * bootstrap registered in the PHPUnit configuration/command line switches.
+     *
+     * We are explicitly setting this value to false to preserve BC with test
+     * cases that are expecting old functionality of the bootstrap not being
+     * included if preserving global state is turned off.
+     *
+     * @var boolean
+     */
+    protected $includeBootstrap = FALSE;
+
+    /**
      * @var array
      */
     private $data = array();
@@ -744,6 +756,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $iniSettings   = '';
             }
 
+            if ($this->includeBootstrap) {
+                $bootstrapPath = PHPUnit_Util_GlobalState::getPhpUnitBootstrap();
+            } else {
+                $bootstrapPath = '';
+            }
+
             if ($result->getCollectCodeCoverageInformation()) {
                 $coverage = 'TRUE';
             } else {
@@ -786,7 +804,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 'include_path'                   => $includePath,
                 'included_files'                 => $includedFiles,
                 'iniSettings'                    => $iniSettings,
-                'strict'                         => $strict
+                'strict'                         => $strict,
+                'bootstrapPath'                  => $bootstrapPath
               )
             );
 
@@ -1176,6 +1195,14 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     {
         if (is_bool($inIsolation)) {
             $this->inIsolation = $inIsolation;
+        } else {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'boolean');
+        }
+    }
+
+    public function setIncludeBootstrap($includeBootstrap) {
+        if (is_bool($includeBootstrap)) {
+            $this->includeBootstrap = $includeBootstrap;
         } else {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'boolean');
         }

--- a/PHPUnit/Runner/Version.php
+++ b/PHPUnit/Runner/Version.php
@@ -56,6 +56,7 @@
  */
 class PHPUnit_Runner_Version
 {
+
     private static $version;
 
     /**

--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -442,4 +442,17 @@ class PHPUnit_Util_GlobalState
             self::$phpunitFiles[$file] = TRUE;
         }
     }
+
+    /**
+     * Returns $GLOBALS['__PHPUNIT_BOOTSTRAP'] or empty string if not set
+     *
+     * @return string
+     */
+    public static function getPhpUnitBootstrap() {
+        $bootstrap = '';
+        if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
+            $bootstrap = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
+        }
+        return $bootstrap;
+    }
 }

--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -908,7 +908,8 @@ class PHPUnit_Util_XML
         $result = '';
 
         foreach ($node->childNodes as $childNode) {
-            if ($childNode->nodeType === XML_TEXT_NODE) {
+            if ($childNode->nodeType === XML_TEXT_NODE ||
+                $childNode->nodeType === XML_CDATA_SECTION_NODE) {
                 $result .= trim($childNode->data) . ' ';
             } else {
                 $result .= self::getNodeText($childNode);

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -2848,6 +2848,29 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     /**
      * @covers PHPUnit_Framework_Assert::assertTag
      */
+    public function testAssertTagCdataContentTrue()
+    {
+        $matcher = array('tag' => 'script',
+                         'content' => 'alert(\'Hello, world!\');');
+        $this->assertTag($matcher, $this->html);
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertTag
+     * @expectedException PHPUnit_Framework_AssertionFailedError
+     */
+    public function testAssertTagCdataontentFalse()
+    {
+        $matcher = array('tag' => 'script',
+                         'content' => 'asdf');
+        $this->assertTag($matcher, $this->html);
+    }
+
+
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertTag
+     */
     public function testAssertTagAttributesTrueA()
     {
         $matcher = array('tag' => 'span',

--- a/Tests/Framework/BaseTestListenerTest.php
+++ b/Tests/Framework/BaseTestListenerTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2013, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @author     Giorgio Sironi <info@giorgiosironi.com>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.8.0
+ */
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Success.php';
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @author     Giorgio Sironi <info@giorgiosironi.com>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.8.0
+ */
+class Framework_BaseTestListenerTest extends PHPUnit_Framework_TestCase
+{
+    public function testEndEventsAreCounted()
+    {
+        $this->result = new PHPUnit_Framework_TestResult;
+        $listener = new Tests_Framework_BaseTestListenerSample();
+        $this->result->addListener($listener);
+        $test = new Success;
+        $test->run($this->result);
+
+        $this->assertEquals(1, $listener->endCount);
+    }
+}
+
+class Tests_Framework_BaseTestListenerSample extends PHPUnit_Framework_BaseTestListener
+{
+    public $endCount = 0;
+
+    public function endTest(PHPUnit_Framework_Test $test, $time)
+    {
+        $this->endCount++;
+    }
+}

--- a/Tests/Framework/BaseTestListenerTest.php
+++ b/Tests/Framework/BaseTestListenerTest.php
@@ -43,6 +43,7 @@
  */
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Success.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BaseTestListenerSample.php';
 
 /**
  *
@@ -59,21 +60,11 @@ class Framework_BaseTestListenerTest extends PHPUnit_Framework_TestCase
     public function testEndEventsAreCounted()
     {
         $this->result = new PHPUnit_Framework_TestResult;
-        $listener = new Tests_Framework_BaseTestListenerSample();
+        $listener = new BaseTestListenerSample();
         $this->result->addListener($listener);
         $test = new Success;
         $test->run($this->result);
 
         $this->assertEquals(1, $listener->endCount);
-    }
-}
-
-class Tests_Framework_BaseTestListenerSample extends PHPUnit_Framework_BaseTestListener
-{
-    public $endCount = 0;
-
-    public function endTest(PHPUnit_Framework_Test $test, $time)
-    {
-        $this->endCount++;
     }
 }

--- a/Tests/Framework/TestCaseTest.php
+++ b/Tests/Framework/TestCaseTest.php
@@ -58,6 +58,8 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ThrowNoExceptionTestCase.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'WasRun.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ChangeCurrentWorkingDirectoryTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'PreserveGlobalStateTestCase.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DoNotPreserveGlobalStateTestCase.php';
 
 $GLOBALS['a']  = 'a';
 $_ENV['b']     = 'b';
@@ -454,6 +456,40 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $test->run();
 
         $this->assertSame($expectedCwd, getcwd());
+    }
+
+    public function testPreservingGlobalStateTemplateHasBootstrapPathWhenConfigured()
+    {
+        $test = new PreserveGlobalStateTestCase();
+
+        $GLOBALS['__PHPUNIT_BOOTSTRAP'] = 'known_path/preserving_globals';
+        $test->setIncludeBootstrap(TRUE);
+        $test->run();
+
+        $template = $test->getTemplate();
+        $this->assertInstanceOf('Text_Template', $template);
+        $values = self::getObjectAttribute($template, 'values');
+        $this->assertArrayHasKey('bootstrapPath', $values);
+        $path = $values['bootstrapPath'];
+        $expected = 'known_path/preserving_globals';
+        $this->assertSame($expected, $path);
+    }
+
+    public function testNotPreservingGlobalStateTemplateHasBootstrapPathWhenConfigured()
+    {
+        $test = new DoNotPreserveGlobalStateTestCase();
+
+        $GLOBALS['__PHPUNIT_BOOTSTRAP'] = 'known_path/not_preserving_globals';
+        $test->setIncludeBootstrap(TRUE);
+        $test->run();
+
+        $template = $test->getTemplate();
+        $this->assertInstanceOf('Text_Template', $template);
+        $values = self::getObjectAttribute($template, 'values');
+        $this->assertArrayHasKey('bootstrapPath', $values);
+        $path = $values['bootstrapPath'];
+        $expected = 'known_path/not_preserving_globals';
+        $this->assertSame($expected, $path);
     }
 
 }

--- a/Tests/Regression/GitHub/797.phpt
+++ b/Tests/Regression/GitHub/797.phpt
@@ -1,0 +1,20 @@
+--TEST--
+#797: assert bootstraps included in code running in separate process
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][4] = '--process-isolation';
+$_SERVER['argv'][5] = 'Issue797Test';
+$_SERVER['argv'][6] = dirname(__FILE__).'/797/Issue797Test.php';
+
+require_once dirname(dirname(dirname(dirname(__FILE__)))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %i %s, Memory: %sMb
+
+OK (1 test, 2 assertions)

--- a/Tests/Regression/GitHub/797/Issue797Test.php
+++ b/Tests/Regression/GitHub/797/Issue797Test.php
@@ -1,0 +1,29 @@
+<?php
+
+
+/**
+ * Ensures that the code template for code running in separate process will include
+ * the configured bootstrap regardless of preserving global state.
+ *
+ * @author Charles Sprayberry
+ */
+class Issue797Test extends PHPUnit_Framework_TestCase
+{
+
+    public function run(PHPUnit_Framework_TestResult $result = null)
+    {
+        // although we have marked to run in isolation we must set this explicitly
+        // or first assertion in test is not valid.
+        $this->setRunTestInSeparateProcess(TRUE);
+        $this->setIncludeBootstrap(TRUE);
+        $GLOBALS['__PHPUNIT_BOOTSTRAP'] = __DIR__ . '/bootstrap.php';
+        parent::run($result);
+    }
+
+    public function testRunningInSeparateProcessIncludesBootstrapPath()
+    {
+        $this->assertTrue($this->runTestInSeparateProcess, 'This test is not being ran in a separate process');
+        $this->assertSame('797', GITHUB_ISSUE_797, 'The constant created by test bootstrap was not ran in isolation process');
+    }
+
+}

--- a/Tests/Regression/GitHub/797/bootstrap.php
+++ b/Tests/Regression/GitHub/797/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+define('GITHUB_ISSUE_797', '797');

--- a/Tests/_files/BaseTestListenerSample.php
+++ b/Tests/_files/BaseTestListenerSample.php
@@ -1,0 +1,11 @@
+<?php
+
+class BaseTestListenerSample extends PHPUnit_Framework_BaseTestListener
+{
+    public $endCount = 0;
+
+    public function endTest(PHPUnit_Framework_Test $test, $time)
+    {
+        $this->endCount++;
+    }
+}

--- a/Tests/_files/DoNotPreserveGlobalStateTestCase.php
+++ b/Tests/_files/DoNotPreserveGlobalStateTestCase.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Test case to ensure that functionality when running in separate process while
+ * NOT preserving global state works as intended.
+ *
+ * @author Charles Sprayberry
+ */
+class DoNotPreserveGlobalStateTestCase extends PHPUnit_Framework_TestCase
+{
+
+    protected $preserveGlobalState = FALSE;
+
+    protected $runTestInSeparateProcess = TRUE;
+
+    protected $inIsolation = TRUE;
+
+    /**
+     * @var Text_Template
+     */
+    protected $template;
+
+    /**
+     * Taking advantage of PHPUnit_Framework_TestCase::run() calling this method
+     * to ensure we have access to the Text_Template created by the method.
+     *
+     * @param Text_Template $template
+     */
+    public function prepareTemplate(Text_Template $template)
+    {
+        $this->template = $template;
+        parent::prepareTemplate($template);
+    }
+
+    /**
+     * @return Text_Template
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+}

--- a/Tests/_files/PreserveGlobalStateTestCase.php
+++ b/Tests/_files/PreserveGlobalStateTestCase.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Test case to ensure that functionality when running in separate process while
+ * preserving global state works as intended.
+ *
+ * @author Charles Sprayberry
+ */
+class PreserveGlobalStateTestCase extends PHPUnit_Framework_TestCase
+{
+
+    protected $preserveGlobalState = TRUE;
+
+    protected $runTestInSeparateProcess = TRUE;
+
+    protected $inIsolation = FALSE;
+
+    /**
+     * @var Text_Template
+     */
+    protected $template;
+
+    /**
+     * Taking advantage of PHPUnit_Framework_TestCase::run() calling this method
+     * to ensure we have access to the Text_Template created by the method.
+     *
+     * @param Text_Template $template
+     */
+    public function prepareTemplate(Text_Template $template)
+    {
+        $this->template = $template;
+        parent::prepareTemplate($template);
+    }
+
+    /**
+     * @return Text_Template
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+}

--- a/Tests/_files/SelectorAssertionsFixture.html
+++ b/Tests/_files/SelectorAssertionsFixture.html
@@ -4,7 +4,7 @@
  <head>
   <title>Login</title>
   <link type="text/css" rel="Stylesheet" href="/stylesheets/screen.css">
-  <script type="text/javaScript" src="/javascripts/login.js">
+  <script type="text/javascript">alert('Hello, world!');</script>
  </head>
  <body id="login">
   <ul id="my_ul" class="my_ul_class">

--- a/build.xml
+++ b/build.xml
@@ -48,7 +48,7 @@
  </target>
 
  <target name="phpab" description="Generate autoloader scripts">
-  <exec executable="phpab">
+  <exec executable="phpab" passthru="true">
    <arg value="--output" />
    <arg path="PHPUnit/Autoload.php" />
    <arg value="--template" />

--- a/build.xml
+++ b/build.xml
@@ -48,7 +48,7 @@
  </target>
 
  <target name="phpab" description="Generate autoloader scripts">
-  <exec executable="phpab" passthru="true">
+  <exec executable="phpab">
    <arg value="--output" />
    <arg path="PHPUnit/Autoload.php" />
    <arg value="--template" />

--- a/package.xml
+++ b/package.xml
@@ -113,6 +113,7 @@
      </dir>
      <file baseinstalldir="/" name="AssertionFailedError.php" role="php" />
      <file baseinstalldir="/" name="Assert.php" role="php" />
+     <file baseinstalldir="/" name="BaseTestListener.php" role="php" />
      <file baseinstalldir="/" name="ComparatorFactory.php" role="php" />
      <file baseinstalldir="/" name="Comparator.php" role="php" />
      <file baseinstalldir="/" name="ComparisonFailure.php" role="php" />


### PR DESCRIPTION
Right now the code template used to run a test in a separate process only includes the configured bootstrap if preserving global state has set to be preserved through `PHPUnit_Framework_TestCase::setPreserveGlobalState()`. I feel this is a bug and likely not intended behavior by the calling code. Although global state might not need to be preserved the test case being ran in the separate process still needs to be bootstrapped.

This pull request:
- Adds a new template value 'bootstrapPath' and conditionally requires file based on this value
- Adds `PHPUnit_Util_GlobalState::getPhpUnitBootstrap()` public method to retrieve bootstrap path
- Adds tests for TestCase to ensure the template being rendered includes the appropriate 'bootstrapPath' value regardless of preserving global state

---

Although this fixes the problem of code in separate processes having bootstrap included this does not remove the dependency on global state to retrieve the bootstrap path. It may be worthwhile to consider removing this dependency at some point. My pull request does not include this because this is my first contribution to the project so didn't want to make drastic changes.
