### PR TITLE
Changed doc due to no more serialize on export

### DIFF
--- a/PHPUnit/TextUI/Command.php
+++ b/PHPUnit/TextUI/Command.php
@@ -839,7 +839,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --coverage-clover <file>  Generate code coverage report in Clover XML format.
   --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
   --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Serialize PHP_CodeCoverage object to file.
+  --coverage-php <file>     Export PHP_CodeCoverage object to file.
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.

--- a/Tests/TextUI/help.phpt
+++ b/Tests/TextUI/help.phpt
@@ -22,7 +22,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --coverage-clover <file>  Generate code coverage report in Clover XML format.
   --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
   --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Serialize PHP_CodeCoverage object to file.
+  --coverage-php <file>     Export PHP_CodeCoverage object to file.
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.

--- a/Tests/TextUI/help2.phpt
+++ b/Tests/TextUI/help2.phpt
@@ -23,7 +23,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --coverage-clover <file>  Generate code coverage report in Clover XML format.
   --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
   --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Serialize PHP_CodeCoverage object to file.
+  --coverage-php <file>     Export PHP_CodeCoverage object to file.
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.


### PR DESCRIPTION
Export and import for PHP_CodeCoverage in our project was too long - approx 70 hours. With changing serialize/unserialize approach we've got 2.5 hours. New approach is var_export and include.
