### PR TITLE
fixes #1771 - don't print colors to stdout in text coverage summary when 'never' is used

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -496,6 +496,9 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 if ($arguments['coverageText'] == 'php://stdout') {
                     $outputStream = $this->printer;
                     $colors       = $arguments['colors'];
+                    if ($colors == PHPUnit_TextUI_ResultPrinter::COLOR_NEVER) {
+                        $colors = false;
+                    }
                 } else {
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
                     $colors       = false;

--- a/tests/TextUI/full-coverage-text-summary-only-without-colors.phpt
+++ b/tests/TextUI/full-coverage-text-summary-only-without-colors.phpt
@@ -1,0 +1,26 @@
+--TEST--
+phpunit --configuration=../TextUI/full-coverage-text-summary-only-without-colors.xml FullCoverageClassTest ../_files/FullCoverageClassTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--configuration=' . dirname(__FILE__) . '/../TextUI/full-coverage-text-summary-only-without-colors.xml';
+$_SERVER['argv'][2] = 'FullCoverageClassTest';
+$_SERVER['argv'][3] = dirname(__FILE__).'/../_files/FullCoverageClassTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.
+
+Time: %s, Memory: %sMb
+
+OK (1 test, 0 assertions)
+
+
+Code Coverage Report Summary:
+  Classes: 100.00% (1/1)     
+  Methods: 100.00% (1/1)     
+  Lines:   100.00% (1/1)     

--- a/tests/TextUI/full-coverage-text-summary-only-without-colors.xml
+++ b/tests/TextUI/full-coverage-text-summary-only-without-colors.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.4/phpunit.xsd"
+         colors="never">
+
+    <filter>
+        <whitelist>
+            <file>../_files/FullCoverageClass.php</file>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text"
+             target="php://stdout"
+             lowUpperBound="100"
+             highLowerBound="100"
+             showUncoveredFiles="false"
+             showOnlySummary="true" />
+    </logging>
+</phpunit>
+

--- a/tests/TextUI/ignore-coverage-text-summary-only-without-colors.phpt
+++ b/tests/TextUI/ignore-coverage-text-summary-only-without-colors.phpt
@@ -1,0 +1,26 @@
+--TEST--
+phpunit --configuration=../TextUI/ignore-coverage-text-summary-only-without-colors.xml FullCoverageClassTest ../_files/IgnoreCoverageClassTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--configuration=' . dirname(__FILE__) . '/../TextUI/ignore-coverage-text-summary-only-without-colors.xml';
+$_SERVER['argv'][2] = 'IgnoreCoverageClassTest';
+$_SERVER['argv'][3] = dirname(__FILE__).'/../_files/IgnoreCoverageClassTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.
+
+Time: %s, Memory: %sMb
+
+OK (1 test, 0 assertions)
+
+
+Code Coverage Report Summary:
+  Classes: 100.00% (1/1)     
+  Methods:        (0/0)      
+  Lines:          (0/0)     

--- a/tests/TextUI/ignore-coverage-text-summary-only-without-colors.xml
+++ b/tests/TextUI/ignore-coverage-text-summary-only-without-colors.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.4/phpunit.xsd"
+         colors="never">
+
+    <filter>
+        <whitelist>
+            <file>../_files/IgnoreCoverageClass.php</file>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text"
+             target="php://stdout"
+             lowUpperBound="100"
+             highLowerBound="100"
+             showUncoveredFiles="false"
+             showOnlySummary="true" />
+    </logging>
+</phpunit>
+

--- a/tests/_files/FullCoverageClass.php
+++ b/tests/_files/FullCoverageClass.php
@@ -1,0 +1,9 @@
+<?php
+
+class FullCoverageClass
+{
+    public function publicMethod()
+    {
+
+    }
+}

--- a/tests/_files/FullCoverageClassTest.php
+++ b/tests/_files/FullCoverageClassTest.php
@@ -1,0 +1,13 @@
+<?php
+
+class FullCoverageClassTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers FullCoverageClass
+     */
+    public function testSomething()
+    {
+        $o = new FullCoverageClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/IgnoreCoverageClass.php
+++ b/tests/_files/IgnoreCoverageClass.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * 
+ * @codeCoverageIgnore
+ */
+class IgnoreCoverageClass
+{
+    public function publicMethod()
+    {
+
+    }
+}

--- a/tests/_files/IgnoreCoverageClassTest.php
+++ b/tests/_files/IgnoreCoverageClassTest.php
@@ -1,0 +1,13 @@
+<?php
+
+class IgnoreCoverageClassTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers IgnoreCoverageClass
+     */
+    public function testSomething()
+    {
+        $o = new IgnoreCoverageClass;
+        $o->publicMethod();
+    }
+}


### PR DESCRIPTION
coverage-text-summary-only-without-colors - do not print colors to stdout in text coverage summary when \PHPUnit_TextUI_ResultPrinter::COLOR_NEVER is used.

@sebastianbergmann i'm new to phpt large tests. is this the way you would cover that change? i'd like to get this merged so that i can write a similar test to make sure that codeCoverageIgnore is disabled in a new pull request that makes use of that feature (https://github.com/sebastianbergmann/php-code-coverage/pull/338).
