### PR TITLE
Rename a parameter of function assertJson

### DIFF
--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -808,11 +808,11 @@ function assertInternalType($expected, $actual, $message = '')
 /**
  * Asserts that a string is a valid JSON string.
  *
- * @param  string $filename
+ * @param  string $actualJson
  * @param  string $message
  * @since  Method available since Release 3.7.20
  */
-function assertJson($expectedJson, $message = '')
+function assertJson($actualJson, $message = '')
 {
     return call_user_func_array(
         'PHPUnit_Framework_Assert::assertJson',


### PR DESCRIPTION
Rename `$expectedJson` to `$actualJson` according to commit
672d9c912be0962832a91bd6fda3403bebfe38ce. Also, rename param `$filename` in
docblock, which seems to be a typo, to `$actualJson`.
