### PR TITLE
fix logicalAnd, logicalOr, logicalXor

### DIFF
--- a/PHPUnit/Framework/Assert/Functions.php
+++ b/PHPUnit/Framework/Assert/Functions.php
@@ -37,6 +37,7 @@
  * @package    PHPUnit
  * @subpackage Framework
  * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Kuzuha SHINODA <kuzuha01@hotmail.com>
  * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://www.phpunit.de/
@@ -1758,7 +1759,8 @@ function lessThanOrEqual($value)
  */
 function logicalAnd()
 {
-    return PHPUnit_Framework_Assert::logicalAnd();
+    $args = func_get_args();
+    return call_user_func_array('PHPUnit_Framework_Assert::logicalAnd', $args);
 }
 
 /**
@@ -1781,7 +1783,8 @@ function logicalNot(PHPUnit_Framework_Constraint $constraint)
  */
 function logicalOr()
 {
-    return PHPUnit_Framework_Assert::logicalOr();
+    $args = func_get_args();
+    return call_user_func_array('PHPUnit_Framework_Assert::logicalOr', $args);
 }
 
 /**
@@ -1792,7 +1795,8 @@ function logicalOr()
  */
 function logicalXor()
 {
-    return PHPUnit_Framework_Assert::logicalXor();
+    $args = func_get_args();
+    return call_user_func_array('PHPUnit_Framework_Assert::logicalXor', $args);
 }
 
 /**

--- a/Tests/Framework/Assert/FunctionsTest.php
+++ b/Tests/Framework/Assert/FunctionsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2013, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @author     Kuzuha SHINODA <kuzuha01@hotmail.com>
+ * @copyright  2013-2013 Kuzuha SHINODA <kuzuha01@hotmail.com>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.8.0
+ */
+
+require_once dirname(dirname(dirname(__DIR__))) . '/PHPUnit/Framework/Assert/Functions.php';
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @author     Kuzuha SHINODA <kuzuha01@hotmail.com>
+ * @copyright  2013-2013 Kuzuha SHINODA <kuzuha01@hotmail.com>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.8.0
+ */
+class Framework_Assert_FunctionsTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testLogicalAnd()
+    {
+        $expected = $this->logicalAnd($this->isTrue(), $this->isFalse());
+        $actual = logicalAnd($this->isTrue(), $this->isFalse());
+        $this->assertSame($expected->toString(), $actual->toString());
+    }
+
+    public function testLogicalOr()
+    {
+        $expected = $this->logicalOr($this->isTrue(), $this->isFalse());
+        $actual = logicalOr($this->isTrue(), $this->isFalse());
+        $this->assertSame($expected->toString(), $actual->toString());
+    }
+
+    public function testLogicalXor()
+    {
+        $expected = $this->logicalXor($this->isTrue(), $this->isFalse());
+        $actual = logicalXor($this->isTrue(), $this->isFalse());
+        $this->assertSame($expected->toString(), $actual->toString());
+    }
+}


### PR DESCRIPTION
logicalAnd/logicalOr/logicalXor functions doesn't work
in shortcut functions at Framework/Assert/Functions.php.

fixed this bug and added tests.

maybe this fix can merge old branches. (for 3.5, 3.6, 3.7)
