### PR TITLE
Allow onNotSuccessfulTest() to accept Throwable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1852,13 +1852,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     /**
      * This method is called when a test method did not execute successfully.
      *
-     * @param Exception $e
+     * @param Exception|Throwable $e
      * @since Method available since Release 3.4.0
-     * @throws Exception
+     * @throws Exception|Throwable
      */
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest($e)
     {
-        throw $e;
+        $expected = (PHP_MAJOR_VERSION >= 7 ? 'Throwable' : 'Exception');
+        if ($e instanceof $expected) {
+            throw $e;
+        }
+        throw new InvalidArgumentException(sprintf(
+            'Argument 1 passed to %s must be an instance of %s, %s given',
+            __METHOD__, $expected, (is_object($e) ? get_class($e) : gettype($e))));
     }
 
     /**


### PR DESCRIPTION
Remove "Exception" type-hint for onNotSuccessfulTest() and replace with inline checking for proper type based on PHP major version. The calling context for this method was changed in #1748 such that both objects of type Exception and interface Throwable can be passed.

Throwable was introduced in 7.0.0-alpha2, so changing the type-hint to "Throwable" is a BC break; this fix attempts to do the right thing while maintaining BC.
