### PR TITLE
Performance improvement when using --filter option with large test code ...

### DIFF
--- a/PHPUnit/Framework/TestSuite.php
+++ b/PHPUnit/Framework/TestSuite.php
@@ -828,43 +828,36 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      */
     protected function addTestMethod(ReflectionClass $class, ReflectionMethod $method)
     {
+        if (!$this->isTestMethod($method))
+            return;
+
         $name = $method->getName();
 
-        if ($this->isPublicTestMethod($method)) {
-            $test = self::createTest($class, $name);
-
-            if ($test instanceof PHPUnit_Framework_TestCase ||
-                $test instanceof PHPUnit_Framework_TestSuite_DataProvider) {
-                $test->setDependencies(
-                  PHPUnit_Util_Test::getDependencies($class->getName(), $name)
-                );
-            }
-
-            $this->addTest($test, PHPUnit_Util_Test::getGroups(
-              $class->getName(), $name)
-            );
-        }
-
-        else if ($this->isTestMethod($method)) {
+        if (!$method->isPublic()) {
             $this->addTest(
-              self::warning(
-                sprintf(
-                  'Test method "%s" in test class "%s" is not public.',
-                  $name,
-                  $class->getName()
-                )
-              )
-            );
+                self::warning(
+                    sprintf(
+                        'Test method "%s" in test class "%s" is not public.',
+                        $name,
+                        $class->getName()
+                        )
+                    )
+                );
+            return;
         }
-    }
 
-    /**
-     * @param  ReflectionMethod $method
-     * @return boolean
-     */
-    public static function isPublicTestMethod(ReflectionMethod $method)
-    {
-        return (self::isTestMethod($method) && $method->isPublic());
+        $test = self::createTest($class, $name);
+
+        if ($test instanceof PHPUnit_Framework_TestCase ||
+            $test instanceof PHPUnit_Framework_TestSuite_DataProvider) {
+            $test->setDependencies(
+                PHPUnit_Util_Test::getDependencies($class->getName(), $name)
+                );
+        }
+
+        $this->addTest($test, PHPUnit_Util_Test::getGroups(
+                       $class->getName(), $name)
+            );
     }
 
     /**
@@ -879,8 +872,9 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
 
         // @scenario on TestCase::testMethod()
         // @test     on TestCase::testMethod()
-        return strpos($method->getDocComment(), '@test')     !== FALSE ||
-               strpos($method->getDocComment(), '@scenario') !== FALSE;
+        $doc_comment = $method->getDocComment();
+        return strpos($doc_comment, '@test')     !== FALSE ||
+               strpos($doc_comment, '@scenario') !== FALSE;
     }
 
     /**


### PR DESCRIPTION
...base: PHPUnit_Framework_TestSuite::isTestMethod is the bottleneck.
- Now 2 times less calls from PHPUnit_Framework_TestSuite::addTestMethod
- Only 1 call to ReflectionFunctionAbstract::getDocComment
