### PR TITLE
Add directory assertions.

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -877,6 +877,42 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts that a directory exists.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryExists($directory, $message = '')
+    {
+        if (!is_string($directory)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_DirectoryExists;
+
+        self::assertThat($directory, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a directory does not exist.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryNotExists($directory, $message = '')
+    {
+        if (!is_string($directory)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_Not(
+            new PHPUnit_Framework_Constraint_DirectoryExists
+        );
+
+        self::assertThat($directory, $constraint, $message);
+    }
+
+    /**
      * Asserts that a condition is true.
      *
      * @param  boolean                                $condition
@@ -2577,6 +2613,16 @@ abstract class PHPUnit_Framework_Assert
     public static function fileExists()
     {
         return new PHPUnit_Framework_Constraint_FileExists;
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_DirectoryExists matcher object.
+     *
+     * @return PHPUnit_Framework_Constraint_DirectoryExists
+     */
+    public static function directoryExists()
+    {
+        return new PHPUnit_Framework_Constraint_DirectoryExists;
     }
 
     /**

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -913,6 +913,54 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts the number of items in a directory, minus "." and "..".
+     *
+     * @param int $expectedCount
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryCount($expectedCount, $directory, $message = '')
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertEquals(
+            $expectedCount,
+            iterator_count(
+                new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS)
+            ),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that a directory is empty, other than "." and "..".
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryEmpty($directory, $message = '')
+    {
+        self::assertDirectoryCount(0, $directory, $message);
+    }
+
+    /**
+     * Asserts that a directory is not empty, other than "." and "..".
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryNotEmpty($directory, $message = '')
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertNotEquals(
+            0,
+            iterator_count(
+                new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS)
+            ),
+            $message
+        );
+    }
+
+    /**
      * Asserts that a condition is true.
      *
      * @param  boolean                                $condition

--- a/src/Framework/Constraint/DirectoryExists.php
+++ b/src/Framework/Constraint/DirectoryExists.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Kevin Laude <nerfyoda@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+
+/**
+ * Constraint that checks if the directory(name) that it is evaluated for exists.
+ *
+ * The directory path to check is passed as $other in evaluate().
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Kevin Laude <nerfyoda@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class PHPUnit_Framework_Constraint_DirectoryExists extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param  mixed $other Value or object to evaluate.
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return file_exists($other) && is_dir($other);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param  mixed  $other Evaluated value or object.
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return sprintf(
+          'directory "%s" exists',
+
+          $other
+        );
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'directory exists';
+    }
+}

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -1402,6 +1402,38 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryCount
+     */
+    public function testAssertDirectoryCount()
+    {
+        $count = iterator_count(
+            new \RecursiveDirectoryIterator(__DIR__, \RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        $this->assertDirectoryCount($count, __DIR__);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryEmpty
+     */
+    public function testAssertDirectoryEmpty()
+    {
+        $directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'Test';
+
+        mkdir($directory);
+        $this->assertDirectoryEmpty($directory);
+        rmdir($directory);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryNotEmpty
+     */
+    public function testAssertDirectoryNotEmpty()
+    {
+        $this->assertDirectoryNotEmpty(__DIR__);
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertObjectHasAttribute
      */
     public function testAssertObjectHasAttribute()

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -1357,6 +1357,51 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryExists
+     */
+    public function testAssertDirectoryExists()
+    {
+        $this->assertDirectoryExists(__DIR__);
+
+        try {
+            $this->assertDirectoryExists(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryNotExists
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryNotExistsThrowsException()
+    {
+        $this->assertDirectoryNotExists(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryNotExists
+     */
+    public function testAssertDirectoryNotExists()
+    {
+        $this->assertDirectoryNotExists(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+
+        try {
+            $this->assertDirectoryNotExists(__DIR__);
+        }
+
+        catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertObjectHasAttribute
      */
     public function testAssertObjectHasAttribute()

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -338,6 +338,143 @@ EOF
     }
 
     /**
+     * @covers PHPUnit_Framework_Constraint_DirectoryExists
+     * @covers PHPUnit_Framework_Assert::directoryExists
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintDirectoryExists()
+    {
+        $constraint = PHPUnit_Framework_Assert::directoryExists();
+
+        $this->assertFalse($constraint->evaluate('foo', '', true));
+        $this->assertEquals('directory exists', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('foo');
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that directory "foo" exists.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_DirectoryExists
+     * @covers PHPUnit_Framework_Assert::directoryExists
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintDirectoryExists2()
+    {
+        $constraint = PHPUnit_Framework_Assert::directoryExists();
+
+        try {
+            $constraint->evaluate('foo', 'custom message');
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(<<<EOF
+custom message
+Failed asserting that directory "foo" exists.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_DirectoryExists
+     * @covers PHPUnit_Framework_Constraint_Not
+     * @covers PHPUnit_Framework_Assert::logicalNot
+     * @covers PHPUnit_Framework_Assert::directoryExists
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintDirectoryNotExists()
+    {
+        $directory = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files';
+
+        $constraint = PHPUnit_Framework_Assert::logicalNot(
+            PHPUnit_Framework_Assert::directoryExists()
+        );
+
+        $this->assertFalse($constraint->evaluate($directory, '', true));
+        $this->assertEquals('directory does not exist', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate($directory);
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that directory "$directory" does not exist.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_DirectoryExists
+     * @covers PHPUnit_Framework_Constraint_Not
+     * @covers PHPUnit_Framework_Assert::logicalNot
+     * @covers PHPUnit_Framework_Assert::directoryExists
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintDirectoryNotExists2()
+    {
+        $directory = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files';
+
+        $constraint = PHPUnit_Framework_Assert::logicalNot(
+            PHPUnit_Framework_Assert::directoryExists()
+        );
+
+        try {
+            $constraint->evaluate($directory, 'custom message');
+        }
+
+        catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(<<<EOF
+custom message
+Failed asserting that directory "$directory" does not exist.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Constraint_GreaterThan
      * @covers PHPUnit_Framework_Assert::greaterThan
      * @covers PHPUnit_Framework_Constraint::count


### PR DESCRIPTION
Add the following assertions:
- `assertDirectoryExists()`
- `assertDirectoryNotExists()`
- `assertDirectoryCount()`
- `assertDirectoryEmpty()`
- `assertDirectoryNotEmpty()`

I was working with directory processing for a project at work, and figured these assertions may come in handy. I think I've followed the conventions present in the existing code, though I've left `@since` docblock tags out since I don't know which version it'd go into, provided it's merged. Thanks!
