### PR TITLE
coverage-text: do not use colors if --colors=never

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -489,10 +489,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($arguments['coverageText'])) {
                 if ($arguments['coverageText'] == 'php://stdout') {
                     $outputStream = $this->printer;
-                    $colors       = $arguments['colors'];
-                    if($colors == PHPUnit_TextUI_ResultPrinter::COLOR_NEVER) {
-                        $colors = false;
-                    }
+                    $colors = $arguments['colors'] && $arguments['colors'] != PHPUnit_TextUI_ResultPrinter::COLOR_NEVER;
                 } else {
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
                     $colors       = false;

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -490,6 +490,9 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 if ($arguments['coverageText'] == 'php://stdout') {
                     $outputStream = $this->printer;
                     $colors       = $arguments['colors'];
+                    if($colors == PHPUnit_TextUI_ResultPrinter::COLOR_NEVER) {
+                        $colors = false;
+                    }
                 } else {
                     $outputStream = new PHPUnit_Util_Printer($arguments['coverageText']);
                     $colors       = false;

--- a/tests/TextUI/coverage-text-colors-never.phpt
+++ b/tests/TextUI/coverage-text-colors-never.phpt
@@ -1,5 +1,11 @@
 --TEST--
 phpunit --configuration=../_files/configuration.coverage-text.only-summary.colors-never.xml CoveredClass ../_files/CoverageClassTest.php
+--SKIPIF--
+<?php
+if (PHP_MAJOR_VERSION == 7) {
+    print 'skip: PHP 7 has no code coverage driver';
+}
+?>
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--configuration=' . dirname(__FILE__) . '/../_files/configuration.coverage-text.only-summary.colors-never.xml';

--- a/tests/TextUI/coverage-text-colors-never.phpt
+++ b/tests/TextUI/coverage-text-colors-never.phpt
@@ -1,0 +1,25 @@
+--TEST--
+phpunit --configuration=../_files/configuration.coverage-text.only-summary.colors-never.xml CoveredClass ../_files/CoverageClassTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--configuration=' . dirname(__FILE__) . '/../_files/configuration.coverage-text.only-summary.colors-never.xml';
+$_SERVER['argv'][2] = 'CoveredClass';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/CoverageClassTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %sMb
+
+OK (1 test, 0 assertions)
+
+
+Code Coverage Report Summary:
+  Classes: 50.00% (1/2)%s
+  Methods: 50.00% (3/6)%s
+  Lines:   58.33% (7/12)

--- a/tests/_files/configuration.coverage-text.only-summary.colors-never.xml
+++ b/tests/_files/configuration.coverage-text.only-summary.colors-never.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="never">
+    <filter>
+        <whitelist>
+            <file>../_files/CoveredClass.php</file>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-text"
+             target="php://stdout"
+             showUncoveredFiles="false"
+             showOnlySummary="true"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
Don't use colors when using `--coverage-text` along with `--colors=never`.

See #1771 and #1892 

(replaces #1906)
