### PR TITLE
#1007 added caching to prevent duplicate directory scanning

### DIFF
--- a/PHPUnit/Util/GlobalState.php
+++ b/PHPUnit/Util/GlobalState.php
@@ -95,6 +95,7 @@ class PHPUnit_Util_GlobalState
      * @var array
      */
     protected static $phpunitFiles;
+    protected static $phpunitDirs;
 
     public static function backupGlobals(array $blacklist)
     {
@@ -416,6 +417,16 @@ class PHPUnit_Util_GlobalState
         for ($i = 0; $i < $parent; $i++) {
             $directory = dirname($directory);
         }
+
+        if (isset(self::$phpunitDirs)) {
+            if (isset(self::$phpunitDirs[$directory])) {
+                // already scanned this directory, ignore
+                return;
+            }
+        } else {
+            self::$phpunitDirs = array();
+        }
+        self::$phpunitDirs[$directory] = true;
 
         $facade = new File_Iterator_Facade;
 


### PR DESCRIPTION
Some of the classes passed to addDirectoryContainingClassToPHPUnitFilesList in PHPUnit_Util_GlobalState::phpunitFiles() can resolve to the same directory. If this is a large directory (eg. in my case the pear/PHP directory that was processed 3 times), this duplicate scanning will cause delays that can be avoided.
