### PR TITLE
Allow a test to identify whether it runs in isolation

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1051,6 +1051,14 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @return boolean
+     */
+    public function isInIsolation()
+    {
+        return $this->inIsolation;
+    }
+
+    /**
      * @return mixed
      * @since  Method available since Release 3.4.0
      */

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -362,6 +362,25 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertSame(123, self::$_testStatic);
     }
 
+    public function testIsInIsolationReturnsFalse()
+    {
+        $test   = new IsolationTest('testIsInIsolationReturnsFalse');
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testIsInIsolationReturnsTrue()
+    {
+        $test   = new IsolationTest('testIsInIsolationReturnsTrue');
+        $test->setRunTestInSeparateProcess(true);
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
     public function testExpectOutputStringFooActualFoo()
     {
         $test   = new OutputTestCase('testExpectOutputStringFooActualFoo');

--- a/tests/_files/IsolationTest.php
+++ b/tests/_files/IsolationTest.php
@@ -1,0 +1,13 @@
+<?php
+class IsolationTest extends PHPUnit_Framework_TestCase
+{
+    public function testIsInIsolationReturnsFalse()
+    {
+        $this->assertFalse($this->isInIsolation());
+    }
+
+    public function testIsInIsolationReturnsTrue()
+    {
+        $this->assertTrue($this->isInIsolation());
+    }
+}


### PR DESCRIPTION
A custom setup of test fixtures may use the new `PHPUnit_Framework_TestCase::isTestInIsolation()` method to determine whether to skip additional performance optimizations that only make sense if multiple tests are executed in the same process.

The tests I'm currently working on need to boot up application framework objects that are very expensive to (re-)build (a full-stack Symfony Kernel/ContainerBuilder).  In my case, all test methods of a single test class are always initialized in the same way, so precompiling it once and cloning it for every test method dramatically improved performance (related: symfony/symfony#11422). — However, that obviously doesn't make sense in case only one test is executed in isolation.

It is possible to identify this already, but the `$isInIsolation` property is private, so it's clunky:

``` php
  protected function isTestInIsolation() {
    return function_exists('__phpunit_run_isolated_test');
  }
```

~~In light of #950, I named the new method `isTestInIsolation()` instead of `isInIsolation()`.~~

As this is a minor addition, my hope is to get it into the next 4.1.5 stable.

---

Additionally necessary for #1359 (in case that solution is acceptable)
