### PR TITLE
Less memory-consuming way to detect array recursions

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -1707,48 +1707,44 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     {
         $result = array();
 
-        // There seems to be no other way to check arrays for recursion
-        // http://www.php.net/manual/en/language.types.array.php#73936
-        preg_match_all('/\n            \[(\w+)\] => Array\s+\*RECURSION\*/', print_r($data, TRUE), $matches);
-        $recursiveKeys = array_unique($matches[1]);
-
-        // Convert to valid array keys
-        // Numeric integer strings are automatically converted to integers
-        // by PHP
-        foreach ($recursiveKeys as $key => $recursiveKey) {
-            if ((string)(integer)$recursiveKey === $recursiveKey) {
-                $recursiveKeys[$key] = (integer)$recursiveKey;
-            }
-        }
+        set_error_handler(function($errno, $errstr, $errfile, $errline) {
+            throw new ErrorException($errstr, $errno, $errno, $errfile, $errline);
+        }, E_WARNING);
 
         foreach ($data as $key => $_data) {
-            if (in_array($key, $recursiveKeys, TRUE)) {
-                $result[] = '*RECURSION*';
-            }
+            try {
+                // Detect array-recursions by using count
+                // http://php.net/manual/en/function.count.php
+                $iRecursiveCheck = count($_data, COUNT_RECURSIVE);
 
-            else if (is_array($_data)) {
-                $result[] = 'array(' . $this->dataToString($_data) . ')';
-            }
+                if (is_array($_data)) {
+                    $result[] = 'array(' . $this->dataToString($_data) . ')';
+                }
 
-            else if (is_object($_data)) {
-                $object = new ReflectionObject($_data);
+                else if (is_object($_data)) {
+                    $object = new ReflectionObject($_data);
 
-                if ($object->hasMethod('__toString')) {
-                    $result[] = (string)$_data;
-                } else {
-                    $result[] = get_class($_data);
+                    if ($object->hasMethod('__toString')) {
+                        $result[] = (string)$_data;
+                    } else {
+                        $result[] = get_class($_data);
+                    }
+                }
+
+                else if (is_resource($_data)) {
+                    $result[] = '<resource>';
+                }
+
+                else {
+                    $result[] = var_export($_data, TRUE);
                 }
             }
-
-            else if (is_resource($_data)) {
-                $result[] = '<resource>';
-            }
-
-            else {
-                $result[] = var_export($_data, TRUE);
+            catch (ErrorException $e) {
+                $result[] = '*RECURSION*';
             }
         }
 
+        restore_error_handler();
         return join(', ', $result);
     }
 


### PR DESCRIPTION
I had issues (segmentation-faults) with the array-recursion-detection when $data was a large array (without recursions). This was already mentioned sometimes (e.g. http://stackoverflow.com/questions/6343674/phpunit-segmentation-fault).

I changed the detection to use http://php.net/manual/en/function.count.php, which triggers an E_WARNING when it detects a recursion.
