### PR TITLE
Add comparator for SplDoublyLinkedList family

### DIFF
--- a/PHPUnit/Framework/Comparator/SplDoublyLinkedList.php
+++ b/PHPUnit/Framework/Comparator/SplDoublyLinkedList.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2013, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework
+ * @author     Sam Boyer <tech@samboyer.org>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.7.29
+ */
+
+/**
+ * Compares instances of SplDoublyLinkedList and children (SplQueue, SplStack) for equality.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Comparator
+ * @author     Sam Boyer <tech@samboyer.org>
+ * @copyright  2001-2013 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 3.7.29
+ */
+class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework_Comparator_Array
+{
+    /**
+     * Returns whether the comparator can compare two values.
+     *
+     * @param  mixed $expected The first value to compare
+     * @param  mixed $actual The second value to compare
+     * @return boolean
+     */
+    public function accepts($expected, $actual)
+    {
+        return $expected instanceof SplDoublyLinkedList && $actual instanceof SplDoublyLinkedList;
+    }
+
+    /**
+     * Asserts that two values are equal.
+     *
+     * @param  mixed $expected The first value to compare
+     * @param  mixed $actual The second value to compare
+     * @param  float $delta The allowed numerical distance between two values to
+     *                      consider them equal
+     * @param  bool  $canonicalize If set to TRUE, arrays are sorted before
+     *                             comparison
+     * @param  bool  $ignoreCase If set to TRUE, upper- and lowercasing is
+     *                           ignored when comparing string values
+     * @throws PHPUnit_Framework_ComparisonFailure Thrown when the comparison
+     *                           fails. Contains information about the
+     *                           specific errors that lead to the failure.
+     */
+    public function assertEquals($expected, $actual, $delta = 0, $canonicalize = FALSE, $ignoreCase = FALSE)
+    {
+        // Because PHP implements queues and stacks as specializations of a
+        // doubly linked list differentiated only by an iteration mode flag,
+        // it is truer to compare the flag than the particular (sub)class in
+        // use. Use a mask to focus on only the first two bits, as the SplQueue
+        // and SplStack seem to have the third bit set for undocumented reasons.
+        $mask = SplDoublyLinkedList::IT_MODE_LIFO | SplDoublyLinkedList::IT_MODE_DELETE;
+        if (($actual->getIteratorMode() & $mask) !== ($expected->getIteratorMode() & $mask)) {
+            throw new PHPUnit_Framework_ComparisonFailure(
+              $expected,
+              $actual,
+              PHPUnit_Util_Type::export($expected),
+              PHPUnit_Util_Type::export($actual),
+              FALSE,
+              'Failed asserting that both structures are iterating in the same mode.'
+            );
+        }
+
+        if ($actual->count() !== $expected->count()) {
+            throw new PHPUnit_Framework_ComparisonFailure(
+              $expected,
+              $actual,
+              PHPUnit_Util_Type::export($expected),
+              PHPUnit_Util_Type::export($actual),
+              FALSE,
+              'Failed asserting that both structures are equal; they have different length.'
+            );
+        }
+
+        // If the list is set to delete items when iterating, flip that off
+        // while inspecting it.
+        $delete = FALSE;
+        if ($actual->getIteratorMode() & SplDoublyLinkedList::IT_MODE_DELETE) {
+            $delete = TRUE;
+            $actual->setIteratorMode($actual->getIteratorMode() & ~SplDoublyLinkedList::IT_MODE_DELETE);
+            $expected->setIteratorMode($expected->getIteratorMode() & ~SplDoublyLinkedList::IT_MODE_DELETE);
+        }
+
+        $expected->rewind();
+        foreach ($actual as $item) {
+            $expected->next();
+            if ($expected->current() != $item || !$expected->valid()) {
+                throw new PHPUnit_Framework_ComparisonFailure(
+                  $expected,
+                  $actual,
+                  PHPUnit_Util_Type::export($expected),
+                  PHPUnit_Util_Type::export($actual),
+                  FALSE,
+                  'Failed asserting that two objects are equal.'
+                );
+            }
+        }
+
+        if ($delete) {
+            $actual->setIteratorMode($actual->getIteratorMode() | SplDoublyLinkedList::IT_MODE_DELETE);
+            $expected->setIteratorMode($expected->getIteratorMode() | SplDoublyLinkedList::IT_MODE_DELETE);
+        }
+    }
+
+    protected function toArray(SplDoublyLinkedList $list)
+    {
+    }
+}

--- a/PHPUnit/Framework/Comparator/SplDoublyLinkedList.php
+++ b/PHPUnit/Framework/Comparator/SplDoublyLinkedList.php
@@ -75,8 +75,8 @@ class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework
      * @param  mixed $actual The second value to compare
      * @param  float $delta The allowed numerical distance between two values to
      *                      consider them equal
-     * @param  bool  $canonicalize If set to TRUE, arrays are sorted before
-     *                             comparison
+     * @param  bool  $canonicalize Ignored; ordering must be checked as it is
+     *                             an inherent guarantee of the datastructure.
      * @param  bool  $ignoreCase If set to TRUE, upper- and lowercasing is
      *                           ignored when comparing string values
      * @throws PHPUnit_Framework_ComparisonFailure Thrown when the comparison
@@ -85,6 +85,11 @@ class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework
      */
     public function assertEquals($expected, $actual, $delta = 0, $canonicalize = FALSE, $ignoreCase = FALSE)
     {
+        // Quick escape hatch if they are the same object.
+        if ($expected === $actual) {
+            return;
+        }
+
         // Because PHP implements queues and stacks as specializations of a
         // doubly linked list differentiated only by an iteration mode flag,
         // it is truer to compare the flag than the particular (sub)class in
@@ -123,9 +128,10 @@ class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework
         }
 
         $expected->rewind();
-        foreach ($actual as $item) {
-            $expected->next();
-            if ($expected->current() != $item || !$expected->valid()) {
+        $actual->rewind();
+        while ($actual->valid()) {
+            list($a_item, $e_item) = array($actual->current(), $expected->current());
+            if ($e_item != $a_item) {
                 throw new PHPUnit_Framework_ComparisonFailure(
                   $expected,
                   $actual,
@@ -135,15 +141,13 @@ class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework
                   'Failed asserting that two objects are equal.'
                 );
             }
+            $expected->next();
+            $actual->next();
         }
 
         if ($delete) {
             $actual->setIteratorMode($actual->getIteratorMode() | SplDoublyLinkedList::IT_MODE_DELETE);
             $expected->setIteratorMode($expected->getIteratorMode() | SplDoublyLinkedList::IT_MODE_DELETE);
         }
-    }
-
-    protected function toArray(SplDoublyLinkedList $list)
-    {
     }
 }

--- a/PHPUnit/Framework/Comparator/SplDoublyLinkedList.php
+++ b/PHPUnit/Framework/Comparator/SplDoublyLinkedList.php
@@ -54,7 +54,7 @@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release 3.7.29
  */
-class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework_Comparator_Array
+class PHPUnit_Framework_Comparator_SplDoublyLinkedList extends PHPUnit_Framework_Comparator
 {
     /**
      * Returns whether the comparator can compare two values.

--- a/PHPUnit/Framework/ComparatorFactory.php
+++ b/PHPUnit/Framework/ComparatorFactory.php
@@ -80,6 +80,7 @@ class PHPUnit_Framework_ComparatorFactory
         $this->register(new PHPUnit_Framework_Comparator_Object);
         $this->register(new PHPUnit_Framework_Comparator_Exception);
         $this->register(new PHPUnit_Framework_Comparator_SplObjectStorage);
+        $this->register(new PHPUnit_Framework_Comparator_SplDoublyLinkedList);
         $this->register(new PHPUnit_Framework_Comparator_DOMDocument);
         $this->register(new PHPUnit_Framework_Comparator_MockObject);
     }

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -694,10 +694,10 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
             array($storage1, $storage2),
             // SplDoublyLinkedList, SplStack, SplQueue
             array($dll1, $dll2),
-            array(clone $dll1, $dll3),
-            array(clone $dll1, $dll4),
-            array(clone $dll1, $dll5),
-            array(clone $dll1, $stack),
+            array($dll1, $dll3),
+            array($dll1, $dll4),
+            array($dll1, $dll5),
+            array($dll1, $stack),
             array($stack, $queue),
             // DOMDocument
             array(
@@ -755,30 +755,29 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $storage2 = new SplObjectStorage;
         $storage2->attach($object1);
 
-        $object3 = new SampleClass(16, 23, 42);
         $dll1 = new SplDoublyLinkedList();
-        $dll1->push($object1);
-        $dll1->push($object3);
+        $dll1->push('foo');
+        $dll1->push('bar');
 
         $dll2 = new SplDoublyLinkedList();
-        $dll2->push($object1);
-        $dll2->push($object3);
+        $dll2->push('foo');
+        $dll2->push('bar');
 
         $stack1 = new SplStack(); // dlls have diff iter mode from stacks by default
-        $stack1->push($object1);
-        $stack1->push($object3);
+        $stack1->push('foo');
+        $stack1->push('bar');
 
         $stack2 = new SplStack(); // dlls have diff iter mode from stacks by default
-        $stack2->push($object1);
-        $stack2->push($object3);
+        $stack2->push('foo');
+        $stack2->push('bar');
 
         $queue1 = new SplQueue();
-        $queue1->push($object1);
-        $queue1->push($object3);
+        $queue1->push('foo');
+        $queue1->push('bar');
 
         $queue2 = new SplQueue();
-        $queue2->push($object1);
-        $queue2->push($object3);
+        $queue2->push('foo');
+        $queue2->push('bar');
 
         return array(
             // strings

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -636,6 +636,27 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $storage2 = new SplObjectStorage;
         $storage2->attach($object3); // same content, different object
 
+        $dll1 = new SplDoublyLinkedList();
+        $dll1->push($object1);
+        $dll1->push($object2);
+
+        $dll2 = new SplDoublyLinkedList();
+        $dll2->push($object1); // shorter than first
+
+        $dll3 = new SplDoublyLinkedList();
+        $dll3->push($object2); // different content than first
+        $dll3->push($object3);
+
+        $dll4 = new SplDoublyLinkedList();
+        $dll4->push($object3); // same content, different object than first TODO this breaks now
+        $dll4->push($object2);
+
+        $dll5 = clone($dll1);
+        $dll5->push('foo'); // longer than first
+
+        $stack = new SplStack(); // dlls have diff iter mode from stacks by default
+        $queue = new SplQueue();
+
         // cannot use $filesDirectory, because neither setUp() nor
         // setUpBeforeClass() are executed before the data providers
         $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'foo.xml';
@@ -671,6 +692,13 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
             array(fopen($file, 'r'), fopen($file, 'r')),
             // SplObjectStorage
             array($storage1, $storage2),
+            // SplDoublyLinkedList, SplStack, SplQueue
+            array($dll1, $dll2),
+            array(clone $dll1, $dll3),
+            array(clone $dll1, $dll4),
+            array(clone $dll1, $dll5),
+            array(clone $dll1, $stack),
+            array($stack, $queue),
             // DOMDocument
             array(
                 $this->createDOMDocument('<root></root>'),
@@ -727,6 +755,31 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $storage2 = new SplObjectStorage;
         $storage2->attach($object1);
 
+        $object3 = new SampleClass(16, 23, 42);
+        $dll1 = new SplDoublyLinkedList();
+        $dll1->push($object1);
+        $dll1->push($object3);
+
+        $dll2 = new SplDoublyLinkedList();
+        $dll2->push($object1);
+        $dll2->push($object3);
+
+        $stack1 = new SplStack(); // dlls have diff iter mode from stacks by default
+        $stack1->push($object1);
+        $stack1->push($object3);
+
+        $stack2 = new SplStack(); // dlls have diff iter mode from stacks by default
+        $stack2->push($object1);
+        $stack2->push($object3);
+
+        $queue1 = new SplQueue();
+        $queue1->push($object1);
+        $queue1->push($object3);
+
+        $queue2 = new SplQueue();
+        $queue2->push($object1);
+        $queue2->push($object3);
+
         return array(
             // strings
             array('a', 'A', 0, FALSE, TRUE), // ignore case
@@ -747,6 +800,11 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
             array($book1, $book2),
             // SplObjectStorage
             array($storage1, $storage2),
+            // SplDoublyLinkedList, SplStack, SplQueue
+            array($dll1, $dll2),
+            array($stack1, $stack2),
+            array($queue1, $queue2),
+            array($dll1, $queue1),
             // DOMDocument
             array(
                 $this->createDOMDocument('<root></root>'),

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -763,11 +763,11 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $dll2->push('foo');
         $dll2->push('bar');
 
-        $stack1 = new SplStack(); // dlls have diff iter mode from stacks by default
+        $stack1 = new SplStack();
         $stack1->push('foo');
         $stack1->push('bar');
 
-        $stack2 = new SplStack(); // dlls have diff iter mode from stacks by default
+        $stack2 = new SplStack();
         $stack2->push('foo');
         $stack2->push('bar');
 
@@ -803,7 +803,8 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
             array($dll1, $dll2),
             array($stack1, $stack2),
             array($queue1, $queue2),
-            array($dll1, $queue1),
+            array($dll1, $queue1), // dll and queue are same by default
+            array(new SplDoublyLinkedList(), new SplQueue()), // ensure empties work
             // DOMDocument
             array(
                 $this->createDOMDocument('<root></root>'),

--- a/Tests/Framework/ComparatorTest.php
+++ b/Tests/Framework/ComparatorTest.php
@@ -86,6 +86,8 @@ class Framework_ComparatorTest extends PHPUnit_Framework_TestCase
             array($tmpfile, $tmpfile, 'PHPUnit_Framework_Comparator_Resource'),
             array(new stdClass, new stdClass, 'PHPUnit_Framework_Comparator_Object'),
             array(new SplObjectStorage, new SplObjectStorage, 'PHPUnit_Framework_Comparator_SplObjectStorage'),
+            array(new SplDoublyLinkedList, new SplDoublyLinkedList, 'PHPUnit_Framework_Comparator_SplDoublyLinkedList'),
+            array(new SplQueue, new SplStack, 'PHPUnit_Framework_Comparator_SplDoublyLinkedList'),
             array(new Exception, new Exception, 'PHPUnit_Framework_Comparator_Exception'),
             array(new DOMDocument, new DOMDocument, 'PHPUnit_Framework_Comparator_DOMDocument'),
             // mixed types


### PR DESCRIPTION
pursuant to #1076, this introduces a comparator for handling `SplDoublyLinkedList` and its built-in children, `SplStack` and `SplQueue`.

although Sebastian indicated in the original issue that he preferred to have separate comparators for each spl datastructure, a look at the code should make it obvious as to why i condensed these three into one. (it's because [Liskov](http://en.wikipedia.org/wiki/Liskov_substitution_principle) more or less holds)

i think this covers most of the things, but this being my first PR for phpunit, i have some questions:
- when creating the new file, i just copied the header and changed the values that seemed to make sense. (my name under authorship, the "available since" version number). not sure if this was correct, lmk if not, or if i missed something.
- there are two test failures locally, both from the same provider data: when an object that is equal, but not the same, is provided, the system considers them equal. this is because the comparator is using a simple equality check. i suspect this is not the desirable behavior, but i wanted guidance before going after what i think IS...
- ...which is that, going back to the discussion in #1076, we extend the array converter to have special cases for this datastructure. this seems better, as while there is value in the comparator itself (it checks length and iteration mode), normalizing the datastructure back to the array may be useful to other diffing segments.

of course, this is for equals, not for identity, so maybe it's good the way it is. i wrote php data diffing engine a little while back in which i absolutely had to deal with identity, never equality, so my thinking is kinda slanted in that direction.
