### PR TITLE
Fixed #1860

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1825,6 +1825,9 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
     {
+        new SimpleXMLElement($expectedXml);
+        new SimpleXMLElement($actualXml);
+        
         $expected                     = new DOMDocument;
         $expected->preserveWhiteSpace = false;
         $expected->loadXML($expectedXml);


### PR DESCRIPTION
SimpleXMLElement will trigger E_WARNING error messages if XML strings to be compared are not well-formed.
