### PR TITLE
#1013 added configuration path to globals for reinitializing php values in tpl

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -674,6 +674,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $includePath        = "'." . $includePath . ".'";
             $codeCoverageFilter = "'." . $codeCoverageFilter . ".'";
 
+            $configurationFilePath = (isset($GLOBALS['__PHPUNIT_CONFIGURATION_FILE']) ? $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] : '');
+
             $template->setVar(
                 [
                     'composerAutoload'                           => $composerAutoload,
@@ -695,7 +697,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     'enforcesTimeLimit'                          => $enforcesTimeLimit,
                     'isStrictAboutTodoAnnotatedTests'            => $isStrictAboutTodoAnnotatedTests,
                     'isStrictAboutResourceUsageDuringSmallTests' => $isStrictAboutResourceUsageDuringSmallTests,
-                    'codeCoverageFilter'                         => $codeCoverageFilter
+                    'codeCoverageFilter'                         => $codeCoverageFilter,
+                    'configurationFile'                          => $configurationFilePath
                 ]
             );
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -585,6 +585,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     {
         if (isset($arguments['configuration']) &&
             !$arguments['configuration'] instanceof PHPUnit_Util_Configuration) {
+            $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
             $arguments['configuration'] = PHPUnit_Util_Configuration::getInstance(
                 $arguments['configuration']
             );

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -71,6 +71,13 @@ function __phpunit_run_isolated_test()
     );
 }
 
+$configurationFile = '{configurationFile}';
+
+if('' !== $configurationFile) {
+    $configuration = PHPUnit_Util_Configuration::getInstance($configurationFile);
+    $configuration->handlePHPConfiguration();
+}
+
 {constants}
 {included_files}
 {globals}


### PR DESCRIPTION
This is a fix for issue #1013 which causes phpunit to loose any php value configured in configuration xml to be lost when test is ran in isolation and preserve globals is disabled.
