### PR TITLE
add --atleast-version command option

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -34,6 +34,7 @@ class PHPUnit_TextUI_Command
      * @var array
      */
     protected $longOptions = [
+        'atleast-version='        => null,
         'bootstrap='              => null,
         'colors=='                => null,
         'columns='                => null,
@@ -447,6 +448,13 @@ class PHPUnit_TextUI_Command
                 case 'v':
                 case '--verbose':
                     $this->arguments['verbose'] = true;
+                    break;
+
+                case '--atleast-version':
+                    exit (version_compare(PHPUnit_Runner_Version::id(), $option[1], '>=')
+                        ? PHPUnit_TextUI_TestRunner::SUCCESS_EXIT
+                        : PHPUnit_TextUI_TestRunner::FAILURE_EXIT
+                    );
                     break;
 
                 case '--version':
@@ -953,6 +961,7 @@ Miscellaneous Options:
 
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
+  --atleast-version min     Checks the version is greater than min and exits.
 
 EOT;
 

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -90,3 +90,4 @@ Miscellaneous Options:
 
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
+  --atleast-version min     Checks the version is greater than min and exits.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -91,3 +91,4 @@ Miscellaneous Options:
 
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
+  --atleast-version min     Checks the version is greater than min and exits.


### PR DESCRIPTION
This option mimic the pkg-config one.

Probably not very useful for most user which use composer or phpunit.phar, but will be appreciated when "phpunit" is not under the user control.

```
if phpunit --atleast-version 5; then
    phpunit --verbose
else
    echo "PHPUnit is too old"
fi
```

Especially for Package in Fedora/EPEL (same spec file used in all branches) as we are going to be stick to 4.x, because of PHP dependencies.

Of course, will be nice to have in 4.8...  but as "phpunit --atleast-version 5" fails (unrecognized option) this should be enough.
