### PR TITLE
Added two calls to PHPUnit_Framework_TestResult::endTestSuite() from PHP...

### DIFF
--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -663,6 +663,8 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
                     $result->addFailure($this, $e, 0);
                 }
 
+                $result->endTestSuite($this);
+
                 return $result;
             }
 
@@ -672,6 +674,8 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
                 for ($i = 0; $i < $numTests; $i++) {
                     $result->addError($this, $e, 0);
                 }
+
+                $result->endTestSuite($this);
 
                 return $result;
             }


### PR DESCRIPTION
...Unit_Framework_TestSuite::run() to make sure test suites are ended properly when an exception (e.g. PHPUnit_Framework_SkippedTestError) in a test's setUpBeforeClass() method
