### PR TITLE
Updated path resolution for symlinks

### DIFF
--- a/composer/bin/phpunit
+++ b/composer/bin/phpunit
@@ -38,8 +38,8 @@
 define('PHPUnit_MAIN_METHOD', 'PHPUnit_TextUI_Command::main');
 
 $files = array(
-  __DIR__ . '/../../vendor/autoload.php',
-  __DIR__ . '/../../../../autoload.php'
+  realpath(__DIR__) . '/../../vendor/autoload.php',
+  realpath(__DIR__) . '/../../../../autoload.php'
 );
 
 foreach ($files as $file) {


### PR DESCRIPTION
I wanted to symlink the file in vendor/bin to an other folder and `__DIR__` was resolved to this new folder.

by adding `realpath` it resolves the symlink and works again.
