### PR TITLE
Fixes #785 and refs #688

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -203,6 +203,10 @@ else if (stream_resolve_include_path('PHPUnit/Extensions/SeleniumTestCase/Autolo
     require_once 'PHPUnit/Extensions/SeleniumTestCase/Autoload.php';
 }
 
+if (stream_resolve_include_path('Symfony/Component/Yaml/Tests/bootstrap.php')) {
+    require_once 'Symfony/Component/Yaml/Tests/bootstrap.php';
+}
+
 if (stream_resolve_include_path('PHPUnit/Extensions/Story/Autoload.php')) {
     require_once 'PHPUnit/Extensions/Story/Autoload.php';
 }

--- a/PHPUnit/Autoload.php.in
+++ b/PHPUnit/Autoload.php.in
@@ -86,6 +86,10 @@ else if (stream_resolve_include_path('PHPUnit/Extensions/SeleniumTestCase/Autolo
     require_once 'PHPUnit/Extensions/SeleniumTestCase/Autoload.php';
 }
 
+if (stream_resolve_include_path('Symfony/Component/Yaml/Tests/bootstrap.php')) {
+    require_once 'Symfony/Component/Yaml/Tests/bootstrap.php';
+}
+
 if (stream_resolve_include_path('PHPUnit/Extensions/Story/Autoload.php')) {
     require_once 'PHPUnit/Extensions/Story/Autoload.php';
 }

--- a/PHPUnit/Util/Log/TAP.php
+++ b/PHPUnit/Util/Log/TAP.php
@@ -43,11 +43,6 @@
  * @since      File available since Release 3.0.0
  */
 
-if (!class_exists('Symfony\\Component\\Yaml\\Dumper') &&
-    stream_resolve_include_path('Symfony/Component/Yaml/Dumper.php')) {
-    require_once 'Symfony/Component/Yaml/Dumper.php';
-}
-
 /**
  * A TestListener that generates a logfile of the
  * test execution using the Test Anything Protocol (TAP).


### PR DESCRIPTION
Use the autoloader installed with the PEAR version of `Symfony/Component/Yaml`.
