### PR TITLE
Simplified phar build

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,0 +1,25 @@
+{
+    "chmod": "0755",
+    "directories": [
+        "src", "vendor/phpunit/php-code-coverage/src"
+    ],
+    "files": [
+        "LICENSE"
+    ],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": [
+                "Tests",
+                "Test",
+                "tests",
+                "build",
+                "scripts"
+            ],
+            "in": "vendor"
+        }
+    ],
+    "main": "phpunit",
+    "output": "build/phpunit.phar",
+    "stub": true
+}


### PR DESCRIPTION
Hi,

Current phar build goes like this:

> You need ant to build the phar. Just checkout a tagged release and run ant phar where you would normally run composer install. The phar should end up in the build directory.

I know you guys are using **ant** to do much more than build a phar file (at least the xml config looks like to be doing a lot), but sometimes a poor user just wants to apply a temporary patch and build a new phpunit binary without java.

So, here is a simplified pure PHP build approach using [php-box](https://github.com/kherge/php-box). Once inside `phpunit` project dir:
1. composer install
2. box build --verbose

After following these two steps a `phpunit.phar` will be available at `/build` folder.

Also notice the box build will produce a ~2,5 MB phar file instead of a ~3,2 MB, like we get with current ant build. I **guess** a lot of superfluous files are being put into current phar releases and it could be improved too.

Cheers!
