### PR TITLE
Process isolation blocks infinitely upon fatal error in child process

### DIFF
--- a/tests/Regression/GitHub/1340.phpt
+++ b/tests/Regression/GitHub/1340.phpt
@@ -12,7 +12,7 @@ PHPUnit_TextUI_Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.
-
+%A
 .E.EE
 
 Time: %s, Memory: %sMb
@@ -27,10 +27,7 @@ PHPUnit_Framework_Exception: shutdown: stderr:%d
 %A
 3) Issue1340Test::testFatalErrorDoesNotPass
 PHPUnit_Framework_Exception: Fatal error: Call to undefined function undefined_function() in %s on line %d
-
-Call Stack:
-%a
-
+%A
 shutdown: stderr:%d
 %A
 FAILURES!

--- a/tests/Regression/GitHub/1340.phpt
+++ b/tests/Regression/GitHub/1340.phpt
@@ -1,0 +1,43 @@
+--TEST--
+GH-1340: Process isolation blocks infinitely upon fatal error
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][3] = 'Issue1340Test';
+$_SERVER['argv'][4] = dirname(__FILE__).'/1340/Issue1340Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.E.EE
+
+Time: %s, Memory: %sMb
+
+There were 3 errors:
+
+1) Issue1340Test::testLargeStderrOutputDoesNotBlockInIsolation
+PHPUnit_Framework_Exception: testLargeStderrOutputDoesNotBlockInIsolation: stderr:%d
+
+%a
+
+2) Issue1340Test::testPhpNoticeWithStderrOutputIsAnError
+PHPUnit_Framework_Exception: shutdown: stderr:%d
+
+%a
+
+3) Issue1340Test::testFatalErrorDoesNotPass
+PHPUnit_Framework_Exception: Fatal error: Call to undefined function undefined_function() in %s on line %d
+
+Call Stack:
+%a
+
+shutdown: stderr:%d
+
+%a
+
+FAILURES!
+Tests: 5, Assertions: 3, Errors: 3.

--- a/tests/Regression/GitHub/1340.phpt
+++ b/tests/Regression/GitHub/1340.phpt
@@ -21,14 +21,10 @@ There were 3 errors:
 
 1) Issue1340Test::testLargeStderrOutputDoesNotBlockInIsolation
 PHPUnit_Framework_Exception: testLargeStderrOutputDoesNotBlockInIsolation: stderr:%d
-
-%a
-
+%A
 2) Issue1340Test::testPhpNoticeWithStderrOutputIsAnError
 PHPUnit_Framework_Exception: shutdown: stderr:%d
-
-%a
-
+%A
 3) Issue1340Test::testFatalErrorDoesNotPass
 PHPUnit_Framework_Exception: Fatal error: Call to undefined function undefined_function() in %s on line %d
 
@@ -36,8 +32,6 @@ Call Stack:
 %a
 
 shutdown: stderr:%d
-
-%a
-
+%A
 FAILURES!
 Tests: 5, Assertions: 3, Errors: 3.

--- a/tests/Regression/GitHub/1340/Issue1340Test.php
+++ b/tests/Regression/GitHub/1340/Issue1340Test.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @see https://bugs.php.net/bug.php?id=51800
+ */
+class Issue1340Test extends PHPUnit_Framework_TestCase
+{
+    private static function get4KB()
+    {
+        return str_repeat('1', 4096 + 1);
+    }
+
+    /**
+     * Also fails despite no isolation, because a phpt test is executed in
+     * subprocess on its own.
+     */
+    public function testLargeStderrOutputDoesNotBlock()
+    {
+        // STDERR of a phpt test is not caught/validated at this point, so this
+        // error output does not cause this test to fail.
+        // @see https://github.com/sebastianbergmann/phpunit/issues/1169
+        error_log("\n" . __FUNCTION__ . ": stderr:" . self::get4KB() . "\n");
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testLargeStderrOutputDoesNotBlockInIsolation()
+    {
+        error_log("\n" . __FUNCTION__ . ": stderr:" . self::get4KB() . "\n");
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @expectedException \PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Undefined variable: foo
+     */
+    public function testPhpNoticeIsCaught()
+    {
+        $bar = $foo['foo'];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @expectedException \PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Undefined variable: foo
+     */
+    public function testPhpNoticeWithStderrOutputIsAnError()
+    {
+        register_shutdown_function(__CLASS__ . '::onShutdown');
+        $bar = $foo['foo'];
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFatalErrorDoesNotPass()
+    {
+        register_shutdown_function(__CLASS__ . '::onShutdown');
+        $undefined = 'undefined_function';
+        $undefined();
+    }
+
+    public static function onShutdown() {
+        echo "\nshutdown: stdout:", self::get4KB(), "\n";
+        error_log("\nshutdown: stderr:" . self::get4KB());
+    }
+}


### PR DESCRIPTION
| PHPUnit | Platform |
| --- | --- |
| 4.1.3 | Windows 7 64-bit |

When using `--process-isolation`, `@runTestsInSeparateProcess`, or `@runInSeparateProcess` and the child process terminates with a PHP Fatal Error, the parent process blocks infinitely on Windows.

The fix is to read `stderr` before `stdout`.

cf. https://bugs.php.net/bug.php?id=51800:

> If called as shown below, the script will hang in the loop that reads the STDOUT pipe. The same would happen if you would read the STDERR pipe before. If you lower the amount of data in process.php the script will run to the end. In my tests everything below ~2000 bytes was ok, above this value the script hang.
> 
> If you change the script below to not include the STDERR descriptor or if you change the STDERR descriptor to a file output everything will work fine. Also if you close the STDERR pipe before reading from STDOUT it will work. There seems to be some deadlock.

---

`stderr` contains the fatal error, `stdout` is empty.  I had to debug this phantom for the past two days…:

After `stdin` is written/processed and closed, `stream_get_meta_data($pipes[1])` reports that `stdout` still appears to be present:

```
$ phpunit -v --debug --process-isolation ...
PHPUnit 4.1.3 by Sebastian Bergmann.

Starting test '...'.
array(7) {
  'stream_type' =>
  string(5) "STDIO"
  'mode' =>
  string(1) "r"
  'unread_bytes' =>
  int(0)
  'seekable' =>
  bool(false)
  'timed_out' =>
  bool(false)
  'blocked' =>
  bool(true)
  'eof' =>
  bool(false)
}
```

But as soon as `$stdout = stream_get_contents($pipes[1])` is called, the script hangs.

Changing the order in which `$stdout` and `$stderr` are read suddenly fixes the problem, and `stream_get_meta_data()` reports the same info for both pipes.

---

All of the usual resolutions for this common problem did not work in this case, and I'm not able to explain why.  However, I'd like to make clear that I did try all of the below:
1. [Opening stderr in append mode instead of write mode](http://php.net/manual/en/function.proc-open.php#97012): Normally, that is almost always the solution.  However, for some reason, this caused the parent process to not receive any output on stderr at all, and so a test passed despite a fatal error.
2. [Setting stderr to non-blocking](http://php.net/manual/en/function.proc-open.php#81317): As mentioned in this [user comment](http://php.net/manual/en/function.stream-set-blocking.php#110997), that's not supported by `proc_open()` on Windows.
   - https://bugs.php.net/bug.php?id=51800
   - https://bugs.php.net/bug.php?id=34972
   - https://bugs.php.net/bug.php?id=47918
3. …

**D'oh.**  Somehow I didn't notice the first PHP bug link.  [#51800](https://bugs.php.net/bug.php?id=51800) fully cuts it.  Nothing further to add to that.

Since the bug is still unresolved, I'd recommend to move forward with this PR as-is and just simply change the order in which stderr and stdout are read.
