### PR TITLE
Allow to define options to display colors

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -75,7 +75,7 @@ class PHPUnit_TextUI_Command
      * @var array
      */
     protected $longOptions = array(
-      'colors' => null,
+      'colors==' => null,
       'bootstrap=' => null,
       'columns=' => null,
       'configuration=' => null,
@@ -280,7 +280,7 @@ class PHPUnit_TextUI_Command
         foreach ($this->options[0] as $option) {
             switch ($option[0]) {
                 case '--colors': {
-                    $this->arguments['colors'] = true;
+                    $this->arguments['colors'] = $option[1] ?: PHPUnit_TextUI_ResultPrinter::COLOR_AUTO;
                     }
                 break;
 
@@ -948,7 +948,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore \$GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress outout.
   --columns max             Use maximum number of columns for progress outout.
   --stderr                  Write to STDERR instead of STDOUT.

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -63,6 +63,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
     const EVENT_TESTSUITE_START = 2;
     const EVENT_TESTSUITE_END   = 3;
 
+    const COLOR_NEVER   = 'never';
+    const COLOR_AUTO    = 'auto';
+    const COLOR_ALWAYS  = 'always';
+    const COLOR_DEFAULT = self::COLOR_NEVER;
+
     /**
      * @var array
      */
@@ -138,13 +143,13 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
      *
      * @param  mixed                       $out
      * @param  boolean                     $verbose
-     * @param  boolean                     $colors
+     * @param  string                      $colors
      * @param  boolean                     $debug
      * @param  integer|string              $numberOfColumns
      * @throws PHPUnit_Framework_Exception
      * @since  Method available since Release 3.0.0
      */
-    public function __construct($out = null, $verbose = false, $colors = false, $debug = false, $numberOfColumns = 80)
+    public function __construct($out = null, $verbose = false, $colors = self::COLOR_DEFAULT, $debug = false, $numberOfColumns = 80)
     {
         parent::__construct($out);
 
@@ -152,8 +157,12 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
             throw PHPUnit_Util_InvalidArgumentHelper::factory(2, 'boolean');
         }
 
-        if (!is_bool($colors)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(3, 'boolean');
+        $availableColors = array(self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS);
+        if (!in_array($colors, $availableColors)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                3,
+                vsprintf('value from "%s", "%s" or "%s"', $availableColors)
+            );
         }
 
         if (!is_bool($debug)) {
@@ -174,8 +183,13 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
 
         $this->numberOfColumns = $numberOfColumns;
         $this->verbose         = $verbose;
-        $this->colors          = $colors && $console->hasColorSupport();
         $this->debug           = $debug;
+
+        if ($colors === self::COLOR_AUTO && $console->hasColorSupport()) {
+            $this->colors = true;
+        } else {
+            $this->colors = (self::COLOR_ALWAYS === $colors);
+        }
     }
 
     /**

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -491,7 +491,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($arguments['coverageText'])) {
                 if ($arguments['coverageText'] == 'php://stdout') {
                     $outputStream = $this->printer;
-                    $colors       = (bool) $arguments['colors'];
+                    $colors       = $arguments['colors'];
                 } else {
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
                     $colors       = false;
@@ -905,7 +905,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['backupStaticAttributes']             = isset($arguments['backupStaticAttributes'])             ? $arguments['backupStaticAttributes']             : null;
         $arguments['cacheTokens']                        = isset($arguments['cacheTokens'])                        ? $arguments['cacheTokens']                        : false;
         $arguments['columns']                            = isset($arguments['columns'])                            ? $arguments['columns']                            : 80;
-        $arguments['colors']                             = isset($arguments['colors'])                             ? $arguments['colors']                             : false;
+        $arguments['colors']                             = isset($arguments['colors'])                             ? $arguments['colors']                             : PHPUnit_TextUI_ResultPrinter::COLOR_DEFAULT;
         $arguments['convertErrorsToExceptions']          = isset($arguments['convertErrorsToExceptions'])          ? $arguments['convertErrorsToExceptions']          : true;
         $arguments['convertNoticesToExceptions']         = isset($arguments['convertNoticesToExceptions'])         ? $arguments['convertNoticesToExceptions']         : true;
         $arguments['convertWarningsToExceptions']        = isset($arguments['convertWarningsToExceptions'])        ? $arguments['convertWarningsToExceptions']        : true;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -590,8 +590,9 @@ class PHPUnit_Util_Configuration
         }
 
         if ($root->hasAttribute('colors')) {
-            $result['colors'] = $this->getBoolean(
-                (string) $root->getAttribute('colors'), false
+            $result['colors'] = $this->getColorFlag(
+                (string) $root->getAttribute('colors'),
+                PHPUnit_TextUI_ResultPrinter::COLOR_DEFAULT
             );
         }
 
@@ -977,6 +978,30 @@ class PHPUnit_Util_Configuration
         }
 
         return $suite;
+    }
+
+    /**
+     * @param  string  $value
+     * @param  boolean $default
+     * @return boolean
+     */
+    protected function getColorFlag($value, $default)
+    {
+        $currentValue = strtolower($value);
+
+        if (in_array($currentValue, array('true', 'auto'))) {
+            return PHPUnit_TextUI_ResultPrinter::COLOR_AUTO;
+        }
+
+        if (in_array($currentValue, array('false', 'never'))) {
+            return PHPUnit_TextUI_ResultPrinter::COLOR_NEVER;
+        }
+
+        if (in_array($currentValue, array('always'))) {
+            return PHPUnit_TextUI_ResultPrinter::COLOR_ALWAYS;
+        }
+
+        return $default;
     }
 
     /**

--- a/tests/TextUI/colors-always.phpt
+++ b/tests/TextUI/colors-always.phpt
@@ -1,0 +1,19 @@
+--TEST--
+phpunit --colors=always BankAccountTest ../_files/BankAccountTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=always';
+$_SERVER['argv'][3] = __DIR__.'/../_files/BankAccountTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+...
+
+Time: %s, Memory: %sMb
+
+%s[30;42mOK (3 tests, 3 assertions)%s[0m

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -54,7 +54,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress outout.
   --columns max             Use maximum number of columns for progress outout.
   --stderr                  Write to STDERR instead of STDOUT.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -55,7 +55,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress outout.
   --columns max             Use maximum number of columns for progress outout.
   --stderr                  Write to STDERR instead of STDOUT.

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -342,7 +342,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'bootstrap' => '/path/to/bootstrap.php',
             'cacheTokens' => false,
             'columns' => 80,
-            'colors' => false,
+            'colors' => 'never',
             'stderr' => false,
             'convertErrorsToExceptions' => true,
             'convertNoticesToExceptions' => true,


### PR DESCRIPTION
Related to #1458 and #1525.

It's basically the same idea of #1526 but this also allows you to use the configuration file to define the colors while #1526 only allows you to do it by command line.
