### PR TITLE
Improved JSON detection: Empty string is not treated as a valid JSON string anymore

### DIFF
--- a/src/Framework/Constraint/IsJson.php
+++ b/src/Framework/Constraint/IsJson.php
@@ -24,6 +24,10 @@ class PHPUnit_Framework_Constraint_IsJson extends PHPUnit_Framework_Constraint
      */
     protected function matches($other)
     {
+        if ($other === '') {
+            return false;
+        }
+
         json_decode($other);
         if (json_last_error()) {
             return false;
@@ -43,6 +47,10 @@ class PHPUnit_Framework_Constraint_IsJson extends PHPUnit_Framework_Constraint
      */
     protected function failureDescription($other)
     {
+        if ($other === '') {
+            return 'an empty string is valid JSON';
+        }
+
         json_decode($other);
         $error = PHPUnit_Framework_Constraint_JsonMatches_ErrorMessageProvider::determineJsonError(
             json_last_error()

--- a/tests/Framework/Constraint/IsJsonTest.php
+++ b/tests/Framework/Constraint/IsJsonTest.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Framework_Constraint_IsJsonTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider evaluateDataprovider
+     * @covers PHPUnit_Framework_Constraint_IsJson::evaluate
+     * @covers PHPUnit_Framework_Constraint_IsJson::matches
+     * @covers PHPUnit_Framework_Constraint_IsJson::__construct
+     */
+    public function testEvaluate($expected, $jsonOther)
+    {
+        $constraint = new PHPUnit_Framework_Constraint_IsJson();
+        $this->assertEquals($expected, $constraint->evaluate($jsonOther, '', true));
+    }
+
+    public static function evaluateDataprovider()
+    {
+        return [
+            'valid JSON'                                     => [true, '{}'],
+            'empty string should be treated as invalid JSON' => [false, ''],
+        ];
+    }
+}


### PR DESCRIPTION
When passing an empty string to json_decode() null gets returned and no "error" is detected by json_last_error(). I added an explicit check to PHPUnit_Framework_Constraint_IsJson::matches() to detect an empty string and fail in this case.
