### PR TITLE
Logging version using printer rather than printing on stdout

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -271,7 +271,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         }
 
         if (!$this->printer instanceof PHPUnit_Util_Log_TAP) {
-            $this->printVersionString();
+            if (!self::$versionStringPrinted) {
+              $this->printer->write(
+                PHPUnit_Runner_Version::getVersionString() . "\n\n"
+              );
+            }
 
             if (isset($arguments['configuration'])) {
                 $this->printer->write(


### PR DESCRIPTION
This reverts the change done on https://github.com/sebastianbergmann/phpunit/commit/8a2e4cb2d7177028b56240ef900d3e0e67e7916c#diff-cbf17ecbbe14be4db21eaca7a622156fL253

When testing things like Session, where output can't be send, I enable the `--stderr` flag. Without the revert, the version will be sent to stdout even when the flag is enabled.
