### PR TITLE
Add system-out node to testcase element in JUnit XML output

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -438,6 +438,14 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
 
                 $this->testSuiteTests[$this->testSuiteLevel]++;
                 $this->testSuiteTimes[$this->testSuiteLevel] += $time;
+
+                if (method_exists($test, 'hasOutput') && $test->hasOutput()) {
+                    $systemOut = $this->document->createElement('system-out');
+                    $systemOut->appendChild(
+                      $this->document->createTextNode($test->getActualOutput())
+                    );
+                    $this->currentTestCase->appendChild($systemOut);
+                }
             }
         }
 


### PR DESCRIPTION
Currently only the JSON logger supports outputting a test's standard output. This pull request adds this ability to the JUnit XML logger, using the standard system-out element.
