### PR TITLE
Data provider without annotation master

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -337,34 +337,22 @@ class PHPUnit_Util_Test
         $docComment = $reflector->getDocComment();
         $data       = null;
 
-        $dataProvider = null;
+        $dataProviderMethodNameNamespace = null;
 
         if (method_exists($className, 'getDataProvider')) {
-            $dataProviderMethodName = call_user_func(array($className, 'getDataProvider'), $methodName);
-
-            if ($dataProviderMethodName != null) {
-                $dataProviderClass  = new ReflectionClass($className);
-                $dataProviderMethod = $dataProviderClass->getMethod(
-                    $dataProviderMethodName
-                );
-
-                if ($dataProviderMethod->isStatic()) {
-                    $object = NULL;
-                } else {
-                    $object = $dataProviderClass->newInstance();
-                }
-
-                if ($dataProviderMethod->getNumberOfParameters() == 0) {
-                    $data = $dataProviderMethod->invoke($object);
-                } else {
-                    $data = $dataProviderMethod->invoke($object, $methodName);
-                }
+            $dataProviderMethodNameNamespace = call_user_func(array($className, 'getDataProvider'), $methodName);
+            if ($dataProviderMethodNameNamespace != null) {
+                //Data is required in array later
+                $dataProviderMethodNameNamespace = array($dataProviderMethodNameNamespace);
             }
         }
 
 
-        if ($data == null && preg_match(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
+        if ($dataProviderMethodNameNamespace == null && preg_match(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
             $dataProviderMethodNameNamespace = explode('\\', $matches[1]);
+        }
+        
+        if ($dataProviderMethodNameNamespace) { 
             $leaf                            = explode('::', array_pop($dataProviderMethodNameNamespace));
             $dataProviderMethodName          = array_pop($leaf);
 


### PR DESCRIPTION
Adds support for setting up DataProviders for tests without using an annotation, which is issue #1093

This is to allow people to run tests in a close reproduction of their production environment, in which annotations may not work due to the comments in source files being unavailable due to OPCache removing all comments if the setting `opcache.save_comments` is false.
