### PR TITLE
Added 'flowId' parameter to each Teamcity message for parallel tests

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -272,6 +272,8 @@ class PHPUnit_Util_Log_TeamCity extends PHPUnit_TextUI_ResultPrinter
     {
         $this->write("\n##teamcity[$eventName");
 
+        $params['flowId'] = getmypid();
+
         foreach ($params as $key => $value) {
             $escapedValue = self::escapeValue($value);
             $this->write(" $key='$escapedValue'");


### PR DESCRIPTION
TeamCity can't handle correctly output from several instances of PHPUnit running in parallel. In my case some tests are reported with "Unknown test name"

According to https://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-MessageFlowId it's possible to use 'flowId' parameter in service message to help TeamCity to do this.
