### PR TITLE
Added 'order' argument to randomize the test runner execution order

### DIFF
--- a/src/Extensions/RandomTestSuite.php
+++ b/src/Extensions/RandomTestSuite.php
@@ -1,0 +1,88 @@
+<?php
+
+class PHPUnit_Extensions_RandomTestSuite
+{
+	/**
+     * Order the TestSuite tests in a random order.
+     * 
+     * @param  \PHPUnit_Framework_Test  $suite     The suite to randomize.
+     * @param  array                    $arguments Arguments to use.
+     * @return \PHPUnit_Framework_Test
+     */
+	public function randomizeTestSuite(\PHPUnit_Framework_Test $suite, $seed)
+	{
+        if ($this->testSuiteContainsOtherSuites($suite))
+        {
+            $this->randomizeSuiteThatContainsOtherSuites($suite, $seed);
+        }
+        else
+        {
+            $this->randomizeSuite($suite, $seed);
+        }
+
+        return $suite;
+	}
+
+	/**
+	 * Randomize each Test Suite inside the main Test Suite.
+	 * 
+	 * @param  \PHPUnit_Framework_Test $suite Main Test Suite to randomize.
+	 * @param  integer                 $seed  Seed to use.
+	 * @return \PHPUnit_Framework_Test
+	 */
+	private function randomizeSuiteThatContainsOtherSuites($suite, $seed)
+    {
+        $order = 0;
+        foreach ($suite->tests() as $test) {
+            $this->randomizeSuite($test, $seed, $order);
+            $order++;
+        }
+
+        return $this->randomizeSuite($suite, $seed, $order);
+    }
+
+    /**
+     * Test Suites can contain other Test Suites or just Test Cases.
+     * 
+     * @param  \PHPUnit_Framework_Test $suite
+     * @return Boolean
+     */
+    private function testSuiteContainsOtherSuites($suite)
+    {
+        $tests = $suite->tests();
+        return isset($tests[0]) && $tests[0] instanceof \PHPUnit_Framework_TestSuite;
+    }
+
+    /**
+     * Randomize the test cases inside a TestSuite, with the given seed.
+     * 
+     * @param  \PHPUnit_Framework_Test 	$suite Test suite to randomize.
+     * @param  integer 					$seed  Seed to be used for the random funtion.
+     * @param  integer 					$order Arbitrary value to "salt" the seed.
+     * @return \PHPUnit_Framework_Test
+     */
+    private function randomizeSuite($suite, $seed, $order = 0)
+    {
+        $reflected = new \ReflectionObject($suite);
+        $property = $reflected->getProperty('tests');
+        $property->setAccessible(true);
+        $property->setValue($suite, $this->randomizeTestsCases($suite->tests(), $seed, $order));
+
+        return $suite;
+    }
+
+    /**
+     * Randomize an array of TestCases.
+     *
+     * @param  array 	$tests  TestCases to randomize.
+     * @param  integer  $seed   Seed used for PHP to randomize the array.
+     * @param  integer  $order  A salt so it doesn't randomize all the classes in the same "random" order.
+     * @return array            Randomized array
+     */
+    private function randomizeTestsCases(array $tests, $seed, $order)
+    {
+        srand($seed + $order);
+        shuffle($tests);
+        return $tests;
+    }
+}

--- a/src/Extensions/RandomTestSuite.php
+++ b/src/Extensions/RandomTestSuite.php
@@ -1,5 +1,60 @@
 <?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Bernhard Schussek <bschussek@2bepublished.at>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 4.5.0
+ */
 
+/**
+ * Class that takes a TestSuite and randomize the order of the tests inside.
+ *
+ * @package    PHPUnit
+ * @subpackage Extensions
+ * @author     Jose Armesto <jose@armesto.net>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.5.0
+ */
 class PHPUnit_Extensions_RandomTestSuite
 {
 	/**

--- a/src/Extensions/RandomTestSuitePrinter.php
+++ b/src/Extensions/RandomTestSuitePrinter.php
@@ -1,5 +1,60 @@
 <?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Bernhard Schussek <bschussek@2bepublished.at>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 4.5.0
+ */
 
+/**
+ * Adds the seed used to randomize the order of the tests, to the final output.
+ *
+ * @package    PHPUnit
+ * @subpackage Extensions
+ * @author     Jose Armesto <jose@armesto.net>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.5.0
+ */
 class PHPUnit_Extensions_RandomTestSuitePrinter extends \PHPUnit_TextUI_ResultPrinter
 {
     /**

--- a/src/Extensions/RandomTestSuitePrinter.php
+++ b/src/Extensions/RandomTestSuitePrinter.php
@@ -1,0 +1,41 @@
+<?php
+
+class PHPUnit_Extensions_RandomTestSuitePrinter extends \PHPUnit_TextUI_ResultPrinter
+{
+    /**
+     * Seed used to randomize the order of the tests.
+     *
+     * @var integer
+     */
+    protected $seed;
+
+    /**
+     * Constructor.
+     *
+     * @param  mixed                       $out
+     * @param  boolean                     $verbose
+     * @param  boolean                     $colors
+     * @param  boolean                     $debug
+     * @throws PHPUnit_Framework_Exception
+     * @since  Method available since Release 3.0.0
+     */
+    public function __construct($out = null, $verbose = false, $colors = false, $debug = false, $seed = null)
+    {
+        parent::__construct($out, $verbose, $colors, $debug);
+        $this->seed = $seed;
+    }
+
+    /**
+     * Just add to the output the seed used to randomize the test suite.
+     * 
+     * @param  PHPUnit_Framework_TestResult $result
+     */
+    protected function printFooter(\PHPUnit_Framework_TestResult $result)
+    {
+        parent::printFooter($result);
+
+        $this->writeNewLine();
+        $this->write("Randomized with seed: {$this->seed}");
+        $this->writeNewLine();
+    }
+} 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -98,6 +98,7 @@ class PHPUnit_TextUI_Command
       'log-tap=' => null,
       'process-isolation' => null,
       'repeat=' => null,
+      'order=' => null,
       'stderr' => null,
       'stop-on-error' => null,
       'stop-on-failure' => null,
@@ -426,6 +427,11 @@ class PHPUnit_TextUI_Command
 
                 case '--repeat': {
                     $this->arguments['repeat'] = (int) $option[1];
+                    }
+                break;
+
+                case '--order': {
+                    $this->handleOrder($option[1]);
                     }
                 break;
 
@@ -887,6 +893,39 @@ class PHPUnit_TextUI_Command
     }
 
     /**
+     * Only called when 'order' argument is used.
+     *
+     * @param  string $order_parameter The order argument passed in command line.
+     */
+    protected function handleOrder($order_parameter)
+    {
+        list($order, $seed)         = $this->getOrderAndSeed($order_parameter);
+        $this->arguments['order']   = $order;
+        $this->arguments['seed']    = $seed;
+    }
+
+    /**
+     * Parses arguments to know if random order is desired, and if seed was chosen.
+     *
+     * @param  string $order String from command line parameter.
+     * @return array
+     */
+    private function getOrderAndSeed($order)
+    {
+        @list($order, $seed) = explode(':', $order, 2);
+
+        if (empty($seed)) {
+            $seed = rand(0, 9999);
+        }
+
+        if (!is_numeric($seed)) {
+            $this->showError("Could not use '$seed' as seed.");
+        }
+
+        return array($order, $seed);
+    }
+
+    /**
      * Show the help message.
      */
     protected function showHelp()
@@ -950,6 +989,7 @@ Test Execution Options:
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --repeat <times>          Runs the test(s) repeatedly.
+  --order <rand[:seed]>     Randomize the order of the tests. Optionally accepts seed.
   --tap                     Report test execution progress in TAP format.
   --testdox                 Report test execution progress in TestDox format.
   --printer <printer>       TestListener implementation to use.

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -212,6 +212,13 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $suite->addTest($test);
         }
 
+        if (isset($arguments['order']))
+        {
+            $this->addPrinter($arguments);
+            $randomizer = new PHPUnit_Extensions_RandomTestSuite();
+            $randomizer->randomizeTestSuite($suite, $arguments['seed']);
+        }
+
         $result = $this->createTestResult();
 
         if (!$arguments['convertErrorsToExceptions']) {
@@ -573,6 +580,27 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         }
 
         return $this->loader;
+    }
+
+    /**
+     * Sets printer to show the seed used to randomize the TestSuite.
+     *
+     * @param array $arguments Arguments to use.
+     */
+    private function addPrinter($arguments)
+    {
+        $this->printer = new PHPUnit_Extensions_RandomTestSuitePrinter(
+            NULL,
+            $arguments['verbose'],
+            $arguments['colors'],
+            $arguments['debug'],
+            $arguments['seed']
+        );
+
+        if (isset($arguments['printer']) &&
+            $arguments['printer'] instanceof \PHPUnit_Util_Printer) {
+            $this->printer = $arguments['printer'];
+        }
     }
 
     /**

--- a/tests/Extensions/RandomTestSuiteTest.php
+++ b/tests/Extensions/RandomTestSuiteTest.php
@@ -60,46 +60,50 @@ class Extensions_RandomTestSuiteTest extends PHPUnit_Framework_TestCase
 
     public function testItRandomizesOrderOfTestSuitesInsideMainTestSuite()
     {
+        $suite      = $this->givenTestSuiteWithFourTests();
         $randomizer = new PHPUnit_Extensions_RandomTestSuite;
-        $suite      = $this->givenTestSuiteWithThreeTestsNamed('suite1', 'suite2', 'suite3');
-
         $randomizer->randomizeTestSuite($suite, self::CONSTANT_SEED);
 
-        $tests = $suite->tests();
-        $this->assertEquals('suite3', $tests[0]->getName());
-        $this->assertEquals('suite1', $tests[1]->getName());
-        $this->assertEquals('suite2', $tests[2]->getName());
+        $this->assertOrderOfTestsIsNotTheSameAsBefore($suite->tests());
     }
 
     public function testItRandomizesOrderOfTestCasesInsideTestSuite()
     {
-        $suite = new PHPUnit_Framework_TestSuite('suite1');
+        $suite = new PHPUnit_Framework_TestSuite();
         $suite->addTest(new Success('test1'));
         $suite->addTest(new Success('test2'));
         $suite->addTest(new Success('test3'));
+        $suite->addTest(new Success('test4'));
         $randomizer = new PHPUnit_Extensions_RandomTestSuite;
 
         $randomizer->randomizeTestSuite($suite, self::CONSTANT_SEED);
 
-        $tests = $suite->tests();
-        $this->assertEquals('test2', $tests[0]->getName());
-        $this->assertEquals('test1', $tests[1]->getName());
-        $this->assertEquals('test3', $tests[2]->getName());
+        $this->assertOrderOfTestsIsNotTheSameAsBefore($suite->tests());
     }
 
-    private function givenTestSuiteWithThreeTestsNamed($test1, $test2, $test3)
+    private function givenTestSuiteWithFourTests()
     {
-        $suite1 = new PHPUnit_Framework_TestSuite('suite1');
+        $suite1 = new PHPUnit_Framework_TestSuite('test1');
         $suite1->addTest(new Success);
-        $suite2 = new PHPUnit_Framework_TestSuite('suite2');
+        $suite2 = new PHPUnit_Framework_TestSuite('test2');
         $suite2->addTest(new Success);
-        $suite3 = new PHPUnit_Framework_TestSuite('suite3');
+        $suite3 = new PHPUnit_Framework_TestSuite('test3');
         $suite3->addTest(new Success);
+        $suite4 = new PHPUnit_Framework_TestSuite('test4');
+        $suite4->addTest(new Success);
         $main_suite = new PHPUnit_Framework_TestSuite();
         $main_suite->addTest($suite1);
         $main_suite->addTest($suite2);
         $main_suite->addTest($suite3);
+        $main_suite->addTest($suite4);
 
         return $main_suite;
+    }
+
+    private function assertOrderOfTestsIsNotTheSameAsBefore(array $tests)
+    {
+        $tests_names    = array($tests[0]->getName(), $tests[1]->getName(), $tests[2]->getName(), $tests[3]->getName());
+        $default_order  = array('test1', 'test2', 'test3', 'test4');
+        $this->assertNotEquals($default_order, $tests_names, 'The order must be different');
     }
 }

--- a/tests/Extensions/RandomTestSuiteTest.php
+++ b/tests/Extensions/RandomTestSuiteTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Bernhard Schussek <bschussek@2bepublished.at>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 4.5.0
+ */
+
+/**
+ * Constraint that asserts that the array it is evaluated for has a specified subset.
+ *
+ * Uses array_replace_recursive() to check if a key value subset is part of the
+ * subject array.
+ *
+ * @package    PHPUnit
+ * @subpackage Extensions
+ * @author     Jose Armesto <jose@armesto.net>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.5.0
+ * @covers     PHPUnit_Extensions_RandomTestSuite
+ */
+class Extensions_RandomTestSuiteTest extends PHPUnit_Framework_TestCase
+{
+    const CONSTANT_SEED = 0;
+
+    public function testItRandomizesOrderOfTestSuitesInsideMainTestSuite()
+    {
+        $randomizer = new PHPUnit_Extensions_RandomTestSuite;
+        $suite      = $this->givenTestSuiteWithThreeTestsNamed('suite1', 'suite2', 'suite3');
+
+        $randomizer->randomizeTestSuite($suite, self::CONSTANT_SEED);
+
+        $tests = $suite->tests();
+        $this->assertEquals('suite3', $tests[0]->getName());
+        $this->assertEquals('suite1', $tests[1]->getName());
+        $this->assertEquals('suite2', $tests[2]->getName());
+    }
+
+    public function testItRandomizesOrderOfTestCasesInsideTestSuite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('suite1');
+        $suite->addTest(new Success('test1'));
+        $suite->addTest(new Success('test2'));
+        $suite->addTest(new Success('test3'));
+        $randomizer = new PHPUnit_Extensions_RandomTestSuite;
+
+        $randomizer->randomizeTestSuite($suite, self::CONSTANT_SEED);
+
+        $tests = $suite->tests();
+        $this->assertEquals('test2', $tests[0]->getName());
+        $this->assertEquals('test1', $tests[1]->getName());
+        $this->assertEquals('test3', $tests[2]->getName());
+    }
+
+    private function givenTestSuiteWithThreeTestsNamed($test1, $test2, $test3)
+    {
+        $suite1 = new PHPUnit_Framework_TestSuite('suite1');
+        $suite1->addTest(new Success);
+        $suite2 = new PHPUnit_Framework_TestSuite('suite2');
+        $suite2->addTest(new Success);
+        $suite3 = new PHPUnit_Framework_TestSuite('suite3');
+        $suite3->addTest(new Success);
+        $main_suite = new PHPUnit_Framework_TestSuite();
+        $main_suite->addTest($suite1);
+        $main_suite->addTest($suite2);
+        $main_suite->addTest($suite3);
+
+        return $main_suite;
+    }
+}

--- a/tests/Extensions/RandomTestSuiteTest.php
+++ b/tests/Extensions/RandomTestSuiteTest.php
@@ -45,11 +45,6 @@
  */
 
 /**
- * Constraint that asserts that the array it is evaluated for has a specified subset.
- *
- * Uses array_replace_recursive() to check if a key value subset is part of the
- * subject array.
- *
  * @package    PHPUnit
  * @subpackage Extensions
  * @author     Jose Armesto <jose@armesto.net>

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -66,6 +66,7 @@ Test Execution Options:
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --repeat <times>          Runs the test(s) repeatedly.
+  --order <rand[:seed]>     Randomize the order of the tests. Optionally accepts seed.
   --tap                     Report test execution progress in TAP format.
   --testdox                 Report test execution progress in TestDox format.
   --printer <printer>       TestListener implementation to use.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -67,6 +67,7 @@ Test Execution Options:
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --repeat <times>          Runs the test(s) repeatedly.
+  --order <rand[:seed]>     Randomize the order of the tests. Optionally accepts seed.
   --tap                     Report test execution progress in TAP format.
   --testdox                 Report test execution progress in TestDox format.
   --printer <printer>       TestListener implementation to use.


### PR DESCRIPTION
With this change, we can pass a new command line argument to randomize the execution order of the tests. Here you can see how it works https://github.com/fiunchinho/phpunit-randomizer, but basically you pass the 'order' argument, with the "rand" value.
Optionally, you can tell PHP the seed to use so you get a specific order.
![Executing randomly your tests](http://i.imgur.com/uTWtspK.png)
### Why?

Because this way you can identify if you have tests that share state somehow. If you execute them randomly, this state will no longer be there, and tests will fail, making you aware of the situation.
