### PR TITLE
Ouput Buffering Fixes

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1933,10 +1933,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     private function startOutputBuffering()
     {
-        while (!defined('PHPUNIT_TESTSUITE') && ob_get_level() > 0) {
-            ob_end_clean();
-        }
-
         ob_start();
 
         $this->outputBufferingActive = true;
@@ -1949,9 +1945,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     private function stopOutputBuffering()
     {
         if (ob_get_level() != $this->outputBufferingLevel) {
-            while (ob_get_level() > 0) {
+            while (ob_get_level() > $this->outputBufferingLevel-1) {
                 ob_end_clean();
             }
+
+            $this->outputBufferingActive = false;
+            $this->outputBufferingLevel = null;
 
             throw new PHPUnit_Framework_RiskyTestError(
                 'Test code or tested code did not (only) close its own output buffers'
@@ -1972,7 +1971,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         ob_end_clean();
 
         $this->outputBufferingActive = false;
-        $this->outputBufferingLevel  = ob_get_level();
+        $this->outputBufferingLevel  = null;
     }
 
     private function snapshotGlobalState()

--- a/tests/Regression/GitHub/1545.phpt
+++ b/tests/Regression/GitHub/1545.phpt
@@ -1,0 +1,29 @@
+--TEST--
+GH-1545: Output buffering broken by PHPUnit
+--FILE--
+<?php
+
+require __DIR__ . '/../../bootstrap.php';
+
+class Issue1545Test extends PHPUnit_Framework_TestCase
+{
+    public function testExample()
+    {
+        $this->assertTrue(true);
+    }
+}
+
+$suite = new PHPUnit_Framework_TestSuite();
+$suite->addTestSuite('Issue1545Test');
+
+ob_start();
+echo 'start';
+$suite->run();
+$results = ob_get_contents();
+ob_end_clean();
+
+echo $results;
+
+?>
+--EXPECT--
+start

--- a/tests/Regression/GitHub/1553.phpt
+++ b/tests/Regression/GitHub/1553.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-1553: Tests That Fail to Close Their Output Buffers Have Any Output Swallowed.
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/1553/Issue1553Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Rhere.there
+
+Time: %s, Memory: %sMb
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 2, Assertions: 0, Risky: 1.

--- a/tests/Regression/GitHub/1553/Issue1553Test.php
+++ b/tests/Regression/GitHub/1553/Issue1553Test.php
@@ -1,0 +1,14 @@
+<?php
+class Issue1553Test extends PHPUnit_Framework_TestCase
+{
+    public function testTestsThatDoNotCloseTheirOutputBuffersHaveOutputSwallowed()
+    {
+        ob_start();
+        echo 'here';
+    }
+
+    public function testTestsWithoutOutputBufferingDoNotHaveTheirOutputSwallowed()
+    {
+        echo 'there';
+    }
+}


### PR DESCRIPTION
Fixes #1545 #1553 

May also fix #1398

Was a bit unsure about removing this bit:

```php
while (!defined('PHPUNIT_TESTSUITE') && ob_get_level() > 0) {
    ob_end_clean();
}
```

But it seemed to be added arbitrarily? There's no need to reduce the output buffering to zero as long as the test keeps track of the output buffering level it started.

May also fix #1398