### PR TITLE
Move phpunit to bin/phpunit to avoid composer weirdness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ Tests/TextUI/*.exp
 Tests/TextUI/*.log
 Tests/TextUI/*.out
 Tests/TextUI/*.php
-/bin
 /vendor
 /composer.lock
 /composer.phar

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -35,7 +35,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ext-tokenizer": "*"
     },
     "bin": [
-        "phpunit"
+        "bin/phpunit"
     ],
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
composer doesn’t like having a file and a directory share the same name
(case insensitive)

Before this fix PHPUnit master branch was uninstallable through composer
