### PR TITLE
fixed DOMNode comparator for canonical comparison

### DIFF
--- a/src/Framework/Comparator/DOMNode.php
+++ b/src/Framework/Comparator/DOMNode.php
@@ -85,8 +85,8 @@ class PHPUnit_Framework_Comparator_DOMNode extends PHPUnit_Framework_Comparator_
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
     {
-        $expectedAsString = $this->domToText($expected);
-        $actualAsString   = $this->domToText($actual);
+        $expectedAsString = $expected->C14N();
+        $actualAsString   = $actual->C14N();
 
         if ($ignoreCase === true) {
             $expectedAsString = strtolower($expectedAsString);
@@ -103,8 +103,8 @@ class PHPUnit_Framework_Comparator_DOMNode extends PHPUnit_Framework_Comparator_
             throw new PHPUnit_Framework_ComparisonFailure(
               $expected,
               $actual,
-              $expectedAsString,
-              $actualAsString,
+              $this->domToText($expected),
+              $this->domToText($actual),
               false,
               sprintf('Failed asserting that two DOM %s are equal.', $type)
             );

--- a/tests/Framework/Comparator/DOMNodeTest.php
+++ b/tests/Framework/Comparator/DOMNodeTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 2.0.0
+ */
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.0.19
+ */
+class Framework_Comparator_DOMNodeTest extends PHPUnit_Framework_TestCase
+{
+    public function testAssertEqualsNormalizesAttributes()
+    {
+        $comparator = new PHPUnit_Framework_Comparator_DOMNode();
+
+        $document1 = new DOMDocument();
+        $document1->loadXML("<a x='' a=''/>");
+
+        $document2 = new DOMDocument();
+        $document2->loadXML("<a a='' x=''/>");
+
+        $comparator->assertEquals($document1, $document2);
+    }
+}


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/commit/7dadedf6c770feb18c0e17d895e698d57a6fb9bb introduced with Release 4.0.18 a bug when comparing two DOMNodes.

Previously, the comparison was always canonical (thanks to C14N), but now it no longer is. I would call that a BC break. This PR is basically a revert of that commit to make the DOMNode comparator canonical again. The test should make the problem pretty clear:

``` php
    public function testAssertEqualsNormalizesAttributes()
    {
        $comparator = new PHPUnit_Framework_Comparator_DOMNode();

        $document1 = new DOMDocument();
        $document1->loadXML("<a x='' a=''/>");

        $document2 = new DOMDocument();
        $document2->loadXML("<a a='' x=''/>");

        $comparator->assertEquals($document1, $document2);    // this fails since 4.0.18
    }
```

Realworld example: https://github.com/brianium/paratest/pull/90
