### PR TITLE
correct autoload.php path inclusion

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -13,7 +13,7 @@ if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');
 }
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php', __DIR__ . '/../autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
when installing with composer this files get copied to $vendorDir/bin and the autoload.php-file is directly in $vendorDir.
So the the file_exists-statement should include that path too.
