### PR TITLE
Fix running tests for autoloaded classes

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -134,6 +134,11 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     protected $testCase = false;
 
     /**
+     * @var array
+     */
+    protected $untestedClasses = array();
+    
+    /**
      * @var PHPUnit_Runner_Filter_Factory
      */
     private $iteratorFilter = null;
@@ -357,9 +362,10 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         $classes    = get_declared_classes();
         $filename   = PHPUnit_Util_Fileloader::checkAndLoad($filename);
         $newClasses = array_values(array_diff(get_declared_classes(), $classes));
+        $this->untestedClasses = array_merge($this->untestedClasses, $newClasses);
         $baseName   = str_replace('.php', '', basename($filename));
 
-        foreach ($newClasses as $className) {
+        foreach ($this->untestedClasses as $className) {
             if (substr($className, 0 - strlen($baseName)) == $baseName) {
                 $class = new ReflectionClass($className);
 

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -80,6 +80,8 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
             $loadedClasses = array_values(
               array_diff(get_declared_classes(), $loadedClasses)
             );
+            
+            $loadedClasses[] = $suiteClassName;
         }
 
         if (!class_exists($suiteClassName, false) && !empty($loadedClasses)) {

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -80,7 +80,6 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
             $loadedClasses = array_values(
               array_diff(get_declared_classes(), $loadedClasses)
             );
-
         }
 
         if (!class_exists($suiteClassName, false) && !empty($loadedClasses)) {

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -80,8 +80,7 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
             $loadedClasses = array_values(
               array_diff(get_declared_classes(), $loadedClasses)
             );
-            
-            $loadedClasses[] = $suiteClassName;
+
         }
 
         if (!class_exists($suiteClassName, false) && !empty($loadedClasses)) {

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -87,6 +87,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
         $suite->addTest(new Framework_SuiteTest('testBeforeClassAndAfterClassAnnotations'));
         $suite->addTest(new Framework_SuiteTest('testBeforeAnnotation'));
         $suite->addTest(new Framework_SuiteTest('testRequirementsBeforeClassHook'));
+        $suite->addTest(new Framework_SuiteTest('testDontSkipInheritedClass'));
 
         return $suite;
     }
@@ -225,5 +226,20 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(0, $this->result->errorCount());
         $this->assertEquals(1, $this->result->skippedCount());
+    }
+
+    public function testDontSkipInheritedClass()
+    {
+        $suite = new PHPUnit_Framework_TestSuite(
+          'DontSkipInheritedClass'
+        );
+
+        $dir = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Inheritance' . DIRECTORY_SEPARATOR;
+
+        $suite->addTestFile($dir.'InheritanceA.php');
+        $suite->addTestFile($dir.'InheritanceB.php');
+        $result = $suite->run();
+        $this->assertEquals(2, count($result));
+
     }
 }

--- a/tests/_files/Inheritance/InheritanceA.php
+++ b/tests/_files/Inheritance/InheritanceA.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once(__DIR__.'/InheritanceB.php');
+
+class InheritanceA extends InheritanceB
+{
+
+}

--- a/tests/_files/Inheritance/InheritanceB.php
+++ b/tests/_files/Inheritance/InheritanceB.php
@@ -1,0 +1,9 @@
+<?php
+
+class InheritanceB extends PHPUnit_Framework_TestCase
+{
+    public function testSomething()
+    {
+
+    }
+}


### PR DESCRIPTION
Should fix this issue: https://github.com/sebastianbergmann/phpunit/issues/529

This will always perform the check for $suiteClassName inside loaded classes
