### PR TITLE
Fixes #830.

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -65,10 +65,10 @@ class PHPUnit_Util_XML
     public static function prepareString($string)
     {
         return preg_replace_callback(
-          '([\\x00-\\x04\\x0b\\x0c\\x0e-\\x1f\\x7f])',
+          '/[\\x00-\\x04\\x0b\\x0c\\x0e-\\x1f\\x7f]/',
           function ($matches)
           {
-              return sprintf('&#x%02x;', ord($matches[1]));
+              return sprintf('&#x%02x;', ord($matches[0]));
           },
           htmlspecialchars(
             PHPUnit_Util_String::convertToUtf8($string), ENT_COMPAT, 'UTF-8'

--- a/Tests/Util/XMLTest.php
+++ b/Tests/Util/XMLTest.php
@@ -320,4 +320,9 @@ class Util_XMLTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($tag, $converted);
     }
+
+    public function testPrepareStringEscapesChars()
+    {
+        $this->assertEquals('&#x1b;', PHPUnit_Util_XML::prepareString("\033"));
+    }
 }


### PR DESCRIPTION
- Use the right index as there is no capturing subpattern in this regexp.
- Use a pattern delimiter that isn't so easily confused with a subpattern delimiter.
