### PR TITLE
Redirect STDERR to STDOUT when running PHPT tests

### DIFF
--- a/src/Extensions/PhptTestCase.php
+++ b/src/Extensions/PhptTestCase.php
@@ -108,6 +108,9 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
 
         $result->startTest($this);
 
+        // Redirects STDERR to STDOUT
+        $php->setUseStderrRedirection(true);
+
         if (isset($sections['SKIPIF'])) {
             $jobResult = $php->runJob($sections['SKIPIF'], $this->settings);
 

--- a/src/Util/PHP.php
+++ b/src/Util/PHP.php
@@ -8,6 +8,8 @@
  * file that was distributed with this source code.
  */
 
+use SebastianBergmann\Environment\Runtime;
+
 /**
  * Utility methods for PHP sub-processes.
  *
@@ -21,6 +23,53 @@
  */
 abstract class PHPUnit_Util_PHP
 {
+    /**
+     * @var Runtime
+     */
+    protected $runtime;
+
+    /**
+     * @var bool
+     */
+    protected $stderrRedirection = false;
+
+    /**
+     * Creates internal Runtime instance.
+     */
+    public function __construct()
+    {
+        $this->runtime = new Runtime();
+    }
+
+    /**
+     * Defines if should use STDERR redirection or not.
+     *
+     * Then $stderrRedirection is TRUE, STDERR is redirected to STDOUT.
+     *
+     * @throws PHPUnit_Framework_Exception
+     * @param  boolean                     $stderrRedirection
+     *
+     * @return null
+     */
+    public function setUseStderrRedirection($stderrRedirection)
+    {
+        if (!is_bool($stderrRedirection)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'boolean');
+        }
+
+        $this->stderrRedirection = $stderrRedirection;
+    }
+
+    /**
+     * Returns TRUE if uses STDERR redirection or FALSE if not.
+     *
+     * @return boolean
+     */
+    public function useStderrRedirection()
+    {
+        return $this->stderrRedirection;
+    }
+
     /**
      * @return PHPUnit_Util_PHP
      * @since  Method available since Release 3.5.12
@@ -51,6 +100,23 @@ abstract class PHPUnit_Util_PHP
         $this->processChildResult(
             $test, $result, $_result['stdout'], $_result['stderr']
         );
+    }
+
+    /**
+     * Returns the command based into the configurations.
+     *
+     * @return string
+     */
+    public function getCommand(array $settings)
+    {
+        $command = $this->runtime->getBinary();
+        $command .= $this->settingsToParameters($settings);
+
+        if (true === $this->stderrRedirection) {
+            $command .= ' 2>&1';
+        }
+
+        return $command;
     }
 
     /**

--- a/src/Util/PHP/Default.php
+++ b/src/Util/PHP/Default.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use SebastianBergmann\Environment\Runtime;
-
 /**
  * Default utility for PHP sub-processes.
  *
@@ -33,10 +31,8 @@ class PHPUnit_Util_PHP_Default extends PHPUnit_Util_PHP
      */
     public function runJob($job, array $settings = array())
     {
-        $runtime = new Runtime;
-
         $process = proc_open(
-            $runtime->getBinary() . $this->settingsToParameters($settings),
+            $this->getCommand($settings),
             array(
             0 => array('pipe', 'r'),
             1 => array('pipe', 'w'),

--- a/src/Util/PHP/Windows.php
+++ b/src/Util/PHP/Windows.php
@@ -8,8 +8,6 @@
  * file that was distributed with this source code.
  */
 
-use SebastianBergmann\Environment\Runtime;
-
 /**
  * Windows utility for PHP sub-processes.
  *
@@ -38,8 +36,6 @@ class PHPUnit_Util_PHP_Windows extends PHPUnit_Util_PHP_Default
      */
     public function runJob($job, array $settings = array())
     {
-        $runtime = new Runtime;
-
         if (false === $stdout_handle = tmpfile()) {
             throw new PHPUnit_Framework_Exception(
                 'A temporary file could not be created; verify that your TEMP environment variable is writable'
@@ -47,7 +43,7 @@ class PHPUnit_Util_PHP_Windows extends PHPUnit_Util_PHP_Default
         }
 
         $process = proc_open(
-            $runtime->getBinary() . $this->settingsToParameters($settings),
+            $this->getCommand($settings),
             array(
             0 => array('pipe', 'r'),
             1 => $stdout_handle,

--- a/tests/TextUI/phpt-stderr.phpt
+++ b/tests/TextUI/phpt-stderr.phpt
@@ -1,0 +1,9 @@
+--TEST--
+GH-1169: PHPT runner doesn't look at STDERR.
+--FILE--
+<?php
+$stderr = fopen('php://stderr', 'w');
+fwrite($stderr, 'PHPUnit must look at STDERR when running PHPT tests.'.PHP_EOL);
+?>
+--EXPECTF--
+PHPUnit must look at STDERR when running PHPT tests.

--- a/tests/Util/PHPTest.php
+++ b/tests/Util/PHPTest.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @package    PHPUnit
+ * @author     Henrique Moody <henriquemoody@gmail.com>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @covers     PHPUnit_Util_PHP
+ */
+class PHPUnit_Util_PHPTest extends PHPUnit_Framework_TestCase
+{
+    public function testShouldNotUseStderrRedirectionByDefault()
+    {
+        $phpMock = $this->getMockForAbstractClass('PHPUnit_Util_PHP');
+
+        $this->assertFalse($phpMock->useStderrRedirection());
+    }
+
+    public function testShouldDefinedIfUseStderrRedirection()
+    {
+        $phpMock = $this->getMockForAbstractClass('PHPUnit_Util_PHP');
+        $phpMock->setUseStderrRedirection(true);
+
+        $this->assertTrue($phpMock->useStderrRedirection());
+    }
+
+    public function testShouldDefinedIfDoNotUseStderrRedirection()
+    {
+        $phpMock = $this->getMockForAbstractClass('PHPUnit_Util_PHP');
+        $phpMock->setUseStderrRedirection(false);
+
+        $this->assertFalse($phpMock->useStderrRedirection());
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage Argument #1 (No Value) of PHPUnit_Util_PHP::setUseStderrRedirection() must be a boolean
+     */
+    public function testShouldThrowsExceptionWhenStderrRedirectionVariableIsNotABoolean()
+    {
+        $phpMock = $this->getMockForAbstractClass('PHPUnit_Util_PHP');
+        $phpMock->setUseStderrRedirection(null);
+    }
+
+    public function testShouldUseGivenSettingsToCreateCommand()
+    {
+        $phpMock = $this->getMockForAbstractClass('PHPUnit_Util_PHP');
+
+        $settings = array(
+            'allow_url_fopen=1',
+            'auto_append_file=',
+            'display_errors=1',
+        );
+
+        $expectedCommandFormat  = '%s -d allow_url_fopen=1 -d auto_append_file= -d display_errors=1';
+        $actualCommand          = $phpMock->getCommand($settings);
+
+        $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);
+    }
+
+    public function testShouldRedirectStderrToStdoutWhenDefined()
+    {
+        $phpMock = $this->getMockForAbstractClass('PHPUnit_Util_PHP');
+        $phpMock->setUseStderrRedirection(true);
+
+        $expectedCommandFormat  = '%s 2>&1';
+        $actualCommand          = $phpMock->getCommand(array());
+
+        $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);
+    }
+}


### PR DESCRIPTION
This is the current behaviour of the [run-tests.php](https://github.com/php/php-src/blob/master/run-tests.php) script which runs all entire PHP source test suite.

Fix #1169.
