### PR TITLE
Don't declare missing native constant JSON_PRETTY_PRINT

### DIFF
--- a/src/Util/Log/JSON.php
+++ b/src/Util/Log/JSON.php
@@ -8,10 +8,6 @@
  * file that was distributed with this source code.
  */
 
-if (!defined('JSON_PRETTY_PRINT')) {
-    define('JSON_PRETTY_PRINT', 128);
-}
-
 /**
  * A TestListener that generates JSON messages.
  *
@@ -240,6 +236,11 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
             }
         });
 
-        parent::write(json_encode($buffer, JSON_PRETTY_PRINT));
+        $options = 0;
+        if (defined('JSON_PRETTY_PRINT')) {
+            $options |= JSON_PRETTY_PRINT;
+        }
+
+        parent::write(json_encode($buffer, $options));
     }
 }


### PR DESCRIPTION
Declaring system constants in PHPUnit can result is side effects in projects checking constant definition.

Example in LemonRestBundle, the code assumes that if `JSON_PRETTY_PRINT` is defined, the other constant `JSON_UNESCAPED_SLASHES` is also defined.
https://github.com/stanlemon/rest-bundle/blob/0.8.0/DependencyInjection/Extension.php#L29
