### PR TITLE
Remove ctype extension dependency (use OS check); issue #946

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -1012,10 +1012,19 @@ class PHPUnit_Util_Configuration
      */
     protected function toAbsolutePath($path, $useIncludePath = FALSE)
     {
-        // Check whether the path is already absolute.
-        if ($path[0] === '/' || $path[0] === '\\' ||
-            (strlen($path) > 3 && ctype_alpha($path[0]) &&
-             $path[1] === ':' && ($path[2] === '\\' || $path[2] === '/'))) {
+        // Check if this is a Windows path of either UNC or full path with
+        //   drive letter.
+        // No one should really be defining this except maybe in an odd-case
+        //   unit test that's not run on Windows.
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            if ($path[0] === '\\' || // UNC path or \\.\d: type path
+                (strlen($path) >= 3 && preg_match('#^[A-Z]\:[/\\\]#i', substr($path, 0, 3)))) {
+                return $path;
+            }
+        }
+
+        // Check whether the path is already absolute (POSIX).
+        if ($path[0] === '/') {
             return $path;
         }
 


### PR DESCRIPTION
This uses a very basic OS check and a case-insensitive regular expression to do the same thing as the `ctype_alpha($path[0]) && $path[1] === ':' && $path[2] === '\\'`.

Paths:

```
\\NetworkComputer\Path
\\.\D:
\\.\c:
C:\Windows
C:\windows
C:/windows
c:/windows
/posix-path/
```

And so on.

I think the `i` modifier on the regular expression is safe because Windows has remained case-insensitive since its early days in DOS.
