### PR TITLE
Allow phpunit to be called from vendor/bin

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -35,7 +35,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
Provide a path that is suitable for executing vendor/bin/phpunit, otherwise it print the !defined(''PHPUNIT_COMPOSER_INSTALL') message when composer has indeed been run.
