### PR TITLE
Check both the function and the method via '@requires function' annotation

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -583,20 +583,25 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             );
         }
 
-        foreach ($this->required['functions'] as $requiredFunction) {
-            if (!function_exists($requiredFunction)) {
-                $missingRequirements[] = sprintf(
-                  'Function %s is required.',
-                  $requiredFunction
-                );
+        foreach ($this->required['functions'] as $function) {
+            $pieces = explode('::', $function);
+            if (2 === count($pieces) && method_exists($pieces[0], $pieces[1])) {
+                continue;
             }
+            if (function_exists($function)) {
+                continue;
+            }
+            $missingRequirements[] = sprintf(
+              'Function %s is required.',
+              $function
+            );
         }
 
-        foreach ($this->required['extensions'] as $requiredExtension) {
-            if (!extension_loaded($requiredExtension)) {
+        foreach ($this->required['extensions'] as $extension) {
+            if (!extension_loaded($extension)) {
                 $missingRequirements[] = sprintf(
                   'Extension %s is required.',
-                  $requiredExtension
+                  $extension
                 );
             }
         }

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -422,6 +422,13 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRequiringAnExistingMethodDoesNotSkip()
+    {
+        $test   = new RequirementsTest('testExistingMethod');
+        $result = $test->run();
+        $this->assertEquals(0, $result->skippedCount());
+    }
+
     public function testRequiringAnExistingFunctionDoesNotSkip()
     {
         $test   = new RequirementsTest('testExistingFunction');

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -98,6 +98,13 @@ class RequirementsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @requires function ReflectionMethod::setAccessible
+     */
+    public function testExistingMethod()
+    {
+    }
+
+    /**
      * @requires extension spl
      */
     public function testExistingExtension()


### PR DESCRIPTION
Make `@requires function ReflectionMethod::setAccessible` work according to the [documentation](http://phpunit.de/manual/4.1/en/incomplete-and-skipped-tests.html#incomplete-and-skipped-tests.skipping-tests-using-requires).
