### PR TITLE
Allow markTestSkipped/Incomplete() in dataProvider

### DIFF
--- a/src/Framework/IncompleteTestCase.php
+++ b/src/Framework/IncompleteTestCase.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 2.0.0
+ */
+
+/**
+ * An incomplete test case
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Davey Shafik <me@daveyshafik.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.3
+ */
+class PHPUnit_Framework_IncompleteTestCase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    protected $message = '';
+
+    /**
+     * @var boolean
+     */
+    protected $backupGlobals = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $backupStaticAttributes = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $runTestInSeparateProcess = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $useErrorHandler = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $useOutputBuffering = FALSE;
+
+    /**
+     * @param string $message
+     */
+    public function __construct($className, $methodName, $message = '')
+    {
+        $this->message = $message;
+        parent::__construct($className . '::' . $methodName);
+    }
+
+    /**
+     * @throws PHPUnit_Framework_Exception
+     */
+    protected function runTest()
+    {
+        $this->markTestIncomplete($this->message);
+    }
+
+    /**
+     * @return string
+     * @since  Method available since Release 3.0.0
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * Returns a string representation of the test case.
+     *
+     * @return string
+     * @since  Method available since Release 3.4.0
+     */
+    public function toString()
+    {
+        return $this->getName();
+    }
+}

--- a/src/Framework/SkippedTestCase.php
+++ b/src/Framework/SkippedTestCase.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 2.0.0
+ */
+
+/**
+ * A skipped test case
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Davey Shafik <me@daveyshafik.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.3
+ */
+class PHPUnit_Framework_SkippedTestCase extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    protected $message = '';
+
+    /**
+     * @var boolean
+     */
+    protected $backupGlobals = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $backupStaticAttributes = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $runTestInSeparateProcess = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $useErrorHandler = FALSE;
+
+    /**
+     * @var boolean
+     */
+    protected $useOutputBuffering = FALSE;
+
+    /**
+     * @param string $message
+     */
+    public function __construct($className, $methodName, $message = '')
+    {
+        $this->message = $message;
+        parent::__construct($className . '::' . $methodName);
+    }
+
+    /**
+     * @throws PHPUnit_Framework_Exception
+     */
+    protected function runTest()
+    {
+        $this->markTestSkipped($this->message);
+    }
+
+    /**
+     * @return string
+     * @since  Method available since Release 3.0.0
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * Returns a string representation of the test case.
+     *
+     * @return string
+     * @since  Method available since Release 3.4.0
+     */
+    public function toString()
+    {
+        return $this->getName();
+    }
+}

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -44,6 +44,8 @@
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeAndAfterTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeClassAndAfterClassTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderSkippedTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderIncompleteTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'InheritedTestCase.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'NoTestCaseClass.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'NoTestCases.php';
@@ -86,6 +88,8 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
         $suite->addTest(new Framework_SuiteTest('testShadowedTests'));
         $suite->addTest(new Framework_SuiteTest('testBeforeClassAndAfterClassAnnotations'));
         $suite->addTest(new Framework_SuiteTest('testBeforeAnnotation'));
+        $suite->addTest(new Framework_SuiteTest('testSkippedTestDataProvider'));
+        $suite->addTest(new Framework_SuiteTest('testIncompleteTestDataProvider'));
         $suite->addTest(new Framework_SuiteTest('testRequirementsBeforeClassHook'));
 
         return $suite;
@@ -213,6 +217,26 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(2, BeforeAndAfterTest::$beforeWasRun);
         $this->assertEquals(2, BeforeAndAfterTest::$afterWasRun);
+    }
+
+    public function testSkippedTestDataProvider()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('DataProviderSkippedTest');
+
+        $suite->run($this->result);
+
+        $this->assertEquals(3, $this->result->count());
+        $this->assertEquals(1, $this->result->skippedCount());
+    }
+
+    public function testIncompleteTestDataProvider()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('DataProviderIncompleteTest');
+
+        $suite->run($this->result);
+
+        $this->assertEquals(3, $this->result->count());
+        $this->assertEquals(1, $this->result->notImplementedCount());
     }
 
     public function testRequirementsBeforeClassHook()

--- a/tests/_files/DataProviderIncompleteTest.php
+++ b/tests/_files/DataProviderIncompleteTest.php
@@ -1,0 +1,37 @@
+<?php
+class DataProviderIncompleteTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider incompleteTestProviderMethod
+     */
+    public function testIncomplete($a, $b, $c)
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider providerMethod
+     */
+    public function testAdd($a, $b, $c)
+    {
+        $this->assertEquals($c, $a + $b);
+    }
+
+    public function incompleteTestProviderMethod()
+    {
+        $this->markTestIncomplete("incomplete");
+
+        return array(
+            array(0, 0, 0),
+            array(0, 1, 1),
+        );
+    }
+
+    public static function providerMethod()
+    {
+        return array(
+            array(0, 0, 0),
+            array(0, 1, 1),
+        );
+    }
+}

--- a/tests/_files/DataProviderSkippedTest.php
+++ b/tests/_files/DataProviderSkippedTest.php
@@ -1,0 +1,37 @@
+<?php
+class DataProviderSkippedTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider skippedTestProviderMethod
+     */
+    public function testSkipped($a, $b, $c)
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider providerMethod
+     */
+    public function testAdd($a, $b, $c)
+    {
+        $this->assertEquals($c, $a + $b);
+    }
+
+    public function skippedTestProviderMethod()
+    {
+        $this->markTestSkipped("skipped");
+
+        return array(
+            array(0, 0, 0),
+            array(0, 1, 1),
+        );
+    }
+
+    public static function providerMethod()
+    {
+        return array(
+            array(0, 0, 0),
+            array(0, 1, 1),
+        );
+    }
+}


### PR DESCRIPTION
- If you call `$this->markTestSkipped()` or
  `$this->markTestIncomplete()` in a dataProvider, it will now skip/incomplete
  the test, counting it as one test
