### PR TITLE
Data Provider with \ at the end of the name breaks with process isolation

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -631,11 +631,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
 
             $data            = var_export(serialize($this->data), true);
+            $dataName        = var_export($this->dataName, true);
             $dependencyInput = var_export(serialize($this->dependencyInput), true);
             $includePath     = var_export(get_include_path(), true);
             // must do these fixes because TestCaseMethod.tpl has unserialize('{data}') in it, and we can't break BC
             // the lines above used to use addcslashes() rather than var_export(), which breaks null byte escape sequences
             $data            = "'." . $data . ".'";
+            $dataName        = "'.(" . $dataName . ").'";
             $dependencyInput = "'." . $dependencyInput . ".'";
             $includePath     = "'." . $includePath . ".'";
 
@@ -648,7 +650,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 'methodName'                              => $this->name,
                 'collectCodeCoverageInformation'          => $coverage,
                 'data'                                    => $data,
-                'dataName'                                => $this->dataName,
+                'dataName'                                => $dataName,
                 'dependencyInput'                         => $dependencyInput,
                 'constants'                               => $constants,
                 'globals'                                 => $globals,

--- a/tests/Regression/GitHub/1337.phpt
+++ b/tests/Regression/GitHub/1337.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GH-1300: Data Provider with \ at the end of the name breaks with process isolation
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = 'Issue1337Test';
+$_SERVER['argv'][4] = dirname(__FILE__).'/1337/Issue1337Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+..
+
+Time: %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)

--- a/tests/Regression/GitHub/1337/Issue1337Test.php
+++ b/tests/Regression/GitHub/1337/Issue1337Test.php
@@ -1,0 +1,19 @@
+<?php
+class Issue1337Test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testProvider($a)
+    {
+        $this->assertTrue($a);
+    }
+
+    public function dataProvider()
+    {
+        return array(
+            'c:\\'=>array(true),
+            0.9=>array(true)
+        );
+    }
+}


### PR DESCRIPTION
When using process isolation and a test which has a data provider which has a "\" at the of the name an invalid php file is generated by the process isolation template.
