### PR TITLE
Fix JUnit XML Format:

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -337,7 +337,7 @@ class PHPUnit_Util_Log_JUnit extends PHPUnit_Util_Printer implements PHPUnit_Fra
             if ($class->hasMethod($methodName)) {
                 $method = $class->getMethod($test->getName());
 
-                $testCase->setAttribute('class', $class->getName());
+                $testCase->setAttribute('classname', $class->getName());
                 $testCase->setAttribute('file', $class->getFileName());
                 $testCase->setAttribute('line', $method->getStartLine());
             }


### PR DESCRIPTION
testcase's attribute "class" must be called "classname"
```XSD
<xs:attribute name="classname" type="xs:token" use="required">
```
[http://help.catchsoftware.com/display/ET/JUnit+Format]