### PR TITLE
Fixed a bug in PHPUnit_Framework_Constraint_Count

### DIFF
--- a/PHPUnit/Framework/Constraint/Count.php
+++ b/PHPUnit/Framework/Constraint/Count.php
@@ -94,8 +94,20 @@ class PHPUnit_Framework_Constraint_Count extends PHPUnit_Framework_Constraint
         }
 
         else if ($other instanceof Iterator) {
-            return iterator_count($other);
+            $key = $other->key();
+            $count = iterator_count($other);
+
+            // manually rewind $other to previous key, since iterator_count moves pointer
+            if ($key !== null) {
+                $other->rewind();
+                while ($key !== $other->key()) {
+                    $other->next();
+                }
+            }
+
+            return $count;
         }
+
     }
 
 

--- a/Tests/Framework/Constraint/CountTest.php
+++ b/Tests/Framework/Constraint/CountTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Jeroen Versteeg <jversteeg@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.9.0
+ */
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'TestIterator.php';
+
+class TestIterator2 implements Iterator {
+
+    protected $data;
+
+    public function __construct(array $array)
+    {
+        $this->data = $array;
+    }
+
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    public function next()
+    {
+        next($this->data);
+    }
+
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function valid()
+    {
+        return key($this->data) !== null;
+    }
+
+    public function rewind()
+    {
+        reset($this->data);
+    }
+}
+
+class CountTest extends PHPUnit_Framework_TestCase {
+
+    public function test_Count() {
+        $countConstraint = new PHPUnit_Framework_Constraint_Count(3);
+        $this->assertTrue($countConstraint->evaluate(array(1,2,3), '', true));
+
+        $countConstraint = new PHPUnit_Framework_Constraint_Count(0);
+        $this->assertTrue($countConstraint->evaluate(array(), '', true));
+
+        $countConstraint = new PHPUnit_Framework_Constraint_Count(2);
+        $it = new TestIterator(array(1, 2));
+        $this->assertTrue($countConstraint->evaluate($it, '', true));
+    }
+
+    public function test_CountDoesNotChangeIteratorKey ()
+    {
+        $countConstraint = new PHPUnit_Framework_Constraint_Count(2);
+
+        // test with 1st implementation of Iterator
+        $it = new TestIterator(array(1, 2));
+
+        $countConstraint->evaluate($it, '', true);
+        $this->assertEquals(1, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($it, '', true);
+        $this->assertEquals(2, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($it, '', true);
+        $this->assertFalse($it->valid());
+
+        // test with 2nd implementation of Iterator
+        $it = new TestIterator2(array(1, 2));
+
+        $countConstraint = new PHPUnit_Framework_Constraint_Count(2);
+        $countConstraint->evaluate($it, '', true);
+        $this->assertEquals(1, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($it, '', true);
+        $this->assertEquals(2, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($it, '', true);
+        $this->assertFalse($it->valid());
+    }
+}

--- a/Tests/_files/TestIterator.php
+++ b/Tests/_files/TestIterator.php
@@ -2,7 +2,7 @@
 class TestIterator implements Iterator
 {
     protected $array;
-    protected $position;
+    protected $position = 0;
 
     public function __construct($array = array())
     {


### PR DESCRIPTION
For instances of Iterator, it called [iterator_count](php.net/manual/en/function.iterator-count.php),
which (unfortunately) changes the instance's key. This fix `rewind`s the iterator's key to where it was.

See #1124
