### PR TITLE
Avoid passing Error to onNotSuccesfulTest on PHP 7

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -848,6 +848,11 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                 $e = new PHPUnit_Framework_AssertionFailedError($e->getMessage());
             }
 
+            if (!$e instanceof Exception) {
+                // Rethrow Error directly on PHP 7 as onNotSuccessfulTest does not support it
+                throw $e;
+            }
+
             $this->onNotSuccessfulTest($e);
         }
     }


### PR DESCRIPTION
onNotSuccessfulTest is typehinted as Exception, so only Exception throwables should be passed to it.

Closes #1882

This does not allow `onNotSuccessfulTest` to be called for `Error` on PHP 7, but this is impossible because of the typehint.
This code simply rethrow the error (which is the default method of the method), so that we get the display of the error instead of seeing the display of a TypeError triggered in PHPUnit.
