### PR TITLE
PHPUnit 4.2: Exceptions with chars used by regular expression can break tests

### DIFF
--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -137,7 +137,8 @@ class PHPUnit_Util_ErrorHandler
             if (!$expired) {
                 $expired = true;
                 // cleans temporary error handler
-                return restore_error_handler();
+                restore_error_handler();
+                throw new Exception();
             }
         };
 

--- a/src/Util/Regex.php
+++ b/src/Util/Regex.php
@@ -58,9 +58,13 @@ class PHPUnit_Util_Regex
 {
     public static function pregMatchSafe($pattern, $subject, $matches = null, $flags = 0, $offset = 0)
     {
-        $handler_terminator = PHPUnit_Util_ErrorHandler::handleErrorOnce(E_WARNING);
-        $match = preg_match($pattern, $subject, $matches, $flags, $offset);
-        $handler_terminator(); // cleaning
+        try {
+            $handler_terminator = PHPUnit_Util_ErrorHandler::handleErrorOnce(E_WARNING);
+            $match = preg_match($pattern, $subject, $matches, $flags, $offset);
+            $handler_terminator(); // cleaning
+        } catch (Exception $e) {
+            $match = false;
+        }
 
         return $match;
     }


### PR DESCRIPTION
Hey,

we just tried to use PHPUnit 4.2 on our project and ran into a rather tricky problem, from which I've created a simpler example project you can use to test this bug.

https://github.com/dreis2211/phpunit-exception-test

or you try to run this

``` php
<?php

class ExampleClass {

    public function doSomething() {
        throw new Exception('[Have you done something wrong? Try again.]');
    }

}

class ExampleClassTest extends PHPUnit_Framework_TestCase {

    public function testExceptionWithQuestionMark() {
        $this->setExpectedException('Exception', '[Have you done something wrong? Try again.]');

        $model = new ExampleClass();
        $model->doSomething();
    }
}
```

This behaviour was most likely introduced with the following commit.
https://github.com/sebastianbergmann/phpunit/commit/f8826506baf9ec673aaf56887a6682093bccffb1

Cheers,

dreis2211
