### PR TITLE
report PHP version used for test

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -249,6 +249,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
             self::$versionStringPrinted = true;
 
+            $this->printer->write(
+                sprintf("Using PHP version %s\n", PHP_VERSION)
+            );
+
             if (isset($arguments['configuration'])) {
                 $this->printer->write(
                     sprintf(


### PR DESCRIPTION
I think this can be useful
- For user of multiple PHP versions on the same computer (especially when environment module are used to switch)
- For bug report, when the reporter copy/paste the output of phpunit command.
