### PR TITLE
Fix error in doc and make it more clear

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1360,8 +1360,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
     /**
      * Returns a mock object for the specified abstract class with all abstract
-     * methods of the class mocked. Concrete methods to mock can be specified with
-     * the last parameter
+     * methods of the class mocked. Concrete methods are not mocked by default.
+     * To mock concrete methods, use the 7th parameter ($mockedMethods).
      *
      * @param  string                                  $originalClassName
      * @param  array                                   $arguments


### PR DESCRIPTION
The mentioned parameter was no longer last :)

The default behaviour with regard to mocking concrete methods is unexpected, at least to me. So I changed the doc to mention it more explicitly.
