### PR TITLE
Remove obsolete 'include-path' from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,9 +67,5 @@
         "branch-alias": {
             "dev-master": "4.4.x-dev"
         }
-    },
-    "include-path": [
-        "",
-        "../../symfony/yaml/"
-    ]
+    }
 }


### PR DESCRIPTION
`composer.json` declares an `include_path` to be automatically set by the dumped autoloader, which dates back to PHPUnit 3.x PEAR-style includes and is no longer necessary.

Especially the second entry points to nowhere/nirvana, since such a directory does not exist.
