### PR TITLE
Fix log-json tests on HHVM nightlies

### DIFF
--- a/tests/TextUI/log-json-post-66021.phpt
+++ b/tests/TextUI/log-json-post-66021.phpt
@@ -4,8 +4,9 @@ phpunit --log-json php://stdout BankAccountTest ../_files/BankAccountTest.php
 <?php
 if (!((version_compare(PHP_VERSION, '5.4.28', '>=') && version_compare(PHP_VERSION, '5.5', '<')) ||
     (version_compare(PHP_VERSION, '5.5.12', '>=') && version_compare(PHP_VERSION, '5.6', '<')) ||
-    version_compare(PHP_VERSION, '5.6.0beta2', '>=')) || defined('HHVM_VERSION'))
-    print "skip: PHP 5.4.(28+) or PHP 5.5.(12+) or PHP 5.6.0beta2+ required";
+    version_compare(PHP_VERSION, '5.6.0beta2', '>=')) ||
+    (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.2.0-dev', '<')))
+    print "skip: PHP 5.4.(28+) or PHP 5.5.(12+) or PHP 5.6.0beta2+ or HHVM 3.(2+) required";
 ?>
 --FILE--
 <?php

--- a/tests/TextUI/log-json-pre-66021.phpt
+++ b/tests/TextUI/log-json-pre-66021.phpt
@@ -5,8 +5,8 @@ phpunit --log-json php://stdout BankAccountTest ../_files/BankAccountTest.php
 if (!((version_compare(PHP_VERSION, '5.4', '>=') && version_compare(PHP_VERSION, '5.4.27', '<=')) ||
     (version_compare(PHP_VERSION, '5.5', '>=') && version_compare(PHP_VERSION, '5.5.11', '<=')) ||
     (version_compare(PHP_VERSION, '5.6', '>=') && version_compare(PHP_VERSION, '5.6.0beta1', '<=')) ||
-    defined('HHVM_VERSION')))
-    print "skip: PHP 5.4.(0-27) or PHP 5.5.(0-11) or PHP 5.6.(0alpha1-0beta1) or HHVM required";
+    (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.2.0-dev', '<'))))
+    print "skip: PHP 5.4.(0-27) or PHP 5.5.(0-11) or PHP 5.6.(0alpha1-0beta1) or HHVM < 3.2 required";
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
refs facebook/hhvm#2913

```
[fredemmott@devbig076 ~/fio/phpunit] hhvm ./phpunit
tests/TextUI/log-json-pre-66021.phpt
PHPUnit 4.3-gbf93bc2 by Sebastian Bergmann.

Configuration read from /data/fio/phpunit/phpunit.xml.dist

S

Time: 1.29 seconds, Memory: 0.00Mb

There was 1 skipped test:

1) tests/TextUI/log-json-pre-66021.phpt
PHP 5.4.(0-27) or PHP 5.5.(0-11) or PHP 5.6.(0alpha1-0beta1) or HHVM <
3.2 required

/data/fio/phpunit/src/Extensions/PhptTestCase.php:156
/data/fio/phpunit/src/Framework/TestSuite.php:675
/data/fio/phpunit/src/TextUI/TestRunner.php:427
/data/fio/phpunit/src/TextUI/Command.php:186
/data/fio/phpunit/src/TextUI/Command.php:138

OK, but incomplete, skipped, or risky tests!
Tests: 1, Assertions: 1, Skipped: 1.

Generating code coverage report in HTML format ...^C
[fredemmott@devbig076 ~/fio/phpunit] hhvm ./phpunit
tests/TextUI/log-json-post-66021.phpt
PHPUnit 4.3-gbf93bc2 by Sebastian Bergmann.

Configuration read from /data/fio/phpunit/phpunit.xml.dist

.

Time: 21.25 seconds, Memory: 0.14Mb

OK (1 test, 1 assertion)

Generating code coverage report in HTML format ...^C
[fredemmott@devbig076 ~/fio/phpunit] php5 --version
PHP 5.5.7 (cli) (built: Jan 23 2014 15:45:09)
Copyright (c) 1997-2013 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2013 Zend Technologies
[fredemmott@devbig076 ~/fio/phpunit] php5 ./phpunit
tests/TextUI/log-json-pre-66021.phpt
PHPUnit 4.3-gbf93bc2 by Sebastian Bergmann.

Configuration read from /data/fio/phpunit/phpunit.xml.dist

The Xdebug extension is not loaded. No code coverage will be generated.

.

Time: 134 ms, Memory: 2.25Mb

OK (1 test, 1 assertion)
[fredemmott@devbig076 ~/fio/phpunit] php5 ./phpunit
tests/TextUI/log-json-post-66021.phpt
PHPUnit 4.3-gbf93bc2 by Sebastian Bergmann.

Configuration read from /data/fio/phpunit/phpunit.xml.dist

The Xdebug extension is not loaded. No code coverage will be generated.

S

Time: 56 ms, Memory: 2.00Mb

There was 1 skipped test:

1) tests/TextUI/log-json-post-66021.phpt
PHP 5.4.(28+) or PHP 5.5.(12+) or PHP 5.6.0beta2+ or HHVM 3.(2+)
required

/data/fio/phpunit/src/Extensions/PhptTestCase.php:156
/data/fio/phpunit/src/Framework/TestSuite.php:675
/data/fio/phpunit/src/TextUI/TestRunner.php:427
/data/fio/phpunit/src/TextUI/Command.php:186
/data/fio/phpunit/src/TextUI/Command.php:138

OK, but incomplete, skipped, or risky tests!
Tests: 1, Assertions: 1, Skipped: 1.
[fredemmott@devbig076 ~/fio/phpunit]
```
