### PR TITLE
Make TestCase::hasOutput() return true if "0" is outputted

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -393,7 +393,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     public function hasOutput()
     {
-        if (empty($this->output)) {
+        if (strlen($this->output) === 0) {
             return FALSE;
         }
 


### PR DESCRIPTION
This is a copy of PR #921 (on 3.7 instead of master)

TestCase::hasOutput() returns false when "0" is outputted, as it uses empty(), which returns false on the string "0". hasOutput is called when running PHPUnit with strict=true.

This probably already needed some tests, as no tests fail when hasOutput() is set to return random values and hasOutput doesn't seem to be called in any tests. ./Tests/Framework/TestCaseTest.php looks like the place for the test but I'm not sure the best way to test this.
