### PR TITLE
Track php errors as test failures when --filter is used

### DIFF
--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -125,7 +125,8 @@ class PHPUnit_Util_ErrorHandler
     }
 
     /**
-     * Registers a one time self-destructing error handler
+     * Registers an error handler and returns a function that will restore
+     * the previous handler when invoked
      * @param  integer   $severity PHP predefined error constant
      * @link   http://www.php.net/manual/en/errorfunc.constants.php
      * @throws Exception if event of specified severity is emitted
@@ -141,10 +142,8 @@ class PHPUnit_Util_ErrorHandler
             }
         };
 
-        set_error_handler(function ($errno, $errstr) use ($severity, $terminator) {
+        set_error_handler(function ($errno, $errstr) use ($severity) {
             if ($errno === $severity) {
-                $terminator(); // bye
-
                 return;
             }
 


### PR DESCRIPTION
Unregistering the error handler while handling an error was confusing PHP,
this caused normal errors to be displayed in the console instead of tracked
as test failures when the --filter flag was used.
### Steps to reproduce

Add a test method that will produce any notice

``` php
    public function testNotice() {
        $a = $a + 1;
    }
```

Run phpunit with the --filter flag

``` shell
phpunit --filter testNotice my_test.php
```

The notice will be outputted to the console and the test will pass.
