### PR TITLE
Check requirements before "beforeClass" calls in a TestSuite

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -509,40 +509,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * @deprecated
-     * @since Method available since Release 3.6.0
-     */
-    protected function setRequirementsFromAnnotation()
-    {
-        try {
-            $requirements = PHPUnit_Util_Test::getRequirements(
-              get_class($this), $this->name
-            );
-
-            if (isset($requirements['PHP'])) {
-                $this->required['PHP'] = $requirements['PHP'];
-            }
-
-            if (isset($requirements['PHPUnit'])) {
-                $this->required['PHPUnit'] = $requirements['PHPUnit'];
-            }
-
-            if (isset($requirements['OS'])) {
-                $this->required['OS'] = $requirements['OS'];
-            }
-
-            if (isset($requirements['extensions'])) {
-                $this->required['extensions'] = $requirements['extensions'];
-            }
-
-            if (isset($requirements['functions'])) {
-                $this->required['functions'] = $requirements['functions'];
-            }
-        } catch (ReflectionException $e) {
-        }
-    }
-
-    /**
      * @since Method available since Release 3.6.0
      */
     protected function checkRequirements()

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -184,19 +184,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     private $expectedExceptionCode;
 
     /**
-     * The required preconditions for a test.
-     *
-     * @var array
-     */
-    private $required = array(
-        'PHP' => null,
-        'PHPUnit' => null,
-        'OS' => null,
-        'functions' => array(),
-        'extensions' => array()
-    );
-
-    /**
      * The name of the test case.
      *
      * @var string
@@ -522,6 +509,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @deprecated
      * @since Method available since Release 3.6.0
      */
     protected function setRequirementsFromAnnotation()
@@ -559,60 +547,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     protected function checkRequirements()
     {
-        $this->setRequirementsFromAnnotation();
-
-        $missingRequirements = array();
-
-        if ($this->required['PHP'] &&
-            version_compare(PHP_VERSION, $this->required['PHP'], '<')) {
-            $missingRequirements[] = sprintf(
-              'PHP %s (or later) is required.',
-              $this->required['PHP']
-            );
-        }
-
-        $phpunitVersion = PHPUnit_Runner_Version::id();
-        if ($this->required['PHPUnit'] &&
-            version_compare($phpunitVersion, $this->required['PHPUnit'], '<')) {
-            $missingRequirements[] = sprintf(
-              'PHPUnit %s (or later) is required.',
-              $this->required['PHPUnit']
-            );
-        }
-
-        if ($this->required['OS'] &&
-            !preg_match($this->required['OS'], PHP_OS)) {
-            $missingRequirements[] = sprintf(
-              'Operating system matching %s is required.',
-              $this->required['OS']
-            );
-        }
-
-        foreach ($this->required['functions'] as $requiredFunction) {
-            if (!function_exists($requiredFunction)) {
-                $missingRequirements[] = sprintf(
-                  'Function %s is required.',
-                  $requiredFunction
-                );
-            }
-        }
-
-        foreach ($this->required['extensions'] as $requiredExtension) {
-            if (!extension_loaded($requiredExtension)) {
-                $missingRequirements[] = sprintf(
-                  'Extension %s is required.',
-                  $requiredExtension
-                );
-            }
-        }
+        $missingRequirements = PHPUnit_Util_Test::getMissingRequirements(
+            get_class($this), $this->name
+        );
 
         if ($missingRequirements) {
-            $this->markTestSkipped(
-              implode(
-                PHP_EOL,
-                $missingRequirements
-              )
-            );
+            $this->markTestSkipped(implode(PHP_EOL, $missingRequirements));
         }
     }
 

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -638,7 +638,14 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             $this->setUp();
 
             foreach ($hookMethods['beforeClass'] as $beforeClassMethod) {
-                if ($this->testCase === true && class_exists($this->name, false) && method_exists($this->name, $beforeClassMethod)) {
+                if ($this->testCase === true &&
+                    class_exists($this->name, false) &&
+                    method_exists($this->name, $beforeClassMethod)
+                ) {
+                    if ($missingRequirements = PHPUnit_Util_Test::getMissingRequirements($this->name, $beforeClassMethod)) {
+                        $this->markTestSuiteSkipped(implode(PHP_EOL, $missingRequirements));
+                    }
+
                     call_user_func(array($this->name, $beforeClassMethod));
                 }
             }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -252,13 +252,16 @@ class PHPUnit_Util_Test
      */
     public static function getMissingRequirements($className, $methodName)
     {
-        $required = static::getRequirements($className, $methodName) + array(
-                'PHP'           => null,
-                'PHPUnit'       => null,
-                'OS'            => null,
-                'functions'     => array(),
-                'extensions'    => array(),
-            );
+        try {
+            $required = static::getRequirements($className, $methodName) + array(
+                    'PHP'           => null,
+                    'PHPUnit'       => null,
+                    'OS'            => null,
+                    'functions'     => array(),
+                    'extensions'    => array(),
+                );
+        } catch (ReflectionException $e) {
+        }
 
         $missing = array();
 

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -253,42 +253,41 @@ class PHPUnit_Util_Test
     public static function getMissingRequirements($className, $methodName)
     {
         try {
-            $required = static::getRequirements($className, $methodName) + array(
-                    'PHP'           => null,
-                    'PHPUnit'       => null,
-                    'OS'            => null,
-                    'functions'     => array(),
-                    'extensions'    => array(),
-                );
+            $required = static::getRequirements($className, $methodName);
         } catch (ReflectionException $e) {
+            $required = array();
         }
 
         $missing = array();
 
-        if ($required['PHP'] && version_compare(PHP_VERSION, $required['PHP'], '<')) {
+        if (!empty($required['PHP']) && version_compare(PHP_VERSION, $required['PHP'], '<')) {
             $missing[] = sprintf('PHP %s (or later) is required.', $required['PHP']);
         }
 
-        if ($required['PHPUnit']) {
+        if (!empty($required['PHPUnit'])) {
             $phpunitVersion = PHPUnit_Runner_Version::id();
             if (version_compare($phpunitVersion, $required['PHPUnit'], '<')) {
                 $missing[] = sprintf('PHPUnit %s (or later) is required.', $required['PHPUnit']);
             }
         }
 
-        if ($required['OS'] && !preg_match($required['OS'], PHP_OS)) {
+        if (!empty($required['OS']) && !preg_match($required['OS'], PHP_OS)) {
             $missing[] = sprintf('Operating system matching %s is required.', $required['OS']);
         }
 
-        foreach ($required['functions'] as $requiredFunction) {
-            if (!function_exists($requiredFunction)) {
-                $missing[] = sprintf('Function %s is required.', $requiredFunction);
+        if (!empty($required['functions'])) {
+            foreach ($required['functions'] as $requiredFunction) {
+                if (!function_exists($requiredFunction)) {
+                    $missing[] = sprintf('Function %s is required.', $requiredFunction);
+                }
             }
         }
 
-        foreach ($required['extensions'] as $requiredExtension) {
-            if (!extension_loaded($requiredExtension)) {
-                $missing[] = sprintf('Extension %s is required.', $requiredExtension);
+        if (!empty($required['extensions'])) {
+            foreach ($required['extensions'] as $requiredExtension) {
+                if (!extension_loaded($requiredExtension)) {
+                    $missing[] = sprintf('Extension %s is required.', $requiredExtension);
+                }
             }
         }
 

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -243,6 +243,56 @@ class PHPUnit_Util_Test
     }
 
     /**
+     * Returns the missing requirements for a test.
+     *
+     * @param  string $className
+     * @param  string $methodName
+     * @return array
+     * @since  Method available since Release 4.2.0
+     */
+    public static function getMissingRequirements($className, $methodName)
+    {
+        $required = static::getRequirements($className, $methodName) + array(
+                'PHP'           => null,
+                'PHPUnit'       => null,
+                'OS'            => null,
+                'functions'     => array(),
+                'extensions'    => array(),
+            );
+
+        $missing = array();
+
+        if ($required['PHP'] && version_compare(PHP_VERSION, $required['PHP'], '<')) {
+            $missing[] = sprintf('PHP %s (or later) is required.', $required['PHP']);
+        }
+
+        if ($required['PHPUnit']) {
+            $phpunitVersion = PHPUnit_Runner_Version::id();
+            if (version_compare($phpunitVersion, $required['PHPUnit'], '<')) {
+                $missing[] = sprintf('PHPUnit %s (or later) is required.', $required['PHPUnit']);
+            }
+        }
+
+        if ($required['OS'] && !preg_match($required['OS'], PHP_OS)) {
+            $missing[] = sprintf('Operating system matching %s is required.', $required['OS']);
+        }
+
+        foreach ($required['functions'] as $requiredFunction) {
+            if (!function_exists($requiredFunction)) {
+                $missing[] = sprintf('Function %s is required.', $requiredFunction);
+            }
+        }
+
+        foreach ($required['extensions'] as $requiredExtension) {
+            if (!extension_loaded($requiredExtension)) {
+                $missing[] = sprintf('Extension %s is required.', $requiredExtension);
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
      * Returns the expected exception for a test.
      *
      * @param  string $className

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -50,6 +50,7 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'NotPublicTestCase.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'NotVoidTestCase.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'OverrideTestCase.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'RequirementsClassBeforeClassHookTest.php';
 
 /**
  *
@@ -85,6 +86,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
         $suite->addTest(new Framework_SuiteTest('testShadowedTests'));
         $suite->addTest(new Framework_SuiteTest('testBeforeClassAndAfterClassAnnotations'));
         $suite->addTest(new Framework_SuiteTest('testBeforeAnnotation'));
+        $suite->addTest(new Framework_SuiteTest('testRequirementsBeforeClassHook'));
 
         return $suite;
     }
@@ -213,4 +215,15 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(2, BeforeAndAfterTest::$afterWasRun);
     }
 
+    public function testRequirementsBeforeClassHook()
+    {
+        $suite = new PHPUnit_Framework_TestSuite(
+            'RequirementsClassBeforeClassHookTest'
+        );
+
+        $suite->run($this->result);
+
+        $this->assertEquals(0, $this->result->errorCount());
+        $this->assertEquals(1, $this->result->skippedCount());
+    }
 }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -213,6 +213,40 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers       PHPUnit_Util_Test::getMissingRequirements
+     * @dataProvider missingRequirementsProvider
+     */
+    public function testGetMissingRequirements($test, $result)
+    {
+        $this->assertEquals(
+            $result,
+            PHPUnit_Util_Test::getMissingRequirements('RequirementsTest', $test)
+        );
+    }
+
+    public function missingRequirementsProvider()
+    {
+        return array(
+            array('testOne',            array()),
+            array('testNine',           array('Function testFunc is required.')),
+            array('testTen',            array('Extension testExt is required.')),
+            array('testAlwaysSkip',     array('PHPUnit 1111111 (or later) is required.')),
+            array('testAlwaysSkip',     array('PHPUnit 1111111 (or later) is required.')),
+            array('testAlwaysSkip2',    array('PHP 9999999 (or later) is required.')),
+            array('testAlwaysSkip3',    array('Operating system matching /DOESNOTEXIST/i is required.')),
+            array('testAllPossibleRequirements', array(
+                'PHP 99-dev (or later) is required.',
+                'PHPUnit 9-dev (or later) is required.',
+                'Operating system matching /DOESNOTEXIST/i is required.',
+                'Function testFuncOne is required.',
+                'Function testFuncTwo is required.',
+                'Extension testExtOne is required.',
+                'Extension testExtTwo is required.',
+            )),
+        );
+    }
+
+    /**
      * @coversNothing
      * @todo   This test does not really test functionality of PHPUnit_Util_Test
      */

--- a/tests/_files/RequirementsClassBeforeClassHookTest.php
+++ b/tests/_files/RequirementsClassBeforeClassHookTest.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @requires extension nonExistingExtension
+ */
+class RequirementsClassBeforeClassHookTest extends PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        throw new Exception(__METHOD__.' should not be called because of class requirements.');
+    }
+}


### PR DESCRIPTION
This PR aims to fix fatal errors like "Class 'ClassFromNonExistingExtension' not found ..." which is generated for the following test case: 

``` php
<?php

/**
 * @requires extension nonExistingExtension
 */
class FooTest extends PHPUnit_Framework_TestCase
{
    public static function setUpBeforeClass()
    {
        // call a function from a non-existing extension
    }
}
```
