### PR TITLE
Decouple some tests

### DIFF
--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -68,85 +68,91 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
      */
     public function testGetExpectedException()
     {
-        $this->assertSame(
-            array('class' => 'FooBarBaz', 'code' => null, 'message' => '', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testOne')
+        $this->assertArraySubset(
+          array('class' => 'FooBarBaz', 'code' => null, 'message' => ''),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testOne')
         );
 
-        $this->assertSame(
-            array('class' => 'Foo_Bar_Baz', 'code' => null, 'message' => '', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testTwo')
+        $this->assertArraySubset(
+          array('class' => 'Foo_Bar_Baz', 'code' => null, 'message' => ''),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testTwo')
         );
 
-        $this->assertSame(
-            array('class' => 'Foo\Bar\Baz', 'code' => null, 'message' => '', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testThree')
+        $this->assertArraySubset(
+          array('class' => 'Foo\Bar\Baz', 'code' => null, 'message' => ''),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testThree')
         );
 
-        $this->assertSame(
-            array('class' => 'ほげ', 'code' => null, 'message' => '', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testFour')
+        $this->assertArraySubset(
+          array('class' => 'ほげ', 'code' => null, 'message' => ''),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testFour')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testFive')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => 1234, 'message' => 'Message'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testFive')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSix')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => 1234, 'message' => 'Message'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSix')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 'ExceptionCode', 'message' => 'Message', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSeven')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => 'ExceptionCode', 'message' => 'Message'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSeven')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 0, 'message' => 'Message', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testEight')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => 0, 'message' => 'Message'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testEight')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => ExceptionTest::ERROR_CODE, 'message' => ExceptionTest::ERROR_MESSAGE, 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testNine')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => ExceptionTest::ERROR_CODE, 'message' => ExceptionTest::ERROR_MESSAGE),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testNine')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => null, 'message' => '', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSingleLine')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => null, 'message' => ''),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testSingleLine')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE, 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstants')
-        );
-
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => '#regex#'),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessage')
-        );
-
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => '#regex#'),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessageFromClassConstant')
-        );
-
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 1234, 'message' => 'Message', 'message_regex' => 'ExceptionTest::UNKNOWN_MESSAGE_REGEX_CONSTANT'),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithUnknowRegexMessageFromClassConstant')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE),
+          PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstants')
         );
 
         // Ensure the Class::CONST expression is only evaluated when the constant really exists
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 'ExceptionTest::UNKNOWN_CODE_CONSTANT', 'message' => 'ExceptionTest::UNKNOWN_MESSAGE_CONSTANT', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testUnknownConstants')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => 'ExceptionTest::UNKNOWN_CODE_CONSTANT', 'message' => 'ExceptionTest::UNKNOWN_MESSAGE_CONSTANT'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testUnknownConstants')
         );
 
-        $this->assertSame(
-            array('class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT', 'message_regex' => ''),
-            PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testUnknownConstants')
+        $this->assertArraySubset(
+          array('class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT'),
+          PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testUnknownConstants')
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getExpectedException
+     */
+    public function testGetExpectedRegExp()
+    {
+        $this->assertArraySubset(
+          array('message_regex' => '#regex#'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessage')
+        );
+
+        $this->assertArraySubset(
+          array('message_regex' => '#regex#'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessageFromClassConstant')
+        );
+
+        $this->assertArraySubset(
+          array('message_regex' => 'ExceptionTest::UNKNOWN_MESSAGE_REGEX_CONSTANT'),
+          PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithUnknowRegexMessageFromClassConstant')
         );
     }
 


### PR DESCRIPTION
Hi,

I was reviewing latest changes before get started with #1356 and noticed I had some stashed tests.

This aims to decouple tests from`@expectedExceptionMessageRegExp` and `@expectedExceptionMessage`, which are two different features and should not be tested together.
