### PR TITLE
STDOUT/STDERR IO streams do not exist in process isolation

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -1,4 +1,11 @@
 <?php
+if (!defined('STDOUT')) {
+    // php://stdout does not obey output buffering. Any output would break
+    // unserialization of child process results in the parent process.
+    define('STDOUT', fopen('php://temp', 'w+b'));
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+
 {iniSettings}
 ini_set('display_errors', 'stderr');
 set_include_path('{include_path}');
@@ -39,6 +46,11 @@ function __phpunit_run_isolated_test()
     ob_end_clean();
     $test->run($result);
     $output = $test->getActualOutput();
+
+    rewind(STDOUT);
+    if ($stdout = stream_get_contents(STDOUT)) {
+        $output = $stdout . $output;
+    }
 
     print serialize(
       array(

--- a/tests/Regression/GitHub/1348.phpt
+++ b/tests/Regression/GitHub/1348.phpt
@@ -1,5 +1,10 @@
 --TEST--
 GH-1348: STDOUT/STDERR IO streams should exist in process isolation
+--SKIPIF--
+<?php
+if (defined('HHVM_VERSION'))
+    print "skip: PHP runtime required";
+?>
 --FILE--
 <?php
 

--- a/tests/Regression/GitHub/1348.phpt
+++ b/tests/Regression/GitHub/1348.phpt
@@ -1,0 +1,30 @@
+--TEST--
+GH-1348: STDOUT/STDERR IO streams should exist in process isolation
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][] = '--strict';
+$_SERVER['argv'][] = '--process-isolation';
+$_SERVER['argv'][] = 'Issue1348Test';
+$_SERVER['argv'][] = __DIR__ . '/1348/Issue1348Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+STDOUT does not break test result
+E
+
+Time: %s, Memory: %sMb
+
+There was 1 error:
+
+1) Issue1348Test::testSTDERR
+PHPUnit_Framework_Exception: STDERR works as usual.
+
+FAILURES!
+Tests: 2, Assertions: 1, Errors: 1.

--- a/tests/Regression/GitHub/1348/Issue1348Test.php
+++ b/tests/Regression/GitHub/1348/Issue1348Test.php
@@ -1,0 +1,14 @@
+<?php
+class Issue1348Test extends PHPUnit_Framework_TestCase
+{
+    public function testSTDOUT()
+    {
+        fwrite(STDOUT, "\nSTDOUT does not break test result\n");
+        $this->assertTrue(true);
+    }
+
+    public function testSTDERR()
+    {
+        fwrite(STDERR, 'STDERR works as usual.');
+    }
+}


### PR DESCRIPTION
The PHP CLI SAPI does not auto-register the standard IO streams when a script is piped into STDIN (which is the case in process isolation); cf.
- https://bugs.php.net/bug.php?id=43283
- http://php.net/manual/en/features.commandline.io-streams.php
  
  > **Note:** These constants are not available if reading the PHP script from stdin.
- https://gist.github.com/sun/d02c242514c8f34bccdb

When a test is executed without process isolation, then the `STDOUT` and `STDERR` streams are available.  But if the test is executed in a separate process, then attempting to access the streams triggers a PHP Notice (undefined constant), followed by a PHP Warning (`fopen`).

A prominent example of affected code is e.g. [vfsStream](https://github.com/mikey179/vfsStream/blob/master/src/main/php/org/bovigo/vfs/visitor/vfsStreamPrintVisitor.php#L44), which is an officially recommended/endorsed library for PHPUnit.
