### PR TITLE
A --only-repeat-failed PHPUnit argument

### DIFF
--- a/src/Extensions/RepeatedTest.php
+++ b/src/Extensions/RepeatedTest.php
@@ -127,7 +127,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
                         }
                         $testsToRepeat = array_merge(
                             $testsToRepeat,
-                            $this->getkWhichTestsToRepeat($tests, $result, $i)
+                            $this->getWhichTestsToRepeat($tests, $result, $i)
                         );
                     }
                     $this->test->setTests($testsToRepeat);

--- a/src/Extensions/RepeatedTest.php
+++ b/src/Extensions/RepeatedTest.php
@@ -41,6 +41,11 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
     protected $processIsolation = false;
 
     /**
+     * @var boolean
+     */
+    protected $onlyRepeatFailed = false;
+
+    /**
      * @var integer
      */
     protected $timesRepeat = 1;
@@ -49,9 +54,10 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
      * @param  PHPUnit_Framework_Test      $test
      * @param  integer                     $timesRepeat
      * @param  boolean                     $processIsolation
+     * @param  boolean                     $onlyRepeatFailed
      * @throws PHPUnit_Framework_Exception
      */
-    public function __construct(PHPUnit_Framework_Test $test, $timesRepeat = 1, $processIsolation = false)
+    public function __construct(PHPUnit_Framework_Test $test, $timesRepeat = 1, $processIsolation = false, $onlyRepeatFailed = false)
     {
         parent::__construct($test);
 
@@ -66,6 +72,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
         }
 
         $this->processIsolation = $processIsolation;
+        $this->onlyRepeatFailed = $onlyRepeatFailed;
     }
 
     /**
@@ -95,13 +102,89 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
 
         //@codingStandardsIgnoreStart
         for ($i = 0; $i < $this->timesRepeat && !$result->shouldStop(); $i++) {
+            if ($this->onlyRepeatFailed &&
+                $i > 0 &&
+                $this->test instanceof PHPUnit_Framework_TestCase &&
+                !$result->failureCount()) {
+                // The previous test case run succeeded.
+                $this->markNextRepeatedTestsAsSkipped($i, $result, $this->test);
+                // Don't repeat it any more.
+                break;
+            }
             //@codingStandardsIgnoreEnd
             if ($this->test instanceof PHPUnit_Framework_TestSuite) {
                 $this->test->setRunTestInSeparateProcess($this->processIsolation);
+
+                if ($this->onlyRepeatFailed && $i > 0) {
+                    $testsToRepeat = array();
+                    foreach ($this->test->tests() as $test) {
+                        if ($test instanceof PHPUnit_Framework_TestSuite) {
+                            // If the test itself is another test suite, then
+                            // get its tests to check.
+                            $tests = $test->tests();
+                        } else {
+                            $tests = array($test);
+                        }
+                        $testsToRepeat = array_merge(
+                            $testsToRepeat,
+                            $this->getkWhichTestsToRepeat($tests, $result, $i)
+                        );
+                    }
+                    $this->test->setTests($testsToRepeat);
+                }
             }
             $this->test->run($result);
         }
 
         return $result;
+    }
+
+    /**
+     * Get which tests failed, and thus should be repeated.
+     *
+     * @param PHPUnit_Framework_Test[] $tests
+     * @param PHPUnit_Framework_TestResult $result
+     * @param int $ranCount
+     *   How many times did the tests already run?
+     * @return PHPUnit_Framework_Test[]
+     */
+    protected function getWhichTestsToRepeat($tests, $result, $ranCount)
+    {
+        $testsToRepeat = array();
+
+        foreach ($tests as $test) {
+            $failed = false;
+
+            foreach ($result->failures() as $failure) {
+                /** @var $failure PHPUnit_Framework_TestFailure */
+                if ($test === $failure->failedTest()) {
+                    $failed = true;
+                }
+            }
+            if ($failed) {
+                $testsToRepeat[] = $test;
+            } else {
+                // The previous test case run succeeded.
+                $this->markNextRepeatedTestsAsSkipped($ranCount, $result, $test);
+            }
+        }
+
+        return $testsToRepeat;
+    }
+
+    /**
+     * Mark the remaining repeated tests as skipped.
+     *
+     * @param int $ranCount
+     *   How many times did the test already run?
+     * @param PHPUnit_Framework_TestResult $result
+     * @param PHPUnit_Framework_Test $test
+     */
+    protected function markNextRepeatedTestsAsSkipped($ranCount, $result, $test)
+    {
+        $skipped = new PHPUnit_Framework_SkippedTestError('Test already succeeded during previous run.');
+        for ($j = 0; $j < $this->timesRepeat - $ranCount; $j++) {
+            $result->addFailure($test, $skipped, 0);
+        }
     }
 }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -64,6 +64,7 @@ class PHPUnit_TextUI_Command
       'log-tap=' => null,
       'process-isolation' => null,
       'repeat=' => null,
+      'only-repeat-failed' => null,
       'stderr' => null,
       'stop-on-error' => null,
       'stop-on-failure' => null,
@@ -378,6 +379,10 @@ class PHPUnit_TextUI_Command
 
                 case '--repeat':
                     $this->arguments['repeat'] = (int) $option[1];
+                    break;
+
+                case '--only-repeat-failed':
+                    $this->arguments['onlyRepeatFailed'] = true;
                     break;
 
                 case '--stderr':
@@ -886,6 +891,7 @@ Test Execution Options:
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --repeat <times>          Runs the test(s) repeatedly.
+  --only-repeat-failed      Only repeats tests that failed in the previous run.
   --tap                     Report test execution progress in TAP format.
   --testdox                 Report test execution progress in TestDox format.
   --printer <printer>       TestListener implementation to use.

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -172,7 +172,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $test = new PHPUnit_Extensions_RepeatedTest(
                 $suite,
                 $arguments['repeat'],
-                $arguments['processIsolation']
+                $arguments['processIsolation'],
+                $arguments['onlyRepeatFailed']
             );
 
             $suite = new PHPUnit_Framework_TestSuite();
@@ -924,6 +925,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['logIncompleteSkipped']               = isset($arguments['logIncompleteSkipped'])               ? $arguments['logIncompleteSkipped']               : false;
         $arguments['processIsolation']                   = isset($arguments['processIsolation'])                   ? $arguments['processIsolation']                   : false;
         $arguments['repeat']                             = isset($arguments['repeat'])                             ? $arguments['repeat']                             : false;
+        $arguments['onlyRepeatFailed']                   = isset($arguments['onlyRepeatFailed'])                   ? $arguments['onlyRepeatFailed']                   : false;
         $arguments['reportHighLowerBound']               = isset($arguments['reportHighLowerBound'])               ? $arguments['reportHighLowerBound']               : 90;
         $arguments['reportLowUpperBound']                = isset($arguments['reportLowUpperBound'])                ? $arguments['reportLowUpperBound']                : 50;
         $arguments['stopOnError']                        = isset($arguments['stopOnError'])                        ? $arguments['stopOnError']                        : false;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -782,6 +782,13 @@ class PHPUnit_Util_Configuration
             );
         }
 
+        if ($root->hasAttribute('onlyRepeatFailed')) {
+            $result['onlyRepeatFailed'] = $this->getBoolean(
+                (string) $root->getAttribute('onlyRepeatFailed'),
+                false
+            );
+        }
+
         return $result;
     }
 

--- a/tests/Extensions/RepeatedTestTest.php
+++ b/tests/Extensions/RepeatedTestTest.php
@@ -29,24 +29,56 @@ class Extensions_RepeatedTestTest extends PHPUnit_Framework_TestCase
 
         $this->suite->addTest(new Success);
         $this->suite->addTest(new Success);
+        $this->suite->addTest(new Failure);
     }
 
     public function testRepeatedOnce()
     {
         $test = new PHPUnit_Extensions_RepeatedTest($this->suite, 1);
-        $this->assertEquals(2, count($test));
+        $this->assertEquals(3, count($test));
 
         $result = $test->run();
-        $this->assertEquals(2, count($result));
+        $this->assertEquals(3, count($result));
     }
 
     public function testRepeatedMoreThanOnce()
     {
         $test = new PHPUnit_Extensions_RepeatedTest($this->suite, 3);
-        $this->assertEquals(6, count($test));
+        $this->assertEquals(9, count($test));
 
         $result = $test->run();
-        $this->assertEquals(6, count($result));
+        $this->assertEquals(9, count($result));
+    }
+
+    public function testRepeatedMoreThanOnceOnlyFailed()
+    {
+        $test = new PHPUnit_Extensions_RepeatedTest($this->suite, 3, false, true);
+        // Intends to run 9 tests.
+        $this->assertEquals(9, count($test));
+
+        $result = $test->run();
+        // But eventually skips 4 because the Success test already succeeded
+        // the first time it ran, and we chose to only repeat the failed tests.
+        $this->assertEquals(4, $result->skippedCount());
+    }
+
+    public function testRepeatedTestCaseSuccessMoreThanOnceOnlyFailed()
+    {
+        $test = new PHPUnit_Extensions_RepeatedTest(new Success, 3, false, true);
+        $this->assertEquals(3, count($test));
+
+        $result = $test->run();
+        $this->assertEquals(2, $result->skippedCount());
+    }
+
+    public function testRepeatedTestCaseFailureMoreThanOnceOnlyFailed()
+    {
+        $test = new PHPUnit_Extensions_RepeatedTest(new Failure, 3, false, true);
+        $this->assertEquals(3, count($test));
+
+        $result = $test->run();
+        // Test case didn't get skipped because it kept failing.
+        $this->assertEquals(0, $result->skippedCount());
     }
 
     public function testRepeatedZero()

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -68,6 +68,7 @@ Test Execution Options:
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --repeat <times>          Runs the test(s) repeatedly.
+  --only-repeat-failed      Only repeats tests that failed in the previous run.
   --tap                     Report test execution progress in TAP format.
   --testdox                 Report test execution progress in TestDox format.
   --printer <printer>       TestListener implementation to use.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -69,6 +69,7 @@ Test Execution Options:
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --repeat <times>          Runs the test(s) repeatedly.
+  --only-repeat-failed      Only repeats tests that failed in the previous run.
   --tap                     Report test execution progress in TAP format.
   --testdox                 Report test execution progress in TestDox format.
   --printer <printer>       TestListener implementation to use.


### PR DESCRIPTION
Inspired by https://github.com/sebastianbergmann/phpunit/issues/1022 'Automatically rerun failed tests to test for "flaky" tests' I wrote code that builds upon the already existing '--repeat' argument and allows you to run a test like:

```
phpunit --repeat 2 --only-repeat-failed tests/Kanooh/Paddle/Core/
````

This will cause all tests in 'tests/Kanooh/Paddle/Core/' to run 2 times, except for the tests that succeeded in the first run already. The remaining runs will be marked as skipped.

The initial code includes test coverage.