### PR TITLE
Do not die on binary output with json logging

### DIFF
--- a/PHPUnit/Util/Log/JSON.php
+++ b/PHPUnit/Util/Log/JSON.php
@@ -245,6 +245,14 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
      */
     public function write($buffer)
     {
+        array_walk_recursive($buffer, function(&$input)
+        {
+            if (is_string($input))
+            {
+                $input = PHPUnit_Util_String::convertToUtf8($input);
+            }
+        });
+
         parent::write(json_encode($buffer, JSON_PRETTY_PRINT));
     }
 }


### PR DESCRIPTION
If you try to output some binary data in your tests, `json_encode` will throw an exception even if test is completely valid.

This patch fixes that behaviour.
