### PR TITLE
CS: Implode function should be used instead of join function.

### DIFF
--- a/src/Framework/Constraint/StringMatches.php
+++ b/src/Framework/Constraint/StringMatches.php
@@ -99,8 +99,8 @@ class PHPUnit_Framework_Constraint_StringMatches extends PHPUnit_Framework_Const
             }
         }
 
-        $this->string = join("\n", $from);
-        $other        = join("\n", $to);
+        $this->string = implode("\n", $from);
+        $other        = implode("\n", $to);
 
         $differ = new Differ("--- Expected\n+++ Actual\n");
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1730,7 +1730,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
         }
 
-        return join(', ', $result);
+        return implode(', ', $result);
     }
 
     /**

--- a/src/Runner/Filter/Test.php
+++ b/src/Runner/Filter/Test.php
@@ -138,7 +138,7 @@ class PHPUnit_Runner_Filter_Test extends RecursiveFilterIterator
         $tmp = PHPUnit_Util_Test::describe($test, false);
 
         if ($tmp[0] != '') {
-            $name = join('::', $tmp);
+            $name = implode('::', $tmp);
         } else {
             $name = $tmp[1];
         }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -401,7 +401,7 @@ class PHPUnit_Util_Test
             $dataProviderMethodName          = array_pop($leaf);
 
             if (!empty($dataProviderMethodNameNamespace)) {
-                $dataProviderMethodNameNamespace = join('\\', $dataProviderMethodNameNamespace) . '\\';
+                $dataProviderMethodNameNamespace = implode('\\', $dataProviderMethodNameNamespace) . '\\';
             } else {
                 $dataProviderMethodNameNamespace = '';
             }

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -439,7 +439,7 @@ class PHPUnit_Util_XML
                 }
 
                 if ($classes) {
-                    $tag['class'] = join(' ', $classes);
+                    $tag['class'] = implode(' ', $classes);
                 }
 
                 if ($attrs) {


### PR DESCRIPTION
Done by https://github.com/friendsofphp/PHP-CS-Fixer

Because `join` is only an alias.
