### PR TITLE
Attribute validations added to assert methods

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -937,7 +937,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -966,7 +966,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -995,7 +995,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -1024,7 +1024,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -1055,7 +1055,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
         if (!is_object($object)) {
@@ -1084,7 +1084,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
         if (!is_object($object)) {
@@ -2784,7 +2784,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
         if (is_string($classOrObject)) {
@@ -2884,7 +2884,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
         $class = new ReflectionClass($className);
@@ -2929,7 +2929,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
         try {

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -935,6 +935,10 @@ abstract class PHPUnit_Framework_Assert
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
         }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+        }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'class name');
@@ -959,6 +963,10 @@ abstract class PHPUnit_Framework_Assert
     {
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -985,6 +993,10 @@ abstract class PHPUnit_Framework_Assert
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
         }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+        }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'class name');
@@ -1009,6 +1021,10 @@ abstract class PHPUnit_Framework_Assert
     {
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -1037,6 +1053,10 @@ abstract class PHPUnit_Framework_Assert
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
         }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+        }
 
         if (!is_object($object)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'object');
@@ -1061,6 +1081,10 @@ abstract class PHPUnit_Framework_Assert
     {
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
         }
 
         if (!is_object($object)) {
@@ -2758,6 +2782,10 @@ abstract class PHPUnit_Framework_Assert
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'string');
         }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'a valid name of attribute');
+        }
 
         if (is_string($classOrObject)) {
             if (!class_exists($classOrObject)) {
@@ -2854,6 +2882,10 @@ abstract class PHPUnit_Framework_Assert
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'string');
         }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'a valid name of attribute');
+        }
 
         $class = new ReflectionClass($className);
 
@@ -2894,6 +2926,10 @@ abstract class PHPUnit_Framework_Assert
 
         if (!is_string($attributeName)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'string');
+        }
+        
+        if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'a valid name of attribute');
         }
 
         try {

--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -937,7 +937,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -966,7 +966,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -995,7 +995,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -1024,7 +1024,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
         }
 
         if (!is_string($className) || !class_exists($className, FALSE)) {
@@ -1055,7 +1055,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
         }
 
         if (!is_object($object)) {
@@ -1084,7 +1084,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid name of attribute');
         }
 
         if (!is_object($object)) {
@@ -2784,7 +2784,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid name of attribute');
         }
 
         if (is_string($classOrObject)) {
@@ -2884,7 +2884,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid name of attribute');
         }
 
         $class = new ReflectionClass($className);
@@ -2929,7 +2929,7 @@ abstract class PHPUnit_Framework_Assert
         }
         
         if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'a valid name of attribute');
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'valid name of attribute');
         }
 
         try {

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -1709,6 +1709,17 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     {
         $this->readAttribute(NULL, 'foo');
     }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::readAttribute
+     * @covers            PHPUnit_Framework_Assert::getStaticAttribute
+     * @covers            PHPUnit_Framework_Assert::getObjectAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testReadAttributeIfAttributeNameIsNotValid()
+    {
+        $this->readAttribute('StdClass', '2');
+    }
 
     /**
      * @covers PHPUnit_Framework_Assert::assertAttributeContains
@@ -2155,6 +2166,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     {
         $this->assertClassHasAttribute('foo', NULL);
     }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertClassHasAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertClassHasAttributeThrowsExceptionIfAttributeNameIsNotValid()
+    {
+        $this->assertClassHasAttribute('1', 'ClassWithNonPublicAttributes');
+    }
 
     /**
      * @covers            PHPUnit_Framework_Assert::assertClassNotHasAttribute
@@ -2172,6 +2192,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     public function testAssertClassNotHasAttributeThrowsException2()
     {
         $this->assertClassNotHasAttribute('foo', NULL);
+    }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertClassNotHasAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertClassNotHasAttributeThrowsExceptionIfAttributeNameIsNotValid()
+    {
+        $this->assertClassNotHasAttribute('1', 'ClassWithNonPublicAttributes');
     }
 
     /**
@@ -2191,6 +2220,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     {
         $this->assertClassHasStaticAttribute('foo', NULL);
     }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertClassHasStaticAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertClassHasStaticAttributeThrowsExceptionIfAttributeNameIsNotValid()
+    {
+        $this->assertClassHasStaticAttribute('1', 'ClassWithNonPublicAttributes');
+    }
 
     /**
      * @covers            PHPUnit_Framework_Assert::assertClassNotHasStaticAttribute
@@ -2208,6 +2246,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     public function testAssertClassNotHasStaticAttributeThrowsException2()
     {
         $this->assertClassNotHasStaticAttribute('foo', NULL);
+    }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertClassNotHasStaticAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertClassNotHasStaticAttributeThrowsExceptionIfAttributeNameIsNotValid()
+    {
+        $this->assertClassNotHasStaticAttribute('1', 'ClassWithNonPublicAttributes');
     }
 
     /**
@@ -2227,6 +2274,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     {
         $this->assertObjectHasAttribute('foo', NULL);
     }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertObjectHasAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertObjectHasAttributeThrowsExceptionIfAttributeNameIsNotValid()
+    {
+        $this->assertObjectHasAttribute('1', 'ClassWithNonPublicAttributes');
+    }
 
     /**
      * @covers            PHPUnit_Framework_Assert::assertObjectNotHasAttribute
@@ -2244,6 +2300,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     public function testAssertObjectNotHasAttributeThrowsException2()
     {
         $this->assertObjectNotHasAttribute('foo', NULL);
+    }
+    
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertObjectNotHasAttribute
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertObjectNotHasAttributeThrowsExceptionIfAttributeNameIsNotValid()
+    {
+        $this->assertObjectNotHasAttribute('1', 'ClassWithNonPublicAttributes');
     }
 
     /**


### PR DESCRIPTION
- Added additional validation of attribute name in assertions using class/object attributes
- Added new Test in Tests/Framework/AssertTest.php to cover attribute validation

Validating class/object attribute against regex:

``` php
if(!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'valid attribute name');
        }
```

Result:

```
PHPUnit_Framework_Exception: Argument #2 (No Value) of PHPUnit_Framework_Assert::readAttribute() must be a valid attribute name
```
