### PR TITLE
Improves TestCase check in the TestSuite class

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -191,9 +191,9 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             throw new PHPUnit_Framework_Exception;
         }
 
-        if (!$theClass->isSubclassOf('PHPUnit_Framework_TestCase')) {
+        if (!$theClass->isSubclassOf('PHPUnit_Framework_Test')) {
             throw new PHPUnit_Framework_Exception(
-                'Class "' . $theClass->name . '" does not extend PHPUnit_Framework_TestCase.'
+                'Class "' . $theClass->name . '" does not implement the  PHPUnit_Framework_Test interface.'
             );
         }
 


### PR DESCRIPTION
Makes the TestSuite check testcases implement the `PHPUnit_Framework_Test` *interface* rather than check if they extend the `PHPUnit_Framework_TestCase` *class*

Fixes issue #639.