### PR TITLE
Check both the function and the method via '@requires function' annotation

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -271,17 +271,22 @@ class PHPUnit_Util_Test
         }
 
         if (!empty($required['functions'])) {
-            foreach ($required['functions'] as $requiredFunction) {
-                if (!function_exists($requiredFunction)) {
-                    $missing[] = sprintf('Function %s is required.', $requiredFunction);
+            foreach ($required['functions'] as $function) {
+                $pieces = explode('::', $function);
+                if (2 === count($pieces) && method_exists($pieces[0], $pieces[1])) {
+                    continue;
                 }
+                if (function_exists($function)) {
+                    continue;
+                }
+                $missing[] = sprintf('Function %s is required.', $function);
             }
         }
 
         if (!empty($required['extensions'])) {
-            foreach ($required['extensions'] as $requiredExtension) {
-                if (!extension_loaded($requiredExtension)) {
-                    $missing[] = sprintf('Extension %s is required.', $requiredExtension);
+            foreach ($required['extensions'] as $extension) {
+                if (!extension_loaded($extension)) {
+                    $missing[] = sprintf('Extension %s is required.', $extension);
                 }
             }
         }

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -481,6 +481,13 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $result->skippedCount());
     }
 
+    public function testRequiringAnExistingMethodDoesNotSkip()
+    {
+        $test   = new RequirementsTest('testExistingMethod');
+        $result = $test->run();
+        $this->assertEquals(0, $result->skippedCount());
+    }
+
     public function testRequiringAnExistingExtensionDoesNotSkip()
     {
         $test   = new RequirementsTest('testExistingExtension');

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -98,6 +98,13 @@ class RequirementsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @requires function ReflectionMethod::setAccessible
+     */
+    public function testExistingMethod()
+    {
+    }
+
+    /**
      * @requires extension spl
      */
     public function testExistingExtension()


### PR DESCRIPTION
Make `@requires function ReflectionMethod::setAccessible` work according to the [documentation](http://phpunit.de/manual/4.1/en/incomplete-and-skipped-tests.html#incomplete-and-skipped-tests.skipping-tests-using-requires).
