### PR TITLE
define date.timezone to avoid warning (in buildystem)

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -35,6 +35,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+if (!ini_get('date.timezone')) {
+     ini_set('date.timezone', 'UTC');
+}
+
 foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);


### PR DESCRIPTION
date.timezone have to be defined by admin after PHP install.

So in Fedora bulid system (and perhaps other), it is not defined, so every package have to pass it as phpunit command

```
phpunit -d date.timezone=UTC .
```

I think it could have some value (at least for us) to avoid this, and of course, value defined in configuration or command options still have higher priority.
