### PR TITLE
Simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,12 @@ env:
     - INSTALL_PHP_INVOKER=1
 
 before_script:
+    - composer install --dev --prefer-source
     - mkdir -p vendor/SebastianBergmann/
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-text-template.git vendor/php-text-template
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-token-stream.git vendor/php-token-stream
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-file-iterator.git vendor/php-file-iterator
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-code-coverage.git vendor/php-code-coverage
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/phpunit-mock-objects.git vendor/phpunit-mock-objects
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-timer.git vendor/php-timer
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/diff.git vendor/diff
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/exporter.git vendor/exporter
-    - git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/version.git vendor/version
-    - ln -s ~/build/sebastianbergmann/phpunit/vendor/diff/src ~/build/sebastianbergmann/phpunit/vendor/SebastianBergmann/Diff
-    - ln -s ~/build/sebastianbergmann/phpunit/vendor/exporter/src ~/build/sebastianbergmann/phpunit/vendor/SebastianBergmann/Exporter
-    - ln -s ~/build/sebastianbergmann/phpunit/vendor/version/src ~/build/sebastianbergmann/phpunit/vendor/SebastianBergmann/Version
-    - git clone --branch=master --depth=100 --quiet git://github.com/pear/pear-core.git vendor/pear-core
-    - git clone --branch=trunk --depth=100 --quiet git://github.com/pear/Console_Getopt.git vendor/console-getopt
+    - ls vendor/sebastian | while read DIR; do ln -s $(pwd)/vendor/sebastian/$DIR/src vendor/SebastianBergmann/${DIR^}; done
     - sh -c "if [ '$INSTALL_PHP_INVOKER' = '1' ]; then git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-invoker.git vendor/php-invoker; fi"
 
-script: php -d include_path=vendor/php-text-template:vendor/php-token-stream:vendor/php-file-iterator:vendor/php-code-coverage:vendor/phpunit-mock-objects:vendor/php-timer:vendor/php-invoker:vendor/pear-core:vendor/console-getopt:vendor:. ./phpunit.php --configuration ./build/travis-ci.xml
+script: php -d include_path=vendor:vendor/php-invoker -d auto_prepend_file=vendor/autoload.php ./phpunit.php --configuration ./build/travis-ci.xml
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,15 @@
         "ext-reflection": "*",
         "ext-spl": "*"
     },
+    "require-dev": {
+        "pear-pear/pear": "1.9.4"
+    },
+    "repositories": [
+        {
+            "type": "pear",
+            "url": "http://pear.php.net"
+        }
+    ],
     "suggest": {
         "phpunit/php-invoker": ">=1.2.0",
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "irc": "irc://irc.freenode.net/phpunit"
     },
+    "minimum-stability": "dev",
     "require": {
         "php": ">=5.4.7",
         "phpunit/php-file-iterator": ">=1.3.1",


### PR DESCRIPTION
This is an optional addendum to #821. 

It would be nice if `composer install --dev` was all it took to have a fully hackable/testable version of PHPUnit. This PR gets us pretty close to that with the added benefit of simplifying our travis config and enabling us to easily verify the composer install method.
