### PR TITLE
Improve performance of isEqual() by skipping Comparator Factory

### DIFF
--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -149,7 +149,25 @@ class PHPUnit_Framework_Constraint_IsEqual extends PHPUnit_Framework_Constraint
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
-        $comparatorFactory = new SebastianBergmann\Comparator\Factory;
+        if ($this->value === $other)
+        {
+            /*
+             * Shortcut: if $this->value and $other are identical, they are also equal. This is the most common path
+             * and will allow us to skip initialization of all the comparators.
+             */
+            return true;
+        }
+
+        static $comparatorFactory;
+
+        if (NULL === $comparatorFactory)
+        {
+            /*
+             * Initializing the Comparator Factory is not free, keep a static copy around to avoid initializing it for
+             * every evaluation.
+             */
+            $comparatorFactory = new SebastianBergmann\Comparator\Factory;
+        }
 
         try {
             $comparator = $comparatorFactory->getComparatorFor(


### PR DESCRIPTION
For our case, a lot of time during test evaluation is spent on the comparison of different values through the `assertEquals()` assertion. See for example the performance trace of a test run:

![Webgrind run of our tests](https://i.imgur.com/klo4chp.png)

This PR will change PHPUnit to do a quick strict comparison check before doing an equality check. This check is very cheap, and is the most common case during test runs. If the expected and the actual value are not identical, the existing code path is followed and the Comparator library is used.

Performance of tests with this patch:

```
Time: 56.02 seconds, Memory: 261.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 4488, Assertions: 10734, Incomplete: 2, Skipped: 22.
```

Performance with base PHPUnit (4.3.1)

```
Time: 1.21 minutes, Memory: 261.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 4488, Assertions: 10734, Incomplete: 2, Skipped: 22.
```

Performance improvement is about 25-30%.
