### PR TITLE
Add another possible autoload location

### DIFF
--- a/composer/bin/phpunit
+++ b/composer/bin/phpunit
@@ -39,6 +39,7 @@ define('PHPUnit_MAIN_METHOD', 'PHPUnit_TextUI_Command::main');
 
 $files = array(
   __DIR__ . '/../../vendor/autoload.php',
+  __DIR__ . '/../vendor/autoload.php',
   __DIR__ . '/../../../../autoload.php'
 );
 


### PR DESCRIPTION
When using composer, and not symlinked, this binary ended up in `[project]/bin` with the autoloader at `vendor/autoload.php`, so the path needed is just `../vendor/autoload.php`. I'm not sure where this script would ever end up that required `../../` as the path - it may be safe to delete line 41.
