### PR TITLE
Assertion of array items/keys against arbitrary constraint

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -398,6 +398,25 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts that a haystack does not contain a needle matching a constraint.
+     *
+     * @param PHPUnit_Framework_Constraint $needleConstraint
+     * @param string                       $haystack
+     * @param string                       $message
+     */
+    public static function assertNotContainsMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+    {
+        if (!(is_array($haystack) || is_object($haystack) && $haystack instanceof Traversable)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                2,
+                'array or traversable'
+            );
+        }
+
+        self::assertThat($haystack, self::logicalNot(self::containsMatching($needleConstraint)), $message);
+    }
+
+    /**
      * Asserts that a haystack contains only needles matching a constraint.
      *
      * @param PHPUnit_Framework_Constraint $needleConstraint
@@ -414,6 +433,25 @@ abstract class PHPUnit_Framework_Assert
         }
 
         self::assertThat($haystack, self::containsOnlyMatching($needleConstraint), $message);
+    }
+
+    /**
+     * Asserts that a haystack does not contain only needles matching a constraint.
+     *
+     * @param PHPUnit_Framework_Constraint $needleConstraint
+     * @param string                       $haystack
+     * @param string                       $message
+     */
+    public static function assertNotContainsOnlyMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+    {
+        if (!(is_array($haystack) || is_object($haystack) && $haystack instanceof Traversable)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                2,
+                'array or traversable'
+            );
+        }
+
+        self::assertThat($haystack, self::logicalNot(self::containsOnlyMatching($needleConstraint)), $message);
     }
 
     /**

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -379,6 +379,44 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts that a haystack contains a needle matching a constraint.
+     *
+     * @param PHPUnit_Framework_Constraint $needleConstraint
+     * @param string                       $haystack
+     * @param string                       $message
+     */
+    public static function assertContainsMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+    {
+        if (!(is_array($haystack) || is_object($haystack) && $haystack instanceof Traversable)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                2,
+                'array or traversable'
+            );
+        }
+
+        self::assertThat($haystack, self::containsMatching($needleConstraint), $message);
+    }
+
+    /**
+     * Asserts that a haystack contains only needles matching a constraint.
+     *
+     * @param PHPUnit_Framework_Constraint $needleConstraint
+     * @param string                       $haystack
+     * @param string                       $message
+     */
+    public static function assertContainsOnlyMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+    {
+        if (!(is_array($haystack) || is_object($haystack) && $haystack instanceof Traversable)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                2,
+                'array or traversable'
+            );
+        }
+
+        self::assertThat($haystack, self::containsOnlyMatching($needleConstraint), $message);
+    }
+
+    /**
      * Asserts the number of elements of an array, Countable or Traversable.
      *
      * @param integer $expectedCount
@@ -2552,6 +2590,32 @@ abstract class PHPUnit_Framework_Assert
     public static function containsOnlyInstancesOf($classname)
     {
         return new PHPUnit_Framework_Constraint_TraversableContainsOnly($classname, false);
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_TraversableContainsMatching
+     * matcher object.
+     *
+     * @param  PHPUnit_Framework_Constraint                             $itemConstraint
+     * @param  PHPUnit_Framework_Constraint|null                        $keyConstraint
+     * @return PHPUnit_Framework_Constraint_TraversableContainsMatching
+     */
+    public static function containsMatching(PHPUnit_Framework_Constraint $itemConstraint, PHPUnit_Framework_Constraint $keyConstraint = null)
+    {
+        return new PHPUnit_Framework_Constraint_TraversableContainsMatching($itemConstraint, $keyConstraint);
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly
+     * matcher object.
+     *
+     * @param  PHPUnit_Framework_Constraint                                 $itemConstraint
+     * @param  PHPUnit_Framework_Constraint|null                            $keyConstraint
+     * @return PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly
+     */
+    public static function containsOnlyMatching(PHPUnit_Framework_Constraint $itemConstraint, PHPUnit_Framework_Constraint $keyConstraint = null)
+    {
+        return new PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly($itemConstraint, $keyConstraint);
     }
 
     /**

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -578,6 +578,36 @@ function assertContainsOnlyInstancesOf($classname, $haystack, $message = '')
 }
 
 /**
+ * Asserts that a haystack contains a needle matching a constraint.
+ *
+ * @param PHPUnit_Framework_Constraint $needleConstraint
+ * @param string                       $haystack
+ * @param string                       $message
+ */
+function assertContainsMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::assertContainsMatching',
+        func_get_args()
+    );
+}
+
+/**
+ * Asserts that a haystack contains only needles matching a constraint.
+ *
+ * @param PHPUnit_Framework_Constraint $needleConstraint
+ * @param string                       $haystack
+ * @param string                       $message
+ */
+function assertContainsOnlyMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::assertContainsOnlyMatching',
+        func_get_args()
+    );
+}
+
+/**
  * Asserts the number of elements of an array, Countable or Traversable.
  *
  * @param integer $expectedCount

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1933,6 +1933,38 @@ function containsOnlyInstancesOf($classname)
 }
 
 /**
+ * Returns a PHPUnit_Framework_Constraint_TraversableContainsMatching
+ * matcher object.
+ *
+ * @param  PHPUnit_Framework_Constraint                             $itemConstraint
+ * @param  PHPUnit_Framework_Constraint|null                        $keyConstraint
+ * @return PHPUnit_Framework_Constraint_TraversableContainsMatching
+ */
+function containsMatching(PHPUnit_Framework_Constraint $itemConstraint, PHPUnit_Framework_Constraint $keyConstraint = null)
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::containsMatching',
+        func_get_args()
+    );
+}
+
+/**
+ * Returns a PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly
+ * matcher object.
+ *
+ * @param  PHPUnit_Framework_Constraint                                 $itemConstraint
+ * @param  PHPUnit_Framework_Constraint|null                            $keyConstraint
+ * @return PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly
+ */
+function containsOnlyMatching(PHPUnit_Framework_Constraint $itemConstraint, PHPUnit_Framework_Constraint $keyConstraint = null)
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::containsOnlyMatching',
+        func_get_args()
+    );
+}
+
+/**
  * Returns a PHPUnit_Framework_Constraint_IsEqual matcher object.
  *
  * @param  mixed   $value

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -593,6 +593,21 @@ function assertContainsMatching(PHPUnit_Framework_Constraint $needleConstraint, 
 }
 
 /**
+ * Asserts that a haystack does not contain a needle matching a constraint.
+ *
+ * @param PHPUnit_Framework_Constraint $needleConstraint
+ * @param string                       $haystack
+ * @param string                       $message
+ */
+function assertNotContainsMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::assertNotContainsMatching',
+        func_get_args()
+    );
+}
+
+/**
  * Asserts that a haystack contains only needles matching a constraint.
  *
  * @param PHPUnit_Framework_Constraint $needleConstraint
@@ -603,6 +618,21 @@ function assertContainsOnlyMatching(PHPUnit_Framework_Constraint $needleConstrai
 {
     return call_user_func_array(
         'PHPUnit_Framework_Assert::assertContainsOnlyMatching',
+        func_get_args()
+    );
+}
+
+/**
+ * Asserts that a haystack does not contain only needles matching a constraint.
+ *
+ * @param PHPUnit_Framework_Constraint $needleConstraint
+ * @param string                       $haystack
+ * @param string                       $message
+ */
+function assertNotContainsOnlyMatching(PHPUnit_Framework_Constraint $needleConstraint, $haystack, $message = '')
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::assertNotContainsOnlyMatching',
         func_get_args()
     );
 }

--- a/src/Framework/Constraint/TraversableContainsMatching.php
+++ b/src/Framework/Constraint/TraversableContainsMatching.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Constraint that asserts that the traversable it is evaluated for contains
+ * one or more items that match the underlying constraints.
+ *
+ * Iterates traversable (array or object or Traversable instance) and delegates
+ * evaluation of evey item it contains to the underlying constraint instances.
+ *
+ * Item value and key constraints are passed in the constructor.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sergii Shymko <sergey@shymko.net>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class PHPUnit_Framework_Constraint_TraversableContainsMatching extends PHPUnit_Framework_Constraint
+{
+    /**
+     * @var PHPUnit_Framework_Constraint
+     */
+    private $itemConstraint;
+
+    /**
+     * @var PHPUnit_Framework_Constraint
+     */
+    private $keyConstraint;
+
+    /**
+     * @param mixed $itemConstraint
+     * @param mixed $keyConstraint
+     */
+    public function __construct(PHPUnit_Framework_Constraint $itemConstraint, PHPUnit_Framework_Constraint $keyConstraint = null)
+    {
+        parent::__construct();
+        $this->itemConstraint = $itemConstraint;
+        $this->keyConstraint = $keyConstraint;
+    }
+
+    /**
+     * Iterate $other and evaluate each item against underlying constraints.
+     * Skip evaluation of remaining items as soon as result is deterministic.
+     * 
+     * {@inheritdoc}
+     */
+    protected function matches($other)
+    {
+        $result = false;
+        if (is_array($other) || is_object($other) || $other instanceof Traversable) {
+            foreach ($other as $key => $item) {
+                $result = $this->itemConstraint->evaluate($item, '', true);
+                if ($result && $this->keyConstraint) {
+                    $result = $this->keyConstraint->evaluate($key, '', true);
+                }
+                if ($this->isFinalResult($result)) {
+                    break;
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Whether partial result defines the final result regardless of evaluation
+     * of remaining items.
+     * 
+     * Operand TRUE defines the final result like in the logical operator OR.
+     * 
+     * @param bool $partialResult
+     * @return bool
+     */
+    protected function isFinalResult($partialResult)
+    {
+        return $partialResult;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toString()
+    {
+        if ($this->keyConstraint) {
+            $result = sprintf(
+                $this->getItemKeyMessage(),
+                $this->itemConstraint->toString(),
+                $this->keyConstraint->toString()
+            );
+        } else {
+            $result = sprintf(
+                $this->getItemMessage(),
+                $this->itemConstraint->toString()
+            );
+        }
+        return $result;
+    }
+
+    /**
+     * Return string representation of constraint on item value only.
+     * 
+     * @return string
+     */
+    protected function getItemMessage()
+    {
+        return 'contains an item value of which %s';
+    }
+
+    /**
+     * Return string representation of constraint on both item value and key.
+     *
+     * @return string
+     */
+    protected function getItemKeyMessage()
+    {
+        return 'contains an item value of which %s and key %s';
+    }
+}

--- a/src/Framework/Constraint/TraversableContainsMatching.php
+++ b/src/Framework/Constraint/TraversableContainsMatching.php
@@ -123,4 +123,12 @@ class PHPUnit_Framework_Constraint_TraversableContainsMatching extends PHPUnit_F
     {
         return 'contains an item value of which %s and key %s';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->itemConstraint) + count($this->keyConstraint);
+    }
 }

--- a/src/Framework/Constraint/TraversableContainsMatchingOnly.php
+++ b/src/Framework/Constraint/TraversableContainsMatchingOnly.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Constraint that asserts that the traversable it is evaluated for contains
+ * only items that match the underlying constraints.
+ *
+ * @package    PHPUnit
+ * @subpackage Framework_Constraint
+ * @author     Sergii Shymko <sergey@shymko.net>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly
+    extends PHPUnit_Framework_Constraint_TraversableContainsMatching
+{
+    /**
+     * Whether partial result defines the final result regardless of evaluation
+     * of remaining items.
+     *
+     * Operand FALSE defines the final result like in the logical operator AND.
+     *
+     * @param bool $partialResult
+     * @return bool
+     */
+    protected function isFinalResult($partialResult)
+    {
+        return !$partialResult;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getItemMessage()
+    {
+        return 'contains only items value of each of which %s';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getItemKeyMessage()
+    {
+        return 'contains only items value of each of which %s and key %s';
+    }
+}

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -139,9 +139,12 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers PHPUnit_Framework_Assert::assertContainsMatching
+     * @covers PHPUnit_Framework_Assert::assertNotContainsMatching
+     * @covers PHPUnit_Framework_Assert::assertContainsOnlyMatching
+     * @covers PHPUnit_Framework_Assert::assertNotContainsOnlyMatching
      * @dataProvider assertContainsMatchingProvider
      */
-    public function testAssertContainsMatching($partialResult1, $partialResult2, $expectedException = null)
+    public function testAssertContainsMatching($assertionMethod, $partialResult1, $partialResult2, $expectedException = null)
     {
         $book1 = new Book();
         $book2 = new Book();
@@ -154,56 +157,34 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
                 array($this->identicalTo($book1)),
                 array($this->identicalTo($book2))
             )
-            ->will($this->onConsecutiveCalls($partialResult1, $partialResult2))
+            ->will($this->onConsecutiveCalls((bool)$partialResult1, (bool)$partialResult2))
         ;
 
         $this->setExpectedException($expectedException);
 
-        $this->assertContainsMatching($bookConstraint, array($book1, $book2));
+        $this->$assertionMethod($bookConstraint, array($book1, $book2));
     }
-    
+
     public function assertContainsMatchingProvider()
     {
+        $failure = 'PHPUnit_Framework_AssertionFailedError';
         return array(
-            'item 1 mismatch, item 2 mismatch'  => array(false, false, 'PHPUnit_Framework_AssertionFailedError'),
-            'item 1 mismatch, item 2 match'     => array(false, true),
-            'item 1 match, item 2 mismatch'     => array(true, false),
-            'item 1 match, item 2 match'        => array(true, true),
-        );
-    }
-
-    /**
-     * @covers PHPUnit_Framework_Assert::assertContainsOnlyMatching
-     * @dataProvider assertContainsOnlyMatchingProvider
-     */
-    public function testAssertContainsOnlyMatching($partialResult1, $partialResult2, $expectedException = null)
-    {
-        $book1 = new Book();
-        $book2 = new Book();
-
-        $constraint = $this->getMock('PHPUnit_Framework_Constraint');
-        $constraint
-            ->expects($this->atLeastOnce())
-            ->method('evaluate')
-            ->withConsecutive(
-                array($this->identicalTo($book1)),
-                array($this->identicalTo($book2))
-            )
-            ->will($this->onConsecutiveCalls($partialResult1, $partialResult2))
-        ;
-
-        $this->setExpectedException($expectedException);
-
-        $this->assertContainsOnlyMatching($constraint, array($book1, $book2));
-    }
-
-    public function assertContainsOnlyMatchingProvider()
-    {
-        return array(
-            'item 1 mismatch, item 2 mismatch'  => array(false, false, 'PHPUnit_Framework_AssertionFailedError'),
-            'item 1 mismatch, item 2 match'     => array(false, true, 'PHPUnit_Framework_AssertionFailedError'),
-            'item 1 match, item 2 mismatch'     => array(true, false, 'PHPUnit_Framework_AssertionFailedError'),
-            'item 1 match, item 2 match'        => array(true, true),
+            'containsMatching: 0 | 0 = 0'         => array('assertContainsMatching',        0, 0, $failure),
+            'containsMatching: 0 | 1 = 1'         => array('assertContainsMatching',        0, 1),
+            'containsMatching: 1 | 0 = 1'         => array('assertContainsMatching',        1, 0),
+            'containsMatching: 1 | 1 = 1'         => array('assertContainsMatching',        1, 1),
+            '!containsMatching: !(0 | 0) = 1'     => array('assertNotContainsMatching',     0, 0),
+            '!containsMatching: !(0 | 1) = 0'     => array('assertNotContainsMatching',     0, 1, $failure),
+            '!containsMatching: !(1 | 0) = 0'     => array('assertNotContainsMatching',     1, 0, $failure),
+            '!containsMatching: !(1 | 1) = 0'     => array('assertNotContainsMatching',     1, 1, $failure),
+            'containsOnlyMatching: 0 & 0 = 0'     => array('assertContainsOnlyMatching',    0, 0, $failure),
+            'containsOnlyMatching: 0 & 1 = 0'     => array('assertContainsOnlyMatching',    0, 1, $failure),
+            'containsOnlyMatching: 1 & 0 = 0'     => array('assertContainsOnlyMatching',    1, 0, $failure),
+            'containsOnlyMatching: 1 & 1 = 1'     => array('assertContainsOnlyMatching',    1, 1),
+            '!containsOnlyMatching: !(0 & 0) = 1' => array('assertNotContainsOnlyMatching', 0, 0),
+            '!containsOnlyMatching: !(0 & 1) = 1' => array('assertNotContainsOnlyMatching', 0, 1),
+            '!containsOnlyMatching: !(1 & 0) = 1' => array('assertNotContainsOnlyMatching', 1, 0),
+            '!containsOnlyMatching: !(1 & 1) = 0' => array('assertNotContainsOnlyMatching', 1, 1, $failure),
         );
     }
 

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -146,7 +146,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $book1 = new Book();
         $book2 = new Book();
 
-        $bookConstraint = $this->getMock('PHPUnit_Framework_Constraint', array(), array(), '', false);
+        $bookConstraint = $this->getMock('PHPUnit_Framework_Constraint');
         $bookConstraint
             ->expects($this->atLeastOnce())
             ->method('evaluate')
@@ -181,7 +181,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $book1 = new Book();
         $book2 = new Book();
 
-        $constraint = $this->getMock('PHPUnit_Framework_Constraint', array(), array(), '', false);
+        $constraint = $this->getMock('PHPUnit_Framework_Constraint');
         $constraint
             ->expects($this->atLeastOnce())
             ->method('evaluate')

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -138,6 +138,76 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::assertContainsMatching
+     * @dataProvider assertContainsMatchingProvider
+     */
+    public function testAssertContainsMatching($partialResult1, $partialResult2, $expectedException = null)
+    {
+        $book1 = new Book();
+        $book2 = new Book();
+
+        $bookConstraint = $this->getMock('PHPUnit_Framework_Constraint', array(), array(), '', false);
+        $bookConstraint
+            ->expects($this->atLeastOnce())
+            ->method('evaluate')
+            ->withConsecutive(
+                array($this->identicalTo($book1)),
+                array($this->identicalTo($book2))
+            )
+            ->will($this->onConsecutiveCalls($partialResult1, $partialResult2))
+        ;
+
+        $this->setExpectedException($expectedException);
+
+        $this->assertContainsMatching($bookConstraint, array($book1, $book2));
+    }
+    
+    public function assertContainsMatchingProvider()
+    {
+        return array(
+            'item 1 mismatch, item 2 mismatch'  => array(false, false, 'PHPUnit_Framework_AssertionFailedError'),
+            'item 1 mismatch, item 2 match'     => array(false, true),
+            'item 1 match, item 2 mismatch'     => array(true, false),
+            'item 1 match, item 2 match'        => array(true, true),
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertContainsOnlyMatching
+     * @dataProvider assertContainsOnlyMatchingProvider
+     */
+    public function testAssertContainsOnlyMatching($partialResult1, $partialResult2, $expectedException = null)
+    {
+        $book1 = new Book();
+        $book2 = new Book();
+
+        $constraint = $this->getMock('PHPUnit_Framework_Constraint', array(), array(), '', false);
+        $constraint
+            ->expects($this->atLeastOnce())
+            ->method('evaluate')
+            ->withConsecutive(
+                array($this->identicalTo($book1)),
+                array($this->identicalTo($book2))
+            )
+            ->will($this->onConsecutiveCalls($partialResult1, $partialResult2))
+        ;
+
+        $this->setExpectedException($expectedException);
+
+        $this->assertContainsOnlyMatching($constraint, array($book1, $book2));
+    }
+
+    public function assertContainsOnlyMatchingProvider()
+    {
+        return array(
+            'item 1 mismatch, item 2 mismatch'  => array(false, false, 'PHPUnit_Framework_AssertionFailedError'),
+            'item 1 mismatch, item 2 match'     => array(false, true, 'PHPUnit_Framework_AssertionFailedError'),
+            'item 1 match, item 2 mismatch'     => array(true, false, 'PHPUnit_Framework_AssertionFailedError'),
+            'item 1 match, item 2 match'        => array(true, true),
+        );
+    }
+
+    /**
      * @covers            PHPUnit_Framework_Assert::assertArrayHasKey
      * @expectedException PHPUnit_Framework_Exception
      */
@@ -2909,6 +2979,27 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     public function testAssertThatContainsOnlyInstancesOf()
     {
         $this->assertThat(array(new Book), $this->containsOnlyInstancesOf('Book'));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertThat
+     * @covers PHPUnit_Framework_Assert::containsMatching
+     */
+    public function testAssertThatContainsMatching()
+    {
+        $book1 = new Book();
+        $book2 = new Book();
+        $this->assertThat(array($book1, $book2), $this->containsMatching($this->identicalTo($book2)));
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertThat
+     * @covers PHPUnit_Framework_Assert::containsOnlyMatching
+     */
+    public function testAssertThatContainsOnlyMatching()
+    {
+        $book = new Book();
+        $this->assertThat(array($book, $book), $this->containsOnlyMatching($this->identicalTo($book)));
     }
 
     /**


### PR DESCRIPTION
## Introduction

This is an improvement to the support of traversables by PHPUnit. New assertions allow testing of array items against an arbitrary constraint, i.e. an instance of `PHPUnit_Framework_Constraint`. Any existing constraint can be used to assert not only array items, but optionally also array keys.

The problem and the solution have been originally described in the feature request #1637.
## Syntax
### Assertions

Assert that a haystack contains a needle matching a constraint:

``` php
assertContainsMatching (
    PHPUnit_Framework_Constraint $needleConstraint , string $haystack [, string $message ]
)
```

Assert that a haystack contains only needles matching a constraint:

``` php
assertContainsOnlyMatching (
    PHPUnit_Framework_Constraint $needleConstraint , string $haystack [, string $message ]
)
```

Negative assertions `assertNotContainsMatching` and `assertNotContainsOnlyMatching` are provided as well.
### Factory Methods

The following constraint factory methods/functions are available:

``` php
PHPUnit_Framework_Constraint_TraversableContainsMatching containsMatching (
    PHPUnit_Framework_Constraint $itemConstraint [, PHPUnit_Framework_Constraint $keyConstraint ]
)
```

``` php
PHPUnit_Framework_Constraint_TraversableContainsMatchingOnly containsOnlyMatching (
    PHPUnit_Framework_Constraint $itemConstraint [, PHPUnit_Framework_Constraint $keyConstraint ]
)
```

The factory methods support optional constraint for array keys in addition to array items. It is intentionally omitted from the assertion interface to keep the syntax concise for the primary use case, that is asserting array items. Please refer to [Asserting Array Keys](#assertingArrayKeys) for the usage guidelines.
## Usage

The examples below demonstrate usage of the array assertions for scenarios that are otherwise impossible to implement with PHPUnit.
### Asserting Inexact Match

Asserting array items by inexact match can be handy for testing HTTP headers, for example:

``` php
$actualHeaders = array(
    'Date: Sat, 21 Mar 2015 07:13:31 GMT',
    'Content-Type: text/html; charset=utf-8',
    'Content-Length: 42137',
    // ...
);
$this->assertContainsMatching(
    $this->stringStartsWith('Content-Type: text/html'),
    $actualHeaders,
    'HTML page is expected.'
);
```
### Asserting Files

Existing constraint `PHPUnit_Framework_Constraint_FileExists` can be particularly useful to test an array of filenames, for instance:

``` php
$actualFilenames = array(
    '/project/tests/_files/fixture/path/1.txt',
    '/project/tests/_files/fixture/path/2.txt',
    '/project/tests/_files/fixture/path/sub/dir/3.txt',
    // ...
);
$this->assertContainsOnlyMatching(
    $this->fileExists(),
    $actualFilenames,
    'Only existing files are expected.'
);
```
### Asserting Multi-Dimensional Arrays

The syntax comes with the flexibility of constraining array items on any nesting level, for example:

``` php
$actual = array(
    array('a11', 'a12', 'a13'),
    array('a21', 'a22', 'a23'),
    // ...
);
$this->assertContainsOnlyMatching(
    $this->containsOnlyMatching(
        $this->matchesRegularExpression('/^a\d+$/')
    ),
    $actual
);
```

Note that `containsMatching/containsOnlyMatching` can be recursively nested as much as needed to cover array of any depth.
### <a name="assertingArrayKeys"></a>Asserting Array Keys

The constraints implementing the array assertions go beyond validating array items. In particular, optional asserting of array keys is available. It can be used in the following way:

``` php
$actual = array(
    '/project/tests/_files/fixture/path/1.txt' => 'File contents 1',
    '/project/tests/_files/fixture/path/2.txt' => 'File contents 2',
    '/project/tests/_files/fixture/path/sub/dir/3.txt' => 'File contents 3',
    // ...
);
$this->assertThat(
    $actual,
    $this->containsOnlyMatching(
        $this->logicalNot($this->isEmpty()), // item constraint
        $this->stringEndsWith('.txt') // key constraint
    ),
    'Only non-empty text files are expected.'
);
```

Moreover, constraint of array items can be completely dismissed by using `$this->anything()` in place of the required argument. In such a way it is possible to assert solely array keys.
