### PR TITLE
Mute chdir failures

### DIFF
--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -107,7 +107,7 @@ class PHPUnit_Util_XML
         // Required for XInclude on Windows.
         if ($xinclude) {
             $cwd = getcwd();
-            chdir(dirname($filename));
+            @chdir(dirname($filename));
         }
 
         $document  = new DOMDocument;
@@ -139,7 +139,7 @@ class PHPUnit_Util_XML
         error_reporting($reporting);
 
         if ($xinclude) {
-            chdir($cwd);
+            @chdir($cwd);
         }
 
         if ($loaded === false || ($strict && $message !== '')) {


### PR DESCRIPTION
chdir() can be disabled in some environments. In which case it will error with an `E_WARNING`. 

Processing of the configuration works fine though, so there is no need to error out. If an error happens it should do something on line 131.

Stack for the warning: 

```
phpunit-unittests:
     [exec] PHP Warning:  chdir() has been disabled for security reasons in phar:///usr/bin/phpunit/phpunit/Util/XML.php on line 108
     [exec] PHP Stack trace:
     [exec] PHP   1. {main}() /usr/bin/phpunit:0
     [exec] PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:535
     [exec] PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:105
     [exec] PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:115
     [exec] PHP   5. PHPUnit_Util_Configuration::getInstance() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:612
     [exec] PHP   6. PHPUnit_Util_Configuration->__construct() phar:///usr/bin/phpunit/phpunit/Util/Configuration.php:196
     [exec] PHP   7. PHPUnit_Util_XML::loadFile() phar:///usr/bin/phpunit/phpunit/Util/Configuration.php:164
     [exec] PHP   8. PHPUnit_Util_XML::load() phar:///usr/bin/phpunit/phpunit/Util/XML.php:71
     [exec] PHP   9. chdir() phar:///usr/bin/phpunit/phpunit/Util/XML.php:108
     [exec] PHP Warning:  chdir() has been disabled for security reasons in phar:///usr/bin/phpunit/phpunit/Util/XML.php on line 140
     [exec] PHP Stack trace:
     [exec] PHP   1. {main}() /usr/bin/phpunit:0
     [exec] PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:535
     [exec] PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:105
     [exec] PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:115
     [exec] PHP   5. PHPUnit_Util_Configuration::getInstance() phar:///usr/bin/phpunit/phpunit/TextUI/Command.php:612
     [exec] PHP   6. PHPUnit_Util_Configuration->__construct() phar:///usr/bin/phpunit/phpunit/Util/Configuration.php:196
     [exec] PHP   7. PHPUnit_Util_XML::loadFile() phar:///usr/bin/phpunit/phpunit/Util/Configuration.php:164
     [exec] PHP   8. PHPUnit_Util_XML::load() phar:///usr/bin/phpunit/phpunit/Util/XML.php:71
     [exec] PHP   9. chdir() phar:///usr/bin/phpunit/phpunit/Util/XML.php:140
     [exec] PHPUnit 4.6.4 by Sebastian Bergmann and contributors.
```
