### PR TITLE
Support filters when only generating XML coverage

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -838,8 +838,9 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if ((isset($arguments['coverageClover']) ||
                 isset($arguments['coverageCrap4J']) ||
                 isset($arguments['coverageHtml']) ||
-                isset($arguments['coveragePHP'])) ||
-                isset($arguments['coverageText']) &&
+                isset($arguments['coveragePHP']) ||
+                isset($arguments['coverageText']) ||
+                isset($arguments['coverageXml'])) &&
                 $this->canCollectCodeCoverage) {
 
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();


### PR DESCRIPTION
Currently filters are ignored if XML coverage is the only coverage being used. This PR fixes this.

NOTE: This patch also fixes an apparent logic bug; please verify this is a bug before merging. The current code only checks `$this->canCollectCodeCoverage` if `$arguments['coverageText']` is true, which seemed like a bug to me. If this is intentional, I suggest renaming `canCollectCodeCoverage` to `canCollectTextCodeCoverage`.
