### PR TITLE
Make json assertions stricter

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2242,10 +2242,11 @@ abstract class PHPUnit_Framework_Assert
         self::assertJson($expectedJson, $message);
         self::assertJson($actualJson, $message);
 
-        $expected = json_decode($expectedJson);
-        $actual   = json_decode($actualJson);
+        $constraint = new PHPUnit_Framework_Constraint_JsonMatches(
+            $expectedJson
+        );
 
-        self::assertEquals($expected, $actual, $message);
+        self::assertThat($actualJson, $constraint, $message);
     }
 
     /**
@@ -2260,10 +2261,11 @@ abstract class PHPUnit_Framework_Assert
         self::assertJson($expectedJson, $message);
         self::assertJson($actualJson, $message);
 
-        $expected = json_decode($expectedJson);
-        $actual   = json_decode($actualJson);
+        $constraint = new PHPUnit_Framework_Constraint_JsonMatches(
+            $expectedJson
+        );
 
-        self::assertNotEquals($expected, $actual, $message);
+        self::assertThat($actualJson, new PHPUnit_Framework_Constraint_Not($constraint), $message);
     }
 
     /**
@@ -2281,7 +2283,6 @@ abstract class PHPUnit_Framework_Assert
         self::assertJson($expectedJson, $message);
         self::assertJson($actualJson, $message);
 
-        // call constraint
         $constraint = new PHPUnit_Framework_Constraint_JsonMatches(
             $expectedJson
         );
@@ -2304,7 +2305,6 @@ abstract class PHPUnit_Framework_Assert
         self::assertJson($expectedJson, $message);
         self::assertJson($actualJson, $message);
 
-        // call constraint
         $constraint = new PHPUnit_Framework_Constraint_JsonMatches(
             $expectedJson
         );
@@ -2330,7 +2330,6 @@ abstract class PHPUnit_Framework_Assert
         self::assertJson($expectedJson, $message);
         self::assertJson($actualJson, $message);
 
-        // call constraint
         $constraintExpected = new PHPUnit_Framework_Constraint_JsonMatches(
             $expectedJson
         );
@@ -2359,7 +2358,6 @@ abstract class PHPUnit_Framework_Assert
         self::assertJson($expectedJson, $message);
         self::assertJson($actualJson, $message);
 
-        // call constraint
         $constraintExpected = new PHPUnit_Framework_Constraint_JsonMatches(
             $expectedJson
         );

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -48,17 +48,50 @@ class PHPUnit_Framework_Constraint_JsonMatches extends PHPUnit_Framework_Constra
      */
     protected function matches($other)
     {
-        $decodedOther = json_decode($other);
-        if (json_last_error()) {
+        list($error, $recodedOther) = $this->canonicalizeJson($other);
+        if ($error) {
             return false;
         }
 
-        $decodedValue = json_decode($this->value);
-        if (json_last_error()) {
+        list ($error, $recodedValue) = $this->canonicalizeJson($this->value);
+        if ($error) {
             return false;
         }
 
-        return $decodedOther == $decodedValue;
+        return $recodedOther == $recodedValue;
+    }
+
+    /*
+     * To allow comparison of JSON strings, first process them into a consistent
+     * format so that they can be compared as strings.
+     * @return array ($error, $canonicalized_json)  The $error parameter is used
+     * to indicate an error decoding the json.  This is used to avoid ambiguity
+     * with JSON strings consisting entirely of 'null' or 'false'.
+     */
+    private function canonicalizeJson($json)
+    {
+        $decodedJson = json_decode($json, true);
+        if (json_last_error()) {
+            return array(true, null);
+        }
+        $this->recursiveSort($decodedJson);
+        $reencodedJson = json_encode($decodedJson);
+        return array(false, $reencodedJson);
+    }
+
+    /*
+     * JSON object keys are unordered while PHP array keys are ordered.
+     * Sort all array keys to ensure both the expected and actual values have
+     * their keys in the same order.
+     */
+    private function recursiveSort(&$json)
+    {
+        if (is_array($json)) {
+            ksort($json);
+            foreach ($json as $key => &$value) {
+                $this->recursiveSort($value);
+            }
+        }
     }
 
     /**

--- a/tests/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/Framework/Constraint/JsonMatchesTest.php
@@ -50,6 +50,16 @@ class Framework_Constraint_JsonMatchesTest extends PHPUnit_Framework_TestCase
             'error syntax' => array(false, '{"Mascott"::}', json_encode(array('Mascott' => 'Tux'))),
             'error UTF-8' => array(false, json_encode('\xB1\x31'), json_encode(array('Mascott' => 'Tux'))),
             'invalid JSON in class instantiation' => array(false, json_encode(array('Mascott' => 'Tux')), '{"Mascott"::}'),
+            'string type not equals number' => array(false, '{"age": "5"}', '{"age": 5}'),
+            'string type not equals boolean' => array(false, '{"age": "true"}', '{"age": true}'),
+            'string type not equals null' => array(false, '{"age": "null"}', '{"age": null}'),
+            'object fields are unordered' => array(true, '{"first":1, "second":"2"}', '{"second":"2", "first":1}'),
+            'child object fields are unordered' => array(true, '{"Mascott": {"name":"Tux", "age":5}}', '{"Mascott": {"age":5, "name":"Tux"}}'),
+			'null field different from missing field' => array(false, '{"present": true, "missing": null}', '{"present": true}'),
+            'array elements are ordered' => array(false, '["first", "second"]', '["second", "first"]'),
+            'single boolean valid json' => array(true, 'true', 'true'),
+            'single number valid json' => array(true, '5.3', '5.3'),
+            'single null valid json' => array(true, 'null', 'null'),
         );
     }
 }


### PR DESCRIPTION
While writing a regression test for our API output, we discovered that the assertJson* methods allow some strings to pass which are not strictly equal.  These cases are covered particularly in the `string type not equals number` and `string type not equals boolean` test cases which have been added.  The additional tests help to validate behavior for any Json comparison method and in particular the proposed change.  