### PR TITLE
Fix: Acess vs. Access

### DIFF
--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -43,7 +43,7 @@ class PHPUnit_Framework_Constraint_ArraySubset extends PHPUnit_Framework_Constra
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
-     * @param  array|ArrayAccess $other Array or ArrayAcess object to evaluate.
+     * @param  array|ArrayAccess $other Array or ArrayAccess object to evaluate.
      * @return bool
      */
     protected function matches($other)


### PR DESCRIPTION
This PR
- [x] fixes a small typo where `Acess` should be `Access`
