### PR TITLE
Support to pass expected exception to a callback

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -442,18 +442,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
     {
         $this->expectedException = $exceptionName;
-        $this->expectedExceptionCallback = function ($e) use ($exceptionMessage, $exceptionCode) {
+        $self = $this; // workaround for PHP < 5.4 which doesn't bind $this to closures automatically
+        $this->expectedExceptionCallback = function ($e) use ($self, $exceptionMessage, $exceptionCode) {
             // validate exception itself
-            $this->assertThat(
+            $self->assertThat(
                 $e,
                 new PHPUnit_Framework_Constraint_Exception(
-                    $this->expectedException
+                    $self->expectedException
                 )
             );
 
             // validate exception message
             if (!empty($exceptionMessage)) {
-                $this->assertThat(
+                $self->assertThat(
                     $e,
                     new PHPUnit_Framework_Constraint_ExceptionMessage(
                         $exceptionMessage
@@ -463,7 +464,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
             // validate exception code
             if ($exceptionCode !== null) {
-                $this->assertThat(
+                $self->assertThat(
                     $e,
                     new PHPUnit_Framework_Constraint_ExceptionCode(
                         $exceptionCode
@@ -482,18 +483,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     public function setExpectedExceptionRegExp($exceptionName, $exceptionMessageRegExp = '', $exceptionCode = null)
     {
         $this->expectedException = $exceptionName;
-        $this->expectedExceptionCallback = function ($e) use ($exceptionMessageRegExp, $exceptionCode) {
+        $self = $this; // workaround for PHP < 5.4 which doesn't bind $this to closures automatically
+        $this->expectedExceptionCallback = function ($e) use ($self, $exceptionMessageRegExp, $exceptionCode) {
             // validate exception itself
-            $this->assertThat(
+            $self->assertThat(
                 $e,
                 new PHPUnit_Framework_Constraint_Exception(
-                    $this->expectedException
+                    $self->expectedException
                 )
             );
 
             // match with regular expression
             if (!empty($exceptionMessageRegExp)) {
-                $this->assertThat(
+                $self->assertThat(
                     $e,
                     new PHPUnit_Framework_Constraint_ExceptionMessageRegExp(
                         $exceptionMessageRegExp
@@ -503,7 +505,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
             // validate exception code
             if ($exceptionCode !== null) {
-                $this->assertThat(
+                $self->assertThat(
                     $e,
                     new PHPUnit_Framework_Constraint_ExceptionCode(
                         $exceptionCode

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -260,6 +260,33 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($result));
     }
 
+    public function testExceptionCallback()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedExceptionCallback('RuntimeException', function ($e) {
+            $this->assertInstanceof('RuntimeException', $e);
+        });
+
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testExceptionCallbackFailure()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedExceptionCallback('RuntimeException', function ($e) {
+            $this->fail("test failure");
+        });
+
+        $result = $test->run();
+
+        $this->assertEquals(1, $result->failureCount());
+        $this->assertEquals(1, count($result));
+        $this->assertFalse($result->wasSuccessful());
+    }
+
     /**
      * @backupGlobals enabled
      */


### PR DESCRIPTION
In some cases I want to inspect more of the thrown exceptions than just the type, message and errorcode. Up to now, I have to do it manually:

```
try {
    $testee->run();
    $this->fail("expected exception not raised");
} catch (\MyException $e) {
    $this->assertEquals(MyException::CATEGORY_FATAL, $e->category());
}
```
This is both error-prone and ugly. The pull request here adds another function to register expected exceptions to complement the existing two. It allows this kind of test instead:
```
$this->setExpectedExceptionCallback(
    'MyException',
    function ($e) {
        $this->assertEquals(MyException::CATEGORY_FATAL, $e->category());
    }
);
$testee->run();
```
An additional advantage is that the wrong thrown exception is handled as usual, giving test failures instead of errors on failure.
