### PR TITLE
Added possibility to use a own config loader

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -38,6 +38,7 @@ class PHPUnit_TextUI_Command
         'colors=='             => null,
         'columns='             => null,
         'configuration='       => null,
+        'loaderConfigs='       => null,
         'coverage-clover='     => null,
         'coverage-crap4j='     => null,
         'coverage-html='       => null,
@@ -261,6 +262,10 @@ class PHPUnit_TextUI_Command
                 case 'c':
                 case '--configuration':
                     $this->arguments['configuration'] = $option[1];
+                    break;
+
+                case '--loaderConfig':
+                    $this->arguments['configurationClass'] = $option[1];
                     break;
 
                 case '--coverage-clover':
@@ -566,8 +571,10 @@ class PHPUnit_TextUI_Command
 
         if (isset($this->arguments['configuration'])) {
             try {
+                $configurationClass = isset($this->arguments['configurationClass']) ? $this->arguments['configurationClass'] : NULL;
                 $configuration = PHPUnit_Util_Configuration::getInstance(
-                    $this->arguments['configuration']
+                    $this->arguments['configuration'],
+                    $configurationClass
                 );
             } catch (Throwable $e) {
                 print $e->getMessage() . "\n";

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -9,6 +9,86 @@
  */
 
 /**
+ * A PHPUnit configuration class to load all tests and settings.
+ *
+ * @since      Interface available since Release 5.0.0
+ */
+interface PHPUnit_Util_Configuration_Interface {
+
+    /**
+     * Returns the realpath to the configuration file.
+     *
+     * @return string
+     * @since  Method available since Release 3.6.0
+     */
+    public function getFilename();
+
+    /**
+     * Returns the configuration for SUT filtering.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.1
+     */
+    public function getFilterConfiguration();
+
+    /**
+     * Returns the configuration for groups.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.1
+     */
+    public function getGroupConfiguration();
+
+    /**
+     * Returns the configuration for listeners.
+     *
+     * @return array
+     * @since  Method available since Release 3.4.0
+     */
+    public function getListenerConfiguration();
+
+    /**
+     * Returns the logging configuration.
+     *
+     * @return array
+     */
+    public function getLoggingConfiguration();
+
+    /**
+     * Returns the PHP configuration.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.1
+     */
+    public function getPHPConfiguration();
+
+    /**
+     * Handles the PHP configuration.
+     *
+     * @since  Method available since Release 3.2.20
+     */
+    public function handlePHPConfiguration();
+
+    /**
+     * Returns the PHPUnit configuration.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.14
+     */
+    public function getPHPUnitConfiguration();
+
+    /**
+     * Returns the test suite configuration.
+     *
+     * @return PHPUnit_Framework_TestSuite
+     * @since  Method available since Release 3.2.1
+     */
+    public function getTestSuiteConfiguration($testSuiteFilter = null);
+
+
+}
+
+/**
  * Wrapper for the PHPUnit XML configuration file.
  *
  * Example XML configuration file:
@@ -132,7 +212,7 @@
  *
  * @since Class available since Release 3.2.0
  */
-class PHPUnit_Util_Configuration
+class PHPUnit_Util_Configuration implements PHPUnit_Util_Configuration_Interface
 {
     private static $instances = [];
 
@@ -163,10 +243,10 @@ class PHPUnit_Util_Configuration
      * Returns a PHPUnit configuration object.
      *
      * @param  string                     $filename
-     * @return PHPUnit_Util_Configuration
+     * @return PHPUnit_Util_Configuration_Interface
      * @since  Method available since Release 3.4.0
      */
-    public static function getInstance($filename)
+    public static function getInstance($filename, $configurationClass = NULL)
     {
         $realpath = realpath($filename);
 
@@ -180,7 +260,12 @@ class PHPUnit_Util_Configuration
         }
 
         if (!isset(self::$instances[$realpath])) {
-            self::$instances[$realpath] = new self($realpath);
+            if (isset($configurationClass) && class_exists($configurationClass) && in_array('PHPUnit_Util_Configuration_Interface', class_implements($configurationClass))) {
+              self::$instances[$realpath] = new $configurationClass($realpath);
+            }
+            else {
+              self::$instances[$realpath] = new self($realpath);
+            }
         }
 
         return self::$instances[$realpath];

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -32,6 +32,17 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Util_Configuration::getInstance
+     */
+    public function testShouldLoadCustomConfigurator()
+    {
+        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.yaml';
+        $configurationInstance = PHPUnit_Util_Configuration::getInstance($configurationFilename, 'ConfigurationTestClass');
+        $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
+        $this->assertTrue($configurationValues['configurationTestValue']);
+    }
+
+    /**
      * @covers PHPUnit_Util_Configuration::getPHPUnitConfiguration
      */
     public function testShouldReadColorsWhenTrueInConfigurationfile()

--- a/tests/_files/ConfigurationTestClass.php
+++ b/tests/_files/ConfigurationTestClass.php
@@ -1,0 +1,95 @@
+<?php
+
+class ConfigurationTestClass implements PHPUnit_Util_Configuration_Interface {
+
+    /**
+     * Returns the realpath to the configuration file.
+     *
+     * @return string
+     * @since  Method available since Release 3.6.0
+     */
+    public function getFilename()
+    {
+    }
+
+    /**
+     * Returns the configuration for SUT filtering.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.1
+     */
+    public function getFilterConfiguration()
+    {
+    }
+
+    /**
+     * Returns the configuration for groups.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.1
+     */
+    public function getGroupConfiguration()
+    {
+    }
+
+    /**
+     * Returns the configuration for listeners.
+     *
+     * @return array
+     * @since  Method available since Release 3.4.0
+     */
+    public function getListenerConfiguration()
+    {
+    }
+
+    /**
+     * Returns the logging configuration.
+     *
+     * @return array
+     */
+    public function getLoggingConfiguration()
+    {
+    }
+
+    /**
+     * Returns the PHP configuration.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.1
+     */
+    public function getPHPConfiguration()
+    {
+    }
+
+    /**
+     * Handles the PHP configuration.
+     *
+     * @since  Method available since Release 3.2.20
+     */
+    public function handlePHPConfiguration()
+    {
+    }
+
+    /**
+     * Returns the PHPUnit configuration.
+     *
+     * @return array
+     * @since  Method available since Release 3.2.14
+     */
+    public function getPHPUnitConfiguration()
+    {
+        return array(
+            'configurationTestValue' => TRUE
+        );
+    }
+
+    /**
+     * Returns the test suite configuration.
+     *
+     * @return PHPUnit_Framework_TestSuite
+     * @since  Method available since Release 3.2.1
+     */
+    public function getTestSuiteConfiguration($testSuiteFilter = null)
+    {
+    }
+}

--- a/tests/_files/configuration.yaml
+++ b/tests/_files/configuration.yaml
@@ -1,0 +1,1 @@
+not_yet_implemented: TRUE


### PR DESCRIPTION
We needed the possibility to change the test suite configuration, when starting a test. We didn't wanted to use the xml file, as we also needed to add more data for each test in a test suite.

Therefore we create the possibility to have a separate config loader. In our current environment we just extend the default loader and only overwrite getTestSuiteConfiguration(). But for others maybe it becomes handy that you also can overwrite the rest.

To define a separate loader a new argument was added (loaderConfig), where you define the name. To always use it, we copied the phpunit startup script in our own directory and added the argument there. As this is about the config, I didn't had a better idea how you maybe could define it somewhere else. The name is not ideal, but nothing beginning with config can be used (otherwise some regression tests fail).

Looking forward for tips and change requests, so this gets maybe accepted at one time. :)