### PR TITLE
AssertCount on HHVM freezes

### DIFF
--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -3528,6 +3528,22 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     /**
      * @covers PHPUnit_Framework_Assert::assertCount
      */
+    public function testAssertCountTraversable()
+    {
+        $this->assertCount(2, new ArrayIterator(array(1,2)));
+
+        try {
+            $this->assertCount(2, new ArrayIterator(array(1,2,3)));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertCount
+     */
     public function testAssertCountThrowsExceptionIfExpectedCountIsNoInteger()
     {
         try {


### PR DESCRIPTION
This is an issue I discovered in fabpot/php-cs-fixer repository. When I'm using `$this->assertCount(1, $iterator)` the scripts hangs for more than 10 minutes on HHVM... (I have not waited any longer than that)

[This PR on fabpot/php-cs-fixer](https://github.com/fabpot/PHP-CS-Fixer/pull/491/files) is a workaround for the issue. 

This PR does not solve the issue. The test I added is actually passing in HHVM... I want to get some understanding why the tests freezes in PHP-CS-Fixer on HHVM. 

I tried, but I could not reproduce the issue on the [Finder Component](https://github.com/symfony/finder). I don't know how to move forward or where the bug is...
