### PR TITLE
Do not use parenthesis for break instruction

### DIFF
--- a/PHPUnit/Util/XML.php
+++ b/PHPUnit/Util/XML.php
@@ -873,7 +873,7 @@ class PHPUnit_Util_XML
                             }
 
                             if (!$matched) {
-                                break(2);
+                                break 2;
                             }
                         }
                     }


### PR DESCRIPTION
On file Util/XML.php, 'break' is used with parenthesis.
This is tolerated by PHP but the syntax is not strictly exact. Softwares like HipHop requires the instruction to be written without parenthesis.
