### PR TITLE
Feature percentageskip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lyft/phpunit",
+    "name": "phpunit/phpunit",
     "description": "The PHP Unit Testing framework.",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpunit/phpunit",
+    "name": "lyft/phpunit",
     "description": "The PHP Unit Testing framework.",
     "type": "library",
     "keywords": [

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -547,7 +547,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * Skips the current test if --percentage-skip was used and the current PHPUnit test run is not the required
      * percentage complete.
      */
-    protected function checkPercentageSkip()
+    private function checkPercentageSkip()
     {
         /**
          * @var $result \PHPUnit_Framework_TestCase

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -553,7 +553,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
          * @var $result \PHPUnit_Framework_TestCase
          */
         $result = $this->getTestResultObject();
+        if (!is_object($result)) {
+            return;
+        }
         $topTestSuite = $result->topTestSuite();
+        if (!is_object($topTestSuite)) {
+            return;
+        }
         $numTestsInTotal = $topTestSuite->count(true);
         $numTestsRun = $topTestSuite->getNumTestsRun();
         $percentageSkip = $result->getPercentageSkip();
@@ -843,7 +849,10 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
         }
 
-        $this->getTestResultObject()->topTestSuite()->incNumTestsRun();
+        if (is_object($this->getTestResultObject()) && is_object($this->getTestResultObject()->topTestSuite())) {
+            $topTestSuite = $this->getTestResultObject()->topTestSuite();
+            $topTestSuite->incNumTestsRun();
+        }
 
         // Workaround for missing "finally".
         if (isset($e)) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -544,7 +544,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * @since Method available since Release 3.6.0
+     * Skips the current test if --percentage-skip was used and the current PHPUnit test run is not the required
+     * percentage complete.
      */
     protected function checkPercentageSkip()
     {
@@ -555,11 +556,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $topTestSuite = $result->topTestSuite();
         $numTestsInTotal = $topTestSuite->count(true);
         $numTestsRun = $topTestSuite->getNumTestsRun();
-        $skipPercentage = $result->getPercentageSkip();
+        $percentageSkip = $result->getPercentageSkip();
         $percentageOfTestsExecuted = floor(($numTestsRun / $numTestsInTotal) * 100);
 
-        if ($skipPercentage > $percentageOfTestsExecuted) {
-            $this->markTestSkipped("Skipped by jon");
+        if ($percentageSkip > $percentageOfTestsExecuted) {
+            $this->markTestSkipped("Skipped because --percentage-skip is set to $percentageSkip but the current PHPUnit run is only $percentageOfTestsExecuted complete.");
         }
     }
 
@@ -737,7 +738,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $hookMethods = PHPUnit_Util_Test::getHookMethods(get_class($this));
 
         try {
-
             $hasMetRequirements = false;
             $this->checkRequirements();
             $this->checkPercentageSkip();

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -544,6 +544,26 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @since Method available since Release 3.6.0
+     */
+    protected function checkPercentageSkip()
+    {
+        /**
+         * @var $result \PHPUnit_Framework_TestCase
+         */
+        $result = $this->getTestResultObject();
+        $topTestSuite = $result->topTestSuite();
+        $numTestsInTotal = $topTestSuite->count(true);
+        $numTestsRun = $topTestSuite->getNumTestsRun();
+        $skipPercentage = $result->getPercentageSkip();
+        $percentageOfTestsExecuted = floor(($numTestsRun / $numTestsInTotal) * 100);
+
+        if ($skipPercentage > $percentageOfTestsExecuted) {
+            $this->markTestSkipped("Skipped by jon");
+        }
+    }
+
+    /**
      * Returns the status of this test.
      *
      * @return integer
@@ -717,8 +737,10 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         $hookMethods = PHPUnit_Util_Test::getHookMethods(get_class($this));
 
         try {
+
             $hasMetRequirements = false;
             $this->checkRequirements();
+            $this->checkPercentageSkip();
             $hasMetRequirements = true;
 
             if ($this->inIsolation) {
@@ -820,6 +842,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $e = $_e;
             }
         }
+
+        $this->getTestResultObject()->topTestSuite()->incNumTestsRun();
 
         // Workaround for missing "finally".
         if (isset($e)) {

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -24,7 +24,7 @@ class PHPUnit_Framework_TestResult implements Countable
     /**
      * @var integer
      */
-    protected $percentageSkip = 0;
+    private $percentageSkip = 0;
 
     /**
      * @var array

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -22,6 +22,11 @@
 class PHPUnit_Framework_TestResult implements Countable
 {
     /**
+     * @var integer
+     */
+    protected $percentageSkip = 0;
+
+    /**
      * @var array
      */
     protected $passed = array();
@@ -835,6 +840,26 @@ class PHPUnit_Framework_TestResult implements Countable
         }
 
         $this->stopOnFailure = $flag;
+    }
+
+    /**
+     * Sets the percentage of tests which would be skipped by default during a PHPUnit run.
+     *
+     * @param  integer $percentageSkip
+     */
+    public function setPercentageSkip($percentageSkip)
+    {
+        $this->percentageSkip = $percentageSkip;
+    }
+
+    /**
+     * Gets the percentage of tests which would be skipped by default during a PHPUnit run.
+     *
+     * @return integer
+     */
+    public function getPercentageSkip()
+    {
+        return $this->percentageSkip;
     }
 
     /**

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -54,13 +54,6 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     protected $numTestsRun = 0;
 
     /**
-     * Last count of tests in this suite.
-     *
-     * @var integer|null
-     */
-    protected $cachedNumTests;
-
-    /**
      * Enable or disable the backup and restoration of the $GLOBALS array.
      *
      * @var boolean
@@ -420,19 +413,14 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     /**
      * Counts the number of test cases that will be run by this test.
      *
-     * @Param boolean $preferCache Indicates if cache is preferred.
      * @return integer
      */
-    public function count($preferCache = false)
+    public function count()
     {
-        if ($preferCache && $this->cachedNumTests != null) {
-            $numTests = $this->cachedNumTests;
-        } else {
-            $numTests = 0;
-            foreach ($this as $test) {
-                $numTests += count($test);
-            }
-            $this->cachedNumTests = $numTests;
+        $numTests = 0;
+
+        foreach ($this as $test) {
+            $numTests += count($test);
         }
 
         return $numTests;

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -727,8 +727,6 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
          */
         foreach ($this as $test) {
 
-            // echo $test->getName() . "\n"    ;
-
             if ($result->shouldStop()) {
                 break;
             }

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -47,6 +47,20 @@
 class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Framework_SelfDescribing, IteratorAggregate
 {
     /**
+     * Tracks number of tests run.
+     *
+     * @var integer
+     */
+    protected $numTestsRun = 0;
+
+    /**
+     * Last count of tests in this suite.
+     *
+     * @var integer|null
+     */
+    protected $cachedNumTests;
+
+    /**
      * Enable or disable the backup and restoration of the $GLOBALS array.
      *
      * @var boolean
@@ -131,6 +145,8 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      */
     public function __construct($theClass = '', $name = '')
     {
+        $this->numTestsRun = 0;
+
         $argumentsValid = false;
 
         if (is_object($theClass) &&
@@ -404,14 +420,19 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     /**
      * Counts the number of test cases that will be run by this test.
      *
+     * @Param boolean $preferCache Indicates if cache is preferred.
      * @return integer
      */
-    public function count()
+    public function count($preferCache = false)
     {
-        $numTests = 0;
-
-        foreach ($this as $test) {
-            $numTests += count($test);
+        if ($preferCache && $this->cachedNumTests != null) {
+            $numTests = $this->cachedNumTests;
+        } else {
+            $numTests = 0;
+            foreach ($this as $test) {
+                $numTests += count($test);
+            }
+            $this->cachedNumTests = $numTests;
         }
 
         return $numTests;
@@ -701,7 +722,13 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             return $result;
         }
 
+        /**
+         * Loops over each test "suite". Due to how we run PHPUnit, each suite corresponds to a unit test file.
+         */
         foreach ($this as $test) {
+
+            // echo $test->getName() . "\n"    ;
+
             if ($result->shouldStop()) {
                 break;
             }
@@ -727,6 +754,16 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         $result->endTestSuite($this);
 
         return $result;
+    }
+
+    public function incNumTestsRun()
+    {
+        $this->numTestsRun++;
+    }
+
+    public function getNumTestsRun()
+    {
+        return $this->numTestsRun;
     }
 
     /**

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -51,7 +51,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      *
      * @var integer
      */
-    protected $numTestsRun = 0;
+    private $numTestsRun = 0;
 
     /**
      * Enable or disable the backup and restoration of the $GLOBALS array.

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -138,8 +138,6 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      */
     public function __construct($theClass = '', $name = '')
     {
-        $this->numTestsRun = 0;
-
         $argumentsValid = false;
 
         if (is_object($theClass) &&

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -53,6 +53,7 @@ class PHPUnit_TextUI_Command
       'debug' => null,
       'exclude-group=' => null,
       'filter=' => null,
+      'percentage-skip=' => null,
       'testsuite=' => null,
       'group=' => null,
       'help' => null,
@@ -333,6 +334,11 @@ class PHPUnit_TextUI_Command
                 case '--filter': {
                     $this->arguments['filter'] = $option[1];
                     }
+                break;
+
+                case '--percentage-skip': {
+                    $this->arguments['percentageSkip'] = $option[1];
+                }
                 break;
 
                 case '--testsuite': {
@@ -899,6 +905,7 @@ Test Selection Options:
   --list-groups             List available test groups.
   --test-suffix ...         Only search for test in files with specified
                             suffix(es). Default: Test.php,.phpt
+  --percentage-skip <n>     Skip an initial percentage of unit tests.
 
 Test Execution Options:
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -203,6 +203,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $result->stopOnIncomplete(true);
         }
 
+        if ($arguments['percentageSkip']) {
+            $result->setPercentageSkip((int) $arguments['percentageSkip']);
+        }
+
         if ($arguments['stopOnRisky']) {
             $result->stopOnRisky(true);
         }
@@ -907,6 +911,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['enforceTimeLimit']                   = isset($arguments['enforceTimeLimit'])                   ? $arguments['enforceTimeLimit']                   : false;
         $arguments['disallowTodoAnnotatedTests']         = isset($arguments['disallowTodoAnnotatedTests'])         ? $arguments['disallowTodoAnnotatedTests']         : false;
         $arguments['verbose']                            = isset($arguments['verbose'])                            ? $arguments['verbose']                            : false;
+        $arguments['percentageSkip']                     = isset($arguments['percentageSkip'])                     ? $arguments['percentageSkip']                     : 0;
     }
 
     /**


### PR DESCRIPTION
Sometimes PHPUnit fatals before the end of a long test run. By using "--percentage-skip 50", you can skip the first 50% of the tests for example allowing the developer to continue the test run from before a problem area.

Example:
http://screencast.com/t/hG8goERc
