### PR TITLE
Allow IsType('resource') to Match Closed Resources

### DIFF
--- a/src/Framework/Constraint/IsType.php
+++ b/src/Framework/Constraint/IsType.php
@@ -165,7 +165,7 @@ class PHPUnit_Framework_Constraint_IsType extends PHPUnit_Framework_Constraint
                 }
 
             case 'resource': {
-                return is_resource($other);
+                return is_resource($other) || strtolower(@get_resource_type($other)) === 'unknown';
                 }
 
             case 'scalar': {

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -1441,10 +1441,10 @@ EOF
         $fh = fopen(__FILE__, 'r');
         fclose($fh);
 
-        return [
-            'open resource'     => [fopen(__FILE__, 'r')],
-            'closed resource'   => [$fh],
-        ];
+        return array(
+            'open resource'     => array(fopen(__FILE__, 'r')),
+            'closed resource'   => array($fh),
+        );
     }
 
     /**

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -1436,6 +1436,31 @@ EOF
         $this->fail();
     }
 
+    public function resources()
+    {
+        $fh = fopen(__FILE__, 'r');
+        fclose($fh);
+
+        return [
+            'open resource'     => [fopen(__FILE__, 'r')],
+            'closed resource'   => [$fh],
+        ];
+    }
+
+    /**
+     * @dataProvider resources
+     * @covers PHPUnit_Framework_Constraint_IsType
+     * @covers PHPUnit_Framework_Assert::isType
+     */
+    public function testConstraintIsResourceTypeEvaluatesCorrectlyWithResources($resource)
+    {
+        $constraint = PHPUnit_Framework_Assert::isType('resource');
+
+        $this->assertTrue($constraint->evaluate($resource, '', true));
+
+        @fclose($resource);
+    }
+
     /**
      * @covers PHPUnit_Framework_Constraint_IsType
      * @covers PHPUnit_Framework_Constraint_Not


### PR DESCRIPTION
Closes #1451

This uses `get_resource_type` to fetch the "type" of a closed resource
which is "Unknown". `is_resource` returns false for closed resources.
