### PR TITLE
Add support the parsing of options after the arguments

### DIFF
--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -54,8 +54,8 @@ class PHPUnit_Util_Getopt
 
             if ($arg[0] != '-' ||
                 (strlen($arg) > 1 && $arg[1] == '-' && !$long_options)) {
-                $non_opts = array_merge($non_opts, array_slice($args, $i));
-                break;
+                $non_opts[] = $args[$i];
+                continue;
             } elseif (strlen($arg) > 1 && $arg[1] == '-') {
                 self::parseLongOption(
                     substr($arg, 2),

--- a/tests/TextUI/options-after-arguments.phpt
+++ b/tests/TextUI/options-after-arguments.phpt
@@ -1,0 +1,19 @@
+--TEST--
+phpunit BankAccountTest ../_files/BankAccountTest.php --colors
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = __DIR__.'/../_files/BankAccountTest.php';
+$_SERVER['argv'][3] = '--colors=always';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+...
+
+Time: %s, Memory: %sMb
+
+%s[30;42mOK (3 tests, 3 assertions)%s[0m

--- a/tests/Util/GetoptTest.php
+++ b/tests/Util/GetoptTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ *
+ * @package    PHPUnit
+ * @author     Yannick Voyer (http://github.com/yvoyer)
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ * @link       http://www.phpunit.de/
+ */
+class Util_GetoptTest extends PHPUnit_Framework_TestCase
+{
+    public function testItIncludeTheLongOptionsAfterTheArgument()
+    {
+        $args = array(
+            'command',
+            'myArgument',
+            '--colors',
+        );
+        $actual = PHPUnit_Util_Getopt::getopt($args, '', array('colors=='));
+
+        $expected = array(
+            array(
+                array(
+                    '--colors',
+                    null,
+                ),
+            ),
+            array(
+                'myArgument',
+            ),
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItIncludeTheShortOptionsAfterTheArgument()
+    {
+        $args = array(
+            'command',
+            'myArgument',
+            '-v',
+        );
+        $actual = PHPUnit_Util_Getopt::getopt($args, 'v');
+
+        $expected = array(
+            array(
+                array(
+                    'v',
+                    null,
+                ),
+            ),
+            array(
+                'myArgument',
+            ),
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Allow usage of options after the arguments (if any).

```
$phpunit --debug path/to/test.php --colors
```

Before: would ignore the `--colors` option
After: Parse all the options after the path
