### PR TITLE
update travis file for composer work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ matrix:
   allow_failures:
     - php: hhvm
 
-before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+install:
+  - travis_retry composer install --no-interaction --prefer-source
   - if [[ "$TRAVIS_PHP_VERSION" == hhvm* ]]; then echo -e '\nhhvm.libxml.ext_entity_whitelist = "file"' | sudo tee -a /etc/hhvm/php.ini; fi
 
 script:
@@ -30,4 +29,3 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
-


### PR DESCRIPTION
- install deps in install section
- no need to self-update the composer
- no need for --dev as it is by default
- install deps using travis_retry
