### PR TITLE
Patch for exception message expectations

### DIFF
--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -62,11 +62,6 @@ class PHPUnit_Framework_Constraint_ExceptionMessage extends PHPUnit_Framework_Co
     protected $expectedMessage;
 
     /**
-     * @var boolean
-     */
-    protected $regexBased = false;
-
-    /**
      * @param string $expected
      */
     public function __construct($expected)
@@ -84,16 +79,7 @@ class PHPUnit_Framework_Constraint_ExceptionMessage extends PHPUnit_Framework_Co
      */
     protected function matches($other)
     {
-        $match = PHPUnit_Util_Regex::pregMatchSafe($this->expectedMessage, $other->getMessage());
-        if (false !== $match) {
-            $this->regexBased = true;
-        }
-
-        else {
-            $match = strpos($other->getMessage(), $this->expectedMessage) !== false;
-        }
-
-        return (bool) $match;
+        return strpos($other->getMessage(), $this->expectedMessage) !== false;
     }
 
     /**
@@ -108,7 +94,7 @@ class PHPUnit_Framework_Constraint_ExceptionMessage extends PHPUnit_Framework_Co
     protected function failureDescription($other)
     {
         return sprintf(
-          "exception message '%s' {$this->getVerb()} '%s'",
+          "exception message '%s' contains '%s'",
           $other->getMessage(),
           $this->expectedMessage
         );
@@ -119,14 +105,6 @@ class PHPUnit_Framework_Constraint_ExceptionMessage extends PHPUnit_Framework_Co
      */
     public function toString()
     {
-        return "exception message {$this->getVerb()} ";
-    }
-
-    /**
-     * @return string
-     */
-    protected function getVerb()
-    {
-        return ($this->regexBased) ? "matches" : "contains";
+        return 'exception message contains ';
     }
 }

--- a/src/Framework/Constraint/ExceptionMessageRegExp.php
+++ b/src/Framework/Constraint/ExceptionMessageRegExp.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.6.6
+ */
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Márcio Almada <marcio3w@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.0.20
+ */
+class PHPUnit_Framework_Constraint_ExceptionMessageRegExp extends PHPUnit_Framework_Constraint
+{
+    /**
+     * @var integer
+     */
+    protected $expectedMessageRegExp;
+
+    /**
+     * @param string $expected
+     */
+    public function __construct($expected)
+    {
+        parent::__construct();
+        $this->expectedMessageRegExp = $expected;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param  Exception $other
+     * @return boolean
+     */
+    protected function matches($other)
+    {
+        $match = PHPUnit_Util_Regex::pregMatchSafe($this->expectedMessageRegExp, $other->getMessage());
+        
+        if(false === $match) {
+            throw new PHPUnit_Framework_Exception (
+                "Invalid expected exception message regex given: '{$this->expectedMessageRegExp}'"
+            );
+        }
+
+        return 1 === $match;
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param  mixed  $other Evaluated value or object.
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return sprintf(
+          "exception message '%s' matches '%s'",
+          $other->getMessage(),
+          $this->expectedMessageRegExp
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        return "exception message matches ";
+    }
+
+}

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -177,6 +177,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     private $expectedExceptionMessage = '';
 
     /**
+     * The regex pattern to validate the expected Exception message.
+     *
+     * @var string
+     */
+    private $expectedExceptionMessageRegExp = '';
+
+    /**
      * The code of the expected Exception.
      *
      * @var integer
@@ -459,6 +466,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $this->expectedException        = $exceptionName;
         $this->expectedExceptionMessage = $exceptionMessage;
         $this->expectedExceptionCode    = $exceptionCode;
+    }
+
+    /**
+     * @param mixed   $exceptionName
+     * @param string  $exceptionMessageRegExp
+     * @param integer $exceptionCode
+     * @since  Method available since Release 4.0.2
+     */
+    public function setExpectedExceptionRegExp($exceptionName, $exceptionMessageRegExp = '', $exceptionCode = null)
+    {
+        $this->expectedException              = $exceptionName;
+        $this->expectedExceptionMessageRegExp = $exceptionMessageRegExp;
+        $this->expectedExceptionCode          = $exceptionCode;
     }
 
     /**

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -497,6 +497,14 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                   $expectedException['message'],
                   $expectedException['code']
                 );
+
+                if(isset($expectedException['message_regex']) && ! empty($expectedException['message_regex'])) {
+                    $this->setExpectedExceptionRegExp(
+                      $expectedException['class'],
+                      $expectedException['message_regex'],
+                      $expectedException['code']
+                    );
+                }
             }
         } catch (ReflectionException $e) {
         }
@@ -909,6 +917,16 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                       $e,
                       new PHPUnit_Framework_Constraint_ExceptionMessage(
                         $this->expectedExceptionMessage
+                      )
+                    );
+                }
+
+                if (is_string($this->expectedExceptionMessageRegExp) &&
+                    !empty($this->expectedExceptionMessageRegExp)) {
+                    $this->assertThat(
+                      $e,
+                      new PHPUnit_Framework_Constraint_ExceptionMessageRegExp(
+                        $this->expectedExceptionMessageRegExp
                       )
                     );
                 }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -316,12 +316,19 @@ class PHPUnit_Util_Test
             $class   = $matches[1];
             $code    = null;
             $message = '';
+            $messageRegExp = '';
 
             if (isset($matches[2])) {
                 $message = trim($matches[2]);
             } elseif (isset($annotations['method']['expectedExceptionMessage'])) {
                 $message = self::parseAnnotationContent(
                     $annotations['method']['expectedExceptionMessage'][0]
+                );
+            }
+
+            if (isset($annotations['method']['expectedExceptionMessageRegExp'])) {
+                $messageRegExp = self::parseAnnotationContent(
+                    $annotations['method']['expectedExceptionMessageRegExp'][0]
                 );
             }
 
@@ -340,7 +347,7 @@ class PHPUnit_Util_Test
             }
 
             return array(
-              'class' => $class, 'code' => $code, 'message' => $message
+              'class' => $class, 'code' => $code, 'message' => $message, 'message_regex' => $messageRegExp
             );
         }
 

--- a/tests/Framework/Constraint/ExceptionMessageRegExpTest.php
+++ b/tests/Framework/Constraint/ExceptionMessageRegExpTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Jeroen Versteeg <jversteeg@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 3.7.30
+ */
+
+/**
+ *
+ *
+ * @package    PHPUnit
+ * @author     Márcio Almada <marcio3w@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.0.20
+ * @covers     PHPUnit_Framework_Constraint_ExceptionMessageRegExp
+ */
+class ExceptionMessageRegExpTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /^A polymorphic \w+ message/
+     */
+    public function testRegexMessage()
+    {
+        throw new Exception("A polymorphic exception message");
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$/i
+     */
+    public function testRegexMessageExtreme()
+    {
+        throw new Exception("A polymorphic exception message");
+    }
+
+     /**
+     * @runInSeparateProcess
+     * @requires extension xdebug
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp #Screaming preg_match#
+     */
+    public function testMessageXdebugScreamCompatibility()
+    {
+        ini_set('xdebug.scream', '1');
+        throw new Exception("Screaming preg_match");
+    }
+
+    /**
+     * @coversNothing  
+     * @expectedException \Exception variadic
+     * @expectedExceptionMessageRegExp /^A variadic \w+ message/
+     */
+    public function testSimultaneousLiteralAndRegExpExceptionMessage()
+    {
+        throw new Exception("A variadic exception message");
+    }
+
+}

--- a/tests/Framework/Constraint/ExceptionMessageTest.php
+++ b/tests/Framework/Constraint/ExceptionMessageTest.php
@@ -93,33 +93,4 @@ class ExceptionMessageTest extends PHPUnit_Framework_TestCase
         throw new Exception("A partial exception message");
     }
 
-    /**
-     * @runInSeparateProcess
-     * @requires extension xdebug
-     * @expectedException \Exception
-     * @expectedExceptionMessage Screaming preg_match
-     */
-    public function testMessageWithXdebugScreamOn()
-    {
-        ini_set('xdebug.scream', '1');
-        throw new Exception("Screaming preg_match");
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage /^A polymorphic \w+ message/
-     */
-    public function testRegexMessage()
-    {
-        throw new Exception("A polymorphic exception message");
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage /^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$/i
-     */
-    public function testRegexMessageExtreme()
-    {
-        throw new Exception("A polymorphic exception message");
-    }
 }

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -230,32 +230,6 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testExceptionWithRegexpMessage()
-    {
-        $test = new ThrowExceptionTestCase('test');
-        $test->setExpectedException('RuntimeException', '/runtime .*? occurred/');
-
-        $result = $test->run();
-
-        $this->assertEquals(1, count($result));
-        $this->assertTrue($result->wasSuccessful());
-    }
-
-    public function testExceptionWithWrongRegexpMessage()
-    {
-        $test = new ThrowExceptionTestCase('test');
-        $test->setExpectedException('RuntimeException', '/logic .*? occurred/');
-
-        $result = $test->run();
-
-        $this->assertEquals(1, $result->failureCount());
-        $this->assertEquals(1, count($result));
-        $this->assertEquals(
-          "Failed asserting that exception message 'A runtime error occurred' matches '/logic .*? occurred/'.",
-          $test->getStatusMessage()
-        );
-    }
-
     public function testNoException()
     {
         $test = new ThrowNoExceptionTestCase('test');

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -256,6 +256,9 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @covers PHPUnit_Framework_Constraint_ExceptionMessageRegExp
+     */
     public function testExceptionWithInvalidRegexpMessage()
     {
         $test = new ThrowExceptionTestCase('test');

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -230,6 +230,45 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testExceptionWithRegexpMessage()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedExceptionRegExp('RuntimeException', '/runtime .*? occurred/');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testExceptionWithWrongRegexpMessage()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedExceptionRegExp('RuntimeException', '/logic .*? occurred/');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, $result->failureCount());
+        $this->assertEquals(1, count($result));
+        $this->assertEquals(
+          "Failed asserting that exception message 'A runtime error occurred' matches '/logic .*? occurred/'.",
+          $test->getStatusMessage()
+        );
+    }
+
+    public function testExceptionWithInvalidRegexpMessage()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedExceptionRegExp('RuntimeException', '#runtime .*? occurred/'); // wrong delimiter
+
+        $result = $test->run();
+
+        $this->assertEquals(
+          "Invalid expected exception message regex given: '#runtime .*? occurred/'",
+          $test->getStatusMessage()
+        );
+    }
+
     public function testNoException()
     {
         $test = new ThrowNoExceptionTestCase('test');

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -69,68 +69,83 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testGetExpectedException()
     {
         $this->assertSame(
-          array('class' => 'FooBarBaz', 'code' => null, 'message' => ''),
+          array('class' => 'FooBarBaz', 'code' => null, 'message' => '', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testOne')
         );
 
         $this->assertSame(
-          array('class' => 'Foo_Bar_Baz', 'code' => null, 'message' => ''),
+          array('class' => 'Foo_Bar_Baz', 'code' => null, 'message' => '', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testTwo')
         );
 
         $this->assertSame(
-          array('class' => 'Foo\Bar\Baz', 'code' => null, 'message' => ''),
+          array('class' => 'Foo\Bar\Baz', 'code' => null, 'message' => '', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testThree')
         );
 
         $this->assertSame(
-          array('class' => 'ほげ', 'code' => null, 'message' => ''),
+          array('class' => 'ほげ', 'code' => null, 'message' => '', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testFour')
         );
 
         $this->assertSame(
-          array('class' => 'Class', 'code' => 1234, 'message' => 'Message'),
+          array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testFive')
         );
 
         $this->assertSame(
-          array('class' => 'Class', 'code' => 1234, 'message' => 'Message'),
+          array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSix')
         );
 
         $this->assertSame(
-          array('class' => 'Class', 'code' => 'ExceptionCode', 'message' => 'Message'),
+          array('class' => 'Class', 'code' => 'ExceptionCode', 'message' => 'Message', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSeven')
         );
 
         $this->assertSame(
-          array('class' => 'Class', 'code' => 0, 'message' => 'Message'),
+          array('class' => 'Class', 'code' => 0, 'message' => 'Message', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testEight')
         );
 
         $this->assertSame(
-          array('class' => 'Class', 'code' => ExceptionTest::ERROR_CODE, 'message' => ExceptionTest::ERROR_MESSAGE),
+          array('class' => 'Class', 'code' => ExceptionTest::ERROR_CODE, 'message' => ExceptionTest::ERROR_MESSAGE, 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testNine')
         );
 
         $this->assertSame(
-          array('class' => 'Class', 'code' => null, 'message' => ''),
+          array('class' => 'Class', 'code' => null, 'message' => '', 'message_regex' => ''),
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSingleLine')
         );
 
         $this->assertSame(
-            array('class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE),
+            array('class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE, 'message_regex' => ''),
             PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstants')
         );
 
+        $this->assertSame(
+            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => '#regex#'),
+            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessage')
+        );
+
+        $this->assertSame(
+            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => '#regex#'),
+            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessageFromClassConstant')
+        );    
+
+        $this->assertSame(
+            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => 'ExceptionTest::UNKNOWN_MESSAGE_REGEX_CONSTANT'),
+            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithUnknowRegexMessageFromClassConstant')
+        );    
+
         // Ensure the Class::CONST expression is only evaluated when the constant really exists
         $this->assertSame(
-            array('class' => 'Class', 'code' => 'ExceptionTest::UNKNOWN_CODE_CONSTANT', 'message' => 'ExceptionTest::UNKNOWN_MESSAGE_CONSTANT'),
+            array('class' => 'Class', 'code' => 'ExceptionTest::UNKNOWN_CODE_CONSTANT', 'message' => 'ExceptionTest::UNKNOWN_MESSAGE_CONSTANT', 'message_regex' => ''),
             PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testUnknownConstants')
         );
 
         $this->assertSame(
-            array('class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT'),
+            array('class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT', 'message_regex' => ''),
             PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testUnknownConstants')
         );
     }

--- a/tests/_files/ExceptionTest.php
+++ b/tests/_files/ExceptionTest.php
@@ -9,6 +9,13 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
     const ERROR_MESSAGE = 'Exception message';
 
     /**
+     * Exception message
+     *
+     * @var string
+     */
+    const ERROR_MESSAGE_REGEX = '#regex#';
+
+    /**
      * Exception code
      *
      * @var integer
@@ -97,6 +104,36 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
      * @expectedExceptionMessage ExceptionTest::UNKNOWN_MESSAGE_CONSTANT
      */
     public function testUnknownConstants()
+    {
+    }
+
+    /**
+     * @expectedException Class
+     * @expectedExceptionCode 1234
+     * @expectedExceptionMessage Message
+     * @expectedExceptionMessageRegExp #regex#
+     */
+    public function testWithRegexMessage()
+    {
+    }
+
+    /**
+     * @expectedException Class
+     * @expectedExceptionCode 1234
+     * @expectedExceptionMessage Message
+     * @expectedExceptionMessageRegExp ExceptionTest::ERROR_MESSAGE_REGEX
+     */
+    public function testWithRegexMessageFromClassConstant()
+    {
+    }
+
+    /**
+     * @expectedException Class
+     * @expectedExceptionCode 1234
+     * @expectedExceptionMessage Message
+     * @expectedExceptionMessageRegExp ExceptionTest::UNKNOWN_MESSAGE_REGEX_CONSTANT
+     */
+    public function testWithUnknowRegexMessageFromClassConstant()
     {
     }
 }


### PR DESCRIPTION
### Changes:
- adds `@expectedExceptionMessageRegExp` annotation
- adds TestCase::setExpectedExceptionRegex($exceptionClass, $pattern, $code) so regex expectations for exception messages are still first class API citizens
- recovers old behavior of `@expectedExceptionMessage`, keeps the tests introduced by #1264
- for good or bad, both `@expectedExceptionMessage` and `@expectedExceptionMessageRegExp` can now be used simultaneously
- removes ambiguity already discussed in #1328

Relates to: #1266 #1264 #1263
#### Things not exactly related to this PR that I think we could do better:
- I particulary don't like the redundancy of `TestCase::setExpectedException` vs `TestCase::setExpectedExceptionRegex`, but it was the only sane way to keep the feature since there are no granular methods like `TestCase::setExpectedExceptionMessage` or `TestCase::setExpectedExceptionCode`. Any ideas?
- The way PHPUnit grabs annotation from doc blocks is spread across multiple methods at `Util\Test` class, and it can be kinda tricky to expand the API (look at how much edits I had to do just to achieve a minor tweak). There are many annotations libraries around, I recommend to pick one ;). I could make a PR to improve this in the future.
