### PR TITLE
Expect composer-autoloader to be 1 dir up - in case it's not a symlink

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -35,7 +35,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
I'm experiencing that the `bin/phpunit` binary installed by composer is not a symlink but a regular file.
The reason is that [vagrant copies symlinks as regular files](https://github.com/mitchellh/vagrant/commit/2a973df4401e1dc2d07c778080306582e48baab1) since recently, when the `rsync` shared-folder mechanism is used.

Wdyt about expecting this case in the binary?
