### PR TITLE
Issue 1216 with unit test

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -587,10 +587,6 @@ class PHPUnit_TextUI_Command
             );
         }
 
-        if (isset($this->arguments['bootstrap'])) {
-            $this->handleBootstrap($this->arguments['bootstrap']);
-        }
-
         if (isset($this->arguments['printer']) &&
             is_string($this->arguments['printer'])) {
             $this->arguments['printer'] = $this->handlePrinter($this->arguments['printer']);
@@ -639,7 +635,9 @@ class PHPUnit_TextUI_Command
 
             $configuration->handlePHPConfiguration();
 
-            if (!isset($this->arguments['bootstrap']) && isset($phpunit['bootstrap'])) {
+            if (isset($this->arguments['bootstrap'])) {
+                $this->handleBootstrap($this->arguments['bootstrap']);
+            }elseif (isset($phpunit['bootstrap'])) {
                 $this->handleBootstrap($phpunit['bootstrap']);
             }
 

--- a/tests/Regression/GitHub/1216.phpt
+++ b/tests/Regression/GitHub/1216.phpt
@@ -1,0 +1,27 @@
+--TEST--
+GH-1216: PHPUnit bootstrap must take globals vars even when the file is specified in command line
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = dirname(__FILE__).'/1216/phpunit1216.xml';
+$_SERVER['argv'][3] = '--debug';
+$_SERVER['argv'][4] = '--bootstrap';
+$_SERVER['argv'][5] = dirname(__FILE__).'/1216/bootstrap1216.php';
+$_SERVER['argv'][6] = dirname(__FILE__) . '/1216/Issue1216Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+Configuration read from %s
+
+
+Starting test 'Issue1216Test::testConfigAvailableInBootstrap'.
+.
+
+Time: %s ms, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/tests/Regression/GitHub/1216/Issue1216Test.php
+++ b/tests/Regression/GitHub/1216/Issue1216Test.php
@@ -1,0 +1,8 @@
+<?php
+class Issue1216Test extends PHPUnit_Framework_TestCase
+{
+    public function testConfigAvailableInBootstrap()
+    {
+        $this->assertTrue($_ENV['configAvailableInBootstrap']);
+    }
+}

--- a/tests/Regression/GitHub/1216/bootstrap1216.php
+++ b/tests/Regression/GitHub/1216/bootstrap1216.php
@@ -1,0 +1,2 @@
+<?php
+$_ENV['configAvailableInBootstrap'] = isset($_ENV['loadedFromConfig']);

--- a/tests/Regression/GitHub/1216/phpunit1216.xml
+++ b/tests/Regression/GitHub/1216/phpunit1216.xml
@@ -1,0 +1,8 @@
+<phpunit>
+    <testsuite name="Github issue 1216">
+        <file>Issue1216Test.php</file>
+    </testsuite>
+    <php>
+        <env name="loadedFromConfig" value="1"/>
+    </php>
+</phpunit>


### PR DESCRIPTION
Correction of #1216: Now the bootstrap file has environement variables even when the file is set as argument
