### PR TITLE
add ctype ext to deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "phpunit/php-timer": ">=1.0.4",
         "phpunit/phpunit-mock-objects": "~1.2.0",
         "symfony/yaml": "~2.0",
+        "ext-ctype": "*",
         "ext-dom": "*",
         "ext-pcre": "*",
         "ext-reflection": "*",

--- a/package.xml
+++ b/package.xml
@@ -248,6 +248,9 @@
     <max>2.99.99</max>
    </package>
    <extension>
+    <name>ctype</name>
+   </extension>
+   <extension>
     <name>dom</name>
    </extension>
    <extension>


### PR DESCRIPTION
used in `PHPUnit/Util/Configuration.php:1017`:

```
        (strlen($path) > 3 && ctype_alpha($path[0]) &&
```

i.e:

``` php
1007     /**
1008      * @param  string  $path
1009      * @param  boolean $useIncludePath
1010      * @return string
1011      * @since  Method available since Release 3.5.0
1012      */
1013     protected function toAbsolutePath($path, $useIncludePath = FALSE)
1014     {
1015         // Check whether the path is already absolute.
1016         if ($path[0] === '/' || $path[0] === '\\' ||
1017             (strlen($path) > 3 && ctype_alpha($path[0]) &&
1018              $path[1] === ':' && ($path[2] === '\\' || $path[2] === '/'))) {
1019             return $path;
1020         }
1021 

```

also, seems pear package.xml lacks some other extensions (mentioned in composer.json): 'reflection', 'spl', should these be added too?
