### PR TITLE
Include ext-xdebug in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "ext-spl": "*"
     },
     "require-dev": {
-        "pear-pear/pear": "1.9.4"
+        "pear-pear/pear": "1.9.4",
+        "ext-xdebug": "*"
     },
     "repositories": [
         {


### PR DESCRIPTION
On a fresh checkout without xdebug installed, tests are failing.

This should give a warning about it before the tests start falling.
