### PR TITLE
Don't send output from tests in process isolation when testing output

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -45,7 +45,10 @@ function __phpunit_run_isolated_test()
 
     ob_end_clean();
     $test->run($result);
-    $output = $test->getActualOutput();
+    $output = '';
+    if (!$test->hasExpectationOnOutput()) {
+        $output = $test->getActualOutput();
+    }
 
     rewind(STDOUT);
     if ($stdout = stream_get_contents(STDOUT)) {

--- a/tests/TextUI/output-isolation.phpt
+++ b/tests/TextUI/output-isolation.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit --process-isolation --filter testExpectOutputStringFooActualFoo ../_files/OutputTestCase.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = '--filter';
+$_SERVER['argv'][4] = 'testExpectOutputStringFooActualFoo';
+$_SERVER['argv'][5] = dirname(__FILE__).'/../_files/OutputTestCase.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann.
+
+.
+
+Time: %s, Memory: %sMb
+
+OK (1 test, 1 assertion)


### PR DESCRIPTION
This pull request fixes #1452 

Test case to verify bug and fix included. :)
