### PR TITLE
Support pattern modifiers in the filter command line option.

### DIFF
--- a/src/Runner/Filter/Test.php
+++ b/src/Runner/Filter/Test.php
@@ -79,13 +79,27 @@ class PHPUnit_Runner_Filter_Test extends RecursiveFilterIterator
     }
 
     /**
+     * Returns true if the filter is a valid regular expression enclosed in
+     * delimiters.
+     *
+     * @param string $filter
+     * @return bool
+     */
+    private function isFilterStringARegularExpression($filter)
+    {
+        $match = PHPUnit_Util_Regex::pregMatchSafe($filter, '');
+        // A false return value indicates an error.
+        // An error indicates that the filter string is not
+        // a valid regular expression.
+        return $match !== false;
+    }
+
+    /**
      * @param string $filter
      */
     protected function setFilter($filter)
     {
-        if ($filter[0] != substr($filter, -1) ||
-            preg_match('/^[a-zA-Z0-9_]/', $filter)) {
-
+        if (!$this->isFilterStringARegularExpression($filter)) {
             // Handles:
             //  * testAssertEqualsSucceeds#4
             //  * testAssertEqualsSucceeds#4-8

--- a/tests/TextUI/filter-method-case-insensitive.phpt
+++ b/tests/TextUI/filter-method-case-insensitive.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit --filter /balanceIsInitiallyZero/i BankAccountTest ../_files/BankAccountTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--filter';
+$_SERVER['argv'][3] = '/balanceIsInitiallyZero/i';
+$_SERVER['argv'][4] = 'BankAccountTest';
+$_SERVER['argv'][5] = dirname(__FILE__).'/../_files/BankAccountTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %s, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/filter-method-case-sensitive-no-result.phpt
+++ b/tests/TextUI/filter-method-case-sensitive-no-result.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit --filter balanceIsInitiallyZero BankAccountTest ../_files/BankAccountTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--filter';
+$_SERVER['argv'][3] = '/balanceIsInitiallyZero/';
+$_SERVER['argv'][4] = 'BankAccountTest';
+$_SERVER['argv'][5] = dirname(__FILE__).'/../_files/BankAccountTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+
+
+Time: %s, Memory: %sMb
+
+No tests executed!

--- a/tests/TextUI/filter-no-results.phpt
+++ b/tests/TextUI/filter-no-results.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --filter testBalanceIsInitiallyZero BankAccountTest ../_files/BankAccountTest.php
+phpunit --filter doesNotExist BankAccountTest ../_files/BankAccountTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';


### PR DESCRIPTION
Currently phpunit --filter option doesn't support case insensitive filtering by specifying the 'i' pattern modifier. 

Case insensitive filtering can be helpful in some situations. 
For example:
A method is named 'foo'. 
The corresponding test method is named 'testFoo'.
When we want to filter tests that test the method 'foo', we will need to specify the filter as --filter Foo instead of a more natural filter of the exact method name as --filter foo.
This limitation makes some automation code to invoke phpunit tests based on the test method selected in an IDE more difficult. 

Currently when 'phpunit --filter /foo/i  aTest.php' is executed for example, the filter is changed to '/\/foo\/i/' i.e. the code thinks that no regular expression delimiter is given. 

This change adds support for case insensitive filtering by properly detecting that a pattern modifier is given.

Example:
The following 
phpunit --filter /foo/i  aTest.php
will match a test method named 'testFoo'

Testing:
I've manually tested filters with and without regular expression delimiters such as '/' '#'.

I tried writing unit tests for this change. But testing this change indirectly through the current public interface of this class turns out to be a bigger task than I am ready to commit to. Please advice what is the best way to unit test this change if unit tests for this change is needed before this change can be accepted.  
