### PR TITLE
Allow @coversDefaultClass annotation to work on traits

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -921,7 +921,8 @@ class PHPUnit_Util_Test
 
                 foreach ($classes as $className) {
                     if (!class_exists($className) &&
-                        !interface_exists($className)) {
+                        !interface_exists($className) &&
+                        !trait_exists($className)) {
                         throw new PHPUnit_Framework_InvalidCoversTargetException(
                             sprintf(
                                 'Trying to @cover or @use not existing class or ' .


### PR DESCRIPTION
Using a `@coversDefaultClass` annotation would previously fail when used with a trait with the message `Trying to @cover or @use not existing class or interface "Name\Of\Trait"`. This minor change allows traits to be used as a default coverage target.

If setting up a different annotation is preferable I can look into adding it, but traits already work as expected with the standard `@covers` annotations.
