### PR TITLE
Update Prophecy dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/php-code-coverage": "~2.0,>=2.0.11",
         "phpunit/php-timer": "~1.0",
         "phpunit/phpunit-mock-objects": "~2.3",
-        "phpspec/prophecy": "~1.3.1",
+        "phpspec/prophecy": "~1.3,>=1.3.1",
         "symfony/yaml": "~2.1|~3.0",
         "sebastian/comparator": "~1.1",
         "sebastian/diff": "~1.2",


### PR DESCRIPTION
Prophecy has tagged `1.4.0` which is currently not installable.

As Prophecy is a SemVer project there is no reason to constrain the dependency to `1.3.x`.
