### PR TITLE
Require datetime

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -3,3 +3,8 @@ require __DIR__ . '/../PHPUnit/Autoload.php';
 require __DIR__ . '/../PHPUnit/Framework/Assert/Functions.php';
 require __DIR__ . '/_files/CoveredFunction.php';
 require __DIR__ . '/autoload.php';
+
+if (!ini_get('date.timezone')) {
+  echo 'ERROR: These tests will not pass unless date.timzone is set in php.ini';
+  exit(1);
+}


### PR DESCRIPTION
Another little one to ease the development setup

Fails early if missing the timezone, as other tests will fail later if this isn't set.
