### PR TITLE
Convert static PHP_Timer method calls to objects

### DIFF
--- a/PHPUnit/Extensions/PhptTestCase.php
+++ b/PHPUnit/Extensions/PhptTestCase.php
@@ -160,11 +160,12 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
 
         $result->startTest($this);
 
-        PHP_Timer::start();
+        $timer = new PHP_Timer();
+        $timer->start();
 
         $runner->_php = PHP_BINARY;
         $buffer = $runner->run($this->filename, $options);
-        $time   = PHP_Timer::stop();
+        $time   = $timer->stop();
 
         error_reporting($currentErrorReporting);
 

--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -617,7 +617,8 @@ class PHPUnit_Framework_TestResult implements Countable
             $this->codeCoverage->start($test);
         }
 
-        PHP_Timer::start();
+        $timer = new PHP_Timer();
+        $timer->start();
 
         try {
             if (!$test instanceof PHPUnit_Framework_Warning &&
@@ -663,7 +664,7 @@ class PHPUnit_Framework_TestResult implements Countable
             $error = TRUE;
         }
 
-        $time = PHP_Timer::stop();
+        $time = $timer->stop();
         $test->addToAssertionCount(PHPUnit_Framework_Assert::getCount());
 
         if ($this->strictMode && $test->getNumAssertions() == 0) {

--- a/PHPUnit/TextUI/ResultPrinter.php
+++ b/PHPUnit/TextUI/ResultPrinter.php
@@ -112,6 +112,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
     protected $verbose = FALSE;
 
     /**
+     * @var PHP_Timer
+     */
+    private $timer;
+
+    /**
      * Constructor.
      *
      * @param  mixed   $out
@@ -142,6 +147,8 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
         } else {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(4, 'boolean');
         }
+
+        $this->timer = new PHP_Timer();
     }
 
     /**
@@ -334,7 +341,7 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
 
     protected function printHeader()
     {
-        $this->write("\n\n" . PHP_Timer::resourceUsage() . "\n\n");
+        $this->write("\n\n" . $this->timer->resourceUsage() . "\n\n");
     }
 
     /**


### PR DESCRIPTION
As of commit [de74b1](https://github.com/sebastianbergmann/php-timer/commit/de74b17cf85c51d57480c88bc069538b83ffed2f) PHP_Timer cannot be called statically. This updates the PHPUnit classes to create Timer objects instead of calling PHP_Timer statically.
