### PR TITLE
Check the requirements before setUpBeforeClass()

### DIFF
--- a/PHPUnit/Framework/TestCase.php
+++ b/PHPUnit/Framework/TestCase.php
@@ -826,12 +826,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $currentWorkingDirectory = getcwd();
 
         try {
+            $this->checkRequirements();
+
             if ($this->inIsolation) {
                 $this->setUpBeforeClass();
             }
 
             $this->setExpectedExceptionFromAnnotation();
-            $this->checkRequirements();
 
             foreach ($this->beforeMethods as $method) {
                 $this->$method();


### PR DESCRIPTION
This PR is just an updated version of #1086 which allows to skip a test earlier if the requirements are not satisfied.
