### PR TITLE
Don't use PHPUnit's autoloader when the composer binary is used.

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -42,6 +42,10 @@
  * @since      File available since Release 3.5.0
  */
 
+if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+    return;
+}
+
 require_once 'File/Iterator/Autoload.php';
 require_once 'PHP/CodeCoverage/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';

--- a/PHPUnit/Autoload.php.in
+++ b/PHPUnit/Autoload.php.in
@@ -42,6 +42,10 @@
  * @since      File available since Release 3.5.0
  */
 
+if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+    return;
+}
+
 require_once 'File/Iterator/Autoload.php';
 require_once 'PHP/CodeCoverage/Autoload.php';
 require_once 'PHP/Timer/Autoload.php';

--- a/composer/bin/phpunit
+++ b/composer/bin/phpunit
@@ -42,19 +42,17 @@ $files = array(
   __DIR__ . '/../../../../autoload.php'
 );
 
-$found = FALSE;
-
 foreach ($files as $file) {
     if (file_exists($file)) {
         require $file;
 
-        $found = TRUE;
+        define('PHPUNIT_COMPOSER_INSTALL', TRUE);
 
         break;
     }
 }
 
-if (!$found) {
+if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     die(
       'You need to set up the project dependencies using the following commands:' . PHP_EOL .
       'curl -s http://getcomposer.org/installer | php' . PHP_EOL .


### PR DESCRIPTION
This is related to [a comment](https://github.com/sebastianbergmann/phpunit/commit/288bff7b0a08e99fc513e45cc65bfc7430e0659b#commitcomment-2723865) from 288bff7.

Some 3rd-party libraries (especially those providing custom test cases, printers, etc.) include calls to `require_once('PHPUnit/Autoload.php');`. This is obviously an issue if PHPUnit is installed via composer. This PR fixes that problem and provides a useful mechanism for library developers to accommodate for composer-based PHPUnit installs in the future.
