### PR TITLE
Fixes skipping of parent classes

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -134,6 +134,11 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     protected $testCase = false;
 
     /**
+     * @var array
+     */
+    protected $foundClasses = array();
+
+    /**
      * @var PHPUnit_Runner_Filter_Factory
      */
     private $iteratorFilter = null;
@@ -356,18 +361,25 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
 
         $classes    = get_declared_classes();
         $filename   = PHPUnit_Util_Fileloader::checkAndLoad($filename);
-        $newClasses = array_values(array_diff(get_declared_classes(), $classes));
+        $newClasses = array_diff(get_declared_classes(), $classes);
+        foreach($newClasses as $className) {
+            $this->foundClasses[]= $className;
+        }
+
         $baseName   = str_replace('.php', '', basename($filename));
 
-        foreach ($newClasses as $className) {
+        end($this->foundClasses);
+        while($className = current($this->foundClasses)) {
             if (substr($className, 0 - strlen($baseName)) == $baseName) {
                 $class = new ReflectionClass($className);
 
                 if ($class->getFileName() == $filename) {
                     $newClasses = array($className);
+                    unset($this->foundClasses[key($this->foundClasses)]);
                     break;
                 }
             }
+            prev($this->foundClasses);
         }
 
         foreach ($newClasses as $className) {

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -85,6 +85,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
         $suite->addTest(new Framework_SuiteTest('testShadowedTests'));
         $suite->addTest(new Framework_SuiteTest('testBeforeClassAndAfterClassAnnotations'));
         $suite->addTest(new Framework_SuiteTest('testBeforeAnnotation'));
+        $suite->addTest(new Framework_SuiteTest('testDontSkipInheritedClass'));
 
         return $suite;
     }
@@ -211,6 +212,21 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(2, BeforeAndAfterTest::$beforeWasRun);
         $this->assertEquals(2, BeforeAndAfterTest::$afterWasRun);
+    }
+
+    public function testDontSkipInheritedClass()
+    {
+        $suite = new PHPUnit_Framework_TestSuite(
+          'DontSkipInheritedClass'
+        );
+
+        $dir = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Inheritance' . DIRECTORY_SEPARATOR;
+
+        $suite->addTestFile($dir.'InheritanceA.php');
+        $suite->addTestFile($dir.'InheritanceB.php');
+        $result = $suite->run();
+        $this->assertEquals(2, count($result));
+
     }
 
 }

--- a/tests/_files/Inheritance/InheritanceA.php
+++ b/tests/_files/Inheritance/InheritanceA.php
@@ -1,0 +1,8 @@
+<?php
+
+require_once(__DIR__.'/InheritanceB.php');
+
+class InheritanceA extends InheritanceB
+{
+
+}

--- a/tests/_files/Inheritance/InheritanceB.php
+++ b/tests/_files/Inheritance/InheritanceB.php
@@ -1,0 +1,9 @@
+<?php
+
+class InheritanceB extends PHPUnit_Framework_TestCase
+{
+    public function testSomething()
+    {
+
+    }
+}


### PR DESCRIPTION
Should fix this issue: #529

This will always perform the check for $suiteClassName inside loaded classes
