### PR TITLE
Cache vendor directory on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+cache:
+  directories:
+    - vendor
+
 php:
   - 5.3.3
   - 5.3


### PR DESCRIPTION
A similar change was made in #1556, but it was reverted because HHVM was using sudo.

Now, after 5985512, HHVM build is no longer using sudo, but the caching made in #1556 was not reapplied.

This pull request is sent against `4.5` branch in order to improve builds from `4.5`, `4.6` and `4.7` versions.
