### PR TITLE
Blacklist: fixed class-name of doctrine/instantiator

### DIFF
--- a/src/Util/Blacklist.php
+++ b/src/Util/Blacklist.php
@@ -78,7 +78,7 @@ class PHPUnit_Util_Blacklist
         'SebastianBergmann\Exporter\Exporter' => 1,
         'SebastianBergmann\Version' => 1,
         'Composer\Autoload\ClassLoader' => 1,
-        'Instantiator\Instantiator' => 1,
+        'Doctrine\Instantiator\Instantiator' => 1,
         'LazyMap\AbstractLazyMap' => 1
     );
 


### PR DESCRIPTION
This is confusing some autoloaders (e.g. ZF1)
