### PR TITLE
Remove code coverage report from (own) phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,10 +18,6 @@
     </testsuite>
   </testsuites>
 
-  <logging>
-    <log type="coverage-html" target="build/coverage"/>
-  </logging>
-
   <filter>
     <whitelist processUncoveredFilesFromWhitelist="true">
       <directory suffix=".php">src</directory>


### PR DESCRIPTION
Generating a code coverage report takes a lot of additional time.  Especially for HTML.  The total time for running PHPUnit's own tests approximately doubles.  That slows down development.

Currently, whenever I'm working on a PR and need to run the whole test suite repetitively, I always need to patch `phpunit.xml.dist` to remove the section.

I don't want to use a custom copy in `phpunit.xml`, because `.dist` might be changed upstream, in which case my local test environment/results might no longer match.  _(…which is a separate, more fundamental problem with the current concept)_

It would be great if we could simply remove it.

Alternatively, we could replace it with an XInclude that looks for an optional, separate `coverage.xml` file, so that people who always want to have the code coverage report enabled can simply create that file locally (hidden via `.gitignore`).
