### PR TITLE
Issue colors

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -76,6 +76,7 @@ class PHPUnit_TextUI_Command
      */
     protected $longOptions = array(
       'colors' => null,
+      'nocolor' => null,
       'bootstrap=' => null,
       'configuration=' => null,
       'coverage-clover=' => null,

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -283,6 +283,11 @@ class PHPUnit_TextUI_Command
                     }
                 break;
 
+                case '--nocolor': {
+                    $this->arguments['colors'] = false;
+                    }
+                break;
+
                 case '--bootstrap': {
                     $this->arguments['bootstrap'] = $option[1];
                     }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -279,8 +279,11 @@ class PHPUnit_TextUI_Command
 
         foreach ($this->options[0] as $option) {
             switch ($option[0]) {
-                case '--colors': {
-                    $this->arguments['colors'] = true;
+                case '--colors':
+                    if (function_exists("posix_isatty") && !posix_isatty(STDOUT)) {
+                        $this->arguments['colors'] = false;
+                    } else {
+                        $this->arguments['colors'] = true;
                     }
                 break;
 

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -582,6 +582,9 @@ class PHPUnit_Util_Configuration
             $result['colors'] = $this->getBoolean(
                 (string) $root->getAttribute('colors'), false
             );
+            if ($result['colors'] && function_exists("posix_isatty") && !posix_isatty(STDOUT)) {
+                $result['colors'] = false;
+            }
         }
 
         /**


### PR DESCRIPTION
The "colors" option allow to create nice output.
But lot of projects use it, and it create very bad output when the result is redirected to a file.

Here is 2 proposal
- add a --nocolor option (so we can use it when needed, instead of having to change to configuration file)
- add a check to only allow this option when output is a tty.

This PR is opened against, 4.3, but I will understand if you consider it only in 4.4+
