### PR TITLE
Matching coverage config when invoked with 4.x

### DIFF
--- a/PHPUnit/TextUI/TestRunner.php
+++ b/PHPUnit/TextUI/TestRunner.php
@@ -512,6 +512,12 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['filter']    = isset($arguments['filter'])    ? $arguments['filter']    : FALSE;
         $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
+        // For PHPUnit 4.x compatibility
+        if (isset($arguments['coverageHtml']) && !isset($arguments['reportDirectory'])) {
+            $arguments['reportDirectory'] = $arguments['coverageHtml'];
+            unset($arguments['coverageHtml']);
+        }
+
         if (isset($arguments['configuration'])) {
             $arguments['configuration']->handlePHPConfiguration();
 


### PR DESCRIPTION
This is discussed some in my comments in #1253.  I did some more
digging and noticed that when phpunit is invoked from a 4.x binary
(either globally installed via composer, PEAR or a phar on the system
path), but the local composer installed version (that PHPUnit then
loads the class files for) is 3.7.x, HTML coverage would not run from
the command line option “—coverage-html”.  This appears to be because
PHPUnit 4.x is actually setting a “coverageHtml” key in the arguments
array, but PHPUnit 3.7.x is expecting to see “reportDirectory”.  This
change addresses this issue by looking for the “coverageHtml” key, if
present, and the “reportDirectory” key is not already set, it sets it.

I looked to write tests for this, but don’t see any other tests that
make use of the reportDirectory key (all if conditions in this file
that look for that key being set evaluate to false).  I did test in my
environment both when invoking from a PHPUnit 4.x binary, and from the
local PHPUnit 3.7.x binary.  The resulting HTML coverage report for
both runs appears to be the same (blacklists obeyed, etc…).

This, of course, is only applicable to the 3.7 branch of PHPUnit.
