### PR TITLE
Normalize line endings in PHPT tests, fixes #1447

### DIFF
--- a/src/Extensions/PhptTestCase.php
+++ b/src/Extensions/PhptTestCase.php
@@ -166,14 +166,17 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
 
             if (isset($sections['EXPECT'])) {
                 $assertion = 'assertEquals';
-                $expected  = preg_replace('/\r\n/', "\n", trim($sections['EXPECT']));
+                $expected  = $sections['EXPECT'];
             } else {
                 $assertion = 'assertStringMatchesFormat';
-                $expected  = trim($sections['EXPECTF']);
+                $expected  = $sections['EXPECTF'];
             }
 
+            $output = preg_replace('/\r\n/', "\n", trim($jobResult['stdout']));
+            $expected = preg_replace('/\r\n/', "\n", trim($expected));
+
             try {
-                PHPUnit_Framework_Assert::$assertion($expected, trim($jobResult['stdout']));
+                PHPUnit_Framework_Assert::$assertion($expected, $output);
             } catch (PHPUnit_Framework_AssertionFailedError $e) {
                 $result->addFailure($this, $e, $time);
             } catch (Exception $e) {


### PR DESCRIPTION
For PHPT tests, normalize line endings in test output and EXPECT/EXPECTF sections.
Fixes bug #1447 
