### PR TITLE
INI Section Parser Fix

### DIFF
--- a/src/Extensions/PhptTestCase.php
+++ b/src/Extensions/PhptTestCase.php
@@ -235,18 +235,6 @@ class PHPUnit_Extensions_PhptTestCase implements PHPUnit_Framework_Test, PHPUnit
      */
     protected function parseIniSection($content)
     {
-        $lines = preg_split('/\n|\r/', $content, -1, PREG_SPLIT_NO_EMPTY);
-        $settings = array();
-
-        foreach ($lines as $line) {
-            if (strpos($line, '=') === false) {
-                continue;
-            }
-
-            list ($name, $value) = explode('=', $line);
-            $settings[trim($name)] = trim($value);
-        }
-
-        return $settings;
+        return preg_split('/\n|\r/', $content, -1, PREG_SPLIT_NO_EMPTY);
     }
 }

--- a/tests/Extensions/PhptTestCaseTest.php
+++ b/tests/Extensions/PhptTestCaseTest.php
@@ -16,10 +16,11 @@ class Extensions_PhptTestCaseTest extends \PHPUnit_Framework_TestCase
         $settings = $phptTestCase->parseIniSection("foo=1\nbar = 2\rbaz = 3\r\nempty=\nignore");
 
         $expected = array(
-            'foo' => '1',
-            'bar' => '2',
-            'baz' => '3',
-            'empty' => '',
+            'foo=1',
+            'bar = 2',
+            'baz = 3',
+            'empty=',
+            'ignore',
         );
 
         $this->assertEquals($expected, $settings);


### PR DESCRIPTION
Fix PHPT INI Section Parser to produce a list of directives, not key => value pairs. Append to default list.
