### PR TITLE
Update PHP.php

### DIFF
--- a/PHPUnit/Util/PHP.php
+++ b/PHPUnit/Util/PHP.php
@@ -92,7 +92,10 @@ abstract class PHPUnit_Util_PHP
     protected function getPhpBinary()
     {
         if ($this->phpBinary === NULL) {
-            if (defined("PHP_BINARY")) {
+            if (($e = getenv("PHP_BINARY")) !== false) {
+                $this->phpBinary = $e;
+            }
+            else if (defined("PHP_BINARY")) {
                 $this->phpBinary = PHP_BINARY;
             } else if (PHP_SAPI == 'cli' && isset($_SERVER['_'])) {
                 if (strpos($_SERVER['_'], 'phpunit') !== FALSE) {


### PR DESCRIPTION
Check for a PHP_BINARY environment variable before using the pre-defined PHP_BINARY constant.

HHVM has an explicit hhvm binary and a wrapper to mimic php functionality. We were running into issues with tests that ran in their own process where using the hhvm binary does not handle php code sent to it via stdin very well. We get "Nothing to do...pass file" exceptions. Unfortunately, the PHP_BINARY is always set to the explicit binary (the php wrapper is basically a symlink to the explicit binary). So, we thought about adding a check for a PHP_BINARY environment variable as the first choice when getting the PHP binary.
