### PR TITLE
Removed lazymap from blacklist, as it's not longer used

### DIFF
--- a/src/Util/Blacklist.php
+++ b/src/Util/Blacklist.php
@@ -78,8 +78,7 @@ class PHPUnit_Util_Blacklist
         'SebastianBergmann\Exporter\Exporter' => 1,
         'SebastianBergmann\Version' => 1,
         'Composer\Autoload\ClassLoader' => 1,
-        'Doctrine\Instantiator\Instantiator' => 1,
-        'LazyMap\AbstractLazyMap' => 1
+        'Doctrine\Instantiator\Instantiator' => 1
     );
 
     /**

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -308,8 +308,7 @@ class PHPUnit_Util_GlobalState
                 strpos($declaredClasses[$i], 'PHP_Token_Stream') !== 0 &&
                 strpos($declaredClasses[$i], 'Symfony') !== 0 &&
                 strpos($declaredClasses[$i], 'Text_Template') !== 0 &&
-                strpos($declaredClasses[$i], 'Instantiator') !== 0 &&
-                strpos($declaredClasses[$i], 'LazyMap') !== 0) {
+                strpos($declaredClasses[$i], 'Instantiator') !== 0) {
                 $class = new ReflectionClass($declaredClasses[$i]);
 
                 if ($class->isSubclassOf('PHPUnit_Framework_Test')) {


### PR DESCRIPTION
Lazymap was introduced in sebastianbergmann/phpunit@89d74305f8c4a99e6e57551da512b6b3892bd870 because of sebastianbergmann/phpunit-mock-objects@84b27568405dca29de30bc2cdf457e25f5bede7e.

Since doctrine/instantiator does not longer depend on ocramius/lazy-map (like ocramius/instantiator did), it should be removed from the blacklist.
