### PR TITLE
PHPT improvements

### DIFF
--- a/src/Extensions/PhptTestCase.php
+++ b/src/Extensions/PhptTestCase.php
@@ -180,6 +180,11 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
             } catch (Exception $e) {
                 $result->addError($this, $e, $time);
             }
+
+            if (isset($sections['CLEAN'])) {
+                $cleanCode = $this->render($sections['CLEAN']);
+                $php->runJob($cleanCode, $this->settings);
+            }
         }
 
         $result->endTest($this, $time);

--- a/src/Extensions/PhptTestCase.php
+++ b/src/Extensions/PhptTestCase.php
@@ -27,6 +27,11 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
     private $filename;
 
     /**
+     * @var PHPUnit_Util_PHP
+     */
+    private $phpUtil;
+
+    /**
      * @var array
      */
     private $settings = array(
@@ -78,6 +83,34 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
     }
 
     /**
+     * Defines the PHPUnit_Util_PHP instance to run PHP code.
+     *
+     * @param  PHPUnit_Util_PHP $phpUtil
+     *
+     * @return null
+     */
+    public function setPhpUtil(PHPUnit_Util_PHP $phpUtil)
+    {
+        $this->phpUtil = $phpUtil;
+    }
+
+    /**
+     * Returns the current instance of PHPUnit_Util_PHP which runs PHP code.
+     *
+     * If there is not defined instance creates one.
+     *
+     * @return PHPUnit_Util_PHP
+     */
+    public function getPhpUtil()
+    {
+        if (!$this->phpUtil instanceof PHPUnit_Util_PHP) {
+            $this->phpUtil = PHPUnit_Util_PHP::factory();
+        }
+
+        return $this->phpUtil;
+    }
+
+    /**
      * Counts the number of test cases executed by run(TestResult result).
      *
      * @return integer
@@ -102,7 +135,7 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
             $result = new PHPUnit_Framework_TestResult;
         }
 
-        $php  = PHPUnit_Util_PHP::factory();
+        $php = $this->getPhpUtil();
         $skip = false;
         $time = 0;
 

--- a/tests/Extensions/PhptTestCaseTest.php
+++ b/tests/Extensions/PhptTestCaseTest.php
@@ -103,4 +103,22 @@ EOF;
 
         $this->testCase->run();
     }
+
+    public function testShouldRunCleanSectionWhenDefined()
+    {
+        $cleanSection = '<?php unlink("/tmp/something"); ?>' . PHP_EOL;
+
+        $phptFileContent = self::EXPECT_CONTENT . PHP_EOL;
+        $phptFileContent .= '--CLEAN--' . PHP_EOL;
+        $phptFileContent .= $cleanSection;
+
+        file_put_contents($this->filename, $phptFileContent);
+
+        $this->phpUtil
+            ->expects($this->at(1))
+            ->method('runJob')
+            ->with($cleanSection);
+
+        $this->testCase->run();
+    }
 }

--- a/tests/Extensions/PhptTestCaseTest.php
+++ b/tests/Extensions/PhptTestCaseTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @package    PHPUnit
+ * @author     Henrique Moody <henriquemoody@gmail.com>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ * @covers     PHPUnit_Extensions_PhptTestCase
+ */
+class PHPUnit_Extensions_PhptTestCaseTest extends PHPUnit_Framework_TestCase
+{
+    const EXPECT_CONTENT = <<<EOF
+--TEST--
+EXPECT test
+--FILE--
+<?php
+echo "Hello PHPUnit!";
+?>
+--EXPECT--
+Hello PHPUnit!
+EOF;
+    protected $filename;
+    protected $testCase;
+    protected $phpUtil;
+
+    protected function setUp()
+    {
+        $this->filename = sys_get_temp_dir().'/phpunit.phpt';
+        file_put_contents($this->filename, self::EXPECT_CONTENT);
+
+        $this->phpUtil = $this->getMockForAbstractClass('PHPUnit_Util_PHP', array(), '', false);
+
+        $this->testCase = new PHPUnit_Extensions_PhptTestCase($this->filename);
+        $this->testCase->setPhpUtil($this->phpUtil);
+    }
+
+    protected function tearDown()
+    {
+        @unlink($this->filename);
+
+        $this->filename = null;
+        $this->testCase = null;
+    }
+
+    public function testShouldRunFileSectionAsTest()
+    {
+        $fileSection = '<?php'.PHP_EOL.
+                       'echo "Hello PHPUnit!";'.PHP_EOL.
+                       '?>'.PHP_EOL;
+
+        $this->phpUtil
+            ->expects($this->once())
+            ->method('runJob')
+            ->with($fileSection)
+            ->will($this->returnValue(array('stdout' => '', 'stderr' => '')));
+
+        $this->testCase->run();
+    }
+
+    public function testShouldRunSkipifSectionWhenExists()
+    {
+        $skipifSection = '<?php /** Nothing **/ ?>'.PHP_EOL;
+
+        $phptFileContent = self::EXPECT_CONTENT.PHP_EOL;
+        $phptFileContent .= '--SKIPIF--'.PHP_EOL;
+        $phptFileContent .= $skipifSection;
+
+        file_put_contents($this->filename, $phptFileContent);
+
+        $this->phpUtil
+            ->expects($this->at(0))
+            ->method('runJob')
+            ->with($skipifSection)
+            ->will($this->returnValue(array('stdout' => '', 'stderr' => '')));
+
+        $this->testCase->run();
+    }
+
+    public function testShouldNotRunTestSectionIfSkipifSectionReturnsOutputWithSkipWord()
+    {
+        $skipifSection = '<?php echo "skip: Reason"; ?>'.PHP_EOL;
+
+        $phptFileContent = self::EXPECT_CONTENT.PHP_EOL;
+        $phptFileContent .= '--SKIPIF--'.PHP_EOL;
+        $phptFileContent .= $skipifSection;
+
+        file_put_contents($this->filename, $phptFileContent);
+
+        $this->phpUtil
+            ->expects($this->once())
+            ->method('runJob')
+            ->with($skipifSection)
+            ->will($this->returnValue(array('stdout' => 'skip: Reason', 'stderr' => '')));
+
+        $this->testCase->run();
+    }
+}


### PR DESCRIPTION
- Define `PHPUnit_Util_PHP` instance on `PHPUnit_Extensions_PhptTestCase`
- Implement `CLEAN` section for PHPT tests
- Implement `EXPECTREGEX` section for PHPT tests

According to [Sebastian Bergmann](https://github.com/sebastianbergmann/phpunit/issues/1101#issuecomment-32683783) I don't think this would be a problem.
