### PR TITLE
bootstrap.php is not loaded in process isolation with $preserveGlobalState = FALSE

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -702,7 +702,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $iniSettings   = PHPUnit_Util_GlobalState::getIniSettingsAsString();
             } else {
                 $constants     = '';
-                $globals       = '';
+                if (!empty($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
+                  $globals     = '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = ' . var_export($GLOBALS['__PHPUNIT_BOOTSTRAP'], true) . ";\n";
+                }
+                else {
+                  $globals     = '';
+                }
                 $includedFiles = '';
                 $iniSettings   = '';
             }

--- a/tests/Regression/GitHub/797.phpt
+++ b/tests/Regression/GitHub/797.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-797: Disabled $preserveGlobalState does not load bootstrap.php.
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][] = '--process-isolation';
+$_SERVER['argv'][] = '--bootstrap';
+$_SERVER['argv'][] = __DIR__ . '/797/bootstrap797.php';
+$_SERVER['argv'][] = __DIR__ . '/797/Issue797Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %s, Memory: %sMb
+
+OK (1 test, 1 assertion)

--- a/tests/Regression/GitHub/797/Issue797Test.php
+++ b/tests/Regression/GitHub/797/Issue797Test.php
@@ -1,0 +1,10 @@
+<?php
+class Issue797Test extends PHPUnit_Framework_TestCase
+{
+    protected $preserveGlobalState = FALSE;
+
+    public function testBootstrapPhpIsExecutedInIsolation()
+    {
+        $this->assertEquals(GITHUB_ISSUE, 797);
+    }
+}

--- a/tests/Regression/GitHub/797/bootstrap797.php
+++ b/tests/Regression/GitHub/797/bootstrap797.php
@@ -1,0 +1,6 @@
+<?php
+// If process isolation fails to include this file, then
+// PHPUnit_Framework_TestCase itself does not exist. :-)
+require __DIR__ . '/../../../bootstrap.php';
+
+const GITHUB_ISSUE = 797;


### PR DESCRIPTION
Resolves #797
Duplicates #1343 + #1346 for PHPUnit 4.2

The added regression test prominently exposes the problem:  If the test's custom bootstrap.php file is not loaded, then PHPUnit itself and `PHPUnit_Framework_TestCase` does not exist → Fatal error. :collision: :wink: 

Discussion in #797 debated whether this would be a backwards-incompatible change, but due to the above, and because I'm experiencing the exact same problem in Drupal tests in case process isolation is triggered, I'm considering this as a straight bug fix.

This is a bug, because PHPUnit fails to boot itself.

If you specify a `bootstrap` file in your configuration, then phpunit is instructed to load the specified file, regardless of which process.

Currently, this fundamental configuration value is ignored when a child process is spawned and `$preserveGlobalState` is `FALSE`.  Failure to include it means that e.g. your class loader won't exist.
