### PR TITLE
Undo 9d97a3e.

### DIFF
--- a/Tests/Framework/ConstraintTest.php
+++ b/Tests/Framework/ConstraintTest.php
@@ -933,12 +933,6 @@ EOF
      */
     public function testConstraintIsEqual2($expected, $actual, $message)
     {
-        if ($expected instanceof SplObjectStorage) {
-            $this->markTestSkipped(
-              'generates different output on different platforms'
-            );
-        }
-
         $constraint = PHPUnit_Framework_Assert::equalTo($expected);
 
         try {


### PR DESCRIPTION
This has been fixed by sebastianbergmann/exporter@6732d996b0e85da36eb1a096027876d2905b8e72.

The problem was caused by https://github.com/php/php-src/commit/5721132 in PHP >= 5.3.4
