### PR TITLE
Fixes #622

### DIFF
--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -840,6 +840,33 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
         if ($arguments['filter'] !== FALSE &&
             preg_match('/^[a-zA-Z0-9_]/', $arguments['filter'])) {
+
+            // Handles:
+            //  * testAssertEqualsSucceeds#4
+            //  * testAssertEqualsSucceeds#4-8
+            if (preg_match('/^(.+)#(\d+)(?:-(\d+))?$/', $arguments['filter'], $matches)) {
+                $arguments['filter'] = $matches[1] . ' with data set #';
+                if (isset($matches[3]) && $matches[2] < $matches[3]) {
+                    $arguments['filter'] .= sprintf(
+                      '(%s)',
+                      implode('|', range($matches[2], $matches[3]))
+                    );
+                } else {
+                    $arguments['filter'] .= $matches[2];
+                }
+            }
+
+            // Handles:
+            //  * testDetermineJsonError@JSON_ERROR_NONE
+            //  * testDetermineJsonError@JSON.*
+            elseif (preg_match('/^(.+?)@(.+)$/', $arguments['filter'], $matches)) {
+                $arguments['filter'] = sprintf(
+                  '%s with data set "%s"',
+                  $matches[1],
+                  $matches[2]
+                );
+            }
+
             // Escape delimiters in regular expression. Do NOT use preg_quote,
             // to keep magic characters.
             $arguments['filter'] = '/' . str_replace(

--- a/Tests/TextUI/filter-dataprovider-by-number-isolation.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-number-isolation.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --process-isolation --filter testTrue#3 DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = '--filter';
+$_SERVER['argv'][4] = 'testTrue#3';
+$_SERVER['argv'][5] = 'DataProviderFilterTest';
+$_SERVER['argv'][6] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %i %s, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/Tests/TextUI/filter-dataprovider-by-number.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-number.phpt
@@ -1,0 +1,23 @@
+--TEST--
+phpunit --filter testTrue#3 DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--filter';
+$_SERVER['argv'][3] = 'testTrue#3';
+$_SERVER['argv'][4] = 'DataProviderFilterTest';
+$_SERVER['argv'][5] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %i %s, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/Tests/TextUI/filter-dataprovider-by-range-isolation.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-range-isolation.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --process-isolation --filter testTrue#1-3 DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = '--filter';
+$_SERVER['argv'][4] = 'testTrue#1-3';
+$_SERVER['argv'][5] = 'DataProviderFilterTest';
+$_SERVER['argv'][6] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+...
+
+Time: %i %s, Memory: %sMb
+
+OK (3 tests, 3 assertions)

--- a/Tests/TextUI/filter-dataprovider-by-range.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-range.phpt
@@ -1,0 +1,23 @@
+--TEST--
+phpunit --filter testTrue#1-3 DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--filter';
+$_SERVER['argv'][3] = 'testTrue#1-3';
+$_SERVER['argv'][4] = 'DataProviderFilterTest';
+$_SERVER['argv'][5] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+...
+
+Time: %i %s, Memory: %sMb
+
+OK (3 tests, 3 assertions)

--- a/Tests/TextUI/filter-dataprovider-by-regexp-isolation.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-regexp-isolation.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --process-isolation --filter testFalse@false.* DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = '--filter';
+$_SERVER['argv'][4] = 'testFalse@false.*';
+$_SERVER['argv'][5] = 'DataProviderFilterTest';
+$_SERVER['argv'][6] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+..
+
+Time: %i %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)

--- a/Tests/TextUI/filter-dataprovider-by-regexp.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-regexp.phpt
@@ -1,0 +1,23 @@
+--TEST--
+phpunit --filter testFalse@false.* DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--filter';
+$_SERVER['argv'][3] = 'testFalse@false.*';
+$_SERVER['argv'][4] = 'DataProviderFilterTest';
+$_SERVER['argv'][5] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+..
+
+Time: %i %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)

--- a/Tests/TextUI/filter-dataprovider-by-string-isolation.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-string-isolation.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --process-isolation --filter testFalse@false\ test DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = '--filter';
+$_SERVER['argv'][4] = 'testFalse@false test';
+$_SERVER['argv'][5] = 'DataProviderFilterTest';
+$_SERVER['argv'][6] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %i %s, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/Tests/TextUI/filter-dataprovider-by-string.phpt
+++ b/Tests/TextUI/filter-dataprovider-by-string.phpt
@@ -1,0 +1,23 @@
+--TEST--
+phpunit --filter testFalse@false\ test DataProviderFilterTest ../_files/DataProviderFilterTest.php
+--FILE--
+<?php
+define('PHPUNIT_TESTSUITE', TRUE);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--filter';
+$_SERVER['argv'][3] = 'testFalse@false test';
+$_SERVER['argv'][4] = 'DataProviderFilterTest';
+$_SERVER['argv'][5] = dirname(dirname(__FILE__)) . '/_files/DataProviderFilterTest.php';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/PHPUnit/Autoload.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %i %s, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/Tests/_files/DataProviderFilterTest.php
+++ b/Tests/_files/DataProviderFilterTest.php
@@ -1,0 +1,39 @@
+<?php
+class DataProviderFilterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider truthProvider
+     */
+    public function testTrue($truth)
+    {
+        $this->assertTrue($truth);
+    }
+
+    public static function truthProvider()
+    {
+        return array(
+           array(true),
+           array(true),
+           array(true),
+           array(true)
+        );
+    }
+
+    /**
+     * @dataProvider falseProvider
+     */
+    public function testFalse($false)
+    {
+        $this->assertFalse($false);
+    }
+
+    public static function falseProvider()
+    {
+        return array(
+          'false test'=>array(false),
+          'false test 2'=>array(false),
+          'other false test'=>array(false),
+          'other false test2'=>array(false)
+        );
+    }
+}


### PR DESCRIPTION
Added basic support for filtering dataproviders in the following ways:
- `testAssertEqualsSucceeds#4`
- `testAssertEqualsSucceeds#4-8`
- `testDetermineJsonError@JSON_ERROR_NONE`
- `testDetermineJsonError@JSON.*`
