### PR TITLE
Verify that phar file can be overwritten before attempting self update

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -772,6 +772,11 @@ class PHPUnit_TextUI_Command
         );
 
         $localFilename = realpath($_SERVER['argv'][0]);
+        if (!is_writable($localFilename)) {
+            print "No write permission to update " . $localFilename . "\n";
+            exit(PHPUnit_TextUI_TestRunner::EXCEPTION_EXIT);
+        }
+
         $tempFilename  = basename($localFilename, '.phar') . '-temp.phar';
 
         // Workaround for https://bugs.php.net/bug.php?id=65538


### PR DESCRIPTION
The current implementation simply ignores any error when trying to overwrite the phar file when runnig self-update, falsely claiming success.

This PR fixes that.
