### PR TITLE
Issue 1767

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -311,6 +311,9 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
      */
     public function startTest(PHPUnit_Framework_Test $test)
     {
+        $this->attachCurrentTestCase = true;
+        $this->currentTestCase       = null;
+
         $testCase = $this->document->createElement('testcase');
         $testCase->setAttribute('name', $test->getName());
 
@@ -369,9 +372,6 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
                 $this->currentTestCase->appendChild($systemOut);
             }
         }
-
-        $this->attachCurrentTestCase = true;
-        $this->currentTestCase       = null;
     }
 
     /**

--- a/tests/Regression/GitHub/1767.phpt
+++ b/tests/Regression/GitHub/1767.phpt
@@ -25,42 +25,42 @@ There were 3 failures:
 1) Issue1767Test::testTrigger
 This test will skip the next good test from JUnit xml report
 
-/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:5
+%s/Issue1767Test.php:%d
 
 2) Issue1767Test::testShouldNotBeSkipped
 This test SHOULD NOT be skipped from JUnit xml report
 
-/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:16
+%s/Issue1767Test.php:%d
 
 3) Issue1767Test::testAreNotSkipped
 This is the next failing test showing up in JUnit xml report
 
-/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:20
+%s/Issue1767Test.php:%d
 
 FAILURES!
 Tests: 3, Assertions: 0, Failures: 3, Skipped: 1.
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" tests="3" assertions="0" failures="3" errors="0" time="%s">
-    <testcase name="testTrigger" class="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" line="4" assertions="0" time="%s">
+  <testsuite name="Issue1767Test" file="%s/Issue1767Test.php" tests="3" assertions="0" failures="3" errors="0" time="%s">
+    <testcase name="testTrigger" class="Issue1767Test" file="%s/Issue1767Test.php" line="%d" assertions="0" time="%s">
       <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testTrigger
 This test will skip the next good test from JUnit xml report
 
-/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:5
+%s/Issue1767Test.php:%d
 </failure>
     </testcase>
-    <testcase name="testShouldNotBeSkipped" class="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" line="15" assertions="0" time="%s">
+    <testcase name="testShouldNotBeSkipped" class="Issue1767Test" file="%s/Issue1767Test.php" line="%d" assertions="0" time="%s">
       <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testShouldNotBeSkipped
 This test SHOULD NOT be skipped from JUnit xml report
 
-/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:16
+%s/Issue1767Test.php:%d
 </failure>
     </testcase>
-    <testcase name="testAreNotSkipped" class="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" line="19" assertions="0" time="%s">
+    <testcase name="testAreNotSkipped" class="Issue1767Test" file="%s/Issue1767Test.php" line="%d" assertions="0" time="%s">
       <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testAreNotSkipped
 This is the next failing test showing up in JUnit xml report
 
-/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:20
+%s/Issue1767Test.php:%d
 </failure>
     </testcase>
   </testsuite>

--- a/tests/Regression/GitHub/1767.phpt
+++ b/tests/Regression/GitHub/1767.phpt
@@ -1,0 +1,67 @@
+--TEST--
+GH-1767: Test that shows some tests are skipped from JUnit xml log
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--disallow-test-output';
+$_SERVER['argv'][2] = '--log-junit=/tmp/issue1767.xml';
+$_SERVER['argv'][3] = 'Issue1570Test';
+$_SERVER['argv'][4] = dirname(__FILE__) . '/1767/Issue1767Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main(false);
+
+echo file_get_contents('/tmp/issue1767.xml');
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+FSFF
+
+Time: %s ms, Memory: %sMb
+
+There were 3 failures:
+
+1) Issue1767Test::testTrigger
+This test will skip the next good test from JUnit xml report
+
+/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:5
+
+2) Issue1767Test::testShouldNotBeSkipped
+This test SHOULD NOT be skipped from JUnit xml report
+
+/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:16
+
+3) Issue1767Test::testAreNotSkipped
+This is the next failing test showing up in JUnit xml report
+
+/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:20
+
+FAILURES!
+Tests: 3, Assertions: 0, Failures: 3, Skipped: 1.
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" tests="3" assertions="0" failures="3" errors="0" time="%s">
+    <testcase name="testTrigger" class="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" line="4" assertions="0" time="%s">
+      <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testTrigger
+This test will skip the next good test from JUnit xml report
+
+/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:5
+</failure>
+    </testcase>
+    <testcase name="testShouldNotBeSkipped" class="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" line="15" assertions="0" time="%s">
+      <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testShouldNotBeSkipped
+This test SHOULD NOT be skipped from JUnit xml report
+
+/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:16
+</failure>
+    </testcase>
+    <testcase name="testAreNotSkipped" class="Issue1767Test" file="/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php" line="19" assertions="0" time="%s">
+      <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testAreNotSkipped
+This is the next failing test showing up in JUnit xml report
+
+/home/krc/workc/php/phpunit/tests/Regression/GitHub/1767/Issue1767Test.php:20
+</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/Regression/GitHub/1767.phpt
+++ b/tests/Regression/GitHub/1767.phpt
@@ -4,45 +4,21 @@ GH-1767: Test that shows some tests are skipped from JUnit xml log
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--disallow-test-output';
-$_SERVER['argv'][2] = '--log-junit=/tmp/issue1767.xml';
+$_SERVER['argv'][2] = '--log-junit=php://stdout';
 $_SERVER['argv'][3] = 'Issue1570Test';
 $_SERVER['argv'][4] = dirname(__FILE__) . '/1767/Issue1767Test.php';
 
 require __DIR__ . '/../../bootstrap.php';
 PHPUnit_TextUI_Command::main(false);
 
-echo file_get_contents('/tmp/issue1767.xml');
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-FSFF
-
-Time: %s ms, Memory: %sMb
-
-There were 3 failures:
-
-1) Issue1767Test::testTrigger
-This test will skip the next good test from JUnit xml report
-
-%s/Issue1767Test.php:%d
-
-2) Issue1767Test::testShouldNotBeSkipped
-This test SHOULD NOT be skipped from JUnit xml report
-
-%s/Issue1767Test.php:%d
-
-3) Issue1767Test::testAreNotSkipped
-This is the next failing test showing up in JUnit xml report
-
-%s/Issue1767Test.php:%d
-
-FAILURES!
-Tests: 3, Assertions: 0, Failures: 3, Skipped: 1.
-<?xml version="1.0" encoding="UTF-8"?>
+FSFF<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="Issue1767Test" file="%s/Issue1767Test.php" tests="3" assertions="0" failures="3" errors="0" time="%s">
-    <testcase name="testTrigger" class="Issue1767Test" file="%s/Issue1767Test.php" line="%d" assertions="0" time="%s">
+    <testcase name="testTrigger" class="Issue1767Test" file="%s/Issue1767Test.php" line="4" assertions="0" time="%s">
       <failure type="PHPUnit_Framework_AssertionFailedError">Issue1767Test::testTrigger
 This test will skip the next good test from JUnit xml report
 
@@ -65,3 +41,26 @@ This is the next failing test showing up in JUnit xml report
     </testcase>
   </testsuite>
 </testsuites>
+
+
+Time: %d ms, Memory: %sMb
+
+There were 3 failures:
+
+1) Issue1767Test::testTrigger
+This test will skip the next good test from JUnit xml report
+
+%s/Issue1767Test.php:%d
+
+2) Issue1767Test::testShouldNotBeSkipped
+This test SHOULD NOT be skipped from JUnit xml report
+
+%s/Issue1767Test.php:%d
+
+3) Issue1767Test::testAreNotSkipped
+This is the next failing test showing up in JUnit xml report
+
+%s/Issue1767Test.php:%d
+
+FAILURES!
+Tests: 3, Assertions: 0, Failures: 3, Skipped: 1.

--- a/tests/Regression/GitHub/1767/Issue1767Test.php
+++ b/tests/Regression/GitHub/1767/Issue1767Test.php
@@ -1,0 +1,22 @@
+<?php
+class Issue1767Test extends PHPUnit_Framework_TestCase
+{
+    function testTrigger() {
+        $this->fail("This test will skip the next good test from JUnit xml report");
+    }
+
+    /**
+     * @depends testTrigger
+     */
+    function testSkipper() {
+        $this->fail("This test should be skipped from JUnit xml report");
+    }
+
+    function testShouldNotBeSkipped() {
+        $this->fail("This test SHOULD NOT be skipped from JUnit xml report");
+    }
+
+    function testAreNotSkipped() {
+        $this->fail("This is the next failing test showing up in JUnit xml report");
+    }
+}


### PR DESCRIPTION
This fix moves cleanup code from endTest to startTest, so we are no longer dependent on endTest being called when marking tests skipped.

Please advise on where to put files during tests. It is currently stored in /tmp/issue1767.xml, but I guess its either clean nor portable to other platforms. How should I generate the JUnit XML report and verify it contents?