### PR TITLE
files in testsuite are now loaded using an absolute path

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ PHPUnit 3.7
 
 This is the list of changes for the PHPUnit 3.7 release series.
 
+PHPUnit 3.7.22
+--------------
+
+* Files in testsuites were not loaded when PHPUnit was called from a directory different from the XML definition. Directories were not affected.
+
 PHPUnit 3.7.21
 --------------
 

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -885,7 +885,9 @@ class PHPUnit_Util_Configuration
             }
 
             // Get the absolute path to the file
-            $file = $fileIteratorFacade->getFilesAsArray($file);
+            $file = $fileIteratorFacade->getFilesAsArray(
+              $this->toAbsolutePath($file)
+            );
 
             if (!isset($file[0])) {
                 continue;


### PR DESCRIPTION
When using a wrapper around PHPUnit, the files defined in testsuites
might not be found when declared as a relative path.  This is was caused
by PHPUnit not normalizating them to absolute paths although directories
are normalized.

Use case is the MediaWiki test suite which has tests materials under
/tests/phpunit.  There is a phpunit.php wrapper and the suite.xml file
definining a testsuite with <file>suites/ExtensionsTestsuite.php</file>.
When invoking the wrapper in the samedir as the suite.xml, the relative
path is obviously found.  When invoking the wrapper from a parent
directory, it would fail to find it.
