### PR TITLE
Add ArrayOfAType assertion

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -149,6 +149,28 @@ abstract class PHPUnit_Framework_Assert
         self::assertThat($array, $constraint, $message);
     }
 
+	/**
+	 * Assert that an array contains of elements of a specified type only
+	 *
+	 * @param $type
+	 * @param $array|ArrayAccess
+	 * @param string $message
+	 */
+	public function assertArrayOfAType($type, $array, $message = '')
+	{
+		if (!is_string($type)) {
+			throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+		}
+
+		if (!(is_array($array) || $array instanceof ArrayAccess)) {
+			throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'array or ArrayAccess');
+		}
+
+		$constraint = new PHPUnit_Framework_Constraint_ArrayOfAType($type);
+
+		self::assertThat($array, $constraint, $message);
+	}
+
     /**
      * Asserts that a haystack contains a needle.
      *

--- a/src/Framework/Constraint/ArrayOfAType.php
+++ b/src/Framework/Constraint/ArrayOfAType.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHPUnit
+ *
+ * Copyright (c) 2001-2014, Sebastian Bergmann <sebastian@phpunit.de>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Sebastian Bergmann nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @author     Bernhard Schussek <bschussek@2bepublished.at>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      File available since Release 4.4.0
+ */
+
+/**
+ * Constraint that asserts that the array is evaluated for having only elements of specified type.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Tim Bezhashvyly <tim.bezhashvyly@gmail.com>
+ * @copyright  2001-2014 Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @since      Class available since Release 4.5.0
+ */
+class PHPUnit_Framework_Constraint_ArrayOfAType extends PHPUnit_Framework_Constraint
+{
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @param string $type
+     */
+    public function __construct($type)
+    {
+        parent::__construct();
+
+        $this->type = $type;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param array|ArrayAccess $other
+     * @return bool
+     */
+    protected function matches($other)
+    {
+	    foreach ($other as $element) {
+		    if (!($element instanceof $this->type)) {
+			    return false;
+		    }
+	    }
+
+	    return true;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'contains of ' . $this->exporter->export($this->type) . ' elements only';
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param  mixed  $other Evaluated value or object.
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return 'an array ' . $this->toString();
+    }
+}

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -85,7 +85,7 @@ class PHPUnit_Framework_Constraint_ArraySubset extends PHPUnit_Framework_Constra
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
-     * @param  array|ArrayAccess $other  Array or ArrayAcess object to evaluate.
+     * @param  array|ArrayAccess $other  Array or ArrayAccess object to evaluate.
      * @return bool
      */
     protected function matches($other)

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -460,7 +460,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 		$bar = new stdClass;
 		$stdClassArray = array($foo, $bar);
 
-		$this->assertArrayOfAType(stdClass::class, $stdClassArray);
+		$this->assertArrayOfAType('stdClass', $stdClassArray);
 	}
 
 	/**
@@ -469,7 +469,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testAssertArrayOfATypeAcceptsEmptyArray()
 	{
-		$this->assertArrayOfAType(stdClass::class, array());
+		$this->assertArrayOfAType('stdClass', array());
 	}
 
 	/**
@@ -484,7 +484,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 		$bar = 1;
 		$mixedTypesArray = array($foo, $bar);
 
-		$this->assertArrayOfAType(stdClass::class, $mixedTypesArray);
+		$this->assertArrayOfAType('stdClass', $mixedTypesArray);
 	}
 
 	/**
@@ -496,7 +496,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 	{
 		$nonArray = new stdClass;
 
-		$this->assertArrayOfAType(stdClass::class, $nonArray);
+		$this->assertArrayOfAType('stdClass', $nonArray);
 	}
 
 	/**

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -450,6 +450,65 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('bar', $array);
     }
 
+	/**
+	 * @covers PHPUnit_Framework_Assert::assertArrayOfAType
+	 * @covers PHPUnit_Framework_Constraint_ArrayOfAType
+	 */
+	public function testAssertArrayOfATypeAcceptsArrayContainingOnlyElementsOfSpecifiedType()
+	{
+		$foo = new stdClass;
+		$bar = new stdClass;
+		$stdClassArray = array($foo, $bar);
+
+		$this->assertArrayOfAType(stdClass::class, $stdClassArray);
+	}
+
+	/**
+	 * @covers PHPUnit_Framework_Assert::assertArrayOfAType
+	 * @covers PHPUnit_Framework_Constraint_ArrayOfAType
+	 */
+	public function testAssertArrayOfATypeAcceptsEmptyArray()
+	{
+		$this->assertArrayOfAType(stdClass::class, array());
+	}
+
+	/**
+	 * @covers PHPUnit_Framework_Assert::assertArrayOfAType
+	 * @covers PHPUnit_Framework_Constraint_ArrayOfAType
+	 * @expectedException PHPUnit_Framework_AssertionFailedError
+	 * @expectedExceptionMessage Failed asserting that an array contains of 'stdClass' elements only.
+	 */
+	public function testAssertArrayOfATypeProperlyFailsWithArrayContainingElementsOfOtherThenSpecifiedType()
+	{
+		$foo = new stdClass;
+		$bar = 1;
+		$mixedTypesArray = array($foo, $bar);
+
+		$this->assertArrayOfAType(stdClass::class, $mixedTypesArray);
+	}
+
+	/**
+	 * @covers PHPUnit_Framework_Assert::assertArrayOfAType
+	 * @expectedException PHPUnit_Framework_Exception
+	 * @expectedExceptionMessage Argument #2 (No Value) of PHPUnit_Framework_Assert::assertArrayOfAType() must be a array or ArrayAccess
+	 */
+	public function testAssertArrayOfATypeProperlyFailsWithNoValidArrayPassed()
+	{
+		$nonArray = new stdClass;
+
+		$this->assertArrayOfAType(stdClass::class, $nonArray);
+	}
+
+	/**
+	 * @covers PHPUnit_Framework_Assert::assertArrayOfAType
+	 * @expectedException PHPUnit_Framework_Exception
+	 * @expectedExceptionMessage Argument #1 (No Value) of PHPUnit_Framework_Assert::assertArrayOfAType() must be a string
+	 */
+	public function testAssertArrayOfATypeProperlyFailsIfSpecifiedTypeIsNotAString()
+	{
+		$this->assertArrayOfAType(1, array());
+	}
+
     /**
      * @covers            PHPUnit_Framework_Assert::assertContains
      * @expectedException PHPUnit_Framework_Exception

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -443,7 +443,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
      * @covers PHPUnit_Framework_Assert::assertArrayNotHasKey
      * @expectedException PHPUnit_Framework_AssertionFailedError
      */
-    public function testAssertArrayNotHasKeyPropertlyFailsWithArrayAccessValue()
+    public function testAssertArrayNotHasKeyProperlyFailsWithArrayAccessValue()
     {
         $array = new ArrayObject();
         $array['bar'] = 'bar';


### PR DESCRIPTION
New assertion `ArrayOfAType` might be useful for working with arrays which suppose to act as a collection of objects of specific type (e.g. MyClass[] PHP 5.4 syntax). Also can be used to makes sure arrays only contain of elements of simple types.
