### PR TITLE
Fix: serialization of test suits static properties

### DIFF
--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -308,7 +308,7 @@ class PHPUnit_Util_GlobalState
                 strpos($declaredClasses[$i], 'PHP_Token_Stream') !== 0 &&
                 strpos($declaredClasses[$i], 'Symfony') !== 0 &&
                 strpos($declaredClasses[$i], 'Text_Template') !== 0 &&
-                !$declaredClasses[$i] instanceof PHPUnit_Framework_Test) {
+                !is_a($declaredClasses[$i], 'PHPUnit_Framework_Test', true)) {
                 $class = new ReflectionClass($declaredClasses[$i]);
 
                 if (!$class->isUserDefined()) {

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -307,9 +307,12 @@ class PHPUnit_Util_GlobalState
                 strpos($declaredClasses[$i], 'PHP_Timer') !== 0 &&
                 strpos($declaredClasses[$i], 'PHP_Token_Stream') !== 0 &&
                 strpos($declaredClasses[$i], 'Symfony') !== 0 &&
-                strpos($declaredClasses[$i], 'Text_Template') !== 0 &&
-                !is_a($declaredClasses[$i], 'PHPUnit_Framework_Test', true)) {
+                strpos($declaredClasses[$i], 'Text_Template') !== 0) {
                 $class = new ReflectionClass($declaredClasses[$i]);
+
+                if ($class->isSubclassOf('PHPUnit_Framework_Test')) {
+                    continue;
+                }
 
                 if (!$class->isUserDefined()) {
                     break;

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -438,7 +438,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
     public function testRequiringAnExistingOsDoesNotSkip()
     {
         $test   = new RequirementsTest('testExistingOs');
-        $result = $test->run();testStaticAttributesBackupPre
+        $result = $test->run();
         $this->assertEquals(0, $result->skippedCount());
     }
 

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -69,6 +69,11 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
 {
     protected $backupGlobalsBlacklist = array('i', 'singleton');
 
+    /**
+     * Used be testStaticAttributesBackupPre
+     */
+    protected static $_testStatic = 0;
+
     public function testCaseToString()
     {
         $this->assertEquals(
@@ -292,11 +297,16 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
     public function testStaticAttributesBackupPre()
     {
         $GLOBALS['singleton'] = Singleton::getInstance();
+        self::$_testStatic = 123;
     }
 
+    /**
+     * @depends testStaticAttributesBackupPre
+     */
     public function testStaticAttributesBackupPost()
     {
         $this->assertNotSame($GLOBALS['singleton'], Singleton::getInstance());
+        $this->assertSame(123, self::$_testStatic);
     }
 
     public function testExpectOutputStringFooActualFoo()
@@ -428,7 +438,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
     public function testRequiringAnExistingOsDoesNotSkip()
     {
         $test   = new RequirementsTest('testExistingOs');
-        $result = $test->run();
+        $result = $test->run();testStaticAttributesBackupPre
         $this->assertEquals(0, $result->skippedCount());
     }
 


### PR DESCRIPTION
When --backupStaticAttributes switch is set, static properties of classes derived from PHPUnit_Framework_Test are also backed up due to wrong use of instanceof.

string instanceof object|class|string is always false. One should use is_a(stringClassName, stringClassName, true).

This bug affect all versions of PHPUnit that uses PHPUnit_Util_GlobalState class.
