### PR TITLE
add refuteX syntax to alias assertNotX

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -117,6 +117,19 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Refutes that an array has a specified key. Alias of self::assertArrayNotHasKey()
+     *
+     * @param mixed             $key
+     * @param array|ArrayAccess $array
+     * @param string            $message
+     * @since  Method available since Release 4.7.0
+     */
+    public static function refuteArrayHasKey($key, $array, $message = '')
+    {
+        return self::assertArrayNotHasKey($key, $array, $message);
+    }
+
+    /**
      * Asserts that a haystack contains a needle.
      *
      * @param mixed   $needle
@@ -213,6 +226,22 @@ abstract class PHPUnit_Framework_Assert
         }
 
         self::assertThat($haystack, $constraint, $message);
+    }
+
+    /**
+     * Refutes that a haystack contains a needle.
+     *
+     * @param mixed   $needle
+     * @param mixed   $haystack
+     * @param string  $message
+     * @param boolean $ignoreCase
+     * @param boolean $checkForObjectIdentity
+     * @param boolean $checkForNonObjectIdentity
+     * @since  Method available since Release 4.7.0
+     */
+    public static function refuteContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
+    {
+        return self::assertNotContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
     }
 
     /**

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1208,6 +1208,20 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Refutes that two variables have the same type and value.
+     * Used on objects, it refutes that two variables reference
+     * the same object. Alias for self::assertNotSame().
+     *
+     * @param mixed  $expected
+     * @param mixed  $actual
+     * @param string $message
+     */
+    public static function refuteSame($expected, $actual, $message = '')
+    {
+        return call_user_func_array('self::assertNotSame', func_get_args());
+    }
+
+    /**
      * Asserts that a variable and an attribute of an object do not have the
      * same type and value.
      *

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1218,7 +1218,7 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function refuteSame($expected, $actual, $message = '')
     {
-        return call_user_func_array('self::assertNotSame', func_get_args());
+        return self::assertNotSame($expected, $actual, $message);
     }
 
     /**

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1124,6 +1124,20 @@ function assertNotSame($expected, $actual, $message = '')
 }
 
 /**
+ * Refutes that two variables have the same type and value.
+ * Used on objects, it refutes that two variables reference
+ * the same object. assertNotSame().
+ *
+ * @param mixed  $expected
+ * @param mixed  $actual
+ * @param string $message
+ */
+function refuteSame($expected, $actual, $message = '')
+{
+    return call_user_func_array('assertNotSame', func_get_args());
+}
+
+/**
  * Assert that the size of two arrays (or `Countable` or `Traversable` objects)
  * is not the same.
  *

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1134,7 +1134,7 @@ function assertNotSame($expected, $actual, $message = '')
  */
 function refuteSame($expected, $actual, $message = '')
 {
-    return call_user_func_array('assertNotSame', func_get_args());
+    return assertNotSame($expected, $actual, $message);
 }
 
 /**

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -1077,6 +1077,30 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::refuteSame
+     * @dataProvider notSameProvider
+     */
+    public function testRefuteSameSucceeds($a, $b)
+    {
+        $this->refuteSame($a, $b);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteSame
+     * @dataProvider sameProvider
+     */
+    public function testRefuteSameFails($a, $b)
+    {
+        try {
+            $this->refuteSame($a, $b);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertXmlFileEqualsXmlFile
      */
     public function testAssertXmlFileEqualsXmlFile()

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -321,6 +321,40 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers            PHPUnit_Framework_Assert::refuteArrayHasKey
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testRefuteArrayHasKeyThrowsExceptionForInvalidFirstArgument()
+    {
+        $this->refuteArrayHasKey(null, array());
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::refuteArrayHasKey
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testRefuteArrayHasKeyThrowsExceptionForInvalidSecondArgument()
+    {
+        $this->refuteArrayHasKey(0, null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteArrayHasKey
+     */
+    public function testRefuteArrayHasIntegerKey()
+    {
+        $this->refuteArrayHasKey(1, array('foo'));
+
+        try {
+            $this->refuteArrayHasKey(0, array('foo'));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertArrayHasKey
      */
     public function testAssertArrayHasStringKey()
@@ -345,6 +379,22 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertArrayNotHasKey('foo', array('foo' => 'bar'));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteArrayHasKey
+     */
+    public function testRefuteArrayHasStringKey()
+    {
+        $this->refuteArrayHasKey('bar', array('foo' => 'bar'));
+
+        try {
+            $this->refuteArrayHasKey('foo', array('foo' => 'bar'));
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             return;
         }
@@ -408,11 +458,32 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
      * @covers PHPUnit_Framework_Assert::assertArrayNotHasKey
      * @expectedException PHPUnit_Framework_AssertionFailedError
      */
-    public function testAssertArrayNotHasKeyPropertlyFailsWithArrayAccessValue()
+    public function testAssertArrayNotHasKeyPropertyFailsWithArrayAccessValue()
     {
         $array = new ArrayObject();
         $array['bar'] = 'bar';
         $this->assertArrayNotHasKey('bar', $array);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteArrayHasKey
+     */
+    public function testRefuteArrayHaskeyAcceptsArrayAccessValue()
+    {
+        $array = new ArrayObject();
+        $array['foo'] = 'bar';
+        $this->refuteArrayHasKey('bar', $array);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteArrayHasKey
+     * @expectedException PHPUnit_Framework_AssertionFailedError
+     */
+    public function testRefuteArrayHaskeyProperlyFailsWithArrayAccessValue()
+    {
+        $array = new ArrayObject();
+        $array['bar'] = 'bar';
+        $this->refuteArrayHasKey('bar', $array);
     }
 
     /**
@@ -484,6 +555,15 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers            PHPUnit_Framework_Assert::refuteContains
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testRefuteContainsContainsThrowsException()
+    {
+        $this->refuteContains(null, null);
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertNotContains
      */
     public function testAssertSplObjectStorageNotContainsObject()
@@ -497,6 +577,27 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertNotContains($a, $c);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteContains
+     */
+    public function testRefuteSplObjectStorageContainsObject()
+    {
+        $a = new stdClass;
+        $b = new stdClass;
+        $c = new SplObjectStorage;
+        $c->attach($a);
+
+        $this->refuteContains($b, $c);
+
+        try {
+            $this->refuteContains($a, $c);
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             return;
         }
@@ -524,6 +625,25 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::refuteContains
+     */
+    public function testRefuteArrayContainsObject()
+    {
+        $a = new stdClass;
+        $b = new stdClass;
+
+        $this->refuteContains($a, array($b));
+
+        try {
+            $this->refuteContains($a, array($a));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertNotContains
      */
     public function testAssertArrayNotContainsString()
@@ -532,6 +652,22 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertNotContains('foo', array('foo'));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteContains
+     */
+    public function testRefuteArrayContainsString()
+    {
+        $this->refuteContains('foo', array('bar'));
+
+        try {
+            $this->refuteContains('foo', array('foo'));
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             return;
         }
@@ -556,6 +692,22 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::refuteArrayContains
+     */
+    public function testRefuteArrayContainsNonObject()
+    {
+        $this->refuteContains('foo', array(true), '', false, true, true);
+
+        try {
+            $this->refuteContains('foo', array(true));
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertNotContains
      */
     public function testAssertStringNotContainsString()
@@ -564,6 +716,22 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertNotContains('foo', 'foo');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::refuteContains
+     */
+    public function testRefuteContainsString()
+    {
+        $this->refuteContains('foo', 'bar');
+
+        try {
+            $this->refuteContains('foo', 'foo');
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             return;
         }


### PR DESCRIPTION
@sebastianbergmann this is per our brief twitter exchange.

This is just code to add an alias for one method: assertNotSame(). Before I went through and did all of the inverse assertions, I wanted to make sure you were OK with this approach or if you wanted me to modify how I'm doing it.

If this looks good, I'll go through and add the refuteX methods for all of the inversions.