### PR TITLE
Disable code coverage from the command line

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -845,7 +845,8 @@ Code Coverage Options:
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
-  --disable-coverage        Disable code coverage report (overrides configuration XML file)
+  --disable-coverage        Disable code coverage report (overrides
+                            configuration XML file)
 
 Logging Options:
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -50,6 +50,7 @@ class PHPUnit_TextUI_Command
       'coverage-php=' => null,
       'coverage-text==' => null,
       'coverage-xml=' => null,
+      'disable-coverage=' => null,
       'debug' => null,
       'exclude-group=' => null,
       'filter=' => null,
@@ -294,6 +295,10 @@ class PHPUnit_TextUI_Command
 
                 case '--coverage-xml':
                     $this->arguments['coverageXml'] = $option[1];
+                    break;
+
+                case '--disable-coverage':
+                    $this->arguments['coverageDisable'] = true;
                     break;
 
                 case 'd':
@@ -840,6 +845,7 @@ Code Coverage Options:
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
+  --disable-coverage        Disable code coverage report (overrides configuration XML file)
 
 Logging Options:
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -331,6 +331,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $codeCoverageReports++;
         }
 
+        if (isset($arguments['coverageDisable'])) {
+            $codeCoverageReports = 0;
+        }
+
         if (!$this->printer instanceof PHPUnit_Util_Log_TAP) {
             if ($codeCoverageReports > 0 && !$this->codeCoverageFilter->hasWhitelist()) {
                 $this->printer->write("Warning:\tNo whitelist configured for code coverage\n");

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -22,6 +22,8 @@ Code Coverage Options:
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
+  --disable-coverage        Disable code coverage report (overrides
+                            configuration XML file)
 
 Logging Options:
 

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -23,6 +23,8 @@ Code Coverage Options:
   --coverage-text=<file>    Generate code coverage report in text format.
                             Default: Standard output.
   --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
+  --disable-coverage        Disable code coverage report (overrides
+                            configuration XML file)
 
 Logging Options:
 


### PR DESCRIPTION
This PR allows to disable code coverage from the command line, to override a setting defined in the XML config file.
Usage: `phpunit --disable-coverage` or `phpunit --disable-coverage -- tests/some/tests`

I know this was [not on the agenda more than a year ago](https://github.com/sebastianbergmann/phpunit/issues/920) but I feel this would be a valuable addition when you want to quickly run one particular test or test suite and don't want to wait for the coverage generation

Thanks for your consideration (and thanks in any case for this most excellent tool)
