### PR TITLE
Resolve annotations against namespace and use statements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "sebastian/exporter": "~1.0",
         "sebastian/global-state": "1.0.*@dev",
         "sebastian/version": "~1.0",
+        "eloquent/cosmos": "dev-feature/pathogen-based",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-pcre": "*",

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -119,7 +119,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertArraySubset(
-          array('class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE),
+          array('class' => 'My\Space\Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE),
           PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstants')
         );
 
@@ -130,8 +130,22 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertArraySubset(
-          array('class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT'),
+          array('class' => 'My\Space\Class', 'code' => 'ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT'),
           PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testUnknownConstants')
+        );
+
+        $this->assertArraySubset(
+          array(
+            'class' => 'My\Space\Class',
+            'code' => 'Code contains constant ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT (unlikely)',
+            'message' => 'Message contains constant ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT'
+          ),
+          PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstantInsideValue')
+        );
+
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE),
+          PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testFullyQualified')
         );
     }
 
@@ -339,7 +353,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
      */
     public function testGetLinesToBeCovered($test, $lines)
     {
-        if (strpos($test, 'Namespace') === 0) {
+        if (strpos($test, 'Namespace') !== false) {
             $expected = array(
               TEST_FILES_PATH . 'NamespaceCoveredClass.php' => $lines
             );
@@ -588,7 +602,23 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
           array(
             'CoverageNothingTest',
             false
-          )
+          ),
+          array(
+            'Foo\NamespaceCoverageSameNamespaceTest',
+            range(21, 38)
+          ),
+          array(
+            'Bar\NamespaceCoverageDifferentNamespaceTest',
+            range(21, 38)
+          ),
+          array(
+            'Bar\NamespaceCoverageUseStatementTest',
+            range(21, 38)
+          ),
+          array(
+            'Bar\NamespaceCoverageCoversDefaultClassResolutionTest',
+            range(33, 37)
+          ),
         );
     }
 }

--- a/tests/_files/ExceptionNamespaceTest.php
+++ b/tests/_files/ExceptionNamespaceTest.php
@@ -20,8 +20,8 @@ class ExceptionNamespaceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Class
-     * @expectedExceptionMessage My\Space\ExceptionNamespaceTest::ERROR_MESSAGE
-     * @expectedExceptionCode My\Space\ExceptionNamespaceTest::ERROR_CODE
+     * @expectedExceptionMessage ExceptionNamespaceTest::ERROR_MESSAGE
+     * @expectedExceptionCode ExceptionNamespaceTest::ERROR_CODE
      */
     public function testConstants()
     {
@@ -29,10 +29,28 @@ class ExceptionNamespaceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Class
-     * @expectedExceptionCode My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT
-     * @expectedExceptionMessage My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT
+     * @expectedExceptionCode ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT
+     * @expectedExceptionMessage ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT
      */
     public function testUnknownConstants()
+    {
+    }
+
+    /**
+     * @expectedException Class
+     * @expectedExceptionCode Code contains constant ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT (unlikely)
+     * @expectedExceptionMessage Message contains constant ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT
+     */
+    public function testConstantInsideValue()
+    {
+    }
+
+    /**
+     * @expectedException \Class
+     * @expectedExceptionMessage \My\Space\ExceptionNamespaceTest::ERROR_MESSAGE
+     * @expectedExceptionCode \My\Space\ExceptionNamespaceTest::ERROR_CODE
+     */
+    public function testFullyQualified()
     {
     }
 }

--- a/tests/_files/NamespaceCoverageCoversDefaultClassResolutionTest.php
+++ b/tests/_files/NamespaceCoverageCoversDefaultClassResolutionTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace Bar;
+
+use Foo\CoveredClass as Baz;
+
+/**
+ * @coversDefaultClass Baz
+ */
+class NamespaceCoverageCoversDefaultClassResolutionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::publicMethod
+     */
+    public function testSomething()
+    {
+        $o = new Foo\CoveredClass;
+        $o->publicMethod();
+    }
+}
+

--- a/tests/_files/NamespaceCoverageDifferentNamespaceTest.php
+++ b/tests/_files/NamespaceCoverageDifferentNamespaceTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Bar;
+
+class NamespaceCoverageDifferentNamespaceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers \Foo\CoveredClass
+     */
+    public function testSomething()
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/NamespaceCoverageSameNamespaceTest.php
+++ b/tests/_files/NamespaceCoverageSameNamespaceTest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Foo;
+
+class NamespaceCoverageSameNamespaceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers CoveredClass
+     */
+    public function testSomething()
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/NamespaceCoverageUseStatementTest.php
+++ b/tests/_files/NamespaceCoverageUseStatementTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Bar;
+
+use Foo\CoveredClass as Baz;
+
+class NamespaceCoverageUseStatementTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Baz
+     */
+    public function testSomething()
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}


### PR DESCRIPTION
This PR is an updated version of #1279 (see also #730). At this stage, it's just a request for feedback, <del>but if reception is good, I'd be happy to expand the new resolution rules to other annotations like `@covers` etc.</del> actually, I just went ahead and did these too.

To recap, this PR allows the user to utilize `namespace` and `use` statements to shorten the class name for `@expectedException` annotations. I also expanded on #1279 to add similar support to the `@expectedExceptionMessage` and `@expectedExceptionCode` annotations. Relevant tests were also added/updated.

This is currently done using a branch of [Cosmos](https://github.com/eloquent/cosmos/tree/feature/pathogen-based), which will become the next major version as soon as people are happy with this PR.

FYI, Cosmos now fully supports PHP 5.6 `use function` and `use const`, which means no problems with resolution when you move to support 5.6 in future.

**EDIT:** Added resolution for `@covers`, `@coversDefaultClass`, and `@uses`, with tests.