### PR TITLE
Avoid exiting the Travis build script in case the status code testing fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - ./phpunit
-  - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; exit 1; else echo "fail checked"; fi;
+  - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
   - xmllint --noout --schema phpunit.xsd phpunit.xml.dist
   - xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml
   - xmllint --noout --schema phpunit.xsd tests/_files/configuration_empty.xml


### PR DESCRIPTION
`exit` should not be used in the .travis.yml file steps, as it would exit the whole build, leading to no feedback and missing the other steps: http://docs.travis-ci.com/user/customizing-the-build/#How-does-this-work%3F-%28Or%2C-why-you-should-not-use-exit-in-build-steps%29
