### PR TITLE
Adding support to testdox for showing incomplete tests in text output

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -115,6 +115,7 @@ class PHPUnit_TextUI_Command
       'testdox' => null,
       'testdox-html=' => null,
       'testdox-text=' => null,
+      'testdox-text-show-incomplete' => NULL,
       'test-suffix=' => null,
       'no-configuration' => null,
       'no-globals-backup' => null,
@@ -487,6 +488,11 @@ class PHPUnit_TextUI_Command
                 case '--testdox-text': {
                     $this->arguments['testdoxTextFile'] = $option[1];
                     }
+                break;
+
+                case '--testdox-text-show-incomplete': {
+                    $this->arguments['printer'] = new PHPUnit_Util_TestDox_ResultPrinter_TextShowIncomplete;
+                }
                 break;
 
                 case '--no-configuration': {

--- a/src/Util/TestDox/ResultPrinter/TextShowIncomplete.php
+++ b/src/Util/TestDox/ResultPrinter/TextShowIncomplete.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Util_TestDox
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 2.3.0
+ */
+
+/**
+ * Prints TestDox documentation in text format.
+ *
+ * @package    PHPUnit
+ * @subpackage Util_TestDox
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 2.1.0
+ */
+class PHPUnit_Util_TestDox_ResultPrinter_TextShowIncomplete extends PHPUnit_Util_TestDox_ResultPrinter_Text
+{
+    /**
+     * Handler for 'on test' event.
+     *
+     * @param  string  $name
+     * @param  boolean $success
+     */
+    protected function onTest($name, $success = TRUE)
+    {
+        if ($success) {
+            $this->write(' [x] ');
+        } else if ($this->testStatus == PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE){
+            $this->write(' [i] ');
+        } else {
+            $this->write(' [ ] ');
+        }
+
+        $this->write($name . "\n");
+    }
+}


### PR DESCRIPTION
I've been using phpunit's testdox to output our test results, but not being able to differentiate between failed and incomplete tests in the output has made it difficult to understand our results. This updates allows you to pass an  option `--testdox-text-show-incomplete` which makes the differentiation and marks incomplete tests with `[i]`.

Would love to get some feedback on this solution! 
