### PR TITLE
Fix test status being overwritten to error

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -766,9 +766,9 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $e = $_e;
         }
 
-        if (isset($e)) {
+        if (isset($_e)) {
             $this->status        = PHPUnit_Runner_BaseTestRunner::STATUS_ERROR;
-            $this->statusMessage = $e->getMessage();
+            $this->statusMessage = $_e->getMessage();
         }
 
         // Clean up the mock objects.

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -47,8 +47,10 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $test   = new Success;
         $result = $test->run();
 
+        $this->assertEquals(PHPUnit_Runner_BaseTestRunner::STATUS_PASSED, $test->getStatus());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
+        $this->assertEquals(0, $result->skippedCount());
         $this->assertEquals(1, count($result));
     }
 
@@ -57,8 +59,10 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $test   = new Failure;
         $result = $test->run();
 
+        $this->assertEquals(PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE, $test->getStatus());
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(1, $result->failureCount());
+        $this->assertEquals(0, $result->skippedCount());
         $this->assertEquals(1, count($result));
     }
 
@@ -67,8 +71,36 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $test   = new TestError;
         $result = $test->run();
 
+        $this->assertEquals(PHPUnit_Runner_BaseTestRunner::STATUS_ERROR, $test->getStatus());
         $this->assertEquals(1, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
+        $this->assertEquals(0, $result->skippedCount());
+        $this->assertEquals(1, count($result));
+    }
+
+    public function testSkipped()
+    {
+        $test   = new TestSkipped();
+        $result = $test->run();
+
+        $this->assertEquals(PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED, $test->getStatus());
+        $this->assertEquals('Skipped test', $test->getStatusMessage());
+        $this->assertEquals(0, $result->errorCount());
+        $this->assertEquals(0, $result->failureCount());
+        $this->assertEquals(1, $result->skippedCount());
+        $this->assertEquals(1, count($result));
+    }
+
+    public function testIncomplete()
+    {
+        $test   = new TestIncomplete();
+        $result = $test->run();
+
+        $this->assertEquals(PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE, $test->getStatus());
+        $this->assertEquals('Incomplete test', $test->getStatusMessage());
+        $this->assertEquals(0, $result->errorCount());
+        $this->assertEquals(0, $result->failureCount());
+        $this->assertEquals(0, $result->skippedCount());
         $this->assertEquals(1, count($result));
     }
 

--- a/tests/_files/TestIncomplete.php
+++ b/tests/_files/TestIncomplete.php
@@ -1,0 +1,8 @@
+<?php
+class TestIncomplete extends PHPUnit_Framework_TestCase
+{
+    protected function runTest()
+    {
+        $this->markTestIncomplete('Incomplete test');
+    }
+}

--- a/tests/_files/TestSkipped.php
+++ b/tests/_files/TestSkipped.php
@@ -1,0 +1,8 @@
+<?php
+class TestSkipped extends PHPUnit_Framework_TestCase
+{
+    protected function runTest()
+    {
+        $this->markTestSkipped('Skipped test');
+    }
+}


### PR DESCRIPTION
Fixes #1835 and also adds tests to ensure test status is being properly set for all the cases.
