### PR TITLE
Dynamic class resolution for annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "ext-json": "*",
         "ext-pcre": "*",
         "ext-reflection": "*",
-        "ext-spl": "*"
+        "ext-spl": "*",
+        "eloquent/cosmos": "~2.3.1"
     },
     "suggest": {
         "phpunit/php-invoker": "~1.1"

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -43,6 +43,8 @@
  * @since      File available since Release 2.0.0
  */
 
+use Eloquent\Cosmos\ClassName;
+
 /**
  * A TestCase defines the fixture to run multiple tests.
  *
@@ -485,14 +487,38 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             );
 
             if ($expectedException !== false) {
+
+                $exceptionClass = $this->resolveFullQualifiedClassName($expectedException['class']);        
+
                 $this->setExpectedException(
-                  $expectedException['class'],
+                  $exceptionClass,
                   $expectedException['message'],
                   $expectedException['code']
                 );
             }
         } catch (ReflectionException $e) {
         }
+    }
+
+    protected function resolveFullQualifiedClassName($class)
+    {
+        $exceptionClass = ClassName::fromString($class);
+
+        if (! $exceptionClass->isAbsolute()){
+            
+            $namespace = $testClass = ClassName::fromString(get_called_class());
+            
+            if ($testClass->hasParent()) {
+                $namespace = $testClass->parent();
+            }
+            $resolvedClass = $namespace->join($exceptionClass)->toAbsolute();
+
+            if ($resolvedClass->exists()) {
+                $exceptionClass = $resolvedClass;
+            }
+        }
+
+        return $exceptionClass->string();  
     }
 
     /**


### PR DESCRIPTION
W.I.P

This aims to add class resolution to `@expectedException` annotations. With this pull request the following example should work:

``` php
namespace My\Library\Deep\Namespace;

class CustomException extends \RuntimeException {}
```

``` php
namespace My\Library\Deep\Namespace;

class MyDeepTest extends \PHPUnit_Framework_TestCase
{
    /**
     * @expectedException CustomException
     */
    public function testTest()
    {
        throw new CustomException;
    }
}
```

It means that if annotated class is not absolute (begins with a namespace separator `\`) test case will try to resolve full qualified annotated class based on context (test case namespace). Currently, we need to use code like this to achieve the same test as above:

``` php
 /**
  * @expectedException \My\Library\Deep\Namespace\CustomException
  */
```

I also intend to solve #730 by adding support to aliased classes, if possible to implement sanely. 

Maybe other annotations could benefit from this too: `@covers`, `@uses`, etc. But I prefer to have some feedback before add more changes.

Do you think it's worth it?
