### PR TITLE
Closes #1802

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -202,6 +202,7 @@
     <xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
     <xs:attribute name="stopOnError" type="xs:boolean" default="false"/>
     <xs:attribute name="stopOnFailure" type="xs:boolean" default="false"/>
+    <xs:attribute name="stopOnWarning" type="xs:boolean" default="false"/>
     <xs:attribute name="stopOnIncomplete" type="xs:boolean" default="false"/>
     <xs:attribute name="stopOnRisky" type="xs:boolean" default="false"/>
     <xs:attribute name="stopOnSkipped" type="xs:boolean" default="false"/>

--- a/src/Framework/AssertionWarning.php
+++ b/src/Framework/AssertionWarning.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Thrown when an assertion warns.
+ *
+ * @since Class available since Release 5.0.0
+ */
+class PHPUnit_Framework_AssertionWarning extends PHPUnit_Framework_Exception implements PHPUnit_Framework_SelfDescribing
+{
+    /**
+     * Wrapper for getMessage() which is declared as final.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return $this->getMessage();
+    }
+}

--- a/src/Framework/BaseTestListener.php
+++ b/src/Framework/BaseTestListener.php
@@ -21,6 +21,10 @@ abstract class PHPUnit_Framework_BaseTestListener implements PHPUnit_Framework_T
     {
     }
 
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+    }
+
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
     }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -757,6 +757,9 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         } catch (PHPUnit_Framework_SkippedTest $e) {
             $this->status        = PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED;
             $this->statusMessage = $e->getMessage();
+        } catch (PHPUnit_Framework_AssertionWarning $e) {
+            $this->status        = PHPUnit_Runner_BaseTestRunner::STATUS_WARNING;
+            $this->statusMessage = $e->getMessage();
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             $this->status        = PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE;
             $this->statusMessage = $e->getMessage();

--- a/src/Framework/TestListener.php
+++ b/src/Framework/TestListener.php
@@ -25,6 +25,16 @@ interface PHPUnit_Framework_TestListener
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time);
 
     /**
+     * A warning occurred.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                                  $time
+     * @since  Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time);
+    
+    /**
      * A failure occurred.
      *
      * @param PHPUnit_Framework_Test                 $test

--- a/src/Framework/TestListener.php
+++ b/src/Framework/TestListener.php
@@ -27,13 +27,13 @@ interface PHPUnit_Framework_TestListener
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_Test             $test
      * @param PHPUnit_Framework_AssertionWarning $e
-     * @param float                                  $time
-     * @since  Method available since Release 5.0.0
+     * @param float                              $time
+     * @since Method available since Release 5.0.0
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time);
-    
+
     /**
      * A failure occurred.
      *

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -35,6 +35,11 @@ class PHPUnit_Framework_TestResult implements Countable
     /**
      * @var array
      */
+    protected $warnings = [];
+
+    /**
+     * @var array
+     */
     protected $notImplemented = [];
 
     /**
@@ -93,6 +98,11 @@ class PHPUnit_Framework_TestResult implements Countable
      * @var bool
      */
     protected $stopOnFailure = false;
+
+    /**
+     * @var bool
+     */
+    protected $stopOnWarning = false;
 
     /**
      * @var bool
@@ -237,6 +247,29 @@ class PHPUnit_Framework_TestResult implements Countable
 
         $this->lastTestFailed = true;
         $this->time          += $time;
+    }
+
+    /**
+     * Adds a failure to the list of failures.
+     * The passed in exception caused the failure.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                                  $time
+     * @since Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time){
+        if ($this->stopOnWarning){
+            $this->stop();
+        }
+
+        $this->warnings[] = new PHPUnit_Framework_TestFailure($test, $e);
+
+        foreach ($this->listeners as $listener) {
+            $listener->addWarning($test, $e, $time);
+        }
+
+        $this->time += $time;
     }
 
     /**
@@ -498,6 +531,28 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
+     * Gets the number of detected warnings.
+     *
+     * @return int
+     * @since  Method available since Release 5.0.0
+     */
+    public function warningCount()
+    {
+        return count($this->warnings);
+    }
+
+    /**
+     * Returns an Enumeration for the warnings.
+     *
+     * @return array
+     * @since  Method available since Release 5.0.0
+     */
+    public function warnings()
+    {
+        return $this->warnings;
+    }
+
+    /**
      * Returns the names of the tests that have passed.
      *
      * @return array
@@ -541,6 +596,7 @@ class PHPUnit_Framework_TestResult implements Countable
 
         $error      = false;
         $failure    = false;
+        $warning    = false;
         $incomplete = false;
         $risky      = false;
         $skipped    = false;
@@ -626,6 +682,8 @@ class PHPUnit_Framework_TestResult implements Countable
             } elseif ($e instanceof PHPUnit_Framework_SkippedTestError) {
                 $skipped = true;
             }
+        } catch(PHPUnit_Framework_AssertionWarning $e){
+            $warning = true;
         } catch (PHPUnit_Framework_Exception $e) {
             $error = true;
         } catch (Throwable $e) {
@@ -724,6 +782,8 @@ class PHPUnit_Framework_TestResult implements Countable
             $this->addError($test, $e, $time);
         } elseif ($failure === true) {
             $this->addFailure($test, $e, $time);
+        } elseif ($warning === true) {
+            $this->addWarning($test, $e, $time);
         } elseif ($this->beStrictAboutTestsThatDoNotTestAnything &&
                  $test->getNumAssertions() == 0) {
             $this->addFailure(
@@ -868,6 +928,22 @@ class PHPUnit_Framework_TestResult implements Countable
         }
 
         $this->stopOnFailure = $flag;
+    }
+
+    /**
+     * Enables or disables the stopping when a warning occurs.
+     *
+     * @param  bool                        $flag
+     * @throws PHPUnit_Framework_Exception
+     * @since  Method available since Release 5.0.0
+     */
+    public function stopOnWarning($flag)
+    {
+        if (!is_bool($flag)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'boolean');
+        }
+
+        $this->stopOnWarning = $flag;
     }
 
     /**
@@ -1050,7 +1126,7 @@ class PHPUnit_Framework_TestResult implements Countable
      */
     public function wasSuccessful()
     {
-        return empty($this->errors) && empty($this->failures);
+        return empty($this->errors) && empty($this->failures) && empty($this->warnings);
     }
 
     /**

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -250,16 +250,17 @@ class PHPUnit_Framework_TestResult implements Countable
     }
 
     /**
-     * Adds a failure to the list of failures.
-     * The passed in exception caused the failure.
+     * Adds a warning to the list of warnings.
+     * The passed in exception caused the warning.
      *
-     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_Test             $test
      * @param PHPUnit_Framework_AssertionWarning $e
-     * @param float                                  $time
+     * @param float                              $time
      * @since Method available since Release 5.0.0
      */
-    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time){
-        if ($this->stopOnWarning){
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time) 
+    {
+        if ($this->stopOnWarning) {
             $this->stop();
         }
 
@@ -682,7 +683,7 @@ class PHPUnit_Framework_TestResult implements Countable
             } elseif ($e instanceof PHPUnit_Framework_SkippedTestError) {
                 $skipped = true;
             }
-        } catch(PHPUnit_Framework_AssertionWarning $e){
+        } catch (PHPUnit_Framework_AssertionWarning $e) {
             $warning = true;
         } catch (PHPUnit_Framework_Exception $e) {
             $error = true;

--- a/src/Framework/Warning.php
+++ b/src/Framework/Warning.php
@@ -54,7 +54,7 @@ class PHPUnit_Framework_Warning extends PHPUnit_Framework_TestCase
      */
     protected function runTest()
     {
-        $this->fail($this->message);
+        throw new PHPUnit_Framework_AssertionWarning($this->message);
     }
 
     /**

--- a/src/Runner/BaseTestRunner.php
+++ b/src/Runner/BaseTestRunner.php
@@ -21,6 +21,7 @@ abstract class PHPUnit_Runner_BaseTestRunner
     const STATUS_FAILURE    = 3;
     const STATUS_ERROR      = 4;
     const STATUS_RISKY      = 5;
+    const STATUS_WARNING    = 6;
     const SUITE_METHODNAME  = 'suite';
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -71,6 +71,7 @@ class PHPUnit_TextUI_Command
         'stderr'                  => null,
         'stop-on-error'           => null,
         'stop-on-failure'         => null,
+        'stop-on-warning'         => null,
         'stop-on-incomplete'      => null,
         'stop-on-risky'           => null,
         'stop-on-skipped'         => null,
@@ -387,6 +388,10 @@ class PHPUnit_TextUI_Command
 
                 case '--stop-on-failure':
                     $this->arguments['stopOnFailure'] = true;
+                    break;
+
+                case '--stop-on-warning':
+                    $this->arguments['stopOnWarning'] = true;
                     break;
 
                 case '--stop-on-incomplete':
@@ -910,6 +915,7 @@ Test Execution Options:
   --stderr                  Write to STDERR instead of STDOUT.
   --stop-on-error           Stop execution upon first error.
   --stop-on-failure         Stop execution upon first error or failure.
+  --stop-on-warning         Stop execution upon first warning.
   --stop-on-risky           Stop execution upon first risky test.
   --stop-on-skipped         Stop execution upon first skipped test.
   --stop-on-incomplete      Stop execution upon first incomplete test.

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -179,8 +179,8 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
 
         $this->printErrors($result);
         $printSeparator = $result->errorCount() > 0;
-        $hasFailures = $result->failureCount() > 0;
-        $hasWarnings = $result->warningCount() > 0;
+        $hasFailures    = $result->failureCount() > 0;
+        $hasWarnings    = $result->warningCount() > 0;
 
         if ($printSeparator && ($hasFailures || $hasWarnings)) {
             $this->write("\n--\n\n");
@@ -396,10 +396,10 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
 
                 if ($showFailures){
                     $color = 'fg-white, bg-red';
-                    $text = 'FAILURES!';
+                    $text  = 'FAILURES!';
                 } else {
-                    $color = "fg-black, bg-yellow";
-                    $text = 'WARNINGS!';
+                    $color = 'fg-black, bg-yellow';
+                    $text  = 'WARNINGS!';
                 }
 
                 $this->write("\n");
@@ -452,11 +452,11 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
     }
 
     /**
-     * A failure occurred.
+     * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionFailedError $e
-     * @param float                                  $time
+     * @param PHPUnit_Framework_Test             $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                              $time
      * @since Method available since Release 5.0.0
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -179,13 +179,19 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
 
         $this->printErrors($result);
         $printSeparator = $result->errorCount() > 0;
+        $hasFailures = $result->failureCount() > 0;
+        $hasWarnings = $result->warningCount() > 0;
 
-        if ($printSeparator && $result->failureCount() > 0) {
+        if ($printSeparator && ($hasFailures || $hasWarnings)) {
             $this->write("\n--\n\n");
         }
 
-        $printSeparator = $printSeparator || $result->failureCount() > 0;
-        $this->printFailures($result);
+        $printSeparator = $printSeparator || $hasFailures || $hasWarnings;
+        if ($hasWarnings){
+            $this->printWarnings($result);
+        } else {
+            $this->printFailures($result);
+        }
 
         if ($this->verbose) {
             if ($printSeparator && $result->riskyCount() > 0) {
@@ -306,6 +312,14 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
     /**
      * @param PHPUnit_Framework_TestResult $result
      */
+    protected function printWarnings(PHPUnit_Framework_TestResult $result)
+    {
+        $this->printDefects($result->warnings(), 'warning');
+    }
+
+    /**
+     * @param PHPUnit_Framework_TestResult $result
+     */
     protected function printIncompletes(PHPUnit_Framework_TestResult $result)
     {
         $this->printDefects($result->notImplemented(), 'incomplete test');
@@ -371,16 +385,32 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
                     'OK, but incomplete, skipped, or risky tests!'
                 );
             } else {
-                $color = 'fg-white, bg-red';
+                $showFailures = (
+                    $result->errors() ||
+                    $result->failures() ||
+                    $result->skipped() ||
+                    $result->notImplemented() ||
+                    $result->risky()) &&
+                    !$result->warnings()
+                ;
+
+                if ($showFailures){
+                    $color = 'fg-white, bg-red';
+                    $text = 'FAILURES!';
+                } else {
+                    $color = "fg-black, bg-yellow";
+                    $text = 'WARNINGS!';
+                }
 
                 $this->write("\n");
-                $this->writeWithColor($color, 'FAILURES!');
+                $this->writeWithColor($color, $text);
             }
 
             $this->writeCountString(count($result), 'Tests', $color, true);
             $this->writeCountString($this->numAssertions, 'Assertions', $color, true);
             $this->writeCountString($result->errorCount(), 'Errors', $color);
             $this->writeCountString($result->failureCount(), 'Failures', $color);
+            $this->writeCountString($result->warningCount(), 'Warnings', $color);
             $this->writeCountString($result->skippedCount(), 'Skipped', $color);
             $this->writeCountString($result->notImplementedCount(), 'Incomplete', $color);
             $this->writeCountString($result->riskyCount(), 'Risky', $color);
@@ -418,6 +448,20 @@ class PHPUnit_TextUI_ResultPrinter extends PHPUnit_Util_Printer implements PHPUn
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
     {
         $this->writeProgressWithColor('bg-red, fg-white', 'F');
+        $this->lastTestFailed = true;
+    }
+
+    /**
+     * A failure occurred.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionFailedError $e
+     * @param float                                  $time
+     * @since Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+        $this->writeProgressWithColor('fg-yellow, bold', 'W');
         $this->lastTestFailed = true;
     }
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -195,6 +195,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $result->stopOnFailure(true);
         }
 
+        if ($arguments['stopOnWarning']) {
+            $result->stopOnWarning(true);
+        }
+
         if ($arguments['stopOnIncomplete']) {
             $result->stopOnIncomplete(true);
         }
@@ -658,6 +662,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $arguments['stopOnFailure'] = $phpunitConfiguration['stopOnFailure'];
             }
 
+            if (isset($phpunitConfiguration['stopOnWarning']) &&
+                !isset($arguments['stopOnWarning'])) {
+                $arguments['stopOnWarning'] = $phpunitConfiguration['stopOnWarning'];
+            }
+
             if (isset($phpunitConfiguration['stopOnIncomplete']) &&
                 !isset($arguments['stopOnIncomplete'])) {
                 $arguments['stopOnIncomplete'] = $phpunitConfiguration['stopOnIncomplete'];
@@ -961,6 +970,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['crap4jThreshold']                            = isset($arguments['crap4jThreshold'])                            ? $arguments['crap4jThreshold']                            : 30;
         $arguments['stopOnError']                                = isset($arguments['stopOnError'])                                ? $arguments['stopOnError']                                : false;
         $arguments['stopOnFailure']                              = isset($arguments['stopOnFailure'])                              ? $arguments['stopOnFailure']                              : false;
+        $arguments['stopOnWarning']                              = isset($arguments['stopOnWarning'])                              ? $arguments['stopOnWarning']                              : false;
         $arguments['stopOnIncomplete']                           = isset($arguments['stopOnIncomplete'])                           ? $arguments['stopOnIncomplete']                           : false;
         $arguments['stopOnRisky']                                = isset($arguments['stopOnRisky'])                                ? $arguments['stopOnRisky']                                : false;
         $arguments['stopOnSkipped']                              = isset($arguments['stopOnSkipped'])                              ? $arguments['stopOnSkipped']                              : false;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -31,6 +31,7 @@
  *          processIsolation="false"
  *          stopOnError="false"
  *          stopOnFailure="false"
+ *          stopOnWarning="false"
  *          stopOnIncomplete="false"
  *          stopOnRisky="false"
  *          stopOnSkipped="false"
@@ -650,6 +651,13 @@ class PHPUnit_Util_Configuration
         if ($root->hasAttribute('stopOnFailure')) {
             $result['stopOnFailure'] = $this->getBoolean(
                 (string) $root->getAttribute('stopOnFailure'),
+                false
+            );
+        }
+
+        if ($root->hasAttribute('stopOnWarning')) {
+            $result['stopOnWarning'] = $this->getBoolean(
+                (string) $root->getAttribute('stopOnWarning'),
                 false
             );
         }

--- a/src/Util/Log/JSON.php
+++ b/src/Util/Log/JSON.php
@@ -53,9 +53,9 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionWarning     $e
-     * @param float                                  $time
+     * @param PHPUnit_Framework_Test             $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                              $time
      * @since  Method available since Release 5.0.0
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)

--- a/src/Util/Log/JSON.php
+++ b/src/Util/Log/JSON.php
@@ -51,6 +51,27 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
     }
 
     /**
+     * A warning occurred.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionWarning     $e
+     * @param float                                  $time
+     * @since  Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+        $this->writeCase(
+            'warning',
+            $time,
+            PHPUnit_Util_Filter::getFilteredStacktrace($e, false),
+            $e->getMessage(),
+            $test
+        );
+
+        $this->currentTestPass = false;
+    }
+
+    /**
      * A failure occurred.
      *
      * @param PHPUnit_Framework_Test                 $test

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -127,6 +127,20 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
     }
 
     /**
+     * A warning occurred.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionWarning     $e
+     * @param float                                  $time
+     * @since Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+        $this->doAddFault($test, $e, $time, 'warning');
+        $this->testSuiteFailures[$this->testSuiteLevel]++;
+    }
+
+    /**
      * A failure occurred.
      *
      * @param PHPUnit_Framework_Test                 $test

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -129,9 +129,9 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionWarning     $e
-     * @param float                                  $time
+     * @param PHPUnit_Framework_Test             $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                              $time
      * @since Method available since Release 5.0.0
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)

--- a/src/Util/Log/TAP.php
+++ b/src/Util/Log/TAP.php
@@ -59,9 +59,9 @@ class PHPUnit_Util_Log_TAP extends PHPUnit_Util_Printer implements PHPUnit_Frame
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionWarning     $e
-     * @param float                                  $time
+     * @param PHPUnit_Framework_Test             $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                              $time
      * @since Method available since Release 5.0.0
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)

--- a/src/Util/Log/TAP.php
+++ b/src/Util/Log/TAP.php
@@ -57,6 +57,19 @@ class PHPUnit_Util_Log_TAP extends PHPUnit_Util_Printer implements PHPUnit_Frame
     }
 
     /**
+     * A warning occurred.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionWarning     $e
+     * @param float                                  $time
+     * @since Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+       $this->writeNotOk($test, 'Warning');
+    }
+
+    /**
      * A failure occurred.
      *
      * @param PHPUnit_Framework_Test                 $test

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -119,9 +119,9 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
     /**
      * A warning occurred.
      *
-     * @param PHPUnit_Framework_Test                 $test
-     * @param PHPUnit_Framework_AssertionWarning     $e
-     * @param float                                  $time
+     * @param PHPUnit_Framework_Test             $test
+     * @param PHPUnit_Framework_AssertionWarning $e
+     * @param float                              $time
      * @since Method available since Release 5.0.0
      */
     public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -43,6 +43,11 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
     /**
      * @var int
      */
+    protected $warned = 0;
+
+    /**
+     * @var int
+     */
     protected $failed = 0;
 
     /**
@@ -109,6 +114,24 @@ abstract class PHPUnit_Util_TestDox_ResultPrinter extends PHPUnit_Util_Printer i
 
         $this->testStatus = PHPUnit_Runner_BaseTestRunner::STATUS_ERROR;
         $this->failed++;
+    }
+
+    /**
+     * A warning occurred.
+     *
+     * @param PHPUnit_Framework_Test                 $test
+     * @param PHPUnit_Framework_AssertionWarning     $e
+     * @param float                                  $time
+     * @since Method available since Release 5.0.0
+     */
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+        if (!$this->isOfInterest($test)) {
+            return;
+        }
+
+        $this->testStatus = PHPUnit_Runner_BaseTestRunner::STATUS_WARNING;
+        $this->warned++;
     }
 
     /**

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -90,7 +90,8 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
         $suite->run($this->result);
 
         $this->assertTrue(!$this->result->wasSuccessful());
-        $this->assertEquals(1, $this->result->failureCount());
+        $this->assertEquals(0, $this->result->failureCount());
+        $this->assertEquals(1, $this->result->warningCount());
         $this->assertEquals(1, count($this->result));
     }
 

--- a/tests/Framework/TestListenerTest.php
+++ b/tests/Framework/TestListenerTest.php
@@ -17,6 +17,7 @@ class Framework_TestListenerTest extends PHPUnit_Framework_TestCase implements P
     protected $endCount;
     protected $errorCount;
     protected $failureCount;
+    protected $warningCount;
     protected $notImplementedCount;
     protected $riskyCount;
     protected $skippedCount;
@@ -26,6 +27,11 @@ class Framework_TestListenerTest extends PHPUnit_Framework_TestCase implements P
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         $this->errorCount++;
+    }
+
+    public function addWarning(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionWarning $e, $time)
+    {
+        $this->warningCount++;
     }
 
     public function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)

--- a/tests/Regression/684.phpt
+++ b/tests/Regression/684.phpt
@@ -12,14 +12,14 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-F                                                                   1 / 1 (100%)
+W                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %sMb
 
-There was 1 failure:
+There was 1 warning:
 
 1) Warning
 No tests found in class "Foo_Bar_Issue684Test".
 
-FAILURES!
-Tests: 1, Assertions: 0, Failures: 1.
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/Regression/GitHub/498.phpt
+++ b/tests/Regression/GitHub/498.phpt
@@ -15,15 +15,15 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-F                                                                   1 / 1 (100%)
+W                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %sMb
 
-There was 1 failure:
+There was 1 warning:
 
 1) Warning
 The data provider specified for Issue498Test::shouldBeFalse is invalid.
 Can't create the data
 
-FAILURES!
-Tests: 1, Assertions: 0, Failures: 1.
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/Regression/GitHub/765.phpt
+++ b/tests/Regression/GitHub/765.phpt
@@ -13,14 +13,14 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-.F                                                                  2 / 2 (100%)
+.W                                                                  2 / 2 (100%)
 
 Time: %s, Memory: %sMb
 
-There was 1 failure:
+There was 1 warning:
 
 1) Warning
 The data provider specified for Issue765Test::testDependent is invalid.
 
-FAILURES!
-Tests: 2, Assertions: 1, Failures: 1.
+WARNINGS!
+Tests: 2, Assertions: 1, Warnings: 1.

--- a/tests/TextUI/abstract-test-class.phpt
+++ b/tests/TextUI/abstract-test-class.phpt
@@ -12,14 +12,14 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-F                                                                   1 / 1 (100%)
+W                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %sMb
 
-There was 1 failure:
+There was 1 warning:
 
 1) Warning
 Cannot instantiate class "AbstractTest".
 
-FAILURES!
-Tests: 1, Assertions: 0, Failures: 1.
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/TextUI/empty-testcase.phpt
+++ b/tests/TextUI/empty-testcase.phpt
@@ -12,14 +12,14 @@ PHPUnit_TextUI_Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-F                                                                   1 / 1 (100%)
+W                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %sMb
 
-There was 1 failure:
+There was 1 warning:
 
 1) Warning
 No tests found in class "EmptyTestCaseTest".
 
-FAILURES!
-Tests: 1, Assertions: 0, Failures: 1.
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -62,6 +62,7 @@ Test Execution Options:
   --stderr                  Write to STDERR instead of STDOUT.
   --stop-on-error           Stop execution upon first error.
   --stop-on-failure         Stop execution upon first error or failure.
+  --stop-on-warning         Stop execution upon first warning.
   --stop-on-risky           Stop execution upon first risky test.
   --stop-on-skipped         Stop execution upon first skipped test.
   --stop-on-incomplete      Stop execution upon first incomplete test.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -63,6 +63,7 @@ Test Execution Options:
   --stderr                  Write to STDERR instead of STDOUT.
   --stop-on-error           Stop execution upon first error.
   --stop-on-failure         Stop execution upon first error or failure.
+  --stop-on-warning         Stop execution upon first warning.
   --stop-on-risky           Stop execution upon first risky test.
   --stop-on-skipped         Stop execution upon first skipped test.
   --stop-on-incomplete      Stop execution upon first incomplete test.

--- a/tests/TextUI/stop-on-warning-via-cli.phpt
+++ b/tests/TextUI/stop-on-warning-via-cli.phpt
@@ -1,0 +1,26 @@
+--TEST--
+phpunit --stop-on-warning StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--stop-on-warning';
+$_SERVER['argv'][3] = 'StopOnWarningTestSuite';
+$_SERVER['argv'][4] = dirname(dirname(__FILE__)) . '/_files/StopOnWarningTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+W
+
+Time: %s, Memory: %sMb
+
+There was 1 warning:
+
+1) Warning
+No tests found in class "NoTestCases".
+
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/TextUI/stop-on-warning-via-config.phpt
+++ b/tests/TextUI/stop-on-warning-via-config.phpt
@@ -1,0 +1,27 @@
+--TEST--
+phpunit -c ../_files/configuration_stop_on_warning.xml --stop-on-warning StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = dirname(__FILE__).'/../_files/configuration_stop_on_warning.xml';
+$_SERVER['argv'][3] = '--stop-on-warning';
+$_SERVER['argv'][4] = 'StopOnWarningTestSuite';
+$_SERVER['argv'][5] = dirname(dirname(__FILE__)) . '/_files/StopOnWarningTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+W
+
+Time: %s, Memory: %sMb
+
+There was 1 warning:
+
+1) Warning
+No tests found in class "NoTestCases".
+
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -359,6 +359,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'mapTestClassNameToCoveredClassName'         => false,
             'printerClass'                               => 'PHPUnit_TextUI_ResultPrinter',
             'stopOnFailure'                              => false,
+            'stopOnWarning'                              => false,
             'reportUselessTests'                         => false,
             'strictCoverage'                             => false,
             'disallowTestOutput'                         => false,

--- a/tests/_files/StopOnWarningTestSuite.php
+++ b/tests/_files/StopOnWarningTestSuite.php
@@ -1,0 +1,13 @@
+<?php
+class StopOnWarningTestSuite
+{
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('Test Warnings');
+
+        $suite->addTestSuite('NoTestCases');
+        $suite->addTestSuite('CoverageClassTest');
+
+        return $suite;
+    }
+}

--- a/tests/_files/StopsOnWarningTest.php
+++ b/tests/_files/StopsOnWarningTest.php
@@ -1,0 +1,7 @@
+<?php
+class StopsOnWarningTest extends PHPUnit_Framework_TestCase
+{
+    public function testOne()
+    {
+    }
+}

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -14,6 +14,7 @@
          mapTestClassNameToCoveredClassName="false"
          printerClass="PHPUnit_TextUI_ResultPrinter"
          stopOnFailure="false"
+         stopOnWarning="false"
          testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
          beStrictAboutChangesToGlobalState="false"
          beStrictAboutOutputDuringTests="false"

--- a/tests/_files/configuration_stop_on_warning.xml
+++ b/tests/_files/configuration_stop_on_warning.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit stopOnWarning="true" />

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -14,6 +14,7 @@
          mapTestClassNameToCoveredClassName="false"
          printerClass="PHPUnit_TextUI_ResultPrinter"
          stopOnFailure="false"
+         stopOnWarning="false"
          testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
          beStrictAboutChangesToGlobalState="false"
          beStrictAboutOutputDuringTests="false"


### PR DESCRIPTION
Few comments: 
- I have added the `warning` as a separated thing than a `failure`. 
- The example in #1802 shows a very specific scenario for a warning, I have taken this a step farther as I saw that a warning can be shown from a different reasons. 
- As well, I kept the `1) Warning` title as I assumed that it was dropped by mistake. However, the fix for that is simple in case its required though I believe this will create a bit of a mess if thats true only for warnings while its not true for other scenarios. 

I hope this would do the job but feel free to comment out if anything comes in mind. 
Cheers
Shaked
