### PR TITLE
add support for cygwin

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -39,7 +39,7 @@ if (!ini_get('date.timezone')) {
      ini_set('date.timezone', 'UTC');
 }
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php', __DIR__ . '/../../vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
When running in cygwin, `__DIR__` resolves to vendor/bin/ and therefore phpunit can't find the autoload.php from composer.
