### PR TITLE
Fixed unintended autoloader-call (regression)

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -638,7 +638,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             $this->setUp();
 
             foreach ($hookMethods['beforeClass'] as $beforeClassMethod) {
-                if (method_exists($this->name, $beforeClassMethod)) {
+                if ($this->testCase === true && class_exists($this->name, false) && method_exists($this->name, $beforeClassMethod)) {
                     call_user_func(array($this->name, $beforeClassMethod));
                 }
             }
@@ -676,7 +676,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         }
 
         foreach ($hookMethods['afterClass'] as $afterClassMethod) {
-            if (method_exists($this->name, $afterClassMethod)) {
+            if ($this->testCase === true && class_exists($this->name, false) && method_exists($this->name, $afterClassMethod)) {
                 call_user_func(array($this->name, $afterClassMethod));
             }
         }


### PR DESCRIPTION
This is a regression after #1190 was fixed and refactored in cad11af82d1856ccf8c6bfd7d4d49efd04ccea81.

Due to the changes in cad11af82d1856ccf8c6bfd7d4d49efd04ccea81, we'll have the same autoloader-issue which led to #1190 when testing folders, e.g.

phpunit Backend/

will result in:
method_exists('Backend/', 'tearDownAfterClass') in vendor/phpunit/phpunit/src/Framework/TestSuite.php:679
