### PR TITLE
Get hook-methods only if a testcase will run

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -630,7 +630,12 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             return $result;
         }
 
-        $hookMethods = PHPUnit_Util_Test::getHookMethods($this->name);
+        // Get hookMethods only if this is a testcase
+        // Otherwise $this->name may look like UnitTest::testMethod (e.g. when using @dataProvider)
+        $hookMethods = array();
+        if ($this->testCase && class_exists($this->name, false)) {
+            $hookMethods = PHPUnit_Util_Test::getHookMethods($this->name);
+        }
 
         $result->startTestSuite($this);
 


### PR DESCRIPTION
As $hookMethods is only used, if this a testcase will run they should only be gathered in this case.

Otherwise this could lead to issues with autoloaders (e.g. Zend_Loader), because $this->name looks like UnitTest::testMethod when using @dataProvider
