### PR TITLE
Add support for --INI-- section in PhptTestCase

### DIFF
--- a/tests/Extensions/PhptTestCaseTest.php
+++ b/tests/Extensions/PhptTestCaseTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Extensions_PhptTestCaseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testParseIniSection()
+    {
+        $phptTestCase = new PhpTestCaseProxy(__FILE__);
+        $settings = $phptTestCase->parseIniSection("foo=1\nbar = 2\rbaz = 3\r\nempty=\nignore");
+
+        $expected = array(
+            'foo' => '1',
+            'bar' => '2',
+            'baz' => '3',
+            'empty' => '',
+        );
+
+        $this->assertEquals($expected, $settings);
+
+    }
+}
+
+class PhpTestCaseProxy extends PHPUnit_Extensions_PhptTestCase
+{
+    public function parseIniSection($content)
+    {
+        return parent::parseIniSection($content);
+    }
+}


### PR DESCRIPTION
PHPT Tests support a `--INI--` section to prepare both SKIPIF and FILE sections with dedicated INI settings. This Pull Request adds `--INI--` section support for PHPUnits implementation of PHPT.
