### PR TITLE
Fixes #823

### DIFF
--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -127,7 +127,7 @@ abstract class PHPUnit_Util_PHP
             if (!is_readable($this->phpBinary)) {
                 $this->phpBinary = 'php';
             } else {
-                $this->phpBinary = escapeshellcmd($this->phpBinary);
+                $this->phpBinary = escapeshellarg($this->phpBinary);
             }
         }
 


### PR DESCRIPTION
Use `escapeshellarg()` instead of `escapeshellcmd()` for escaping the binary name.
