### PR TITLE
Create tests for "colors" in configuration files

### DIFF
--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -73,6 +73,54 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Configuration::getPHPUnitConfiguration
+     */
+    public function testShouldReadColorsWhenTrueInConfigurationfile()
+    {
+        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.true.xml';
+        $configurationInstance = PHPUnit_Util_Configuration::getInstance($configurationFilename);
+        $configurationValues = $configurationInstance->getPHPUnitConfiguration();
+
+        $this->assertEquals(PHPUnit_TextUI_ResultPrinter::COLOR_AUTO, $configurationValues['colors']);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Configuration::getPHPUnitConfiguration
+     */
+    public function testShouldReadColorsWhenFalseInConfigurationfile()
+    {
+        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.false.xml';
+        $configurationInstance = PHPUnit_Util_Configuration::getInstance($configurationFilename);
+        $configurationValues = $configurationInstance->getPHPUnitConfiguration();
+
+        $this->assertEquals(PHPUnit_TextUI_ResultPrinter::COLOR_NEVER, $configurationValues['colors']);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Configuration::getPHPUnitConfiguration
+     */
+    public function testShouldReadColorsWhenEmptyInConfigurationfile()
+    {
+        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.empty.xml';
+        $configurationInstance = PHPUnit_Util_Configuration::getInstance($configurationFilename);
+        $configurationValues = $configurationInstance->getPHPUnitConfiguration();
+
+        $this->assertEquals(PHPUnit_TextUI_ResultPrinter::COLOR_NEVER, $configurationValues['colors']);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Configuration::getPHPUnitConfiguration
+     */
+    public function testShouldReadColorsWhenInvalidInConfigurationfile()
+    {
+        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
+        $configurationInstance = PHPUnit_Util_Configuration::getInstance($configurationFilename);
+        $configurationValues = $configurationInstance->getPHPUnitConfiguration();
+
+        $this->assertEquals(PHPUnit_TextUI_ResultPrinter::COLOR_NEVER, $configurationValues['colors']);
+    }
+
+    /**
      * @covers PHPUnit_Util_Configuration::getFilterConfiguration
      */
     public function testFilterConfigurationIsReadCorrectly()

--- a/tests/_files/configuration.colors.empty.xml
+++ b/tests/_files/configuration.colors.empty.xml
@@ -1,0 +1,1 @@
+<phpunit colors=""></phpunit>

--- a/tests/_files/configuration.colors.false.xml
+++ b/tests/_files/configuration.colors.false.xml
@@ -1,0 +1,1 @@
+<phpunit colors="false"></phpunit>

--- a/tests/_files/configuration.colors.invalid.xml
+++ b/tests/_files/configuration.colors.invalid.xml
@@ -1,0 +1,1 @@
+<phpunit colors="Something else"></phpunit>

--- a/tests/_files/configuration.colors.true.xml
+++ b/tests/_files/configuration.colors.true.xml
@@ -1,0 +1,1 @@
+<phpunit colors="true"></phpunit>


### PR DESCRIPTION
In order to avoid problems like was described in jackalope/jackalope-doctrine-dbal#235 I created some tests to ensure we keep the behaviour of `colors` configuration.
