### PR TITLE
[minor] Process isolation script unnecessarily restarts output buffer after completion

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -48,8 +48,6 @@ function __phpunit_run_isolated_test()
         'output'        => $output
       )
     );
-
-    ob_start();
 }
 
 {constants}
@@ -62,4 +60,3 @@ if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
 }
 
 __phpunit_run_isolated_test();
-ob_end_clean();


### PR DESCRIPTION
1. OB is started before `__phpunit_run_isolated_test()` is called.
2. Said function ends OB, prints serialized results.
3. End of function restarts OB and the calling global scope immediately ends it again. → superfluous
