### PR TITLE
add flag to disable @codeCoverageIgnore

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -75,6 +75,7 @@ class PHPUnit_TextUI_Command
         'stop-on-risky'           => null,
         'stop-on-skipped'         => null,
         'strict-coverage'         => null,
+        'disable-ignore-coverage' => null,
         'strict-global-state'     => null,
         'tap'                     => null,
         'testdox'                 => null,
@@ -449,6 +450,10 @@ class PHPUnit_TextUI_Command
 
                 case '--strict-coverage':
                     $this->arguments['strictCoverage'] = true;
+                    break;
+
+                case '--disable-ignore-coverage':
+                    $this->arguments['disableCodeCoverageIgnore'] = true;
                     break;
 
                 case '--strict-global-state':
@@ -894,6 +899,7 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --disable-ignore-coverage Disable @codeCoverageIgnore in coverage reports.
   --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --disallow-resource-usage Be strict about resource usage during small tests.

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -377,6 +377,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     $arguments['mapTestClassNameToCoveredClassName']
                 );
             }
+            
+            if (isset($arguments['disableCodeCoverageIgnore'])) {
+                $codeCoverage->setDisableIgnoredLines(true);
+            }
 
             $result->setCodeCoverage($codeCoverage);
         }
@@ -490,7 +494,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($arguments['coverageText'])) {
                 if ($arguments['coverageText'] == 'php://stdout') {
                     $outputStream = $this->printer;
-                    $colors       = $arguments['colors'];
+                    $colors       = $arguments['colors'] !== PHPUnit_TextUI_ResultPrinter::COLOR_NEVER;
                 } else {
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
                     $colors       = false;
@@ -736,6 +740,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($phpunitConfiguration['mapTestClassNameToCoveredClassName']) &&
                 !isset($arguments['mapTestClassNameToCoveredClassName'])) {
                 $arguments['mapTestClassNameToCoveredClassName'] = $phpunitConfiguration['mapTestClassNameToCoveredClassName'];
+            }
+
+            if (isset($phpunitConfiguration['disableCodeCoverageIgnore']) &&
+                !isset($arguments['disableCodeCoverageIgnore'])) {
+                $arguments['disableCodeCoverageIgnore'] = $phpunitConfiguration['disableCodeCoverageIgnore'];
             }
 
             $groupCliArgs = [];

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -633,6 +633,13 @@ class PHPUnit_Util_Configuration
             );
         }
 
+        if ($root->hasAttribute('disableCodeCoverageIgnore')) {
+            $result['disableCodeCoverageIgnore'] = $this->getBoolean(
+                (string) $root->getAttribute('disableCodeCoverageIgnore'),
+                false
+            );
+        }
+
         if ($root->hasAttribute('processIsolation')) {
             $result['processIsolation'] = $this->getBoolean(
                 (string) $root->getAttribute('processIsolation'),

--- a/tests/TextUI/code-coverage-ignore.phpt
+++ b/tests/TextUI/code-coverage-ignore.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout IgnoreCodeCoverageClassTest ../_files/IgnoreCodeCoverageClassTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = __DIR__.'/../_files/IgnoreCodeCoverageClassTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+Warning:	No whitelist configured for code coverage
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (1/1)
+  Methods: 100.00% (1/1)
+  Lines:   50.00% (1/2)%w
+
+IgnoreCodeCoverageClass
+  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  1/  1)

--- a/tests/TextUI/disable-code-coverage-ignore.phpt
+++ b/tests/TextUI/disable-code-coverage-ignore.phpt
@@ -1,0 +1,34 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout --disable-ignore-coverage IgnoreCodeCoverageClassTest ../_files/IgnoreCodeCoverageClassTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = '--disable-ignore-coverage';
+$_SERVER['argv'][5] = __DIR__.'/../_files/IgnoreCodeCoverageClassTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+Warning:	No whitelist configured for code coverage
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (1/1)%w
+  Methods: 100.00% (2/2)%w
+  Lines:%s
+
+IgnoreCodeCoverageClass
+  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  2/  2)

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -46,6 +46,7 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --disable-ignore-coverage Disable @codeCoverageIgnore in coverage reports.
   --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --disallow-resource-usage Be strict about resource usage during small tests.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -47,6 +47,7 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --disable-ignore-coverage Disable @codeCoverageIgnore in coverage reports.
   --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --disallow-resource-usage Be strict about resource usage during small tests.

--- a/tests/_files/IgnoreCodeCoverageClass.php
+++ b/tests/_files/IgnoreCodeCoverageClass.php
@@ -1,0 +1,16 @@
+<?php
+class IgnoreCodeCoverageClass
+{
+    /**
+     * @codeCoverageIgnore
+     */
+    public function returnTrue()
+    {
+        return true;
+    }
+    
+    public function returnFalse()
+    {
+        return false;
+    }
+}

--- a/tests/_files/IgnoreCodeCoverageClassTest.php
+++ b/tests/_files/IgnoreCodeCoverageClassTest.php
@@ -1,0 +1,15 @@
+<?php
+class IgnoreCodeCoverageClassTest extends PHPUnit_Framework_TestCase
+{
+    public function testReturnTrue()
+    {
+        $sut = new IgnoreCodeCoverageClass();
+        $this->assertTrue($sut->returnTrue());
+    }
+    
+    public function testReturnFalse()
+    {
+        $sut = new IgnoreCodeCoverageClass();
+        $this->assertFalse($sut->returnFalse());
+    }
+}


### PR DESCRIPTION
* add new --disable-ignore-coverage flag to disable @codeCoverageIgnore annotation in coverage reports.
* add --disable-ignore-coverage to help menu, and update help.phpt and help2.phpt tests to support the change.
* add two new phpt tests to demonstrate functionality and output when --disable-ignore-coverage is included and when it is excluded by printing the coverage summary text to stdout.
* fix bug where colors are used in text coverage summary even when --colors=never is specified.
