### PR TITLE
Added ability to export PHP_CodeCoverage object to .smart format

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -838,9 +838,9 @@ class PHPUnit_TextUI_Command
 Usage: phpunit [switches] UnitTest [UnitTest.php]
        phpunit [switches] <directory>
 
-  --log-junit <file>        Log test execution in JUnit XML format to file.
-  --log-tap <file>          Log test execution in TAP format to file.
-  --log-json <file>         Log test execution in JSON format.
+  --log-junit <file>         Log test execution in JUnit XML format to file.
+  --log-tap <file>           Log test execution in TAP format to file.
+  --log-json <file>          Log test execution in JSON format.
 
   --coverage-clover <file>   Generate code coverage report in Clover XML format.
   --coverage-crap4j <file>   Generate code coverage report in Crap4J XML format.

--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -82,6 +82,7 @@ class PHPUnit_TextUI_Command
       'coverage-crap4j=' => NULL,
       'coverage-html=' => NULL,
       'coverage-php=' => NULL,
+      'coverage-phpsmart=' => NULL,
       'coverage-text==' => NULL,
       'coverage-xml=' => NULL,
       'debug' => NULL,
@@ -283,6 +284,11 @@ class PHPUnit_TextUI_Command
 
                 case '--coverage-php': {
                     $this->arguments['coveragePHP'] = $option[1];
+                }
+                break;
+
+                case '--coverage-phpsmart': {
+                    $this->arguments['coveragePHPSmart'] = $option[1];
                 }
                 break;
 
@@ -836,54 +842,55 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --log-tap <file>          Log test execution in TAP format to file.
   --log-json <file>         Log test execution in JSON format.
 
-  --coverage-clover <file>  Generate code coverage report in Clover XML format.
-  --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
-  --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Serialize PHP_CodeCoverage object to file.
-  --coverage-text=<file>    Generate code coverage report in text format.
-                            Default: Standard output.
-  --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
+  --coverage-clover <file>   Generate code coverage report in Clover XML format.
+  --coverage-crap4j <file>   Generate code coverage report in Crap4J XML format.
+  --coverage-html <dir>      Generate code coverage report in HTML format.
+  --coverage-php <file>      Serialize PHP_CodeCoverage object to file.
+  --coverage-phpsmart <file> Export PHP_CodeCoverage object to file.
+  --coverage-text=<file>     Generate code coverage report in text format.
+                             Default: Standard output.
+  --coverage-xml <dir>       Generate code coverage report in PHPUnit XML format.
 
-  --testdox-html <file>     Write agile documentation in HTML format to file.
-  --testdox-text <file>     Write agile documentation in Text format to file.
+  --testdox-html <file>      Write agile documentation in HTML format to file.
+  --testdox-text <file>      Write agile documentation in Text format to file.
 
-  --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
-  --group ...               Only runs tests from the specified group(s).
-  --exclude-group ...       Exclude tests from the specified group(s).
-  --list-groups             List available test groups.
-  --test-suffix ...         Only search for test in files with specified
-                            suffix(es). Default: Test.php,.phpt
+  --filter <pattern>         Filter which tests to run.
+  --testsuite <pattern>      Filter which testsuite to run.
+  --group ...                Only runs tests from the specified group(s).
+  --exclude-group ...        Exclude tests from the specified group(s).
+  --list-groups              List available test groups.
+  --test-suffix ...          Only search for test in files with specified
+                             suffix(es). Default: Test.php,.phpt
 
-  --loader <loader>         TestSuiteLoader implementation to use.
-  --printer <printer>       TestSuiteListener implementation to use.
-  --repeat <times>          Runs the test(s) repeatedly.
+  --loader <loader>          TestSuiteLoader implementation to use.
+  --printer <printer>        TestSuiteListener implementation to use.
+  --repeat <times>           Runs the test(s) repeatedly.
 
-  --tap                     Report test execution progress in TAP format.
-  --testdox                 Report test execution progress in TestDox format.
+  --tap                      Report test execution progress in TAP format.
+  --testdox                  Report test execution progress in TestDox format.
 
-  --colors                  Use colors in output.
-  --stderr                  Write to STDERR instead of STDOUT.
-  --stop-on-error           Stop execution upon first error.
-  --stop-on-failure         Stop execution upon first error or failure.
-  --stop-on-skipped         Stop execution upon first skipped test.
-  --stop-on-incomplete      Stop execution upon first incomplete test.
-  --strict                  Run tests in strict mode.
-  -v|--verbose              Output more verbose information.
-  --debug                   Display debugging information during test execution.
+  --colors                   Use colors in output.
+  --stderr                   Write to STDERR instead of STDOUT.
+  --stop-on-error            Stop execution upon first error.
+  --stop-on-failure          Stop execution upon first error or failure.
+  --stop-on-skipped          Stop execution upon first skipped test.
+  --stop-on-incomplete       Stop execution upon first incomplete test.
+  --strict                   Run tests in strict mode.
+  -v|--verbose               Output more verbose information.
+  --debug                    Display debugging information during test execution.
 
-  --process-isolation       Run each test in a separate PHP process.
-  --no-globals-backup       Do not backup and restore \$GLOBALS for each test.
-  --static-backup           Backup and restore static attributes for each test.
+  --process-isolation        Run each test in a separate PHP process.
+  --no-globals-backup        Do not backup and restore \$GLOBALS for each test.
+  --static-backup            Backup and restore static attributes for each test.
 
-  --bootstrap <file>        A "bootstrap" PHP file that is run before the tests.
-  -c|--configuration <file> Read configuration from XML file.
-  --no-configuration        Ignore default configuration file (phpunit.xml).
-  --include-path <path(s)>  Prepend PHP's include_path with given path(s).
-  -d key[=value]            Sets a php.ini value.
+  --bootstrap <file>         A "bootstrap" PHP file that is run before the tests.
+  -c|--configuration <file>  Read configuration from XML file.
+  --no-configuration         Ignore default configuration file (phpunit.xml).
+  --include-path <path(s)>   Prepend PHP's include_path with given path(s).
+  -d key[=value]             Sets a php.ini value.
 
-  -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
+  -h|--help                  Prints this usage information.
+  --version                  Prints the version and exits.
 
 EOT;
 

--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -313,6 +313,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $codeCoverageReports++;
             }
 
+            if (isset($arguments['coveragePHPSmart'])) {
+                $codeCoverageReports++;
+            }
+
             if (isset($arguments['coverageText'])) {
                 $codeCoverageReports++;
             }
@@ -475,6 +479,18 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
                 $writer = new PHP_CodeCoverage_Report_PHP;
                 $writer->process($codeCoverage, $arguments['coveragePHP']);
+
+                $this->printer->write(" done\n");
+                unset($writer);
+            }
+
+            if (isset($arguments['coveragePHPSmart'])) {
+                $this->printer->write(
+                  "\nGenerating code coverage report in PHPSmart format ..."
+                );
+
+                $writer = new PHP_CodeCoverage_Report_PHPSmart;
+                $writer->process($codeCoverage, $arguments['coveragePHPSmart']);
 
                 $this->printer->write(" done\n");
                 unset($writer);
@@ -776,6 +792,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $arguments['coveragePHP'] = $loggingConfiguration['coverage-php'];
             }
 
+            if (isset($loggingConfiguration['coverage-phpsmart']) &&
+                !isset($arguments['coveragePHPSmart'])) {
+                $arguments['coveragePHPSmart'] = $loggingConfiguration['coverage-phpsmart'];
+            }
+
             if (isset($loggingConfiguration['coverage-text']) &&
                 !isset($arguments['coverageText'])) {
                 $arguments['coverageText'] = $loggingConfiguration['coverage-text'];
@@ -835,7 +856,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if ((isset($arguments['coverageClover']) ||
                 isset($arguments['coverageCrap4J']) ||
                 isset($arguments['coverageHtml']) ||
-                isset($arguments['coveragePHP'])) ||
+                isset($arguments['coveragePHP']) ||
+                isset($arguments['coveragePHPSmart'])) ||
                 isset($arguments['coverageText']) &&
                 extension_loaded('xdebug')) {
 

--- a/Tests/TextUI/help.phpt
+++ b/Tests/TextUI/help.phpt
@@ -15,55 +15,56 @@ PHPUnit %s by Sebastian Bergmann.
 Usage: phpunit [switches] UnitTest [UnitTest.php]
        phpunit [switches] <directory>
 
-  --log-junit <file>        Log test execution in JUnit XML format to file.
-  --log-tap <file>          Log test execution in TAP format to file.
-  --log-json <file>         Log test execution in JSON format.
+  --log-junit <file>         Log test execution in JUnit XML format to file.
+  --log-tap <file>           Log test execution in TAP format to file.
+  --log-json <file>          Log test execution in JSON format.
 
-  --coverage-clover <file>  Generate code coverage report in Clover XML format.
-  --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
-  --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Serialize PHP_CodeCoverage object to file.
-  --coverage-text=<file>    Generate code coverage report in text format.
-                            Default: Standard output.
-  --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
+  --coverage-clover <file>   Generate code coverage report in Clover XML format.
+  --coverage-crap4j <file>   Generate code coverage report in Crap4J XML format.
+  --coverage-html <dir>      Generate code coverage report in HTML format.
+  --coverage-php <file>      Serialize PHP_CodeCoverage object to file.
+  --coverage-phpsmart <file> Export PHP_CodeCoverage object to file.
+  --coverage-text=<file>     Generate code coverage report in text format.
+                             Default: Standard output.
+  --coverage-xml <dir>       Generate code coverage report in PHPUnit XML format.
 
-  --testdox-html <file>     Write agile documentation in HTML format to file.
-  --testdox-text <file>     Write agile documentation in Text format to file.
+  --testdox-html <file>      Write agile documentation in HTML format to file.
+  --testdox-text <file>      Write agile documentation in Text format to file.
 
-  --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
-  --group ...               Only runs tests from the specified group(s).
-  --exclude-group ...       Exclude tests from the specified group(s).
-  --list-groups             List available test groups.
-  --test-suffix ...         Only search for test in files with specified
-                            suffix(es). Default: Test.php,.phpt
+  --filter <pattern>         Filter which tests to run.
+  --testsuite <pattern>      Filter which testsuite to run.
+  --group ...                Only runs tests from the specified group(s).
+  --exclude-group ...        Exclude tests from the specified group(s).
+  --list-groups              List available test groups.
+  --test-suffix ...          Only search for test in files with specified
+                             suffix(es). Default: Test.php,.phpt
 
-  --loader <loader>         TestSuiteLoader implementation to use.
-  --printer <printer>       TestSuiteListener implementation to use.
-  --repeat <times>          Runs the test(s) repeatedly.
+  --loader <loader>          TestSuiteLoader implementation to use.
+  --printer <printer>        TestSuiteListener implementation to use.
+  --repeat <times>           Runs the test(s) repeatedly.
 
-  --tap                     Report test execution progress in TAP format.
-  --testdox                 Report test execution progress in TestDox format.
+  --tap                      Report test execution progress in TAP format.
+  --testdox                  Report test execution progress in TestDox format.
 
-  --colors                  Use colors in output.
-  --stderr                  Write to STDERR instead of STDOUT.
-  --stop-on-error           Stop execution upon first error.
-  --stop-on-failure         Stop execution upon first error or failure.
-  --stop-on-skipped         Stop execution upon first skipped test.
-  --stop-on-incomplete      Stop execution upon first incomplete test.
-  --strict                  Run tests in strict mode.
-  -v|--verbose              Output more verbose information.
-  --debug                   Display debugging information during test execution.
+  --colors                   Use colors in output.
+  --stderr                   Write to STDERR instead of STDOUT.
+  --stop-on-error            Stop execution upon first error.
+  --stop-on-failure          Stop execution upon first error or failure.
+  --stop-on-skipped          Stop execution upon first skipped test.
+  --stop-on-incomplete       Stop execution upon first incomplete test.
+  --strict                   Run tests in strict mode.
+  -v|--verbose               Output more verbose information.
+  --debug                    Display debugging information during test execution.
 
-  --process-isolation       Run each test in a separate PHP process.
-  --no-globals-backup       Do not backup and restore $GLOBALS for each test.
-  --static-backup           Backup and restore static attributes for each test.
+  --process-isolation        Run each test in a separate PHP process.
+  --no-globals-backup        Do not backup and restore $GLOBALS for each test.
+  --static-backup            Backup and restore static attributes for each test.
 
-  --bootstrap <file>        A "bootstrap" PHP file that is run before the tests.
-  -c|--configuration <file> Read configuration from XML file.
-  --no-configuration        Ignore default configuration file (phpunit.xml).
-  --include-path <path(s)>  Prepend PHP's include_path with given path(s).
-  -d key[=value]            Sets a php.ini value.
+  --bootstrap <file>         A "bootstrap" PHP file that is run before the tests.
+  -c|--configuration <file>  Read configuration from XML file.
+  --no-configuration         Ignore default configuration file (phpunit.xml).
+  --include-path <path(s)>   Prepend PHP's include_path with given path(s).
+  -d key[=value]             Sets a php.ini value.
 
-  -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
+  -h|--help                  Prints this usage information.
+  --version                  Prints the version and exits.

--- a/Tests/TextUI/help2.phpt
+++ b/Tests/TextUI/help2.phpt
@@ -16,55 +16,56 @@ PHPUnit %s by Sebastian Bergmann.
 Usage: phpunit [switches] UnitTest [UnitTest.php]
        phpunit [switches] <directory>
 
-  --log-junit <file>        Log test execution in JUnit XML format to file.
-  --log-tap <file>          Log test execution in TAP format to file.
-  --log-json <file>         Log test execution in JSON format.
+  --log-junit <file>         Log test execution in JUnit XML format to file.
+  --log-tap <file>           Log test execution in TAP format to file.
+  --log-json <file>          Log test execution in JSON format.
 
-  --coverage-clover <file>  Generate code coverage report in Clover XML format.
-  --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
-  --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Serialize PHP_CodeCoverage object to file.
-  --coverage-text=<file>    Generate code coverage report in text format.
-                            Default: Standard output.
-  --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
+  --coverage-clover <file>   Generate code coverage report in Clover XML format.
+  --coverage-crap4j <file>   Generate code coverage report in Crap4J XML format.
+  --coverage-html <dir>      Generate code coverage report in HTML format.
+  --coverage-php <file>      Serialize PHP_CodeCoverage object to file.
+  --coverage-phpsmart <file> Export PHP_CodeCoverage object to file.
+  --coverage-text=<file>     Generate code coverage report in text format.
+                             Default: Standard output.
+  --coverage-xml <dir>       Generate code coverage report in PHPUnit XML format.
 
-  --testdox-html <file>     Write agile documentation in HTML format to file.
-  --testdox-text <file>     Write agile documentation in Text format to file.
+  --testdox-html <file>      Write agile documentation in HTML format to file.
+  --testdox-text <file>      Write agile documentation in Text format to file.
 
-  --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
-  --group ...               Only runs tests from the specified group(s).
-  --exclude-group ...       Exclude tests from the specified group(s).
-  --list-groups             List available test groups.
-  --test-suffix ...         Only search for test in files with specified
-                            suffix(es). Default: Test.php,.phpt
+  --filter <pattern>         Filter which tests to run.
+  --testsuite <pattern>      Filter which testsuite to run.
+  --group ...                Only runs tests from the specified group(s).
+  --exclude-group ...        Exclude tests from the specified group(s).
+  --list-groups              List available test groups.
+  --test-suffix ...          Only search for test in files with specified
+                             suffix(es). Default: Test.php,.phpt
 
-  --loader <loader>         TestSuiteLoader implementation to use.
-  --printer <printer>       TestSuiteListener implementation to use.
-  --repeat <times>          Runs the test(s) repeatedly.
+  --loader <loader>          TestSuiteLoader implementation to use.
+  --printer <printer>        TestSuiteListener implementation to use.
+  --repeat <times>           Runs the test(s) repeatedly.
 
-  --tap                     Report test execution progress in TAP format.
-  --testdox                 Report test execution progress in TestDox format.
+  --tap                      Report test execution progress in TAP format.
+  --testdox                  Report test execution progress in TestDox format.
 
-  --colors                  Use colors in output.
-  --stderr                  Write to STDERR instead of STDOUT.
-  --stop-on-error           Stop execution upon first error.
-  --stop-on-failure         Stop execution upon first error or failure.
-  --stop-on-skipped         Stop execution upon first skipped test.
-  --stop-on-incomplete      Stop execution upon first incomplete test.
-  --strict                  Run tests in strict mode.
-  -v|--verbose              Output more verbose information.
-  --debug                   Display debugging information during test execution.
+  --colors                   Use colors in output.
+  --stderr                   Write to STDERR instead of STDOUT.
+  --stop-on-error            Stop execution upon first error.
+  --stop-on-failure          Stop execution upon first error or failure.
+  --stop-on-skipped          Stop execution upon first skipped test.
+  --stop-on-incomplete       Stop execution upon first incomplete test.
+  --strict                   Run tests in strict mode.
+  -v|--verbose               Output more verbose information.
+  --debug                    Display debugging information during test execution.
 
-  --process-isolation       Run each test in a separate PHP process.
-  --no-globals-backup       Do not backup and restore $GLOBALS for each test.
-  --static-backup           Backup and restore static attributes for each test.
+  --process-isolation        Run each test in a separate PHP process.
+  --no-globals-backup        Do not backup and restore $GLOBALS for each test.
+  --static-backup            Backup and restore static attributes for each test.
 
-  --bootstrap <file>        A "bootstrap" PHP file that is run before the tests.
-  -c|--configuration <file> Read configuration from XML file.
-  --no-configuration        Ignore default configuration file (phpunit.xml).
-  --include-path <path(s)>  Prepend PHP's include_path with given path(s).
-  -d key[=value]            Sets a php.ini value.
+  --bootstrap <file>         A "bootstrap" PHP file that is run before the tests.
+  -c|--configuration <file>  Read configuration from XML file.
+  --no-configuration         Ignore default configuration file (phpunit.xml).
+  --include-path <path(s)>   Prepend PHP's include_path with given path(s).
+  -d key[=value]             Sets a php.ini value.
 
-  -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
+  -h|--help                  Prints this usage information.
+  --version                  Prints the version and exits.


### PR DESCRIPTION
Export and import for PHP_CodeCoverage in our project was too long - approx 70 hours. With changing serialize/unserialize approach we've got 2.5 hours. New approach is var_export and include.
