### PR TITLE
Intercept SIGINT signal on tests suites

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -27,6 +27,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     const SUCCESS_EXIT   = 0;
     const FAILURE_EXIT   = 1;
     const EXCEPTION_EXIT = 2;
+    const INTERRUPT_EXIT = 3;
 
     /**
      * @var PHP_CodeCoverage_Filter
@@ -325,6 +326,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $codeCoverageReports = 0;
         }
 
+        $codeCoverage = null;
         if ($codeCoverageReports > 0) {
             $codeCoverage = new PHP_CodeCoverage(
                 null, $this->codeCoverageFilter
@@ -395,11 +397,51 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $suite->setRunTestInSeparateProcess($arguments['processIsolation']);
         }
 
+        $this->setInterruptSignalHandler($result, $arguments, $codeCoverage);
+
         $suite->run($result);
 
         unset($suite);
         $result->flushListeners();
 
+        $this->doReports($result, $arguments, $codeCoverage);
+
+        return $result;
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult $result
+     * @param  array                        $arguments
+     * @param  PHP_CodeCoverage             $codeCoverage
+     *
+     * @return boolean
+     */
+    protected function setInterruptSignalHandler($result, array $arguments, PHP_CodeCoverage $codeCoverage = null)
+    {
+        if (!function_exists('pcntl_signal')) {
+            return false;
+        }
+
+        declare (ticks = 1);
+
+        $runner = $this;
+        $handler = function () use ($runner, $result, $arguments, $codeCoverage) {
+            $runner->doReports($result, $arguments, $codeCoverage);
+            exit(PHPUnit_TextUI_TestRunner::INTERRUPT_EXIT);
+        };
+
+        return pcntl_signal(SIGINT, $handler);
+    }
+
+    /**
+     * @param  PHPUnit_Framework_TestResult $result
+     * @param  array                        $arguments
+     * @param  PHP_CodeCoverage             $codeCoverage
+     *
+     * @return null
+     */
+    public function doReports($result, array $arguments, PHP_CodeCoverage $codeCoverage = null)
+    {
         if ($this->printer instanceof PHPUnit_TextUI_ResultPrinter) {
             $this->printer->printResult($result);
         }
@@ -494,8 +536,6 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 unset($writer);
             }
         }
-
-        return $result;
     }
 
     /**

--- a/tests/TextUI/sigint.phpt
+++ b/tests/TextUI/sigint.phpt
@@ -1,0 +1,36 @@
+--TEST--
+phpunit ../_files/SleepTest.php^C
+--SKIPIF--
+<?php
+function_exists('pcntl_fork') || die("skip does not have PCNTL extension installed");
+function_exists('posix_kill') || die("skip does not have POSIX extension installed");
+?>
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = __DIR__.'/../_files/SleepTest.php';
+
+require __DIR__.'/../bootstrap.php';
+$pid = pcntl_fork();
+if ($pid === -1) {
+    echo 'Could not fork process'.PHP_EOL;
+    return;
+}
+
+if ($pid > 0) {
+    usleep(400000);
+    posix_kill($pid, SIGINT);
+    pcntl_wait($status);
+    return;
+}
+
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.
+
+Time: %s, Memory: %s
+
+OK (2 tests, 1 assertion)

--- a/tests/_files/SleepTest.php
+++ b/tests/_files/SleepTest.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This is just a test which delays executions.
+ *
+ * @package    PHPUnit
+ * @author     Henrique Moody <henriquemoody@gmail.com>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class SleepTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @group specification
+     */
+    public function testDoNotSleep()
+    {
+        $this->assertSame(0, sleep(0));
+    }
+
+    /**
+     * @group specification
+     */
+    public function testSleepByTenSeconds()
+    {
+        $this->assertSame(0, sleep(10));
+    }
+}


### PR DESCRIPTION
If the `pcntl_signal()` function exists, creates a signal handler for `SIGINT` which prints the summary of test suite and generates code coverage reports.
Move all code which prints results and generates coverage from `doRun()` method to `doReports()` method on `PHPUnit_TextUI_TestRunner` class.

Here some benchmark of PHPUnit's test suite, without [tests/TextUI/sigint.phpt](https://github.com/henriquemoody/phpunit/blob/sigint-intercept/tests/TextUI/sigint.phpt) file:

**Without SIGINT interception**

| PHP Version | Time | Memory |
| --- | --- | --- |
| 5.3.3 | 28.6 seconds | 31.50Mb |
| 5.3 | 17.85 seconds | 31.50Mb |
| 5.4 | 18.63 seconds | 23.00Mb |
| 5.5 | 19.14 seconds | 23.25Mb |
| 5.6 | 19.21 seconds | 23.50Mb |

**With SIGINT interception**

| PHP Version | Time | Memory |
| --- | --- | --- |
| 5.3.3 | 20.04 seconds | 31.75Mb |
| 5.3 | 21.18 seconds | 31.75Mb |
| 5.4 | 21.76 seconds | 23.25Mb |
| 5.5 | 18.62 seconds | 23.50Mb |
| 5.6 | 20.23 seconds | 23.50Mb |

**See it working**: https://asciinema.org/a/14111
