### PR TITLE
Added formatMessage($message)

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2213,7 +2213,19 @@ abstract class PHPUnit_Framework_Assert
     {
         self::$count += count($constraint);
 
-        $constraint->evaluate($value, $message);
+        $constraint->evaluate($value, static::formatMessage($message));
+    }
+
+    /**
+     * Formats messages prior to output.
+     *
+     * Can be overridden to alter the format of all messages that are output.
+     * @param string The message string.
+     * @return string A formatted version of the message string.
+     */
+    protected static function formatMessage($message)
+    {
+        return $message;
     }
 
     /**


### PR DESCRIPTION
Enables users to format the output of messages from assertions by overriding the formatMessages method. The formatMessages method is called by assertThat() before passing the result on to the constraint.

For example, I find it quite useful to apply bash charcater strings to the beginning and end of these messages so that they stand out from the rest of the output. Admittedly not an essential feature or one that adds vast benefit but none the less a nice addition that allows individual customisation according to circumstance and preference.