### PR TITLE
Fix problem of `--stderr` with `--tap` or `--testdox` options

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -470,12 +470,12 @@ class PHPUnit_TextUI_Command
                 break;
 
                 case '--tap': {
-                    $this->arguments['printer'] = new PHPUnit_Util_Log_TAP;
+                    $this->arguments['printer'] = 'PHPUnit_Util_Log_TAP';
                     }
                 break;
 
                 case '--testdox': {
-                    $this->arguments['printer'] = new PHPUnit_Util_TestDox_ResultPrinter_Text;
+                    $this->arguments['printer'] = 'PHPUnit_Util_TestDox_ResultPrinter_Text';
                     }
                 break;
 
@@ -604,11 +604,6 @@ class PHPUnit_TextUI_Command
             );
         }
 
-        if (isset($this->arguments['printer']) &&
-            is_string($this->arguments['printer'])) {
-            $this->arguments['printer'] = $this->handlePrinter($this->arguments['printer']);
-        }
-
         if ($this->arguments['loader'] !== null) {
             $this->arguments['loader'] = $this->handleLoader($this->arguments['loader']);
         }
@@ -664,11 +659,8 @@ class PHPUnit_TextUI_Command
             /**
              * Issue #657
              */
-            if (isset($phpunit['stderr']) && $phpunit['stderr'] == true) {
-                $this->arguments['printer'] = new PHPUnit_TextUI_ResultPrinter(
-                    'php://stderr',
-                    isset($this->arguments['verbose']) ? $this->arguments['verbose'] : false
-                );
+            if (isset($phpunit['stderr']) && ! isset($this->arguments['stderr'])) {
+                $this->arguments['stderr'] = $phpunit['stderr'];
             }
 
             if (isset($phpunit['printerClass'])) {
@@ -711,6 +703,11 @@ class PHPUnit_TextUI_Command
             }
         } elseif (isset($this->arguments['bootstrap'])) {
             $this->handleBootstrap($this->arguments['bootstrap']);
+        }
+
+        if (isset($this->arguments['printer']) &&
+            is_string($this->arguments['printer'])) {
+            $this->arguments['printer'] = $this->handlePrinter($this->arguments['printer']);
         }
 
         if (isset($this->arguments['test']) && is_string($this->arguments['test']) && substr($this->arguments['test'], -5, 5) == '.phpt') {
@@ -804,7 +801,9 @@ class PHPUnit_TextUI_Command
                     return $printerClass;
                 }
 
-                return $class->newInstance();
+                $outputStream = isset($this->arguments['stderr']) ? 'php://stderr' : null;
+
+                return $class->newInstance($outputStream);
             }
         }
 


### PR DESCRIPTION
I don't think this pull request is the best solution to fix #1455, but I'm sure it solves the problem.

Actually, the main problem, IMO, is because there is no centralized point to create printers instances. `PHPUnit_TextUI_Command` creates and configures printers objects but `PHPUnit_TextUI_TestRunner` too. 

I will be glad to create a Factory for these printers but it requires a quite of change.

PS.: I can not test this, because seems that PHPT does not recognize STDERR.
