### PR TITLE
Add standardized "skipped" status to JUnit XML output

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -303,7 +303,8 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
 
             $this->testSuiteErrors[$this->testSuiteLevel]++;
         } else {
-            $this->attachCurrentTestCase = false;
+            $error = $this->document->createElement('skipped');
+            $this->currentTestCase->appendChild($error);
         }
     }
 


### PR DESCRIPTION
With logIncompleteSkipped=false skipped tests are not included in the JUnit XML output of PHPUnit. The JUnit format supports this case via the "skipped" tag - see http://llg.cubic.org/docs/junit/

This change appends the "skipped" tag to the JUnit XML output. We just tested it with Jenkins and it shows up correctly as skipped.

It may be a breaking change for tools processing JUnit XML reports - does it make sense to beta test this?
