### PR TITLE
Allow relative file paths in testsuites xml configuration

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -885,7 +885,9 @@ class PHPUnit_Util_Configuration
             }
 
             // Get the absolute path to the file
-            $file = $fileIteratorFacade->getFilesAsArray($file);
+            $file = $fileIteratorFacade->getFilesAsArray(
+                $this->toAbsolutePath($file)
+            );
 
             if (!isset($file[0])) {
                 continue;


### PR DESCRIPTION
This simple feature/bug fix has been merged in the 3.6 branch a year ago (#458) and is also present in the master branch, but not in the 3.7, which is quite annoying.
