### PR TITLE
allow unordered occurence of phpType elements

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -161,17 +161,19 @@
   </xs:attributeGroup>
   <xs:complexType name="phpType">
     <xs:sequence>
-      <xs:element name="includePath" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="ini" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="const" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="var" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="env" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="get" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="cookie" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="server" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="files" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element name="request" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="includePath" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="ini" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="const" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="var" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="env" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="get" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="cookie" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="server" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="files" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="request" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:choice>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="namedValueType">


### PR DESCRIPTION
With this change, the ordering of the elements under the `<php>` element in the xml configuration does not matter anymore.

Prior this change, the XML did not validate against the `phpunit.xsd` if - for example - a `env` tag was inserted after a `server` tag inside the `php` tag.

Thank you for considering this pull request.
