### PR TITLE
Add assertNotTrue/assertNotFalse method

### DIFF
--- a/PHPUnit/Framework/Assert.php
+++ b/PHPUnit/Framework/Assert.php
@@ -897,6 +897,19 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts that a condition is not true.
+     *
+     * @param  boolean $condition
+     * @param  string  $message
+     * @throws PHPUnit_Framework_AssertionFailedError
+     */
+    public static function assertNotTrue($condition, $message = '')
+    {
+        self::assertThat($condition, self::logicalNot(self::isTrue()), $message);
+    }
+
+
+    /**
      * Asserts that a condition is false.
      *
      * @param  boolean  $condition
@@ -906,6 +919,18 @@ abstract class PHPUnit_Framework_Assert
     public static function assertFalse($condition, $message = '')
     {
         self::assertThat($condition, self::isFalse(), $message);
+    }
+
+    /**
+     * Asserts that a condition is not false.
+     *
+     * @param  boolean  $condition
+     * @param  string   $message
+     * @throws PHPUnit_Framework_AssertionFailedError
+     */
+    public static function assertNotFalse($condition, $message = '')
+    {
+        self::assertThat($condition, self::logicalNot(self::isFalse()), $message);
     }
 
     /**

--- a/Tests/Framework/AssertTest.php
+++ b/Tests/Framework/AssertTest.php
@@ -1451,6 +1451,26 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::assertNotTrue
+     */
+    public function testAssertNotTrue()
+    {
+        $this->assertNotTrue(FALSE);
+        $this->assertNotTrue(1);
+        $this->assertNotTrue("true");
+
+        try {
+            $this->assertNotTrue(TRUE);
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertFalse
      */
     public function testAssertFalse()
@@ -1459,6 +1479,26 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertFalse(TRUE);
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertNotTrue
+     */
+    public function testAssertNotFalse()
+    {
+        $this->assertNotFalse(TRUE);
+        $this->assertNotFalse(0);
+        $this->assertNotFalse("");
+
+        try {
+            $this->assertNotFalse(FALSE);
         }
 
         catch (PHPUnit_Framework_AssertionFailedError $e) {


### PR DESCRIPTION
`assertNotNull` and `assertNotRegExp` exist, but `assertNotTrue` and `assertNotFalse` do not exist.
## Before

``` php
$this->assertNotSame($actual, false);
```
## After

``` php
$this->assertNotFalse($actual);
```
