### PR TITLE
Test discovery does not account for .hh file extensions

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -378,7 +378,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         // a PEAR/PSR-0 prefixed shortname ('NameSpace_ShortName'), or as a
         // PSR-1 local shortname ('NameSpace\ShortName'). The comparison must be
         // anchored to prevent false-positive matches (e.g., 'OtherShortName').
-        $shortname = basename($filename, '.php');
+        $shortname = basename(basename($filename, '.hh'), '.php');
         $shortnameRegEx = '/(?:^|_|\\\\)' . preg_quote($shortname, '/') . '$/';
 
         foreach ($this->foundClasses as $i => $className) {


### PR DESCRIPTION
Resolves #1389

In essence, this is another incarnation of https://github.com/sebastianbergmann/phpunit/pull/1369#issuecomment-50702040, root cause:

> Without resetting `$newClasses = array();`, all of the validations are executed and they fail, but the original list of newly declared classes is still defined, so all of the arbitrary new classes are added to the test suite.

This PR does not address the root cause; it's only a stop-gap to support `.hh` file extensions.