### PR TITLE
Request merge of Lars Tesmer's assertThrowsException assertion.

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -92,6 +92,7 @@ spl_autoload_register(
             'phpunit_framework_constraint_exception' => '/Framework/Constraint/Exception.php',
             'phpunit_framework_constraint_exceptioncode' => '/Framework/Constraint/ExceptionCode.php',
             'phpunit_framework_constraint_exceptionmessage' => '/Framework/Constraint/ExceptionMessage.php',
+            'phpunit_framework_constraint_exceptionthrown' => '/Framework/Constraint/ExceptionThrown.php',
             'phpunit_framework_constraint_fileexists' => '/Framework/Constraint/FileExists.php',
             'phpunit_framework_constraint_greaterthan' => '/Framework/Constraint/GreaterThan.php',
             'phpunit_framework_constraint_isanything' => '/Framework/Constraint/IsAnything.php',

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -2119,11 +2119,11 @@ abstract class PHPUnit_Framework_Assert
         self::assertFalse($matched, $message);
     }
 
-	public static function assertThrowsException($exceptionName, $code)
-	{
-		$constraint = new PHPUnit_Framework_Constraint_ExceptionThrown($exceptionName);
-		self::assertThat($code, $constraint);
-	}
+    public static function assertThrowsException($exceptionName, $code)
+    {
+        $constraint = new PHPUnit_Framework_Constraint_ExceptionThrown($exceptionName);
+        self::assertThat($code, $constraint);
+    }
 
     /**
      * Evaluates a PHPUnit_Framework_Constraint matcher object.

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -2119,6 +2119,12 @@ abstract class PHPUnit_Framework_Assert
         self::assertFalse($matched, $message);
     }
 
+	public static function assertThrowsException($exceptionName, $code)
+	{
+		$constraint = new PHPUnit_Framework_Constraint_ExceptionThrown($exceptionName);
+		self::assertThat($code, $constraint);
+	}
+
     /**
      * Evaluates a PHPUnit_Framework_Constraint matcher object.
      *

--- a/PHPUnit/Framework/Constraint/ExceptionThrown.php
+++ b/PHPUnit/Framework/Constraint/ExceptionThrown.php
@@ -1,0 +1,56 @@
+<?php
+class PHPUnit_Framework_Constraint_ExceptionThrown extends PHPUnit_Framework_Constraint {
+
+	private $_exceptionName;
+	private $_exceptionThrown = null;
+
+	public function __construct($exceptionName)
+	{
+		$this->_exceptionName = $exceptionName;
+	}
+
+	/**
+	 * Evaluates the constraint for parameter $other. Returns TRUE if the
+	 * constraint is met, FALSE otherwise.
+	 *
+	 * @param mixed $other Value or object to evaluate.
+	 * @return bool
+	 */
+	public function evaluate($code)
+	{
+		try {
+			$code();
+		} catch (\Exception $e) {
+			$this->_exceptionThrown = $e;
+		}
+
+		if (!$this->_exceptionThrown) {
+			return false;
+		}
+
+		if (!$this->_exceptionThrown instanceof \Exception) {
+			return false;
+		}
+
+		if (!$this->_exceptionThrown instanceof $this->_exceptionName) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public function customFailureDescription($other, $description, $not)
+	{
+		if(!$this->_exceptionThrown || !$this->_exceptionThrown instanceof \Exception) {
+			$failureDescription = sprintf("Expected exception <%s> but no exception was thrown.", $this->_exceptionName);
+		}  else {
+			$failureDescription = sprintf("Expected exception: <%s>\nCaught Exception: <%s>.", $this->_exceptionName, get_class($this->_exceptionThrown));
+		}
+		return $failureDescription;
+	}
+	
+	public function toString()
+	{
+	}
+
+}

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -4167,4 +4167,24 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @covers PHPUnit_Framework_Assert::assertThrowsException
+     */
+    public function testAssertThrowsException()
+    {
+		$code = function() {
+			throw new InvalidArgumentException('test');
+		};
+
+		$this->assertThrowsException('InvalidArgumentException', $code);
+
+        try {
+			$this->assertThrowsException('MyMadeUpException', $code);
+        }
+	    catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
 }


### PR DESCRIPTION
Note that this is a minimal implementation, for demonstration purposes, with
just enough code to make it work in PHPUnit.
For a longer discussion see:
http://lars-tesmer.com/blog/2011/08/29/phpunit-better-syntax-for-expecting-exceptions/

Example usage:
$someClass = new SomeClass();
$this->assertThrowsException('InvalidArgumentException', function () use($someClass) {
        $someClass->someMethod();
    }
);

Conflicts:

```
Tests/Framework/AssertTest.php
```
