### PR TITLE
#1013 added configuration path to globals for reinitializing php values in tpl

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -690,7 +690,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     'isStrictAboutOutputDuringTests'          => $isStrictAboutOutputDuringTests,
                     'isStrictAboutTestSize'                   => $isStrictAboutTestSize,
                     'isStrictAboutTodoAnnotatedTests'         => $isStrictAboutTodoAnnotatedTests,
-                    'codeCoverageFilter'                      => $codeCoverageFilter
+                    'codeCoverageFilter'                      => $codeCoverageFilter,
+                    'configurationFile'                       => (isset($GLOBALS['__PHPUNIT_CONFIGURATION_FILE']) ? $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] : '')
                 )
             );
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -670,6 +670,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $includePath        = "'." . $includePath . ".'";
             $codeCoverageFilter = "'." . $codeCoverageFilter . ".'";
 
+            $configurationFilePath = (isset($GLOBALS['__PHPUNIT_CONFIGURATION_FILE']) ? $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] : '');
+
             $template->setVar(
                 array(
                     'composerAutoload'                        => $composerAutoload,
@@ -691,7 +693,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     'isStrictAboutTestSize'                   => $isStrictAboutTestSize,
                     'isStrictAboutTodoAnnotatedTests'         => $isStrictAboutTodoAnnotatedTests,
                     'codeCoverageFilter'                      => $codeCoverageFilter,
-                    'configurationFile'                       => (isset($GLOBALS['__PHPUNIT_CONFIGURATION_FILE']) ? $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] : '')
+                    'configurationFilePath'                   => $configurationFilePath
                 )
             );
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -592,6 +592,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     {
         if (isset($arguments['configuration']) &&
             !$arguments['configuration'] instanceof PHPUnit_Util_Configuration) {
+            $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
             $arguments['configuration'] = PHPUnit_Util_Configuration::getInstance(
                 $arguments['configuration']
             );

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -142,6 +142,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
      */
     public function doRun(PHPUnit_Framework_Test $suite, array $arguments = array())
     {
+        if (isset($arguments['configuration'])) {
+            $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
+        }
+
         $this->handleConfiguration($arguments);
 
         $this->processSuiteFilters($suite, $arguments);
@@ -592,7 +596,6 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
     {
         if (isset($arguments['configuration']) &&
             !$arguments['configuration'] instanceof PHPUnit_Util_Configuration) {
-            $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
             $arguments['configuration'] = PHPUnit_Util_Configuration::getInstance(
                 $arguments['configuration']
             );

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -70,10 +70,10 @@ function __phpunit_run_isolated_test()
     );
 }
 
-$configurationFile = '{configurationFile}';
+$configurationFilePath = '{configurationFilePath}';
 
-if('' !== $configurationFile) {
-    $configuration = PHPUnit_Util_Configuration::getInstance($configurationFile);
+if ('' !== $configurationFilePath) {
+    $configuration = PHPUnit_Util_Configuration::getInstance($configurationFilePath);
     $configuration->handlePHPConfiguration();
 }
 

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -70,6 +70,13 @@ function __phpunit_run_isolated_test()
     );
 }
 
+$configurationFile = '{configurationFile}';
+
+if('' !== $configurationFile) {
+    $configuration = PHPUnit_Util_Configuration::getInstance($configurationFile);
+    $configuration->handlePHPConfiguration();
+}
+
 {constants}
 {included_files}
 {globals}


### PR DESCRIPTION
This is a fix for issue #1013 which causes tests that are ran in isolation. to lose any php value configured in configuration xml. This only happens when preserve globals is disabled.
