### PR TITLE
Use the realpath to require the error files as HHVM does not resolve them in phars

### DIFF
--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -10,10 +10,11 @@
 
 // Workaround for http://bugs.php.net/bug.php?id=47987,
 // see https://github.com/sebastianbergmann/phpunit/issues#issue/125 for details
-require_once __DIR__ . '/../Framework/Error.php';
-require_once __DIR__ . '/../Framework/Error/Notice.php';
-require_once __DIR__ . '/../Framework/Error/Warning.php';
-require_once __DIR__ . '/../Framework/Error/Deprecated.php';
+// Use dirname(__DIR__) instead of using /../ because of https://github.com/facebook/hhvm/issues/5215
+require_once dirname(__DIR__) . '/Framework/Error.php';
+require_once dirname(__DIR__) . '/Framework/Error/Notice.php';
+require_once dirname(__DIR__) . '/Framework/Error/Warning.php';
+require_once dirname(__DIR__) . '/Framework/Error/Deprecated.php';
 
 /**
  * Error handler that converts PHP errors and warnings to exceptions.


### PR DESCRIPTION
This avoids loading the file twice on HHVM because it considers the 2 paths to be different even though they reference the same file when normalized.
Refs #1684
