### PR TITLE
add flag to disable @codeCoverageIgnore annotations

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -80,6 +80,7 @@ class PHPUnit_TextUI_Command
         'fail-on-warning'         => null,
         'fail-on-risky'           => null,
         'strict-coverage'         => null,
+        'disable-ignore-coverage' => null,
         'strict-global-state'     => null,
         'tap'                     => null,
         'teamcity'                => null,
@@ -483,6 +484,10 @@ class PHPUnit_TextUI_Command
 
                 case '--strict-coverage':
                     $this->arguments['strictCoverage'] = true;
+                    break;
+
+                case '--disable-ignore-coverage':
+                    $this->arguments['disableCodeCoverageIgnore'] = true;
                     break;
 
                 case '--strict-global-state':
@@ -953,6 +958,7 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --disable-ignore-coverage Disable @codeCoverageIgnore in coverage reports.
   --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --disallow-resource-usage Be strict about resource usage during small tests.

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -373,6 +373,10 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     $arguments['mapTestClassNameToCoveredClassName']
                 );
             }
+            
+            if (isset($arguments['disableCodeCoverageIgnore'])) {
+                $codeCoverage->setDisableIgnoredLines(true);
+            }
 
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
@@ -782,6 +786,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if (isset($phpunitConfiguration['mapTestClassNameToCoveredClassName']) &&
                 !isset($arguments['mapTestClassNameToCoveredClassName'])) {
                 $arguments['mapTestClassNameToCoveredClassName'] = $phpunitConfiguration['mapTestClassNameToCoveredClassName'];
+            }
+
+            if (isset($phpunitConfiguration['disableCodeCoverageIgnore']) &&
+                !isset($arguments['disableCodeCoverageIgnore'])) {
+                $arguments['disableCodeCoverageIgnore'] = $phpunitConfiguration['disableCodeCoverageIgnore'];
             }
 
             $groupCliArgs = [];

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -619,6 +619,13 @@ class PHPUnit_Util_Configuration
             );
         }
 
+        if ($root->hasAttribute('disableCodeCoverageIgnore')) {
+            $result['disableCodeCoverageIgnore'] = $this->getBoolean(
+                (string) $root->getAttribute('disableCodeCoverageIgnore'),
+                false
+            );
+        }
+
         if ($root->hasAttribute('processIsolation')) {
             $result['processIsolation'] = $this->getBoolean(
                 (string) $root->getAttribute('processIsolation'),

--- a/tests/TextUI/code-coverage-ignore.phpt
+++ b/tests/TextUI/code-coverage-ignore.phpt
@@ -1,0 +1,37 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout IgnoreCodeCoverageClassTest ../_files/IgnoreCodeCoverageClassTest.php --whitelist ../../tests/_files/IgnoreCodeCoverageClass.php
+--SKIPIF--
+<?php
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+?>
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = __DIR__.'/../_files/IgnoreCodeCoverageClassTest.php';
+$_SERVER['argv'][5] = '--whitelist';
+$_SERVER['argv'][6] = __DIR__.'/../_files/IgnoreCodeCoverageClass.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (1/1)
+  Methods:%w(0/0)%w
+  Lines:%w(0/0)%w

--- a/tests/TextUI/disable-code-coverage-ignore.phpt
+++ b/tests/TextUI/disable-code-coverage-ignore.phpt
@@ -1,0 +1,41 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout --disable-ignore-coverage IgnoreCodeCoverageClassTest tests/_files/IgnoreCodeCoverageClassTest.php --whitelist ../../tests/_files/IgnoreCodeCoverageClass.php
+--SKIPIF--
+<?php
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+?>
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = '--disable-ignore-coverage';
+$_SERVER['argv'][5] = __DIR__.'/../_files/IgnoreCodeCoverageClassTest.php';
+$_SERVER['argv'][6] = '--whitelist';
+$_SERVER['argv'][7] = __DIR__.'/../_files/IgnoreCodeCoverageClass.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (1/1)%w
+  Methods: 100.00% (2/2)%w
+  Lines:%s
+
+IgnoreCodeCoverageClass
+  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  2/  2)

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -48,6 +48,7 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --disable-ignore-coverage Disable @codeCoverageIgnore in coverage reports.
   --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --disallow-resource-usage Be strict about resource usage during small tests.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -49,6 +49,7 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --disable-ignore-coverage Disable @codeCoverageIgnore in coverage reports.
   --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --disallow-resource-usage Be strict about resource usage during small tests.

--- a/tests/_files/IgnoreCodeCoverageClass.php
+++ b/tests/_files/IgnoreCodeCoverageClass.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @codeCoverageIgnore
+ */
+class IgnoreCodeCoverageClass
+{
+    public function returnTrue()
+    {
+        return true;
+    }
+    
+    public function returnFalse()
+    {
+        return false;
+    }
+}

--- a/tests/_files/IgnoreCodeCoverageClassTest.php
+++ b/tests/_files/IgnoreCodeCoverageClassTest.php
@@ -1,0 +1,15 @@
+<?php
+class IgnoreCodeCoverageClassTest extends PHPUnit_Framework_TestCase
+{
+    public function testReturnTrue()
+    {
+        $sut = new IgnoreCodeCoverageClass();
+        $this->assertTrue($sut->returnTrue());
+    }
+    
+    public function testReturnFalse()
+    {
+        $sut = new IgnoreCodeCoverageClass();
+        $this->assertFalse($sut->returnFalse());
+    }
+}


### PR DESCRIPTION
- add new --disable-ignore-coverage flag to disable @codeCoverageIgnore annotation in coverage reports.
- add --disable-ignore-coverage to help menu, and update help.phpt and help2.phpt tests to support the change.
- add two new phpt tests to demonstrate functionality and output when --disable-ignore-coverage is included and when it is excluded by printing the coverage summary text to stdout.
