### PR TITLE
Don't Overwrite Already Existing Environment Vars

### DIFF
--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -524,15 +524,11 @@ class PHPUnit_Util_Configuration
             }
         }
 
-        foreach (array('var', 'env', 'post', 'get', 'cookie', 'server', 'files', 'request') as $array) {
+        foreach (array('var', 'post', 'get', 'cookie', 'server', 'files', 'request') as $array) {
             // See https://github.com/sebastianbergmann/phpunit/issues/277
             switch ($array) {
                 case 'var':
                     $target = &$GLOBALS;
-                    break;
-
-                case 'env':
-                    $target = &$_ENV;
                     break;
 
                 case 'server':
@@ -550,7 +546,12 @@ class PHPUnit_Util_Configuration
         }
 
         foreach ($configuration['env'] as $name => $value) {
-            putenv("$name=$value");
+            if (false === getenv($name)) {
+                putenv("{$name}={$value}");
+            }
+            if (!isset($_ENV[$name])) {
+                $_ENV[$name] = $value;
+            }
         }
     }
 

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -287,6 +287,32 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $_REQUEST['foo']);
     }
 
+    /**
+     * @backupGlobals enabled
+     * @see https://github.com/sebastianbergmann/phpunit/issues/1181
+     */
+    public function testHandlePHPConfigurationDoesNotOverwrittenExistingEnvArrayVariables()
+    {
+        $_ENV['foo'] = false;
+        $this->configuration->handlePHPConfiguration();
+
+        $this->assertEquals(false, $_ENV['foo']);
+        $this->assertEquals(true, getenv('foo'));
+    }
+
+    /**
+     * @backupGlobals enabled
+     * @see https://github.com/sebastianbergmann/phpunit/issues/1181
+     */
+    public function testHandlePHPConfigurationDoesNotOverriteVariablesFromPutEnv()
+    {
+        putenv('foo=putenv');
+        $this->configuration->handlePHPConfiguration();
+
+        $this->assertEquals(true, $_ENV['foo']);
+        $this->assertEquals('putenv', getenv('foo'));
+    }
+
     public function testPHPUnitConfigurationIsReadCorrectly()
     {
         $this->assertEquals(


### PR DESCRIPTION
Closes #1181

If a variable is already set via `putenv` or if the variable is already
present in the `$_ENV` array, it will no longer be ovewritten by
`PHPUnit_Util_Configuration::handlePHPConfiguration`.

This allows users to pass in environment variables fia the command line
in the usual ways:

```
bash$ SOME_VAR="a value" ./path/to/phpunit
```
