### PR TITLE
Make TestCase::hasOutput() return true if "0" is outputted

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -410,7 +410,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     public function hasOutput()
     {
-        if (empty($this->output)) {
+        if (strlen($this->output) === 0) {
             return FALSE;
         }
 


### PR DESCRIPTION
TestCase::hasOutput() returns false when "0" is outputted, as it uses empty(), which returns false on the string "0". hasOutput is called when running PHPUnit with strict=true.

This probably already needed some tests, as no tests fail when hasOutput() is set to return random values and hasOutput doesn't seem to be called in any tests. `./Tests/Framework/TestCaseTest.php` looks like the place for the test but I'm not sure the best way to test this.

Sending this PR to master, but as it's a bug fix, should it go to 3.7?
