### PR TITLE
always use realpath to get test filename

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -527,7 +527,7 @@ class PHPUnit_TextUI_Command
             }
 
             if (isset($this->options[1][1])) {
-                $this->arguments['testFile'] = $this->options[1][1];
+                $this->arguments['testFile'] = realpath($this->options[1][1]);
             } else {
                 $this->arguments['testFile'] = '';
             }


### PR DESCRIPTION
if we don't use realpath here, we end up in an "class x does not exist in y" exception when trying to run a specific test in a windows symlink directory.
