### PR TITLE
STDOUT/STDERR IO streams do not exist in process isolation

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -1,4 +1,9 @@
 <?php
+if (!defined('STDOUT')) {
+    define('STDOUT', fopen('php://stdout', 'wb'));
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+
 {iniSettings}
 ini_set('display_errors', 'stderr');
 set_include_path('{include_path}');


### PR DESCRIPTION
The PHP CLI SAPI does not auto-register the standard IO streams when a script is piped into STDIN (which is the case in process isolation); cf.
- https://bugs.php.net/bug.php?id=43283
- http://php.net/manual/en/features.commandline.io-streams.php
  
  > **Note:** These constants are not available if reading the PHP script from stdin.
- https://gist.github.com/sun/d02c242514c8f34bccdb

When a test is executed without process isolation, then the `STDOUT` and `STDERR` streams are available.  But if the test is executed in a separate process, then attempting to access the streams triggers a PHP Notice (undefined constant), followed by a PHP Warning (`fopen`).

A prominent example of affected code is e.g. [vfsStream](https://github.com/mikey179/vfsStream/blob/master/src/main/php/org/bovigo/vfs/visitor/vfsStreamPrintVisitor.php#L44), which is an officially recommended/endorsed library for PHPUnit.

I'll add a regression test shortly.
