### PR TITLE
@noSetup annotation to skip @before and @after functions for the specifi...

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -148,6 +148,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     private $inIsolation = FALSE;
 
     /**
+     * Whether or not run before and after procedures for this test.
+     *
+     * @var boolean
+     */
+    private $runSetup = TRUE;
+
+    /**
      * @var array
      */
     private $data = array();
@@ -504,6 +511,16 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     */
+    protected function setRunSetupFromAnnotation()
+    {
+        $annotations = $this->getAnnotations();
+        if (isset($annotations['method']['noSetup'][0])) {
+            $this->runSetup = FALSE;
+        }
+    }
+
+    /**
      * @param boolean $useErrorHandler
      * @since Method available since Release 3.4.0
      */
@@ -831,9 +848,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
 
             $this->setExpectedExceptionFromAnnotation();
-            foreach ($this->beforeMethods as $method) {
-                $this->$method();
+
+            if ($this->runSetup) {
+                foreach ($this->beforeMethods as $method) {
+                    $this->$method();
+                }
             }
+
             $this->checkRequirements();
             $this->assertPreConditions();
             $this->testResult = $this->runTest();
@@ -868,8 +889,10 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         // Tear down the fixture. An exception raised in tearDown() will be
         // caught and passed on when no exception was raised before.
         try {
-            foreach ($this->afterMethods as $method) {
-                $this->$method();
+            if ($this->runSetup) {
+                foreach ($this->afterMethods as $method) {
+                    $this->$method();
+                }
             }
 
             if ($this->inIsolation) {

--- a/Tests/Framework/TestCaseTest.php
+++ b/Tests/Framework/TestCaseTest.php
@@ -442,4 +442,12 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expectedCwd, getcwd());
     }
 
+    public function testNoSetup()
+    {
+        $test   = new NoSetupTest('testSomething');
+        $result = $test->run();
+
+        $this->assertTrue($test->testSomething);
+        $this->assertFalse($test->setup);
+    }
 }

--- a/Tests/_files/NoSetUpTest.php
+++ b/Tests/_files/NoSetUpTest.php
@@ -1,0 +1,24 @@
+<?php
+class NoSetupTest extends PHPUnit_Framework_TestCase
+{
+    public $setup = FALSE;
+    public $testSomething = FALSE;
+
+    protected function setUp()
+    {
+        $this->setup = TRUE;
+    }
+
+    protected function tearDown()
+    {
+        $this->setup = TRUE;
+    }
+
+    /**
+     * @noSetup
+     */
+    public function testSomething()
+    {
+        $this->testSomething = TRUE;
+    }
+}


### PR DESCRIPTION
Was originally written for 3.7, where "SetUp" had more meaning, so maybe annotation name itself could be different? I have changed it from "@noSetUp" to "@noSetup" for now.
