### PR TITLE
Create factory implementation for printers

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -622,25 +622,6 @@ class PHPUnit_TextUI_Command
                 $this->handleBootstrap($phpunit['bootstrap']);
             }
 
-            /**
-             * Issue #657
-             */
-            if (isset($phpunit['stderr']) && ! isset($this->arguments['stderr'])) {
-                $this->arguments['stderr'] = $phpunit['stderr'];
-            }
-
-            if (isset($phpunit['printerClass'])) {
-                if (isset($phpunit['printerFile'])) {
-                    $file = $phpunit['printerFile'];
-                } else {
-                    $file = '';
-                }
-
-                $this->arguments['printer'] = $this->handlePrinter(
-                    $phpunit['printerClass'], $file
-                );
-            }
-
             if (isset($phpunit['testSuiteLoaderClass'])) {
                 if (isset($phpunit['testSuiteLoaderFile'])) {
                     $file = $phpunit['testSuiteLoaderFile'];
@@ -669,11 +650,6 @@ class PHPUnit_TextUI_Command
             }
         } elseif (isset($this->arguments['bootstrap'])) {
             $this->handleBootstrap($this->arguments['bootstrap']);
-        }
-
-        if (isset($this->arguments['printer']) &&
-            is_string($this->arguments['printer'])) {
-            $this->arguments['printer'] = $this->handlePrinter($this->arguments['printer']);
         }
 
         if (isset($this->arguments['test']) && is_string($this->arguments['test']) && substr($this->arguments['test'], -5, 5) == '.phpt') {
@@ -730,53 +706,6 @@ class PHPUnit_TextUI_Command
             sprintf(
                 'Could not use "%s" as loader.',
                 $loaderClass
-            )
-        );
-    }
-
-    /**
-     * Handles the loading of the PHPUnit_Util_Printer implementation.
-     *
-     * @param  string               $printerClass
-     * @param  string               $printerFile
-     * @return PHPUnit_Util_Printer
-     */
-    protected function handlePrinter($printerClass, $printerFile = '')
-    {
-        if (!class_exists($printerClass, false)) {
-            if ($printerFile == '') {
-                $printerFile = PHPUnit_Util_Filesystem::classNameToFilename(
-                    $printerClass
-                );
-            }
-
-            $printerFile = stream_resolve_include_path($printerFile);
-
-            if ($printerFile) {
-                require $printerFile;
-            }
-        }
-
-        if (class_exists($printerClass)) {
-            $class = new ReflectionClass($printerClass);
-
-            if ($class->implementsInterface('PHPUnit_Framework_TestListener') &&
-                $class->isSubclassOf('PHPUnit_Util_Printer') &&
-                $class->isInstantiable()) {
-                if ($class->isSubclassOf('PHPUnit_TextUI_ResultPrinter')) {
-                    return $printerClass;
-                }
-
-                $outputStream = isset($this->arguments['stderr']) ? 'php://stderr' : null;
-
-                return $class->newInstance($outputStream);
-            }
-        }
-
-        $this->showError(
-            sprintf(
-                'Could not use "%s" as printer.',
-                $printerClass
             )
         );
     }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -44,6 +44,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     protected $printer = null;
 
     /**
+     * @var PHPUnit_Util_Printer_Factory
+     */
+    protected $printerFactory = null;
+
+    /**
      * @var boolean
      */
     protected static $versionStringPrinted = false;
@@ -108,6 +113,18 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     protected function createTestResult()
     {
         return new PHPUnit_Framework_TestResult;
+    }
+
+    /**
+     * @return PHPUnit_Util_Printer_Factory
+     */
+    protected function getPrinterFactory()
+    {
+        if (!$this->printerFactory instanceof PHPUnit_Util_Printer_Factory) {
+            $this->printerFactory = new PHPUnit_Util_Printer_Factory();
+        }
+
+        return $this->printerFactory;
     }
 
     private function processSuiteFilters(PHPUnit_Framework_TestSuite $suite, array $arguments)
@@ -212,30 +229,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         }
 
         if ($this->printer === null) {
-            if (isset($arguments['printer']) &&
-                $arguments['printer'] instanceof PHPUnit_Util_Printer) {
-                $this->printer = $arguments['printer'];
-            } else {
-                $printerClass = 'PHPUnit_TextUI_ResultPrinter';
-
-                if (isset($arguments['printer']) &&
-                    is_string($arguments['printer']) &&
-                    class_exists($arguments['printer'], false)) {
-                    $class = new ReflectionClass($arguments['printer']);
-
-                    if ($class->isSubclassOf('PHPUnit_TextUI_ResultPrinter')) {
-                        $printerClass = $arguments['printer'];
-                    }
-                }
-
-                $this->printer = new $printerClass(
-                  isset($arguments['stderr']) ? 'php://stderr' : null,
-                  $arguments['verbose'],
-                  $arguments['colors'],
-                  $arguments['debug'],
-                  $arguments['columns']
-                );
-            }
+            $this->printer = $this->getPrinterFactory()->getPrinter($arguments);
         }
 
         if (!$this->printer instanceof PHPUnit_Util_Log_TAP) {
@@ -574,6 +568,21 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
             if (isset($phpunitConfiguration['deprecatedStrictModeSetting'])) {
                 $arguments['deprecatedStrictModeSetting'] = true;
+            }
+
+            if (isset($phpunitConfiguration['stderr']) &&
+                !isset($this->arguments['stderr'])) {
+                $this->arguments['stderr'] = $phpunitConfiguration['stderr'];
+            }
+
+            if (isset($phpunitConfiguration['printerClass']) &&
+                !isset($this->arguments['printerClass'])) {
+                $this->arguments['printerClass'] = $phpunitConfiguration['printerClass'];
+            }
+
+            if (isset($phpunitConfiguration['printerFile']) &&
+                !isset($this->arguments['printerFile'])) {
+                $this->arguments['printerFile'] = $phpunitConfiguration['printerFile'];
             }
 
             if (isset($phpunitConfiguration['backupGlobals']) &&

--- a/src/Util/Exception.php
+++ b/src/Util/Exception.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @package    PHPUnit
+ * @subpackage Util
+ * @author     Henrique Moody <henriquemoody@gmail.com>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class PHPUnit_Util_Exception extends Exception implements PHPUnit_Exception
+{
+}

--- a/src/Util/Printer/Factory.php
+++ b/src/Util/Printer/Factory.php
@@ -1,0 +1,147 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @package    PHPUnit
+ * @subpackage Util
+ * @author     Henrique Moody <henriquemoody@gmail.com>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class PHPUnit_Util_Printer_Factory
+{
+    const RESULT_PRINTER = 'PHPUnit_TextUI_ResultPrinter';
+
+    /**
+     * @return array
+     */
+    private function parseOptions(array $options)
+    {
+        if (isset($options['printerClass']) && ! isset($options['printer'])) {
+            $options['printer'] = $options['printerClass'];
+        } elseif (!isset($options['printer'])) {
+            $options['printer'] = self::RESULT_PRINTER;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return array
+     */
+    private function parseDefaultConstructorArguments(array $options)
+    {
+        $arguments = array();
+        $arguments[0] = 'php://stdout';
+        if (isset($options['stderr']) && true === $options['stderr']) {
+            $arguments[0] = 'php://stderr';
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Creates a printer based on the given options.
+     *
+     * @throws PHPUnit_Util_Exception
+     * @param  array                  $options
+     *
+     * @return PHPUnit_Util_Printer
+     */
+    public function getPrinter(array $options)
+    {
+        $parsedOptions = $this->parseOptions($options);
+
+        if ($parsedOptions['printer'] instanceof PHPUnit_Util_Printer) {
+            return $parsedOptions['printer'];
+        }
+
+        $constructorArguments = $this->parseDefaultConstructorArguments($parsedOptions);
+
+        if (self::RESULT_PRINTER === $parsedOptions['printer']) {
+            return $this->getResultPrinter($parsedOptions, $constructorArguments);
+        }
+
+        return $this->getGenericPrinter($parsedOptions, $constructorArguments);
+    }
+
+    /**
+     * @throws PHPUnit_Util_Exception
+     * @param  array                  $options
+     * @param  array                  $constructorArguments
+     *
+     * @return PHPUnit_TextUI_ResultPrinter
+     */
+    private function getResultPrinter(array $options, array $constructorArguments)
+    {
+        $keys = array('verbose', 'colors', 'debug', 'columns');
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $options)) {
+                break;
+            }
+
+            $constructorArguments[] = $options[$key];
+        }
+
+        return $this->getGenericPrinter($options, $constructorArguments);
+    }
+
+    /**
+     * @throws PHPUnit_Util_Exception
+     * @param  array                  $options
+     * @param  array                  $constructorArguments
+     *
+     * @return PHPUnit_Util_Printer
+     */
+    private function getGenericPrinter(array $options, array $constructorArguments)
+    {
+        $this->loadPrinterFile($options);
+
+        if (!class_exists($options['printer'])) {
+            throw new PHPUnit_Util_Exception(sprintf('"%s" was not found', $options['printer']));
+        }
+
+        $reflection = new ReflectionClass($options['printer']);
+        if (!$reflection->isSubclassOf('PHPUnit_Util_Printer')) {
+            throw new PHPUnit_Util_Exception(sprintf('"%s" is not a valid printer', $options['printer']));
+        }
+
+        return $reflection->newInstanceArgs($constructorArguments);
+    }
+
+    /**
+     * @throws PHPUnit_Util_Exception
+     * @param  array                  $options
+     *
+     * @return null
+     */
+    private function loadPrinterFile(array $options)
+    {
+        if (class_exists($options['printer'], false)) {
+            return;
+        }
+
+        if (!isset($options['printerFile'])) {
+            return;
+        }
+
+        if (empty($options['printerFile'])) {
+            $options['printerFile'] = PHPUnit_Util_Filesystem::classNameToFilename($options['printer']);
+        }
+
+        $filename = stream_resolve_include_path($options['printerFile']);
+        if (false === $filename) {
+            throw new PHPUnit_Util_Exception(sprintf('Could not load "%s"', $options['printerFile']));
+        }
+
+        require $filename;
+    }
+}

--- a/tests/Util/Printer/FactoryTest.php
+++ b/tests/Util/Printer/FactoryTest.php
@@ -1,0 +1,236 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @package    PHPUnit
+ * @author     Sebastian Bergmann <sebastian@phpunit.de>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @covers     PHPUnit_Util_Printer_Factory
+ */
+class PHPUnit_Util_Printer_FactoryTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PHPUnit_Util_Printer_Factory
+     */
+    protected $factory;
+
+    protected function setUp()
+    {
+        $this->factory = new PHPUnit_Util_Printer_Factory();
+    }
+
+    public function testShouldReturnTheSamePrinterKeyWhenItIsAValidInstance()
+    {
+        $printerMock = $this
+            ->getMockBuilder('PHPUnit_Util_Printer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $options = array(
+            'printer' => $printerMock,
+        );
+
+        $actualPrinter = $this->factory->getPrinter($options);
+        $expectedPrinter = $options['printer'];
+
+        $this->assertSame($expectedPrinter, $actualPrinter);
+    }
+
+    public function testShouldCreateAnInstanceOfDefaultObjectWhenOptionsAreEmpty()
+    {
+        $options = array();
+
+        $actualPrinter = $this->factory->getPrinter($options);
+        $expectedPrinterType = PHPUnit_Util_Printer_Factory::RESULT_PRINTER;
+
+        $this->assertInstanceOf($expectedPrinterType, $actualPrinter);
+    }
+
+    public function testShouldWriteInStandardOutputByDefault()
+    {
+        $options = array();
+
+        $printer = $this->factory->getPrinter($options);
+        $expectedStream = 'php://stdout';
+
+        $this->assertAttributeEquals($expectedStream, 'outTarget', $printer);
+    }
+
+    public function testShouldWriteInStandardErrorWhenDefined()
+    {
+        $options = array(
+            'stderr' => true,
+        );
+
+        $printer = $this->factory->getPrinter($options);
+        $expectedStream = 'php://stderr';
+
+        $this->assertAttributeEquals($expectedStream, 'outTarget', $printer);
+    }
+
+    public function testShouldCreatePrinterInstanceBasedOnClassNameGivenByPrinterKey()
+    {
+        $printerMock = $this
+            ->getMockBuilder('PHPUnit_Util_Printer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $options = array(
+            'printer' => get_class($printerMock),
+        );
+
+        $actualPrinter = $this->factory->getPrinter($options);
+        $expectedPrinterType = $options['printer'];
+
+        $this->assertInstanceOf($expectedPrinterType, $actualPrinter);
+    }
+
+    public function testShouldFactoryDefaultPrinterUsingTheGivenVerboseValue()
+    {
+        $options = array(
+            'verbose' => true,
+        );
+
+        $printer = $this->factory->getPrinter($options);
+
+        $this->assertAttributeEquals($options['verbose'], 'verbose', $printer);
+    }
+
+    public function testShouldFactoryDefaultPrinterUsingTheGivenColorsValue()
+    {
+        $options = array(
+            'verbose'   => true,
+            'colors'    => PHPUnit_TextUI_ResultPrinter::COLOR_ALWAYS,
+        );
+
+        $printer = $this->factory->getPrinter($options);
+        $expectedColorFlag = true;
+
+        $this->assertAttributeEquals($expectedColorFlag, 'colors', $printer);
+    }
+
+    public function testShouldFactoryDefaultPrinterUsingTheGivenDebugValue()
+    {
+        $options = array(
+            'verbose'   => true,
+            'colors'    => PHPUnit_TextUI_ResultPrinter::COLOR_ALWAYS,
+            'debug'     => true,
+        );
+
+        $printer = $this->factory->getPrinter($options);
+
+        $this->assertAttributeEquals($options['debug'], 'debug', $printer);
+    }
+
+    public function testShouldFactoryDefaultPrinterUsingTheGivenNumberOfColumns()
+    {
+        $options = array(
+            'verbose'   => true,
+            'colors'    => PHPUnit_TextUI_ResultPrinter::COLOR_ALWAYS,
+            'debug'     => true,
+            'columns'   => 10,
+        );
+
+        $printer = $this->factory->getPrinter($options);
+
+        $this->assertAttributeEquals($options['columns'], 'numberOfColumns', $printer);
+    }
+
+    /**
+     * @expectedException PHPUnit_Util_Exception
+     * @expectedExceptionMessage "Invalid_Printer" was not found
+     */
+    public function testShouldThrowsAnExceptionWhenGivenPrinterCanNotBeFound()
+    {
+        $options = array(
+            'printer' => 'Invalid_Printer',
+        );
+
+        $this->factory->getPrinter($options);
+    }
+
+    /**
+     * @expectedException PHPUnit_Util_Exception
+     * @expectedExceptionMessage "stdClass" is not a valid printer
+     */
+    public function testShouldThrowsAnExceptionWhenGivenPrinterIsNotAValidType()
+    {
+        $options = array(
+            'printer' => 'stdClass',
+        );
+
+        $this->factory->getPrinter($options);
+    }
+
+    public function testShouldChoosePrinterOverPrinterClassKey()
+    {
+        $printerMock = $this
+            ->getMockBuilder('PHPUnit_Util_Printer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $options = array(
+            'printer' => get_class($printerMock),
+            'printerClass' => 'stdClass',
+        );
+
+        $actualPrinter = $this->factory->getPrinter($options);
+        $expectedPrinterType = $options['printer'];
+
+        $this->assertInstanceOf($expectedPrinterType, $actualPrinter);
+    }
+
+    public function testShouldUsePrinterClassKeyWhenPrinterKeyIsNotDefined()
+    {
+        $printerMock = $this
+            ->getMockBuilder('PHPUnit_Util_Printer')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $options = array(
+            'printerClass' => get_class($printerMock),
+        );
+
+        $actualPrinter = $this->factory->getPrinter($options);
+        $expectedPrinterType = $options['printerClass'];
+
+        $this->assertInstanceOf($expectedPrinterType, $actualPrinter);
+    }
+
+    /**
+     * @expectedException PHPUnit_Util_Exception
+     * @expectedExceptionMessage Could not load "IHopeThisIsNotAValidFile.php"
+     */
+    public function testShouldThrowsAnExceptionWhenPrinterFileCanNotBeLoaded()
+    {
+        $options = array(
+            'printerFile' => 'IHopeThisIsNotAValidFile.php',
+            'printerClass' => 'IHopeThisIsNotAValidPrinter',
+        );
+
+        $this->factory->getPrinter($options);
+    }
+
+    /**
+     * @expectedException PHPUnit_Util_Exception
+     * @expectedExceptionMessage Could not load "IHopeThisIsNotAValidPrinter.php"
+     */
+    public function testShouldLoadByFilenameWhenPrinterFileIsEmpty()
+    {
+        $options = array(
+            'printerFile' => '',
+            'printerClass' => 'IHopeThisIsNotAValidPrinter',
+        );
+
+        $this->factory->getPrinter($options);
+    }
+}


### PR DESCRIPTION
This pull request centralizes creation of printers instances into a single point removing duplication from `PHPUnit_TextUI_Command` and `PHPUnit_TextUI_TestRunner`.
Now `PHPUnit_TextUI_Command` has nothing to do with printers, it only populates the arguments used by `PHPUnit_TextUI_TestRunner`.

This pays the technical debts of #1537.
