### PR TITLE
Simplified the composer install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,9 @@ env:
     - INSTALL_PHP_INVOKER=1
 
 before_script:
-    - composer install --dev --prefer-source
-    - sh -c "if [ '$INSTALL_PHP_INVOKER' = '1' ]; then git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-invoker.git vendor/php-invoker; fi"
+    - sh -c "if [ '$INSTALL_PHP_INVOKER' = '1' ]; then composer require --dev --prefer-source phpunit/php-invoker:\>=1.2.0; else composer install --dev --prefer-source; fi"
 
-script: php -d include_path=vendor/php-invoker ./phpunit.php --configuration ./build/travis-ci.xml
+script: ./phpunit.php --configuration ./build/travis-ci.xml
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ env:
 
 before_script:
     - composer install --dev --prefer-source
-    - mkdir -p vendor/SebastianBergmann/
-    - ls vendor/sebastian | while read DIR; do ln -s $(pwd)/vendor/sebastian/$DIR/src vendor/SebastianBergmann/${DIR^}; done
     - sh -c "if [ '$INSTALL_PHP_INVOKER' = '1' ]; then git clone --branch=master --depth=100 --quiet git://github.com/sebastianbergmann/php-invoker.git vendor/php-invoker; fi"
 
-script: php -d include_path=vendor:vendor/php-invoker -d auto_prepend_file=vendor/autoload.php ./phpunit.php --configuration ./build/travis-ci.xml
+script: php -d include_path=vendor/php-invoker ./phpunit.php --configuration ./build/travis-ci.xml
 
 notifications:
   email: false

--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -42,6 +42,12 @@
  * @since      File available since Release 3.5.0
  */
 
+if (is_dir(dirname(dirname(__FILE__)) . '/vendor/composer') &&
+    is_file(dirname(dirname(__FILE__)) . '/vendor/autoload.php')) {
+    require_once dirname(dirname(__FILE__)) . '/vendor/autoload.php';
+    return;
+}
+
 require_once 'File/Iterator/Autoload.php';
 require_once 'PHP/CodeCoverage/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';

--- a/PHPUnit/Autoload.php.in
+++ b/PHPUnit/Autoload.php.in
@@ -42,6 +42,12 @@
  * @since      File available since Release 3.5.0
  */
 
+if (is_dir(dirname(dirname(__FILE__)) . '/vendor/composer') &&
+    is_file(dirname(dirname(__FILE__)) . '/vendor/autoload.php')) {
+    require_once dirname(dirname(__FILE__)) . '/vendor/autoload.php';
+    return;
+}
+
 require_once 'File/Iterator/Autoload.php';
 require_once 'PHP/CodeCoverage/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';


### PR DESCRIPTION
I've been working on making the following possible:

```
git clone git@github.com:sebastianbergmann/phpunit.git
cd phpunit
composer install --dev
./phpunit.php
```

After 06ae86d, the only reason this doesn't work is due to hardcoded `require 'PHPUnit/Autoload.php'` calls in the following places:
- [PHPUnit/Framework/Process/TestCaseMethod.tpl.dist](https://github.com/sebastianbergmann/phpunit/blob/fd877d2c1f114317aba8700f382dc7418ea7f0ec/PHPUnit/Framework/Process/TestCaseMethod.tpl.dist#L5)
- [phpunit.xml.dist](https://github.com/sebastianbergmann/phpunit/blob/fd877d2c1f114317aba8700f382dc7418ea7f0ec/phpunit.xml.dist#L4)
- All PHPT tests (like [Tests/TextUI/abstract-test-class.phpt](https://github.com/sebastianbergmann/phpunit/blob/fd877d2c1f114317aba8700f382dc7418ea7f0ec/Tests/TextUI/abstract-test-class.phpt#L11)).

The problem is the paths from `PHPUnit/Autoload.php` differ from the composer paths for the following packages:

```
"sebastian/diff": ">=1.0.0",
"sebastian/exporter": ">=1.0.0",
"sebastian/version": ">=1.0.0",
```

There are a couple of ways to fix this, but by far the simplest is to check for a composer-based environment inside of `PHPUnit/Autoload.php`. The downside to this approach is obviously extra file system operations for non-composer users. This can be avoided for PEAR users if necessary–not sure how important it is.
