### PR TITLE
Set the `minimum-stability` to `dev` for the master branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "irc": "irc://irc.freenode.net/phpunit"
     },
+    "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.7",
         "phpunit/php-file-iterator": ">=1.3.1",


### PR DESCRIPTION
Not sure if this has been discussed before, but it would be nice if contributors could run:

```
git clone git@github.com:sebastianbergmann/phpunit.git
cd phpunit
composer install --dev
```

But you'll get the following errors:

```
Problem 1
  - The requested package phpunit/php-timer >=1.1.0 could not be found.
Problem 2
  - The requested package sebastian/diff could not be found in any version, there may be a typo in the package name.
Problem 3
  - The requested package sebastian/exporter could not be found in any version, there may be a typo in the package name.
```

The problem is that the master branch requires dev packages. Setting  `minimum-stability` to `dev` in `composer.json` fixes that problem.
