### PR TITLE
CS: A return statement wishing to return nothing should be simply `return`

### DIFF
--- a/src/Runner/BaseTestRunner.php
+++ b/src/Runner/BaseTestRunner.php
@@ -106,7 +106,7 @@ abstract class PHPUnit_Runner_BaseTestRunner
         } catch (PHPUnit_Framework_Exception $e) {
             $this->runFailed($e->getMessage());
 
-            return null;
+            return;
         }
 
         try {
@@ -117,7 +117,7 @@ abstract class PHPUnit_Runner_BaseTestRunner
                     'suite() method must be static.'
                 );
 
-                return null;
+                return;
             }
 
             try {
@@ -130,7 +130,7 @@ abstract class PHPUnit_Runner_BaseTestRunner
                     )
                 );
 
-                return null;
+                return;
             }
         } catch (ReflectionException $e) {
             try {

--- a/tests/_files/NonStatic.php
+++ b/tests/_files/NonStatic.php
@@ -3,6 +3,6 @@ class NonStatic
 {
     public function suite()
     {
-        return null;
+        return;
     }
 }


### PR DESCRIPTION
Done by https://github.com/friendsofphp/PHP-CS-Fixer
