### PR TITLE
Fix phpunit not searching all places for composer's autoload

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -13,7 +13,14 @@ if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');
 }
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+$directories = array(
+    __DIR__ . '/../../autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php',
+    __DIR__ . '/../autoload.php'
+);
+
+foreach ($directories as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;

--- a/phpunit
+++ b/phpunit
@@ -26,7 +26,7 @@ foreach ($directories as $file) {
         break;
     }
 }
-
+unset($directories);
 unset($file);
 
 if (!defined('PHPUNIT_COMPOSER_INSTALL')) {


### PR DESCRIPTION
In my installation of latest Laravel (5) the phpunit bin script is located in vendor/bin/phpunit. When it looks for composer's autoload.php it fails because it doesn't look for it in ../

phpunit bash script location - PROJECT_ROOT/vendor/bin/phpunit
autoload.php location - PROJECT_ROOT/vendor/autoload.php

After this change it searches 1 level above too solving my issue
