### PR TITLE
Remove instantiated (child process) objects from TestFailure

### DIFF
--- a/src/Framework/Error.php
+++ b/src/Framework/Error.php
@@ -54,7 +54,7 @@
  * @link       http://www.phpunit.de/
  * @since      Class available since Release 2.2.0
  */
-class PHPUnit_Framework_Error extends Exception
+class PHPUnit_Framework_Error extends PHPUnit_Framework_Exception
 {
     /**
      * Constructor.

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -74,7 +74,10 @@ class PHPUnit_Framework_ExceptionWrapper extends PHPUnit_Framework_Exception
 
     public function __construct(Exception $e)
     {
-        parent::__construct($e->getMessage(), $e->getCode());
+        // PDOException::getCode() is a string.
+        // @see http://php.net/manual/en/class.pdoexception.php#95812
+        parent::__construct($e->getMessage(), (int) $e->getCode());
+
         $this->classname = get_class($e);
         $this->file = $e->getFile();
         $this->line = $e->getLine();

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -40,62 +40,69 @@
  * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://www.phpunit.de/
- * @since      File available since Release 3.4.0
+ * @since      File available since Release 4.1.5
  */
 
 /**
- * Base class for all PHPUnit Framework exceptions.
+ * Wraps Exceptions thrown by code under test.
  *
- * Ensures that exceptions thrown during a test run do not leave stray
- * references behind.
+ * Re-instantiates Exceptions thrown by user-space code to retain their original
+ * class names, properties, and stack traces (but without arguments).
  *
- * Every Exception contains a stack trace. Each stack frame contains the 'args'
- * of the called function. The function arguments can contain references to
- * instantiated objects. The references prevent the objects from being
- * destructed (until test results are eventually printed), so memory cannot be
- * freed up.
- *
- * With enabled process isolation, test results are serialized in the child
- * process and unserialized in the parent process. The stack trace of Exceptions
- * may contain objects that cannot be serialized or unserialized (e.g., PDO
- * connections). Unserializing user-space objects from the child process into
- * the parent would break the intended encapsulation of process isolation.
- *
- * @see http://fabien.potencier.org/article/9/php-serialization-stack-traces-and-exceptions
+ * Unlike PHPUnit_Framework_Exception, the complete stack of previous Exceptions
+ * is processed.
  *
  * @package    PHPUnit
  * @subpackage Framework
- * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Daniel F. Kudwien <sun@unleashedmind.com>
  * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
  * @link       http://www.phpunit.de/
- * @since      Class available since Release 3.4.0
+ * @since      Class available since Release 4.1.5
  */
-class PHPUnit_Framework_Exception extends RuntimeException implements PHPUnit_Exception
+class PHPUnit_Framework_ExceptionWrapper extends PHPUnit_Framework_Exception
 {
     /**
-     * @var array
+     * @var string
      */
-    protected $serializableTrace;
+    protected $classname;
 
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    /**
+     * @var PHPUnit_Framework_ExceptionWrapper|null
+     */
+    protected $previous;
+
+    public function __construct(Exception $e)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct($e->getMessage(), $e->getCode());
+        $this->classname = get_class($e);
+        $this->file = $e->getFile();
+        $this->line = $e->getLine();
 
-        $this->serializableTrace = $this->getTrace();
+        $this->serializableTrace = $e->getTrace();
         foreach ($this->serializableTrace as $i => $call) {
             unset($this->serializableTrace[$i]['args']);
+        }
+
+        if ($e->getPrevious()) {
+            $this->previous = new self($e->getPrevious());
         }
     }
 
     /**
-     * Returns the serializable trace (without 'args').
-     *
-     * @return array
+     * @return string
      */
-    public function getSerializableTrace()
+    public function getClassname()
     {
-        return $this->serializableTrace;
+        return $this->classname;
+    }
+
+    /**
+     * @return PHPUnit_Framework_ExceptionWrapper
+     */
+    public function getPreviousWrapped()
+    {
+        return $this->previous;
     }
 
     /**
@@ -109,11 +116,10 @@ class PHPUnit_Framework_Exception extends RuntimeException implements PHPUnit_Ex
             $string .= "\n" . $trace;
         }
 
-        return $string;
-    }
+        if ($this->previous) {
+            $string .= "\nCaused by\n" . $this->previous;
+        }
 
-    public function __sleep()
-    {
-        return array_keys(get_object_vars($this));
+        return $string;
     }
 }

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -57,9 +57,9 @@
 class PHPUnit_Framework_TestFailure
 {
     /**
-     * @var    PHPUnit_Framework_Test
+     * @var string
      */
-    protected $failedTest;
+    private $testName;
 
     /**
      * @var    Exception
@@ -74,7 +74,11 @@ class PHPUnit_Framework_TestFailure
      */
     public function __construct(PHPUnit_Framework_Test $failedTest, Exception $thrownException)
     {
-        $this->failedTest      = $failedTest;
+        if ($failedTest instanceof PHPUnit_Framework_SelfDescribing) {
+            $this->testName = $failedTest->toString();
+        } else {
+            $this->testName = get_class($failedTest);
+        }
         $this->thrownException = $thrownException;
     }
 
@@ -87,8 +91,7 @@ class PHPUnit_Framework_TestFailure
     {
         return sprintf(
           '%s: %s',
-
-          $this->failedTest->toString(),
+          $this->testName,
           $this->thrownException->getMessage()
         );
     }
@@ -125,6 +128,8 @@ class PHPUnit_Framework_TestFailure
             }
         } elseif ($e instanceof PHPUnit_Framework_Error) {
             $buffer = $e->getMessage() . "\n";
+        } elseif ($e instanceof PHPUnit_Framework_ExceptionWrapper) {
+            $buffer = $e->getClassname() . ': ' . $e->getMessage() . "\n";
         } else {
             $buffer = get_class($e) . ': ' . $e->getMessage() . "\n";
         }
@@ -133,13 +138,13 @@ class PHPUnit_Framework_TestFailure
     }
 
     /**
-     * Gets the failed test.
+     * Returns the name of the failing test (including data set, if any).
      *
-     * @return PHPUnit_Framework_Test
+     * @return string
      */
-    public function failedTest()
+    public function getTestName()
     {
-        return $this->failedTest;
+        return $this->testName;
     }
 
     /**

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -695,7 +695,10 @@ class PHPUnit_Framework_TestResult implements Countable
             } elseif ($e instanceof PHPUnit_Framework_SkippedTestError) {
                 $skipped = true;
             }
+        } catch (PHPUnit_Framework_Exception $e) {
+            $error = true;
         } catch (Exception $e) {
+            $e = new PHPUnit_Framework_ExceptionWrapper($e);
             $error = true;
         }
 

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -260,20 +260,12 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      */
     protected function printDefectHeader(PHPUnit_Framework_TestFailure $defect, $count)
     {
-        $failedTest = $defect->failedTest();
-
-        if ($failedTest instanceof PHPUnit_Framework_SelfDescribing) {
-            $testName = $failedTest->toString();
-        } else {
-            $testName = get_class($failedTest);
-        }
-
         $this->write(
           sprintf(
             "\n%d) %s\n",
 
             $count,
-            $testName
+            $defect->getTestName()
           )
         );
     }
@@ -283,26 +275,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      */
     protected function printDefectTrace(PHPUnit_Framework_TestFailure $defect)
     {
-        $this->write($defect->getExceptionAsString());
+        $e = $defect->thrownException();
+        $this->write((string) $e);
 
-        $trace = PHPUnit_Util_Filter::getFilteredStacktrace(
-          $defect->thrownException()
-        );
-
-        if (!empty($trace)) {
-            $this->write("\n" . $trace);
-        }
-
-        $e = $defect->thrownException()->getPrevious();
-
-        while ($e) {
-          $this->write(
-            "\nCaused by\n" .
-            PHPUnit_Framework_TestFailure::exceptionToString($e). "\n" .
-            PHPUnit_Util_Filter::getFilteredStacktrace($e)
-          );
-
-          $e = $e->getPrevious();
+        while ($e = $e->getPrevious()) {
+          $this->write("\nCaused by\n" . $e);
         }
     }
 

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -82,12 +82,15 @@ class PHPUnit_Util_Filter
             $eTrace = $e->getSyntheticTrace();
             $eFile  = $e->getSyntheticFile();
             $eLine  = $e->getSyntheticLine();
+        } elseif ($e instanceof PHPUnit_Framework_Exception) {
+            $eTrace = $e->getSerializableTrace();
+            $eFile  = $e->getFile();
+            $eLine  = $e->getLine();
         } else {
             if ($e->getPrevious()) {
-                $eTrace = $e->getPrevious()->getTrace();
-            } else {
-                $eTrace = $e->getTrace();
+                $e = $e->getPrevious();
             }
+            $eTrace = $e->getTrace();
             $eFile  = $e->getFile();
             $eLine  = $e->getLine();
         }

--- a/tests/Regression/GitHub/1351.phpt
+++ b/tests/Regression/GitHub/1351.phpt
@@ -1,0 +1,38 @@
+--TEST--
+GH-1351: Test result does not serialize test class in process isolation
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = 'Issue1351Test';
+$_SERVER['argv'][4] = __DIR__ . '/1351/Issue1351Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+F.E.
+
+Time: %s, Memory: %sMb
+
+There was 1 error:
+
+1) Issue1351Test::testExceptionPre
+RuntimeException: Expected rethrown exception.
+%A
+Caused by
+LogicException: Expected exception.
+%A
+
+--
+
+There was 1 failure:
+
+1) Issue1351Test::testFailurePre
+Expected failure.
+%A
+FAILURES!
+Tests: 4, Assertions: 5, Failures: 1, Errors: 1.

--- a/tests/Regression/GitHub/1351.phpt
+++ b/tests/Regression/GitHub/1351.phpt
@@ -14,17 +14,21 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.
 
-F.E.
+F.E.E
 
 Time: %s, Memory: %sMb
 
-There was 1 error:
+There were 2 errors:
 
 1) Issue1351Test::testExceptionPre
 RuntimeException: Expected rethrown exception.
 %A
 Caused by
 LogicException: Expected exception.
+%A
+
+2) Issue1351Test::testPhpCoreLanguageException
+PDOException: SQLSTATE[HY000]: General error: 1 no such table: php_wtf
 %A
 
 --
@@ -35,4 +39,4 @@ There was 1 failure:
 Expected failure.
 %A
 FAILURES!
-Tests: 4, Assertions: 5, Failures: 1, Errors: 1.
+Tests: 5, Assertions: 5, Failures: 1, Errors: 2.

--- a/tests/Regression/GitHub/1351/ChildProcessClass1351.php
+++ b/tests/Regression/GitHub/1351/ChildProcessClass1351.php
@@ -1,0 +1,4 @@
+<?php
+class ChildProcessClass1351
+{
+}

--- a/tests/Regression/GitHub/1351/Issue1351Test.php
+++ b/tests/Regression/GitHub/1351/Issue1351Test.php
@@ -36,4 +36,13 @@ class Issue1351Test extends PHPUnit_Framework_TestCase
         $this->assertNull($this->instance);
         $this->assertFalse(class_exists('ChildProcessClass1351', false), 'ChildProcessClass1351 is not loaded.');
     }
+
+    public function testPhpCoreLanguageException()
+    {
+        // User-space code cannot instantiate a PDOException with a string code,
+        // so trigger a real one.
+        $connection = new PDO('sqlite::memory:');
+        $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $connection->query("DELETE FROM php_wtf WHERE exception_code = 'STRING'");
+    }
 }

--- a/tests/Regression/GitHub/1351/Issue1351Test.php
+++ b/tests/Regression/GitHub/1351/Issue1351Test.php
@@ -1,0 +1,39 @@
+<?php
+class Issue1351Test extends PHPUnit_Framework_TestCase
+{
+    protected $instance;
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFailurePre()
+    {
+        $this->instance = new ChildProcessClass1351();
+        $this->assertFalse(TRUE, 'Expected failure.');
+    }
+
+    public function testFailurePost()
+    {
+        $this->assertNull($this->instance);
+        $this->assertFalse(class_exists('ChildProcessClass1351', false), 'ChildProcessClass1351 is not loaded.');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testExceptionPre()
+    {
+        $this->instance = new ChildProcessClass1351();
+        try {
+            throw new LogicException('Expected exception.');
+        } catch (LogicException $e) {
+            throw new RuntimeException('Expected rethrown exception.', 0, $e);
+        }
+    }
+
+    public function testExceptionPost()
+    {
+        $this->assertNull($this->instance);
+        $this->assertFalse(class_exists('ChildProcessClass1351', false), 'ChildProcessClass1351 is not loaded.');
+    }
+}

--- a/tests/TextUI/exception-stack.phpt
+++ b/tests/TextUI/exception-stack.phpt
@@ -19,7 +19,7 @@ Time: %s, Memory: %sMb
 There were 2 errors:
 
 1) ExceptionStackTest::testPrintingChildException
-ExceptionStackTestException: Child exception
+PHPUnit_Framework_Exception: Child exception
 message
 Failed asserting that two arrays are equal.
 --- Expected
@@ -31,7 +31,6 @@ Failed asserting that two arrays are equal.
  )
 
 
-%s:%i
 %s:%i
 
 Caused by

--- a/tests/_files/ExceptionStackTest.php
+++ b/tests/_files/ExceptionStackTest.php
@@ -1,6 +1,4 @@
 <?php
-class ExceptionStackTestException extends Exception { }
-
 class ExceptionStackTest extends PHPUnit_Framework_TestCase
 {
     public function testPrintingChildException()
@@ -9,7 +7,7 @@ class ExceptionStackTest extends PHPUnit_Framework_TestCase
             $this->assertEquals(array(1), array(2), 'message');
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
             $message = $e->getMessage() . $e->getComparisonFailure()->getDiff();
-            throw new ExceptionStackTestException("Child exception\n$message", 101, $e);
+            throw new PHPUnit_Framework_Exception("Child exception\n$message", 101, $e);
         }
     }
 


### PR DESCRIPTION
Resolves #1351

Let's keep communication centralized over there.
