### PR TITLE
Fix #1896 wrong test location when combine @depends @dataProvider

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -623,7 +623,9 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $result->convertErrorsToExceptions($this->useErrorHandler);
         }
 
-        if (!$this instanceof PHPUnit_Framework_Warning && !$this->handleDependencies()) {
+        if (!$this instanceof PHPUnit_Framework_Warning &&
+            !$this instanceof PHPUnit_Framework_SkippedTestCase &&
+            !$this->handleDependencies()) {
             return;
         }
 

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -212,9 +212,11 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
 
         $suite->run($this->result);
 
-        $message = $this->result->skipped()[0]->thrownException()->getMessage();
+        $skipped           = $this->result->skipped();
+        $lastSkippedResult = array_pop($skipped);
+        $message           = $lastSkippedResult->thrownException()->getMessage();
 
-        $this->assertContains('DataProviderDependencyTest', $message);
+        $this->assertContains('Test for DataProviderDependencyTest::testDependency skipped by data provider', $message);
     }
 
     public function testIncompleteTestDataProvider()

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -12,6 +12,7 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPAR
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeClassAndAfterClassTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'TestWithTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderSkippedTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderDependencyTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderIncompleteTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'InheritedTestCase.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'NoTestCaseClass.php';
@@ -51,6 +52,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
         $suite->addTest(new self('testBeforeAnnotation'));
         $suite->addTest(new self('testTestWithAnnotation'));
         $suite->addTest(new self('testSkippedTestDataProvider'));
+        $suite->addTest(new self('testTestDataProviderDependency'));
         $suite->addTest(new self('testIncompleteTestDataProvider'));
         $suite->addTest(new self('testRequirementsBeforeClassHook'));
         $suite->addTest(new self('testDontSkipInheritedClass'));
@@ -202,6 +204,17 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(3, $this->result->count());
         $this->assertEquals(1, $this->result->skippedCount());
+    }
+
+    public function testTestDataProviderDependency()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('DataProviderDependencyTest');
+
+        $suite->run($this->result);
+
+        $message = $this->result->skipped()[0]->thrownException()->getMessage();
+
+        $this->assertContains('DataProviderDependencyTest', $message);
     }
 
     public function testIncompleteTestDataProvider()

--- a/tests/_files/DataProviderDependencyTest.php
+++ b/tests/_files/DataProviderDependencyTest.php
@@ -1,0 +1,25 @@
+<?php
+
+class DataProviderDependencyTest extends PHPUnit_Framework_TestCase
+{
+    public function testReference()
+    {
+        $this->markTestSkipped('This test should be skipped.');
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @see https://github.com/sebastianbergmann/phpunit/issues/1896
+     * @depends testReference
+     * @dataProvider provider
+     */
+    public function testDependency($param)
+    {
+    }
+
+    public function provider()
+    {
+        $this->markTestSkipped('Any test with this data provider should be skipped.');
+        return [];
+    }
+}


### PR DESCRIPTION
This is a fix for #1896 by @llaville. Since the data provider marks that the test case should be skipped, this fix simply skips `@depends` check and shows the error message from data provider.

It is a very first time to make a pull request to phpunit for me. Please let me know if there's anything I can improve the code.

Thanks!
