### PR TITLE
PHPUnit test suite fails on Windows

### DIFF
--- a/src/Util/Blacklist.php
+++ b/src/Util/Blacklist.php
@@ -137,11 +137,13 @@ class PHPUnit_Util_Blacklist
                 self::$directories[] = $directory;
             }
 
-            // Process isolation workaround on Windows.
+            // Hide process isolation workaround on Windows.
             // @see PHPUnit_Util_PHP::factory()
             // @see PHPUnit_Util_PHP_Windows::process()
             if (DIRECTORY_SEPARATOR === '\\') {
-                self::$directories[] = sys_get_temp_dir();
+                // tempnam() prefix is limited to first 3 chars.
+                // @see http://php.net/manual/en/function.tempnam.php
+                self::$directories[] = sys_get_temp_dir() . '\\PHP';
             }
        }
     }

--- a/src/Util/Blacklist.php
+++ b/src/Util/Blacklist.php
@@ -136,6 +136,13 @@ class PHPUnit_Util_Blacklist
 
                 self::$directories[] = $directory;
             }
+
+            // Process isolation workaround on Windows.
+            // @see PHPUnit_Util_PHP::factory()
+            // @see PHPUnit_Util_PHP_Windows::process()
+            if (DIRECTORY_SEPARATOR === '\\') {
+                self::$directories[] = sys_get_temp_dir();
+            }
        }
     }
 }

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -135,21 +135,27 @@ class PHPUnit_Util_XML
             return $actual;
         }
 
+        // Required for XInclude on Windows.
+        if ($xinclude) {
+            $cwd = getcwd();
+            chdir(dirname($filename));
+        }
+
         $document  = new DOMDocument;
 
         $internal  = libxml_use_internal_errors(true);
         $message   = '';
         $reporting = error_reporting(0);
 
+        if ('' !== $filename) {
+            // Necessary for xinclude
+            $document->documentURI = $filename;
+        }
+
         if ($isHtml) {
             $loaded = $document->loadHTML($actual);
         } else {
             $loaded = $document->loadXML($actual);
-        }
-
-        if ('' !== $filename) {
-            // Necessary for xinclude
-            $document->documentURI = $filename;
         }
 
         if (!$isHtml && $xinclude) {
@@ -162,6 +168,10 @@ class PHPUnit_Util_XML
 
         libxml_use_internal_errors($internal);
         error_reporting($reporting);
+
+        if ($xinclude) {
+            chdir($cwd);
+        }
 
         if ($loaded === false || $message !== '') {
             if ($filename !== '') {

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -157,14 +157,14 @@ class PHPUnit_Util_XML
         }
 
         foreach (libxml_get_errors() as $error) {
-            $message .= $error->message;
+            $message .= "\n" . $error->message;
         }
 
         libxml_use_internal_errors($internal);
         error_reporting($reporting);
 
-        if ($loaded === false) {
-            if ($filename != '') {
+        if ($loaded === false || $message !== '') {
+            if ($filename !== '') {
                 throw new PHPUnit_Framework_Exception(
                   sprintf(
                     'Could not load "%s".%s',

--- a/tests/Regression/578.phpt
+++ b/tests/Regression/578.phpt
@@ -21,17 +21,17 @@ There were 3 errors:
 1) Issue578Test::testNoticesDoublePrintStackTrace
 Invalid error type specified
 
-%s/Issue578Test.php:%i
+%sIssue578Test.php:%i
 
 2) Issue578Test::testWarningsDoublePrintStackTrace
 Invalid error type specified
 
-%s/Issue578Test.php:%i
+%sIssue578Test.php:%i
 
 3) Issue578Test::testUnexpectedExceptionsPrintsCorrectly
 Exception: Double printed exception
 
-%s/Issue578Test.php:%i
+%sIssue578Test.php:%i
 
 FAILURES!
 Tests: 3, Assertions: 0, Errors: 3.

--- a/tests/Regression/GitHub/74.phpt
+++ b/tests/Regression/GitHub/74.phpt
@@ -22,7 +22,7 @@ There was 1 error:
 1) Issue74Test::testCreateAndThrowNewExceptionInProcessIsolation
 NewException: Testing GH-74
 
-%s/tests/Regression/GitHub/74/Issue74Test.php:7
+%sIssue74Test.php:7
 
 FAILURES!
 Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/TextUI/custom-printer-debug.phpt
+++ b/tests/TextUI/custom-printer-debug.phpt
@@ -14,7 +14,7 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.
 
-Configuration read from %s/configuration.custom-printer.xml
+Configuration read from %sconfiguration.custom-printer.xml
 
 
 Starting test 'BankAccountTest::testBalanceIsInitiallyZero'.

--- a/tests/TextUI/custom-printer-verbose.phpt
+++ b/tests/TextUI/custom-printer-verbose.phpt
@@ -14,7 +14,7 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.
 
-Configuration read from %s/configuration.custom-printer.xml
+Configuration read from %sconfiguration.custom-printer.xml
 
 I
 

--- a/tests/TextUI/dataprovider-log-xml-isolation.phpt
+++ b/tests/TextUI/dataprovider-log-xml-isolation.phpt
@@ -17,7 +17,7 @@ PHPUnit %s by Sebastian Bergmann.
 
 ..F.<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="DataProviderTest" file="%s/DataProviderTest.php" tests="4" assertions="4" failures="1" errors="0" time="%f">
+  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" failures="1" errors="0" time="%f">
     <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" failures="1" errors="0" time="%f">
       <testcase name="testAdd with data set #0" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #1" assertions="1" time="%f"/>

--- a/tests/TextUI/dataprovider-log-xml.phpt
+++ b/tests/TextUI/dataprovider-log-xml.phpt
@@ -16,7 +16,7 @@ PHPUnit %s by Sebastian Bergmann.
 
 ..F.<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="DataProviderTest" file="%s/DataProviderTest.php" tests="4" assertions="4" failures="1" errors="0" time="%f">
+  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" failures="1" errors="0" time="%f">
     <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" failures="1" errors="0" time="%f">
       <testcase name="testAdd with data set #0" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #1" assertions="1" time="%f"/>


### PR DESCRIPTION
PHPUnit's own test suite has various failures on Windows currently.  There are two dominant causes:
1. `DIRECTORY_SEPARATOR` mismatches in PHPT tests.
2. Expected stack traces in PHPT tests do not account for an additional stack frame that is caused by `PHPUnit_Util_PHP_Windows::process()`.

Lastly, there's a difference in libxml behavior with regard to `PHPUnit_Util_XML::load()` on Windows, which causes configuration.xml tests to fail, because relative file paths are not resolved correctly - they're resolved base on the current working directory, instead of the directory in which the configuration file is contained; setting `DOMDocument::$documentURI` does not help in any way (but is required and MUST be set before loading the XML for XInclude to work).
