### PR TITLE
Added phpdoc for TestCase::getMock

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -1299,14 +1299,17 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     /**
      * Returns a mock object for the specified class.
      *
-     * @param  string  $originalClassName
-     * @param  array   $methods
-     * @param  array   $arguments
-     * @param  string  $mockClassName
-     * @param  boolean $callOriginalConstructor
-     * @param  boolean $callOriginalClone
-     * @param  boolean $callAutoload
-     * @param  boolean $cloneArguments
+     * @param  string     $originalClassName       Name of the class to mock.
+     * @param  array|null $methods                 When provided, only methods whose names are in the array
+     *                                             are replaced with a configurable test double. The behavior
+     *                                             of the other methods is not changed.
+     *                                             Providing null means that no methods will be replaced.
+     * @param  array      $arguments               Parameters to pass to the original class' constructor.
+     * @param  string     $mockClassName           Class name for the generated test double class.
+     * @param  boolean    $callOriginalConstructor Can be used to disable the call to the original class' constructor.
+     * @param  boolean    $callOriginalClone       Can be used to disable the call to the original class' clone constructor.
+     * @param  boolean    $callAutoload            Can be used to disable __autoload() during the generation of the test double class.
+     * @param  boolean    $cloneArguments
      * @return PHPUnit_Framework_MockObject_MockObject
      * @throws PHPUnit_Framework_Exception
      * @since  Method available since Release 3.0.0


### PR DESCRIPTION
I added some phpdoc to `TestCase::getMock`. I've been using PHPUnit for at least 4 years and I'm always ending up on the documentation when trying to build a mock. Hopefully this should help.

Texts inspired from the doc: http://phpunit.de/manual/3.7/en/test-doubles.html
