### PR TITLE
Do not silently discard exceptions from after methods

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -792,7 +792,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $this->mockObjects = array();
 
         // Tear down the fixture. An exception raised in tearDown() will be
-        // caught and passed on when no exception was raised before.
+        // caught and passed on when no exception was raised before
+        // and added as an error to result otherwise.
         try {
             if ($hasMetRequirements) {
                 foreach ($hookMethods['after'] as $method) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -808,6 +808,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         } catch (Exception $_e) {
             if (!isset($e)) {
                 $e = $_e;
+            } else {
+                $this->result->addError($this, $_e, 0);
             }
         }
 


### PR DESCRIPTION
In case of error in after test method (i.e. tearDown) add it to result
