### PR TITLE
Check the requirements before calling the setUp()

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -831,10 +831,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
 
             $this->setExpectedExceptionFromAnnotation();
+            $this->checkRequirements();
+
             foreach ($this->beforeMethods as $method) {
                 $this->$method();
             }
-            $this->checkRequirements();
+
             $this->assertPreConditions();
             $this->testResult = $this->runTest();
             $this->verifyMockObjects();


### PR DESCRIPTION
The use case I have an issue with is:

``` php
/**
 * @requires extension redis
 */
class RedisQueueTest extends extends \PHPUnit_Framework_TestCase
{
    protected $queue;

    protected function setUp()
    {
         $redis = new \Redis();
         $this->queue = create_redis_queue($redis);
    }
}
```

Running `phpunit RedisQueueTest` fails with `Fatal error: Call to undefined method Redis::connect() ...` because the redis extension is not installed.
