### PR TITLE
Bump the php-code-coverage requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.3.3",
         "phpunit/php-file-iterator": "~1.3",
         "phpunit/php-text-template": "~1.2",
-        "phpunit/php-code-coverage": "~2.0",
+        "phpunit/php-code-coverage": "~2.0,>=2.0.11",
         "phpunit/php-timer": "~1.0",
         "phpunit/phpunit-mock-objects": "~2.3",
         "phpspec/prophecy": "~1.3.1",


### PR DESCRIPTION
php-code-coverage:2.0.11 was the first version to require php-token-stream:~1.3 which had a fix for the `@runInSeparateProcess` on hhvm (#1090, #1214, #1407)

This was discovered by running tests using the composer option of `--prefer-lowest`.
So at the moment projects that rely on `@runInSeparateProcess` and test on hhvm with `--prefer-lowest` have to add another dependency of `php-code-coverage:2.0.11` or `php-token-stream:~1.3` to the project.
