### PR TITLE
Fix autoload finder

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -13,7 +13,7 @@ if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');
 }
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
Being in this folder:

```
antoniocarlos@titanis 2015-03-26 19:26 /var/www/churchapi
 $ l
total 205
drwxrwxr-x 2 antoniocarlos www-data   4096 May 22 16:57 ./
drwxrwxr-x 2 antoniocarlos www-data  40960 May 22 15:04 ../
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 app/
-rwxrwxr-x 1 antoniocarlos www-data   1094 May 22 15:04 artisan*
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 bootstrap/
-rwxrwxr-x 1 antoniocarlos www-data    667 May 22 21:01 composer.json*
-rwxrwxr-x 1 antoniocarlos www-data 137036 May 22 21:02 composer.lock*
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 database/
-rwxrwxr-x 1 antoniocarlos www-data    642 May 22 15:04 .env*
-rwxrwxr-x 1 antoniocarlos www-data    642 May 22 15:04 .env.example*
-rwxrwxr-x 1 antoniocarlos www-data     13 May 22 15:04 .gitignore*
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:07 .idea/
-rwxrwxr-x 1 antoniocarlos www-data    772 May 22 15:04 phpunit.xml*
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 public/
-rwxrwxr-x 1 antoniocarlos www-data   1542 May 22 15:04 readme.md*
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 resources/
-rwxrwxr-x 1 antoniocarlos www-data    424 May 22 15:04 server.php*
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 storage/
drwxrwxr-x 2 antoniocarlos www-data      0 May 22 15:04 tests/
drwxrwxr-x 2 antoniocarlos www-data      0 May 23 00:07 vendor/
```

In order to run running

```
antoniocarlos@titanis 2015-03-26 19:26 /var/www/churchapi
 $ vendor/bin/phpunit
```

I had to add 

```
__DIR__ . '/../autoload.php'
```

To the array.

Otherwise it would not find the autoloader.
