### PR TITLE
Remove ctype dep

### DIFF
--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -1016,20 +1016,15 @@ class PHPUnit_Util_Configuration
         //   drive letter.
         // No one should really be defining this except maybe in an odd-case
         //   unit test that's not run on Windows.
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            if ($path[0] === '\\' || // UNC path or \\.\d: type path
-                (strlen($path) >= 3 && preg_match('#^[A-Z]\:[/\\\]#i', substr($path, 0, 3)))) {
-                return $path;
-            }
-        }
-
-        // Check whether the path is already absolute (POSIX).
-        if ($path[0] === '/') {
+        // A / is allowed here like POSIX because it will get converted to \
+        //  internally.
+        if ($path[0] === '/') { // POSIX and Windows
             return $path;
-        }
-
-        // Check whether a stream is used.
-        if (strpos($path, '://') !== FALSE) {
+        } else if (defined('PHP_WINDOWS_VERSION_BUILD') &&
+                   ($path[0] === '\\' || // UNC path, \\?\ path or \\.\d: type path
+                   (strlen($path) >= 3 && preg_match('#^[A-Z]\:[/\\\]#i', substr($path, 0, 3))))) {
+            return $path;
+        } else if (strpos($path, '://') !== FALSE) { // Stream
             return $path;
         }
 

--- a/PHPUnit/Util/Configuration.php
+++ b/PHPUnit/Util/Configuration.php
@@ -1012,10 +1012,19 @@ class PHPUnit_Util_Configuration
      */
     protected function toAbsolutePath($path, $useIncludePath = FALSE)
     {
-        // Check whether the path is already absolute.
-        if ($path[0] === '/' || $path[0] === '\\' ||
-            (strlen($path) > 3 && ctype_alpha($path[0]) &&
-             $path[1] === ':' && ($path[2] === '\\' || $path[2] === '/'))) {
+        // Check if this is a Windows path of either UNC or full path with
+        //   drive letter.
+        // No one should really be defining this except maybe in an odd-case
+        //   unit test that's not run on Windows.
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            if ($path[0] === '\\' || // UNC path or \\.\d: type path
+                (strlen($path) >= 3 && preg_match('#^[A-Z]\:[/\\\]#i', substr($path, 0, 3)))) {
+                return $path;
+            }
+        }
+
+        // Check whether the path is already absolute (POSIX).
+        if ($path[0] === '/') {
             return $path;
         }
 


### PR DESCRIPTION
Uses `else if` instead for grouping purposes. Still kept stream check last as I think this is left often the case. This allows `/` at the front of paths to be considered full paths on both Windows and POSIX systems.

Not so sure on how indenting should be done when parentheses are definitely required after ensuring the platform is Windows on the first `else if`.
