### PR TITLE
Fixed performance of TestSuite::addTestFile() + missing docs

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -375,11 +375,15 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             $this->foundClasses = array_merge($newClasses, $this->foundClasses);
         }
 
-        $basename = basename($filename, '.php');
-        $basename_offset = -strlen($basename);
+        // The test class's name must match the filename, either in full, or as
+        // a PEAR/PSR-0 prefixed shortname ('NameSpace_ShortName'), or as a
+        // PSR-1 local shortname ('NameSpace\ShortName'). The comparison must be
+        // anchored to prevent false-positive matches (e.g., 'OtherShortName').
+        $shortname = basename($filename, '.php');
+        $shortname_rx = '/(?:^|_|\\\\)' . preg_quote($shortname, '/') . '$/';
 
         foreach ($this->foundClasses as $i => $className) {
-            if (substr($className, $basename_offset) === $basename) {
+            if (preg_match($shortname_rx, $className)) {
                 $class = new ReflectionClass($className);
 
                 if ($class->getFileName() == $filename) {

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -355,31 +355,39 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             $this->addTest(
               new PHPUnit_Extensions_PhptTestCase($filename, $phptOptions)
             );
-
             return;
         }
 
+        // The given file may contain further stub classes in addition to the
+        // test class itself. Figure out the actual test class.
         $classes    = get_declared_classes();
         $filename   = PHPUnit_Util_Fileloader::checkAndLoad($filename);
         $newClasses = array_diff(get_declared_classes(), $classes);
-        foreach($newClasses as $className) {
-            $this->foundClasses[]= $className;
+
+        // The diff is empty in case a parent class (with test methods) is added
+        // AFTER a child class that inherited from it. To account for that case,
+        // cumulate all discovered classes, so the parent class may be found in
+        // a later invocation.
+        if ($newClasses) {
+            // On the assumption that test classes are defined first in files,
+            // process discovered classes in approximate LIFO order, so as to
+            // avoid unnecessary reflection.
+            $this->foundClasses = array_merge($newClasses, $this->foundClasses);
         }
 
-        $baseName   = str_replace('.php', '', basename($filename));
+        $basename = basename($filename, '.php');
+        $basename_offset = -strlen($basename);
 
-        end($this->foundClasses);
-        while($className = current($this->foundClasses)) {
-            if (substr($className, 0 - strlen($baseName)) == $baseName) {
+        foreach ($this->foundClasses as $i => $className) {
+            if (substr($className, $basename_offset) === $basename) {
                 $class = new ReflectionClass($className);
 
                 if ($class->getFileName() == $filename) {
                     $newClasses = array($className);
-                    unset($this->foundClasses[key($this->foundClasses)]);
+                    unset($this->foundClasses[$i]);
                     break;
                 }
             }
-            prev($this->foundClasses);
         }
 
         foreach ($newClasses as $className) {


### PR DESCRIPTION
Apologies.  My advice in #1362 was based on utterly wrong and outdated information.  It's my duty to correct that mistake.
1. https://gist.github.com/sun/287c1f75528dc75cdb96
2. Even after reviewing and studying #1362 for a while, it still wasn't clear to me why all of this futzing is necessary in the first place.  Dissecting history yielded https://github.com/sebastianbergmann/phpunit/commit/1d15545d8d77d3d1ab561e8167b90536fe4d4361 (_"5096"_ points to former issue in Trac, which no longer exists) and https://github.com/sebastianbergmann/phpunit/commit/1a5d6926442468ba19c18e6117c3afc5949f184d (same commit, but says _"Be more restrictive."_), and finally https://github.com/sebastianbergmann/phpunit/commit/8b8c705ce7dd77b02ba768d39224dddfeb34fb62 (original recreation of svn trunk in git in 2006). — Therefore, I had to reverse-engineer the original intentions in order to document what's actually going on.
   
   I stopped after the loop starts to prevent scope creep - even though I had to dissect the full function body in order to draw final conclusions.
   
   In essence, the code assumes PSR-1 [long before php-fig was a thing], one class per file, classname == filename, and uses reflection to reverse-map discovered class **short**⁣name[s] back to filename[s].  Only upon a direct match, the test class is found.  (It doesn't account for various edge-case conditions though; specifically, the `$newClasses` array is not reset to a single element if there's no direct match, in which case the entire diff/list of classes will be processed.)
   
   The only way around that funky logic would be to have direct access to the active classloader(s), which would allow to manually reverse-map a filesystem path to a classname.
