### PR TITLE
@testWith annotation

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -358,6 +358,36 @@ class PHPUnit_Util_Test
         $docComment = $reflector->getDocComment();
         $data       = null;
 
+        if ($dataProviderData = self::getDataFromDataProviderAnnotation($docComment, $className, $methodName)) {
+            $data = $dataProviderData;
+        }
+
+        if ($testWithData = self::getDataFromTestWithAnnotation($docComment)) {
+            $data = $testWithData;
+        }
+
+        if ($data !== null) {
+            if (is_object($data)) {
+                $data = iterator_to_array($data);
+            }
+
+            foreach ($data as $key => $value) {
+                if (!is_array($value)) {
+                    throw new PHPUnit_Framework_Exception(
+                        sprintf(
+                            'Data set %s is invalid.',
+                            is_int($key) ? '#' . $key : '"' . $key . '"'
+                        )
+                    );
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    private static function getDataFromDataProviderAnnotation($docComment, $className, $methodName)
+    {
         if (preg_match(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
             $dataProviderMethodNameNamespace = explode('\\', $matches[1]);
             $leaf                            = explode('::', array_pop($dataProviderMethodNameNamespace));
@@ -391,30 +421,9 @@ class PHPUnit_Util_Test
             } else {
                 $data = $dataProviderMethod->invoke($object, $methodName);
             }
+
+            return $data;
         }
-
-        if ($testWithData = self::getDataFromTestWithAnnotation($docComment)) {
-            $data = $testWithData;
-        }
-
-        if ($data !== null) {
-            if (is_object($data)) {
-                $data = iterator_to_array($data);
-            }
-
-            foreach ($data as $key => $value) {
-                if (!is_array($value)) {
-                    throw new PHPUnit_Framework_Exception(
-                        sprintf(
-                            'Data set %s is invalid.',
-                            is_int($key) ? '#' . $key : '"' . $key . '"'
-                        )
-                    );
-                }
-            }
-        }
-
-        return $data;
     }
 
     /**

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -347,7 +347,6 @@ class PHPUnit_Util_Test
      * @param  string           $className
      * @param  string           $methodName
      * @return array|Iterator when a data provider is specified and exists
-     *         false          when a data provider is specified but does not exist
      *         null           when no data provider is specified
      * @throws PHPUnit_Framework_Exception
      * @since  Method available since Release 3.2.0
@@ -386,6 +385,16 @@ class PHPUnit_Util_Test
         return $data;
     }
 
+    /**
+     * Returns the provided data for a method.
+     *
+     * @param  string           $docComment
+     * @param  string           $className
+     * @param  string           $methodName
+     * @return array|Iterator when a data provider is specified and exists
+     *         null           when no data provider is specified
+     * @throws PHPUnit_Framework_Exception
+     */
     private static function getDataFromDataProviderAnnotation($docComment, $className, $methodName)
     {
         if (preg_match(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -447,7 +447,7 @@ class PHPUnit_Util_Test
         if (preg_match(self::REGEX_TEST_WITH, $docComment, $matches, PREG_OFFSET_CAPTURE)) {
             $offset = strlen($matches[0][0]) + $matches[0][1];
             $annotationContent = substr($docComment, $offset);
-            $data = [];
+            $data = array();
             foreach (explode("\n", $annotationContent) as $candidateRow) {
                 $candidateRow = trim($candidateRow);
                 $dataSet = json_decode($candidateRow, true);

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -447,6 +447,7 @@ class PHPUnit_Util_Test
         if (preg_match(self::REGEX_TEST_WITH, $docComment, $matches, PREG_OFFSET_CAPTURE)) {
             $offset = strlen($matches[0][0]) + $matches[0][1];
             $annotationContent = substr($docComment, $offset);
+            $data = [];
             foreach (explode("\n", $annotationContent) as $candidateRow) {
                 $candidateRow = trim($candidateRow);
                 $dataSet = json_decode($candidateRow, true);
@@ -454,6 +455,10 @@ class PHPUnit_Util_Test
                     break;
                 }
                 $data[] = $dataSet;
+            }
+
+            if (!$data) {
+                throw new PHPUnit_Framework_Exception("The dataset for the @testWith annotation cannot be parsed.");
             }
 
             return $data;

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -393,6 +393,10 @@ class PHPUnit_Util_Test
             }
         }
 
+        if (preg_match(self::REGEX_TEST_WITH, $docComment, $matches)) {
+            $data = self::getDataFromTestWithAnnotation($docComment);
+        }
+
         if ($data !== null) {
             if (is_object($data)) {
                 $data = iterator_to_array($data);

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -425,10 +425,7 @@ class PHPUnit_Util_Test
      */
     public static function getDataFromTestWithAnnotation($docComment)
     {
-        //removing initial '   * ' for docComment
-        $docComment = preg_replace('/' . '\n' . '\s*' . '\*' . '\s?' . '/', "\n", $docComment);
-        $docComment = substr($docComment, 0, -1);
-        $docComment = rtrim($docComment, "\n");
+        $docComment = self::cleanUpMultiLineAnnotation($docComment);
         if (preg_match(self::REGEX_TEST_WITH, $docComment, $matches, PREG_OFFSET_CAPTURE)) {
             $offset = strlen($matches[0][0]) + $matches[0][1];
             $annotationContent = substr($docComment, $offset);
@@ -443,8 +440,15 @@ class PHPUnit_Util_Test
 
             return $data;
         }
+    }
 
-        return null;
+    private static function cleanUpMultiLineAnnotation($docComment)
+    {
+        //removing initial '   * ' for docComment
+        $docComment = preg_replace('/' . '\n' . '\s*' . '\*' . '\s?' . '/', "\n", $docComment);
+        $docComment = substr($docComment, 0, -1);
+        $docComment = rtrim($docComment, "\n");
+        return $docComment;
     }
 
     /**

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -10,6 +10,7 @@
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeAndAfterTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeClassAndAfterClassTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'TestWithTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderSkippedTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderIncompleteTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'InheritedTestCase.php';
@@ -55,6 +56,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
         $suite->addTest(new Framework_SuiteTest('testShadowedTests'));
         $suite->addTest(new Framework_SuiteTest('testBeforeClassAndAfterClassAnnotations'));
         $suite->addTest(new Framework_SuiteTest('testBeforeAnnotation'));
+        $suite->addTest(new Framework_SuiteTest('testTestWithAnnotation'));
         $suite->addTest(new Framework_SuiteTest('testSkippedTestDataProvider'));
         $suite->addTest(new Framework_SuiteTest('testIncompleteTestDataProvider'));
         $suite->addTest(new Framework_SuiteTest('testRequirementsBeforeClassHook'));
@@ -185,6 +187,18 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(2, BeforeAndAfterTest::$beforeWasRun);
         $this->assertEquals(2, BeforeAndAfterTest::$afterWasRun);
+    }
+
+    public function testTestWithAnnotation()
+    {
+        $test = new PHPUnit_Framework_TestSuite(
+            'TestWithTest'
+        );
+
+        BeforeAndAfterTest::resetProperties();
+        $result = $test->run();
+
+        $this->assertEquals(4, count($result->passed()));
     }
 
     public function testSkippedTestDataProvider()

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -260,6 +260,133 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithEmptyAnnotation()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**\n * @anotherAnnotation\n */");
+        $this->assertNull($result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithSimpleCase()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                                     * @testWith (1)
+                                                                     */");
+        $this->assertEquals(array(array(1)), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithMultiLineMultiParameterCase()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                                     * @testWith (1, 2)
+                                                                     * (3, 4)
+                                                                     */");
+        $this->assertEquals(array(array(1, 2), array(3, 4)), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithMultiCaseInSingleLine()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                                     * @testWith (1) (2) (3)
+                                                                     */");
+        $this->assertEquals(array(array(1), array(2), array(3)), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithVariousTypes()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
+                                                                     * @testWith ("ab") (true) (null)
+                                                                     */');
+        $this->assertEquals(array(array("ab"), array(true), array(null)), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithAnnotationAfter()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                                     * @testWith (1)
+                                                                     *           (2)
+                                                                     * @annotation
+                                                                     */");
+        $this->assertEquals(array(array(1), array(2)), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithSimpleTextAfter()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                                     * @testWith (1)
+                                                                     *           (2)
+                                                                     * blah blah
+                                                                     */");
+        $this->assertEquals(array(array(1), array(2)), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithBraces()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
+                                                                     * @testWith (")", "(")
+                                                                     *           ("(", ")")
+                                                                     */');
+        $this->assertEquals(array(array(")", "("), array("(", ")")), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithCharacterEscape()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
+                                                                     * @testWith ("\"", "\"")
+                                                                     */');
+        $this->assertEquals(array(array('"', '"')), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     */
+    public function testTestWithMultiLineText()
+    {
+        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                                     * @testWith ('a
+                                                                     *             bc')
+                                                                     */");
+
+        $this->assertEquals(array(array("a\n            bc")), $result);
+    }
+
+    /**
+     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testTestWithThrowsProperExceptionIfDatasetCannotBeParsed()
+    {
+        PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
+                                                           * @testWith (s)
+                                                           */");
+    }
+
+    /**
      * @covers PHPUnit_Util_Test::getDependencies
      * @todo   Not sure what this test tests (name is misleading at least)
      */

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -274,7 +274,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testTestWithSimpleCase()
     {
         $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                                     * @testWith (1)
+                                                                     * @testWith [1]
                                                                      */");
         $this->assertEquals(array(array(1)), $result);
     }
@@ -285,21 +285,10 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testTestWithMultiLineMultiParameterCase()
     {
         $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                                     * @testWith (1, 2)
-                                                                     * (3, 4)
+                                                                     * @testWith [1, 2]
+                                                                     * [3, 4]
                                                                      */");
         $this->assertEquals(array(array(1, 2), array(3, 4)), $result);
-    }
-
-    /**
-     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
-     */
-    public function testTestWithMultiCaseInSingleLine()
-    {
-        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                                     * @testWith (1) (2) (3)
-                                                                     */");
-        $this->assertEquals(array(array(1), array(2), array(3)), $result);
     }
 
     /**
@@ -308,8 +297,10 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testTestWithVariousTypes()
     {
         $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
-                                                                     * @testWith ("ab") (true) (null)
-                                                                     */');
+            * @testWith ["ab"]
+            *           [true]
+            *           [null]
+         */');
         $this->assertEquals(array(array("ab"), array(true), array(null)), $result);
     }
 
@@ -319,8 +310,8 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testTestWithAnnotationAfter()
     {
         $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                                     * @testWith (1)
-                                                                     *           (2)
+                                                                     * @testWith [1]
+                                                                     *           [2]
                                                                      * @annotation
                                                                      */");
         $this->assertEquals(array(array(1), array(2)), $result);
@@ -332,8 +323,8 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testTestWithSimpleTextAfter()
     {
         $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                                     * @testWith (1)
-                                                                     *           (2)
+                                                                     * @testWith [1]
+                                                                     *           [2]
                                                                      * blah blah
                                                                      */");
         $this->assertEquals(array(array(1), array(2)), $result);
@@ -342,37 +333,12 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     /**
      * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
      */
-    public function testTestWithBraces()
-    {
-        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
-                                                                     * @testWith (")", "(")
-                                                                     *           ("(", ")")
-                                                                     */');
-        $this->assertEquals(array(array(")", "("), array("(", ")")), $result);
-    }
-
-    /**
-     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
-     */
     public function testTestWithCharacterEscape()
     {
         $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
-                                                                     * @testWith ("\"", "\"")
+                                                                     * @testWith ["\"", "\""]
                                                                      */');
         $this->assertEquals(array(array('"', '"')), $result);
-    }
-
-    /**
-     * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
-     */
-    public function testTestWithMultiLineText()
-    {
-        $result = PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                                     * @testWith ('a
-                                                                     *             bc')
-                                                                     */");
-
-        $this->assertEquals(array(array("a\n            bc")), $result);
     }
 
     /**

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -343,12 +343,15 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
-     * @expectedException PHPUnit_Framework_Exception
      */
     public function testTestWithThrowsProperExceptionIfDatasetCannotBeParsed()
     {
+        $this->setExpectedExceptionRegExp(
+            "PHPUnit_Framework_Exception",
+            "/^The dataset for the @testWith annotation cannot be parsed.$/"
+        );
         PHPUnit_Util_Test::getDataFromTestWithAnnotation("/**
-                                                           * @testWith (s)
+                                                           * @testWith [s]
                                                            */");
     }
 

--- a/tests/_files/TestWithTest.php
+++ b/tests/_files/TestWithTest.php
@@ -1,0 +1,24 @@
+<?php
+class TestWithTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @testWith (0, 0, 0)
+     *           (0, 1, 1)
+     *           (1, 1, 3)
+     *           (1, 0, 1)
+     */
+    public function testAdd($a, $b, $c)
+    {
+        $this->assertEquals($c, $a + $b);
+    }
+
+    public static function providerMethod()
+    {
+        return array(
+          array(0, 0, 0),
+          array(0, 1, 1),
+          array(1, 1, 3),
+          array(1, 0, 1)
+        );
+    }
+}

--- a/tests/_files/TestWithTest.php
+++ b/tests/_files/TestWithTest.php
@@ -2,10 +2,10 @@
 class TestWithTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @testWith (0, 0, 0)
-     *           (0, 1, 1)
-     *           (1, 2, 3)
-     *           (20, 22, 42)
+     * @testWith [0, 0, 0]
+     *           [0, 1, 1]
+     *           [1, 2, 3]
+     *           [20, 22, 42]
      */
     public function testAdd($a, $b, $c)
     {

--- a/tests/_files/TestWithTest.php
+++ b/tests/_files/TestWithTest.php
@@ -4,8 +4,8 @@ class TestWithTest extends PHPUnit_Framework_TestCase
     /**
      * @testWith (0, 0, 0)
      *           (0, 1, 1)
-     *           (1, 1, 3)
-     *           (1, 0, 1)
+     *           (1, 2, 3)
+     *           (20, 22, 42)
      */
     public function testAdd($a, $b, $c)
     {


### PR DESCRIPTION
Implementing #1151.

The scope is reduced to a sequence of lines following the annotation, each containing a JSON array.

In case of annotation parsing error this is signaled through a standard PHPUnit exception. The test for this case has to use `setExceptedExceptionRegExp()` because `@testWith` becomes a reserved keyword inside docblocks.
