### PR TITLE
Travis checks if PHPUnit correctly fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ before_script:
   - composer self-update
   - composer install --no-interaction --prefer-source --dev
 
-script: ./phpunit --configuration ./build/travis-ci.xml
+script:
+  - ./phpunit --configuration ./build/travis-ci.xml
+  - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; exit 1; else echo "fail checked"; fi;
 
 notifications:
   email: false

--- a/build/travis-ci-fail.xml
+++ b/build/travis-ci-fail.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.2/phpunit.xsd"
+         bootstrap="../tests/bootstrap-travis.php"
+         backupGlobals="false"
+         verbose="true">
+  <testsuites>
+    <testsuite name="small">
+      <directory suffix=".phpt">../tests/Fail</directory>
+    </testsuite>
+  </testsuites>
+
+  <php>
+    <const name="PHPUNIT_TESTSUITE" value="true"/>
+  </php>
+</phpunit>

--- a/tests/Fail/fail.phpt
+++ b/tests/Fail/fail.phpt
@@ -1,0 +1,5 @@
+--TEST--
+// This test intentionally fails and it is checked by Travis.
+--FILE--
+--EXPECTF--
+unexpected


### PR DESCRIPTION
This may seem a bit odd, but there are a lot of places where I can make a mistake and PHPUnit starts always report that everything is OK. Example: https://github.com/dg/phpunit/commit/54cf8d3647aa2f88b62f57d95179d9aa078878ec ("bug" in `Command.php`) and Travis is green (see https://travis-ci.org/dg/phpunit/builds/26912136), even there is wrong assertion.

With this fix will be Travis red, see https://travis-ci.org/dg/phpunit/builds/26912256.

Therefore, it is necessary to test that PHPUnit can fail too. 

(This is just draft)
