### PR TITLE
Enable color support for testdox

### DIFF
--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -79,7 +79,7 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_TextUI_ResultP
      */
     public function __construct($out = null, $verbose = false, $colors = self::COLOR_DEFAULT)
     {
-        parent::__construct($out);
+        parent::__construct($out, $verbose, $colors);
 
         $this->prettifier = new PHPUnit_Util_TestDox_NamePrettifier;
         $this->startRun();

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -13,7 +13,7 @@
  *
  * @since Class available since Release 2.1.0
  */
-abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
+abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_TextUI_ResultPrinter implements PHPUnit_Framework_TestListener
 {
     /**
      * @var PHPUnit_Util_TestDox_NamePrettifier
@@ -74,8 +74,10 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
      * Constructor.
      *
      * @param resource $out
+     * @param  bool                        $verbose
+     * @param  string                      $colors
      */
-    public function __construct($out = null)
+    public function __construct($out = null, $verbose = false, $colors = self::COLOR_DEFAULT)
     {
         parent::__construct($out);
 

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -8,13 +8,43 @@
  * file that was distributed with this source code.
  */
 
+use SebastianBergmann\Environment\Console;
+
 /**
  * Base class for printers of TestDox documentation.
  *
  * @since Class available since Release 2.1.0
  */
-abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_TextUI_ResultPrinter implements PHPUnit_Framework_TestListener
+abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer implements PHPUnit_Framework_TestListener
 {
+    const COLOR_NEVER   = 'never';
+    const COLOR_AUTO    = 'auto';
+    const COLOR_ALWAYS  = 'always';
+    const COLOR_DEFAULT = self::COLOR_NEVER;
+
+    /**
+     * @var array
+     */
+    private static $ansiCodes = [
+        'bold'       => 1,
+        'fg-black'   => 30,
+        'fg-red'     => 31,
+        'fg-green'   => 32,
+        'fg-yellow'  => 33,
+        'fg-blue'    => 34,
+        'fg-magenta' => 35,
+        'fg-cyan'    => 36,
+        'fg-white'   => 37,
+        'bg-black'   => 40,
+        'bg-red'     => 41,
+        'bg-green'   => 42,
+        'bg-yellow'  => 43,
+        'bg-blue'    => 44,
+        'bg-magenta' => 45,
+        'bg-cyan'    => 46,
+        'bg-white'   => 47
+    ];
+
     /**
      * @var PHPUnit_Util_TestDox_NamePrettifier
      */
@@ -71,6 +101,11 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_TextUI_ResultP
     protected $currentTestMethodPrettified;
 
     /**
+     * @var bool
+     */
+    protected $colors = false;
+
+    /**
      * Constructor.
      *
      * @param resource $out
@@ -79,10 +114,27 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_TextUI_ResultP
      */
     public function __construct($out = null, $verbose = false, $colors = self::COLOR_DEFAULT)
     {
-        parent::__construct($out, $verbose, $colors);
+        parent::__construct($out);
 
         $this->prettifier = new PHPUnit_Util_TestDox_NamePrettifier;
         $this->startRun();
+
+        $availableColors = [self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS];
+
+        if (!in_array($colors, $availableColors)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                3,
+                vsprintf('value from "%s", "%s" or "%s"', $availableColors)
+            );
+        }
+
+        $console            = new Console;
+
+        if ($colors === self::COLOR_AUTO && $console->hasColorSupport()) {
+            $this->colors = true;
+        } else {
+            $this->colors = (self::COLOR_ALWAYS === $colors);
+        }
     }
 
     /**
@@ -328,6 +380,41 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_TextUI_ResultP
      */
     protected function endRun()
     {
+    }
+
+    /**
+     * Formats a buffer with a specified ANSI color sequence if colors are
+     * enabled.
+     *
+     * @param  string $color
+     * @param  string $buffer
+     * @return string
+     * @since  Method available since Release 4.0.0
+     */
+    protected function formatWithColor($color, $buffer)
+    {
+        if (!$this->colors) {
+            return $buffer;
+        }
+
+        $codes   = array_map('trim', explode(',', $color));
+        $lines   = explode("\n", $buffer);
+        $padding = max(array_map('strlen', $lines));
+        $styles  = [];
+
+        foreach ($codes as $code) {
+            $styles[] = self::$ansiCodes[$code];
+        }
+
+        $style = sprintf("\x1b[%sm", implode(';', $styles));
+
+        $styledLines = [];
+
+        foreach ($lines as $line) {
+            $styledLines[] = $style . str_pad($line, $padding) . "\x1b[0m";
+        }
+
+        return implode("\n", $styledLines);
     }
 
     private function isOfInterest(PHPUnit_Framework_Test $test)

--- a/src/Util/TestDox/ResultPrinter/Text.php
+++ b/src/Util/TestDox/ResultPrinter/Text.php
@@ -34,12 +34,13 @@ class PHPUnit_Util_TestDox_ResultPrinter_Text extends PHPUnit_Util_TestDox_Resul
     protected function onTest($name, $success = true)
     {
         if ($success) {
-            $this->write(' [x] ');
+            $this->write(' [x] '. $name );
         } else {
-            $this->write(' [ ] ');
+            $buffer = $this->formatWithColor('fg-red, bold', ' [ ] ' . $name );
+            $this->write($buffer);
         }
 
-        $this->write($name . "\n");
+        $this->write("\n");
     }
 
     /**


### PR DESCRIPTION
Enable color support for the testdox output.
Failed tests will be shown in red, like the normal output printer.