### PR TITLE
Add support for expectations

### DIFF
--- a/src/Framework/Expect.php
+++ b/src/Framework/Expect.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * A set of expectation methods
+ */
+abstract class PHPUnit_Framework_Expect extends PHPUnit_Framework_Assert
+{
+    private static $failedExpecatations = [];
+
+    public function __call($name, $args)
+    {
+        if (substr($name, 0, 6) === 'expect') {
+            $method = 'assert' . substr($name, 6);
+            if (is_callable([$this, $method])) {
+                try {
+                    call_user_func_array([$this, $method], $args);
+                }  catch (PHPUnit_Framework_AssertionFailedError $e) {
+                    self::$failedExpecatations[] = $e;
+                }
+                return;
+            }
+        }
+        throw new \BadMethodCallException("Unknown static method $name called");
+    }
+
+    protected static function getFailedExpectations()
+    {
+        return self::$failedExpecatations;
+    }
+
+    protected static function resetFailedExpectations()
+    {
+        self::$failedExpecatations = [];
+    }
+
+}

--- a/src/Framework/ExpectationFailedError.php
+++ b/src/Framework/ExpectationFailedError.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Thrown when an assertion failed.
+ *
+ * @since Class available since Release 2.0.0
+ */
+class PHPUnit_Framework_ExpectationFailedError extends PHPUnit_Framework_AssertionFailedError
+{
+
+    protected $failedExpectations = [];
+
+    public function __construct(array $failedExpectations)
+    {
+
+        $this->failedExpectations = $failedExpectations;
+        parent::__construct("Failed Expectations");
+    }
+
+    public function getFailedExpectations()
+    {
+        return $this->failedExpectations;
+    }
+
+    /**
+     * Wrapper for getMessage() which is declared as final.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        $message = $this->getMessage();
+        foreach ($this->failedExpectations as $key => $failed) {
+            $message .= "\n{$key}: " . $failed;
+        }
+        return $message;
+    }
+}

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -63,7 +63,7 @@ use DeepCopy\DeepCopy;
  *
  * @since Class available since Release 2.0.0
  */
-abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert implements PHPUnit_Framework_Test, PHPUnit_Framework_SelfDescribing
+abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Expect implements PHPUnit_Framework_Test, PHPUnit_Framework_SelfDescribing
 {
     /**
      * Enable or disable the backup and restoration of the $GLOBALS array.
@@ -718,7 +718,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     public function runBare()
     {
         $this->numAssertions = 0;
-
+        self::resetFailedExpectations();
         $this->snapshotGlobalState();
         $this->startOutputBuffering();
         clearstatcache();
@@ -748,7 +748,14 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $this->verifyMockObjects();
             $this->assertPostConditions();
 
-            $this->status = PHPUnit_Runner_BaseTestRunner::STATUS_PASSED;
+            $failedExpectations = self::getFailedExpectations();
+            if ($failedExpectations) {
+                $this->status = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE;
+                $e = new PHPUnit_Framework_ExpectationFailedError($failedExpectations);
+                $this->statusMessage = $e->getMessage();
+            } else {
+                $this->status = PHPUnit_Runner_BaseTestRunner::STATUS_PASSED;
+            }
         } catch (PHPUnit_Framework_IncompleteTest $e) {
             $this->status        = PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE;
             $this->statusMessage = $e->getMessage();

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -749,7 +749,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Expect imple
             $this->assertPostConditions();
 
             $failedExpectations = self::getFailedExpectations();
-            if ($failedExpectations) {
+            if (!empty($failedExpectations)) {
                 $this->status = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE;
                 $e = new PHPUnit_Framework_ExpectationFailedError($failedExpectations);
                 $this->statusMessage = $e->getMessage();

--- a/tests/Framework/ExpectTest.php
+++ b/tests/Framework/ExpectTest.php
@@ -20,7 +20,6 @@ class Framework_ExpectTest extends PHPUnit_Framework_TestCase
             $this->expectEquals(1, 2);
             $this->expectEquals(2, 3);
         } catch (Exception $e) {
-            echo $e;
             $this->fail("No exceptions should be thrown!!!");
         }
         $expectations = self::getFailedExpectations();

--- a/tests/Framework/ExpectTest.php
+++ b/tests/Framework/ExpectTest.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @since      Class available since Release 2.0.0
+ */
+class Framework_ExpectTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testExpectEquals()
+    {
+        try {
+            $this->expectEquals(1, 2);
+            $this->expectEquals(2, 3);
+        } catch (Exception $e) {
+            echo $e;
+            $this->fail("No exceptions should be thrown!!!");
+        }
+        $expectations = self::getFailedExpectations();
+        self::resetFailedExpectations();
+        $this->assertCount(2, $expectations);
+        $this->expectEquals("Failed asserting that 2 matches expected 1.", $expectations[0]->toString());
+        $this->expectEquals("Failed asserting that 3 matches expected 2.", $expectations[1]->toString());
+    }
+
+}


### PR DESCRIPTION
**NOTE**: This is not a production PR, but should be used as a point-of-reference for the discussion of `expect*` additions.
## What are expectations

Quite simply, expectations are assertions that don't immediately fail tests. They can accumulate over the execution of a test.
## Why?

Expectations provide the ability to get richer and more complete failure data.
## How it works:

Simply replace "assert" with "expect" in any valid assertion call. The rest is handled by the framework. Instead of a failure halting the test (as with an assertion), expectations keep executing.

**For the proof-of-concept** expectation errors are only displayed if there was no other assertion failure. This should be fixed in the future.
## When would I use expect instead of assert:

In short, if a failure in one place means you can't get any meaningful data out of the rest of the failures, then use assert. Otherwise use expect.

Example:

```
public function testFoo() {
    $array = foo();
    // This is an assertion, because the rest of the test makes no sense without it
    $this->assertTrue(is_array($array), "The return value is an array");
    $this->expectEquals("test", $array[0]);
    $this->expectEquals(123, $array['test']);
   // etc
}
```

The first is an assertion, because continuing the test may be dangerous. The rest are expectations because if one fails, it means nothing to the others. So by using expectations, you get more complete failure information.
## Output:

The POC will generate for the following code:

```
public function testExpectEqualsFailure() 
{
    $this->expectEquals(1, 2);
    $this->expectEquals(2, 3);
}  
```

The following failure:

```
There was 1 failure:

1) Framework_ExpectTest::testExpectEqualsFailure
Failed Expectations
0: Failed asserting that 2 matches expected 1.

    src/Framework/Constraint/IsEqual.php:134
    src/Framework/Assert.php:1934
    src/Framework/Assert.php:486
    src/Framework/Expect.php:24
    tests/Framework/ExpectTest.php:34
    src/Framework/TestCase.php:888
    src/Framework/TestCase.php:747
    src/Framework/TestResult.php:601
    src/Framework/TestCase.php:703
    src/Framework/TestSuite.php:735
    src/Framework/TestSuite.php:735
    src/Framework/TestSuite.php:735
    src/TextUI/TestRunner.php:429
    src/TextUI/Command.php:149
    src/TextUI/Command.php:101

1: Failed asserting that 3 matches expected 2.

    src/Framework/Constraint/IsEqual.php:134
    src/Framework/Assert.php:1934
    src/Framework/Assert.php:486
    src/Framework/Expect.php:24
    tests/Framework/ExpectTest.php:35
    src/Framework/TestCase.php:888
    src/Framework/TestCase.php:747
    src/Framework/TestResult.php:601
    src/Framework/TestCase.php:703
    src/Framework/TestSuite.php:735
    src/Framework/TestSuite.php:735
    src/Framework/TestSuite.php:735
    src/TextUI/TestRunner.php:429
    src/TextUI/Command.php:149
    src/TextUI/Command.php:101

    src/Framework/TestCase.php:754
    src/Framework/TestResult.php:601
    src/Framework/TestCase.php:703
    src/Framework/TestSuite.php:735
    src/Framework/TestSuite.php:735
    src/Framework/TestSuite.php:735
    src/TextUI/TestRunner.php:429
    src/TextUI/Command.php:149
    src/TextUI/Command.php:101

--
```
## Real World

The very test included in this pull request uses expectations.

```
public function testExpectEquals()
{
    try {
        $this->expectEquals(1, 2);
        $this->expectEquals(2, 3);
    } catch (Exception $e) {
        $this->fail("No exceptions should be thrown!!!");
    }
    $expectations = self::getFailedExpectations();
    self::resetFailedExpectations();
    $this->assertCount(2, $expectations);
    $this->expectEquals("Failed asserting that 2 matches expected 1.", $expectations[0]->toString());
    $this->expectEquals("Failed asserting that 3 matches expected 2.", $expectations[1]->toString());
}
```

In this case, we're asserting that there were 2 failed expectations, but then expecting each individual message.

PHPUnit's own test suite has areas where this could be used:

```
/**
 * @covers PHPUnit_Framework_Assert::assertArraySubset
 * @covers PHPUnit_Framework_Constraint_ArraySubset
 */
public function testassertArraySubset()
{
    $array = [
        'a' => 'item a',
        'b' => 'item b',
        'c' => ['a2' => 'item a2', 'b2' => 'item b2'],
        'd' => ['a2' => ['a3' => 'item a3', 'b3' => 'item b3']]
    ];

    $this->assertArraySubset(['a' => 'item a', 'c' => ['a2' => 'item a2']], $array);
    $this->assertArraySubset(['a' => 'item a', 'd' => ['a2' => ['b3' => 'item b3']]], $array);

    try {
        $this->assertArraySubset(['a' => 'bad value'], $array);
    } catch (PHPUnit_Framework_AssertionFailedError $e) {
    }

    try {
        $this->assertArraySubset(['d' => ['a2' => ['bad index' => 'item b3']]], $array);
    } catch (PHPUnit_Framework_AssertionFailedError $e) {
        return;
    }

    $this->fail();
}
```

In this case, the first 2 `assertArraySubset` calls could/should be `expect` calls.
## Next steps

This is just a dirty proof-of-concept to frame the discussion. Check this PR out, try it and see the behavior. And discuss.
