### PR TITLE
Lazily Create Mock Object Generator

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -231,7 +231,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     /**
      * @var array
      */
-    private $mockObjectGenerator;
+    private $mockObjectGenerator = null;
 
     /**
      * @var integer
@@ -313,7 +313,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
         $this->data                = $data;
         $this->dataName            = $dataName;
-        $this->mockObjectGenerator = new PHPUnit_Framework_MockObject_Generator;
     }
 
     /**
@@ -1298,7 +1297,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     public function getMock($originalClassName, $methods = array(), array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false, $callOriginalMethods = false)
     {
-        $mockObject = $this->mockObjectGenerator->getMock(
+        $mockObject = $this->getMockObjectGenerator()->getMock(
           $originalClassName,
           $methods,
           $arguments,
@@ -1379,7 +1378,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     public function getMockForAbstractClass($originalClassName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = array(), $cloneArguments = false)
     {
-        $mockObject = $this->mockObjectGenerator->getMockForAbstractClass(
+        $mockObject = $this->getMockObjectGenerator()->getMockForAbstractClass(
           $originalClassName,
           $arguments,
           $mockClassName,
@@ -1417,7 +1416,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
         if (!class_exists($originalClassName)) {
           eval(
-            $this->mockObjectGenerator->generateClassFromWsdl(
+            $this->getMockObjectGenerator()->generateClassFromWsdl(
               $wsdlFile, $originalClassName, $methods, $options
             )
           );
@@ -1453,7 +1452,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     public function getMockForTrait($traitName, array $arguments = array(), $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = array(), $cloneArguments = false)
     {
-        $mockObject = $this->mockObjectGenerator->getMockForTrait(
+        $mockObject = $this->getMockObjectGenerator()->getMockForTrait(
           $traitName,
           $arguments,
           $mockClassName,
@@ -1485,7 +1484,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     protected function getObjectForTrait($traitName, array $arguments = array(), $traitClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false)
     {
-        return $this->mockObjectGenerator->getObjectForTrait(
+        return $this->getMockObjectGenerator()->getObjectForTrait(
           $traitName,
           $arguments,
           $traitClassName,
@@ -1919,5 +1918,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     public function hookAfterMethod($name)
     {
         $this->afterMethods[] = $name;
+    }
+
+    /**
+     * Get the mock object generator, creating it if it doesn't exist.
+     *
+     * @return   PHPUnit_Framework_MockObject_Generator
+     */
+    protected function getMockObjectGenerator()
+    {
+        if (null === $this->mockObjectGenerator) {
+            $this->mockObjectGenerator = new PHPUnit_Framework_MockObject_Generator;
+        }
+
+        return $this->mockObjectGenerator;
     }
 }


### PR DESCRIPTION
Fixes #1164

Instead of setting up the mock object generator in TestCase's
constructor, it's created whenever a call to `getMockObjectGenerator` is
made.

I wasn't sure where to add tests for this, and it doesn't seem like `getMock` or its siblings are covered in the test suite as it is now.
