### PR TITLE
Fix fatal error referencing PHP_Invoker (3.8-g5514f28)

### DIFF
--- a/PHPUnit/Framework/TestResult.php
+++ b/PHPUnit/Framework/TestResult.php
@@ -637,7 +637,7 @@ class PHPUnit_Framework_TestResult implements Countable
         try {
             if (!$test instanceof PHPUnit_Framework_Warning &&
                 $this->beStrictAboutTestSize &&
-                extension_loaded('pcntl') && class_exists('PHP_Invoker')) {
+                extension_loaded('pcntl') && class_exists('PHP_Invoker', FALSE)) {
                 switch ($test->getSize()) {
                     case PHPUnit_Util_Test::SMALL: {
                         $_timeout = $this->timeoutForSmallTests;

--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -425,7 +425,7 @@ class PHPUnit_Util_GlobalState
      */
     protected static function addDirectoryContainingClassToPHPUnitFilesList($className, $parent = 1)
     {
-        if (!class_exists($className)) {
+        if (!class_exists($className, FALSE)) {
             return;
         }
 


### PR DESCRIPTION
During shutdown, PHPUnit tries to autoload PHP_Invoker which is not part of the composer.json file. This patch works around the issue by explicitly not having the autoloader called when `class_exists()` is used although there is probably a dependency not being resolved correctly as well.

There are a handful of other `class_exists` calls that do not disable the autoloader, they may also be in error.
