### PR TITLE
Fix Handling of DOMNodes in assertions

### DIFF
--- a/PHPUnit/Autoload.php
+++ b/PHPUnit/Autoload.php
@@ -93,7 +93,7 @@ spl_autoload_register(
             'phpunit_framework_comparator' => '/Framework/Comparator.php',
             'phpunit_framework_comparator_array' => '/Framework/Comparator/Array.php',
             'phpunit_framework_comparator_datetime' => '/Framework/Comparator/DateTime.php',
-            'phpunit_framework_comparator_domdocument' => '/Framework/Comparator/DOMDocument.php',
+            'phpunit_framework_comparator_domnode' => '/Framework/Comparator/DOMNode.php',
             'phpunit_framework_comparator_double' => '/Framework/Comparator/Double.php',
             'phpunit_framework_comparator_exception' => '/Framework/Comparator/Exception.php',
             'phpunit_framework_comparator_mockobject' => '/Framework/Comparator/MockObject.php',

--- a/PHPUnit/Framework/Comparator/DOMNode.php
+++ b/PHPUnit/Framework/Comparator/DOMNode.php
@@ -126,6 +126,9 @@ class PHPUnit_Framework_Comparator_DOMNode extends PHPUnit_Framework_Comparator_
         $document->formatOutput = TRUE;
         $document->normalizeDocument();
 
+        if ($node instanceof DOMDocument) {
+            return $node->saveXML();
+        }
         return $document->saveXML($node);
     }
 }

--- a/PHPUnit/Framework/Comparator/DOMNode.php
+++ b/PHPUnit/Framework/Comparator/DOMNode.php
@@ -119,10 +119,11 @@ class PHPUnit_Framework_Comparator_DOMNode extends PHPUnit_Framework_Comparator_
     protected function domToText(DOMNode $node)
     {
         if ($node instanceof DOMDocument) {
-            $node = $node->documentElement;
+            $document = $node;
+        } else {
+            $document = $node->ownerDocument;
         }
 
-        $document = $node->ownerDocument;
         $document->formatOutput = TRUE;
         $document->normalizeDocument();
 

--- a/PHPUnit/Framework/Comparator/DOMNode.php
+++ b/PHPUnit/Framework/Comparator/DOMNode.php
@@ -44,17 +44,17 @@
  */
 
 /**
- * Compares DOMDocument instances for equality.
+ * Compares DOMNodes instances for equality.
  *
  * @package    PHPUnit
  * @subpackage Framework_Comparator
  * @author     Bernhard Schussek <bschussek@2bepublished.at>
+ * @author     Arne Blankerts <arne@blankerts.de>
  * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://www.phpunit.de/
- * @since      Class available since Release 3.6.0
  */
-class PHPUnit_Framework_Comparator_DOMDocument extends PHPUnit_Framework_Comparator_Object
+class PHPUnit_Framework_Comparator_DOMNode extends PHPUnit_Framework_Comparator_Object
 {
     /**
      * Returns whether the comparator can compare two values.
@@ -65,7 +65,7 @@ class PHPUnit_Framework_Comparator_DOMDocument extends PHPUnit_Framework_Compara
      */
     public function accepts($expected, $actual)
     {
-        return $expected instanceof DOMDocument && $actual instanceof DOMDocument;
+        return $expected instanceof DOMNode && $actual instanceof DOMNode;
     }
 
     /**
@@ -85,30 +85,47 @@ class PHPUnit_Framework_Comparator_DOMDocument extends PHPUnit_Framework_Compara
      */
     public function assertEquals($expected, $actual, $delta = 0, $canonicalize = FALSE, $ignoreCase = FALSE)
     {
-        if ($expected->C14N() !== $actual->C14N()) {
+        $expectedXML = $expected->C14N();
+        $actualXML = $actual->C14N();
+        if ($ignoreCase === TRUE) {
+            $expectedXML = strtolower($expectedXML);
+            $actualXML = strtolower($actualXML);
+        }
+        if ($expectedXML !== $actualXML) {
+            if ($expected instanceof DOMDocument) {
+                $type = 'documents';
+            } else {
+                $type = 'nodes';
+            }
+
             throw new PHPUnit_Framework_ComparisonFailure(
               $expected,
               $actual,
               $this->domToText($expected),
               $this->domToText($actual),
               FALSE,
-              'Failed asserting that two DOM documents are equal.'
+              sprintf('Failed asserting that two DOM %s are equal.', $type)
             );
         }
     }
 
     /**
      * Returns the normalized, whitespace-cleaned, and indented textual
-     * representation of a DOMDocument.
+     * representation of a DOMNode.
      *
-     * @param DOMDocument $document
+     * @param DOMNode $node
      * @return string
      */
-    protected function domToText(DOMDocument $document)
+    protected function domToText(DOMNode $node)
     {
+        if ($node instanceof DOMDocument) {
+            $node = $node->documentElement;
+        }
+
+        $document = $node->ownerDocument;
         $document->formatOutput = TRUE;
         $document->normalizeDocument();
 
-        return $document->saveXML();
+        return $document->saveXML($node);
     }
 }

--- a/PHPUnit/Framework/ComparatorFactory.php
+++ b/PHPUnit/Framework/ComparatorFactory.php
@@ -80,7 +80,7 @@ class PHPUnit_Framework_ComparatorFactory
         $this->register(new PHPUnit_Framework_Comparator_Object);
         $this->register(new PHPUnit_Framework_Comparator_Exception);
         $this->register(new PHPUnit_Framework_Comparator_SplObjectStorage);
-        $this->register(new PHPUnit_Framework_Comparator_DOMDocument);
+        $this->register(new PHPUnit_Framework_Comparator_DOMNode);
         $this->register(new PHPUnit_Framework_Comparator_MockObject);
         $this->register(new PHPUnit_Framework_Comparator_DateTime);
     }

--- a/Tests/Framework/ComparatorTest.php
+++ b/Tests/Framework/ComparatorTest.php
@@ -86,7 +86,8 @@ class Framework_ComparatorTest extends PHPUnit_Framework_TestCase
             array(new DateTime, new DateTime, 'PHPUnit_Framework_Comparator_DateTime'),
             array(new SplObjectStorage, new SplObjectStorage, 'PHPUnit_Framework_Comparator_SplObjectStorage'),
             array(new Exception, new Exception, 'PHPUnit_Framework_Comparator_Exception'),
-            array(new DOMDocument, new DOMDocument, 'PHPUnit_Framework_Comparator_DOMDocument'),
+            array(new DOMDocument, new DOMDocument, 'PHPUnit_Framework_Comparator_DOMNode'),
+            array(new DOMNode, new DOMNode, 'PHPUnit_Framework_Comparator_DOMNode'),
             // mixed types
             array($tmpfile, array(1), 'PHPUnit_Framework_Comparator_Type'),
             array(array(1), $tmpfile, 'PHPUnit_Framework_Comparator_Type'),


### PR DESCRIPTION
The current Comparator code can only handle complete DOMDocuments. When passing DOMNodes to assert*(), the object comparator will be used which does not work as expected with this type.

This PR includes a replacement for the DOMDocument Comparator as technically a DOMDocument is also just a DOMNode and the implementation by Bernhard Schussek could almost handle both.

I also implemented support for the optional case-insensitive switch.
