### PR TITLE
Add expectedCount to toString return value

### DIFF
--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -138,6 +138,9 @@ class PHPUnit_Framework_Constraint_Count extends PHPUnit_Framework_Constraint
      */
     public function toString()
     {
-        return 'count matches ';
+        return sprintf(
+            'count matches %d',
+            $this->expectedCount
+        );
     }
 }


### PR DESCRIPTION
Previously when using `assertThat` with `logicalOr` and one of the constraints was `PHPUnit_Framework_Constraint_Count`, the error message was without values (`count is greater than  or count matches .`)
