### PR TITLE
Fixed malformed doc comment descriptions

### DIFF
--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -9,8 +9,7 @@
  */
 
 /**
- * Returns a matcher that matches when the method it is evaluated for
- * is executed zero or more times.
+ * Returns a matcher that matches when the method is executed zero or more times.
  *
  * @return PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount
  * @since  Method available since Release 3.0.0
@@ -1770,8 +1769,7 @@ function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = 
 }
 
 /**
- * Returns a matcher that matches when the method it is evaluated for
- * is invoked at the given $index.
+ * Returns a matcher that matches when the method is executed at the given $index.
  *
  * @param  integer $index
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex
@@ -1786,8 +1784,7 @@ function at($index)
 }
 
 /**
- * Returns a matcher that matches when the method it is evaluated for
- * is executed at least once.
+ * Returns a matcher that matches when the method is executed at least once.
  *
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce
  * @since  Method available since Release 3.0.0
@@ -1952,8 +1949,7 @@ function equalTo($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $i
 }
 
 /**
- * Returns a matcher that matches when the method it is evaluated for
- * is executed exactly $count times.
+ * Returns a matcher that matches when the method is executed exactly $count times.
  *
  * @param  integer $count
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
@@ -2248,8 +2244,7 @@ function matchesRegularExpression($pattern)
 }
 
 /**
- * Returns a matcher that matches when the method it is evaluated for
- * is never executed.
+ * Returns a matcher that matches when the method is never executed.
  *
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
  * @since  Method available since Release 3.0.0
@@ -2291,8 +2286,7 @@ function onConsecutiveCalls()
 }
 
 /**
- * Returns a matcher that matches when the method it is evaluated for
- * is executed exactly once.
+ * Returns a matcher that matches when the method is executed exactly once.
  *
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
  * @since  Method available since Release 3.0.0

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -9,7 +9,8 @@
  */
 
 /**
- * Returns a matcher that matches when the method is executed zero or more times.
+ * Returns a matcher that matches when the method is executed
+ * zero or more times.
  *
  * @return PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount
  * @since  Method available since Release 3.0.0
@@ -1769,7 +1770,8 @@ function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = 
 }
 
 /**
- * Returns a matcher that matches when the method is executed at the given $index.
+ * Returns a matcher that matches when the method is executed
+ * at the given $index.
  *
  * @param  integer $index
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex
@@ -1949,7 +1951,8 @@ function equalTo($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $i
 }
 
 /**
- * Returns a matcher that matches when the method is executed exactly $count times.
+ * Returns a matcher that matches when the method is executed
+ * exactly $count times.
  *
  * @param  integer $count
  * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1487,8 +1487,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is executed zero or more times.
+     * Returns a matcher that matches when the method is executed zero or more times.
      *
      * @return PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount
      * @since  Method available since Release 3.0.0
@@ -1499,8 +1498,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is never executed.
+     * Returns a matcher that matches when the method is never executed.
      *
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
      * @since  Method available since Release 3.0.0
@@ -1511,8 +1509,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is executed at least N times.
+     * Returns a matcher that matches when the method is executed at least N times.
      *
      * @param  integer $requiredInvocations
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount
@@ -1526,8 +1523,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is executed at least once.
+     * Returns a matcher that matches when the method is executed at least once.
      *
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastOnce
      * @since  Method available since Release 3.0.0
@@ -1538,8 +1534,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is executed exactly once.
+     * Returns a matcher that matches when the method is executed exactly once.
      *
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
      * @since  Method available since Release 3.0.0
@@ -1550,8 +1545,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is executed exactly $count times.
+     * Returns a matcher that matches when the method is executed exactly $count times.
      *
      * @param  integer                                           $count
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
@@ -1563,8 +1557,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is executed at most N times.
+     * Returns a matcher that matches when the method is executed at most N times.
      *
      * @param  integer $allowedInvocations
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount
@@ -1578,8 +1571,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method it is evaluated for
-     * is invoked at the given $index.
+     * Returns a matcher that matches when the method is executed at the given index.
      *
      * @param  integer                                             $index
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1487,7 +1487,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method is executed zero or more times.
+     * Returns a matcher that matches when the method is executed
+     * zero or more times.
      *
      * @return PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount
      * @since  Method available since Release 3.0.0
@@ -1509,7 +1510,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method is executed at least N times.
+     * Returns a matcher that matches when the method is executed
+     * at least N times.
      *
      * @param  integer $requiredInvocations
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtLeastCount
@@ -1545,7 +1547,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method is executed exactly $count times.
+     * Returns a matcher that matches when the method is executed
+     * exactly $count times.
      *
      * @param  integer                                           $count
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedCount
@@ -1557,7 +1560,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method is executed at most N times.
+     * Returns a matcher that matches when the method is executed
+     * at most N times.
      *
      * @param  integer $allowedInvocations
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtMostCount
@@ -1571,7 +1575,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Returns a matcher that matches when the method is executed at the given index.
+     * Returns a matcher that matches when the method is executed
+     * at the given index.
      *
      * @param  integer                                             $index
      * @return PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex


### PR DESCRIPTION
Found when browsing phpunit's code for something.

(Probably a result of some unchecked search and replace).

![image](https://cloud.githubusercontent.com/assets/1024071/7306466/b092a1ae-ea05-11e4-9339-4da6ef69fc65.png)
