### PR TITLE
Clone test arguments

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -1837,7 +1837,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                         return FALSE;
                     }
 
-                    $this->dependencyInput[] = $passed[$dependency]['result'];
+                    if (is_object($passed[$dependency]['result'])) {
+                        $this->dependencyInput[] = clone $passed[$dependency]['result'];
+                    } else {
+                        $this->dependencyInput[] = $passed[$dependency]['result'];
+                    }
                 } else {
                     $this->dependencyInput[] = NULL;
                 }

--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -214,6 +214,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     private $dependencyInput = array();
 
     /**
+     * @var String
+     */
+    private $dependencyInjectionPolicy = 'NONE';
+
+    /**
      * @var array
      */
     private $iniSettings = array();
@@ -1099,6 +1104,44 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @param String $input    Value to add as input
+     * @param String $testName Name of test that produced $input
+     * @return bool
+     */
+    public function addDependencyInput($input, $testName)
+    {
+        if (!is_object($input) || $this->dependencyInjectionPolicy == 'NONE') {
+            $this->dependencyInput[] = $input;
+            return TRUE;
+        }
+
+        if ($this->dependencyInjectionPolicy == 'CLONE') {
+            $reflection = new ReflectionObject($input);
+            if ($reflection->isCloneable()) {
+                $this->dependencyInput[] = clone $input;
+                return TRUE;
+            }
+
+            // TODO: How to handle cases where object is not CLONEABLE
+            return FALSE;
+        }
+
+        if ($this->dependencyInjectionPolicy == 'RERUN') {
+            // Not really sure how to implement this.
+        }
+
+        return FALSE;
+    }
+
+    /**
+     * @param String $policy
+     */
+    public function setInjectionPolicy($policy)
+    {
+        $this->dependencyInjectionPolicy = $policy;
+    }
+
+    /**
      * Calling this method in setUp() has no effect!
      *
      * @param  boolean $backupGlobals
@@ -1837,11 +1880,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                         return FALSE;
                     }
 
-                    if (is_object($passed[$dependency]['result'])) {
-                        $this->dependencyInput[] = clone $passed[$dependency]['result'];
-                    } else {
-                        $this->dependencyInput[] = $passed[$dependency]['result'];
-                    }
+                    $this->addDependencyInput($passed[$dependency]['result'], $dependency);
                 } else {
                     $this->dependencyInput[] = NULL;
                 }

--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -840,6 +840,12 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
                 $test->setDependencies(
                   PHPUnit_Util_Test::getDependencies($class->getName(), $name)
                 );
+
+                if (!$test instanceof PHPUnit_Framework_TestSuite_DataProvider) {
+                    $test->setInjectionPolicy(
+                        PHPUnit_Util_Test::getInjectionPolicy($class->getName())
+                    );
+                }
             }
 
             $this->addTest($test, PHPUnit_Util_Test::getGroups(

--- a/PHPUnit/Util/Test.php
+++ b/PHPUnit/Util/Test.php
@@ -674,6 +674,21 @@ class PHPUnit_Util_Test
     }
 
     /**
+     * @param string $className
+     * @return string
+     */
+    public static function getInjectionPolicy($className)
+    {
+        $annotations = self::parseTestMethodAnnotations($className);
+
+        if (empty($annotations['class']['dependsInjectionPolicy'][0])) {
+            return 'NONE';
+        }
+
+        return $annotations['class']['dependsInjectionPolicy'][0];
+    }
+
+    /**
      * Returns the preserve global state settings for a test.
      *
      * @param  string $className

--- a/Tests/Regression/GitHub/1057/Issue1057CloneTest.php
+++ b/Tests/Regression/GitHub/1057/Issue1057CloneTest.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once 'SomeStack.php';
+
+/**
+ * Class Issue1075test
+ * @dependsInjectionPolicy CLONE
+ * @runInSeparateProcess
+ *
+ */
+class Issue1075CloneTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testStackInitiallyEmpty()
+    {
+        $stack = new CloneStack();
+
+        $this->assertEmpty($stack->getItems());
+        $this->assertEquals(1, $stack::$ctr);
+
+        return $stack;
+    }
+
+    /**
+     * @depends testStackInitiallyEmpty
+     */
+    public function testAddItem($stack)
+    {
+        $stack->addItem('SomeItem');
+
+        $this->assertNotEmpty($stack->getItems());
+        $this->assertEquals(1, $stack::$ctr);
+    }
+
+    /**
+     * @depends testStackInitiallyEmpty
+     */
+    public function testSomethingElseThatWantsAnEmptyStack($stack)
+    {
+        $this->assertEmpty($stack->getItems());
+        $this->assertEquals(1, $stack::$ctr);
+    }
+}

--- a/Tests/Regression/GitHub/1057/Issue1057NoneTest.php
+++ b/Tests/Regression/GitHub/1057/Issue1057NoneTest.php
@@ -1,27 +1,20 @@
 <?php
 
-class SomeStack
-{
-    private $items = array();
+require_once 'SomeStack.php';
 
-    public function addItem($item)
-    {
-        $this->items[] = $item;
-    }
-
-    public function getItems()
-    {
-        return $this->items;
-    }
-}
-
-class Issue1075test extends PHPUnit_Framework_TestCase
+/**
+ * Class Issue1075test
+ * @dependsInjectionPolicy NONE
+ * @runInSeparateProcess
+ */
+class Issue1057NoneTest extends PHPUnit_Framework_TestCase
 {
     public function testStackInitiallyEmpty()
     {
         $stack = new SomeStack();
 
         $this->assertEmpty($stack->getItems());
+        $this->assertEquals(1, $stack::$ctr);
 
         return $stack;
     }
@@ -34,6 +27,7 @@ class Issue1075test extends PHPUnit_Framework_TestCase
         $stack->addItem('SomeItem');
 
         $this->assertNotEmpty($stack->getItems());
+        $this->assertEquals(1, $stack::$ctr);
     }
 
     /**
@@ -41,6 +35,7 @@ class Issue1075test extends PHPUnit_Framework_TestCase
      */
     public function testSomethingElseThatWantsAnEmptyStack($stack)
     {
-        $this->assertEmpty($stack->getItems()); // Fails
+        $this->assertNotEmpty($stack->getItems());
+        $this->assertEquals(1, $stack::$ctr);
     }
 }

--- a/Tests/Regression/GitHub/1057/Issue1057RerunTest.php
+++ b/Tests/Regression/GitHub/1057/Issue1057RerunTest.php
@@ -1,0 +1,52 @@
+<?php
+
+require_once 'SomeStack.php';
+
+/**
+ * Class Issue1075test
+ * @dependsInjectionPolicy RERUN
+ * @runInSeparateProcess
+ */
+class Issue1057RerunTest extends PHPUnit_Framework_TestCase
+{
+    public function testStackInitiallyEmpty()
+    {
+        $stack = new RerunStack();
+
+        $this->assertEmpty($stack->getItems());
+
+        return $stack;
+    }
+
+    /**
+     * @depends testStackInitiallyEmpty
+     */
+    public function testAddItem($stack)
+    {
+        $stack->addItem('SomeItem');
+
+        $this->assertNotEmpty($stack->getItems());
+        $this->assertEquals(2, $stack::$ctr);
+
+        return $stack;
+    }
+
+    /**
+     * @depends testStackInitiallyEmpty
+     */
+    public function testSomethingElseThatWantsAnEmptyStack($stack)
+    {
+        $this->assertEmpty($stack->getItems());
+        $this->assertEquals(3, $stack::$ctr);
+
+        return $stack;
+    }
+
+    /**
+     * @depends testAddItem
+     */
+    public function testMultiLevelDepends($stack)
+    {
+        $this->assertNotEmpty($stack->getItems());
+    }
+}

--- a/Tests/Regression/GitHub/1057/Issue1057Test.php
+++ b/Tests/Regression/GitHub/1057/Issue1057Test.php
@@ -1,0 +1,46 @@
+<?php
+
+class SomeStack
+{
+    private $items = array();
+
+    public function addItem($item)
+    {
+        $this->items[] = $item;
+    }
+
+    public function getItems()
+    {
+        return $this->items;
+    }
+}
+
+class Issue1075test extends PHPUnit_Framework_TestCase
+{
+    public function testStackInitiallyEmpty()
+    {
+        $stack = new SomeStack();
+
+        $this->assertEmpty($stack->getItems());
+
+        return $stack;
+    }
+
+    /**
+     * @depends testStackInitiallyEmpty
+     */
+    public function testAddItem($stack)
+    {
+        $stack->addItem('SomeItem');
+
+        $this->assertNotEmpty($stack->getItems());
+    }
+
+    /**
+     * @depends testStackInitiallyEmpty
+     */
+    public function testSomethingElseThatWantsAnEmptyStack($stack)
+    {
+        $this->assertEmpty($stack->getItems()); // Fails
+    }
+}

--- a/Tests/Regression/GitHub/1057/SomeStack.php
+++ b/Tests/Regression/GitHub/1057/SomeStack.php
@@ -1,0 +1,31 @@
+<?php
+
+class SomeStack
+{
+    private $items = array();
+
+    public static $ctr = 0;
+
+    public function __construct()
+    {
+        static::$ctr++;
+    }
+
+    public function addItem($item)
+    {
+        $this->items[] = $item;
+    }
+
+    public function getItems()
+    {
+        return $this->items;
+    }
+}
+
+Class CloneStack extends SomeStack {
+    public static $ctr = 0;
+}
+
+Class RerunStack extends SomeStack {
+    public static $ctr = 0;
+}


### PR DESCRIPTION
If a test uses `@depenends`, clone the arguments that are objects to prevent unintended modification of the objects  by other functions.

My biggest fear here is an bump in memory usage by phpunit, as we now duplicate multiple objects.

Fixes #1057