### PR TITLE
Path coverage switch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=5.6",
         "phpunit/php-file-iterator": "~1.4",
         "phpunit/php-text-template": "~1.2",
-        "phpunit/php-code-coverage": "~3.0",
+        "phpunit/php-code-coverage": "~3.1",
         "phpunit/php-timer": ">=1.0.6",
         "phpunit/phpunit-mock-objects": ">=3.0",
         "phpspec/prophecy": "^1.3.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          backupGlobals="false"
+         enablePathCoverage="true"
          verbose="true">
   <testsuites>
     <testsuite name="small">
@@ -19,7 +20,7 @@
   </testsuites>
 
   <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true" enablePathCoverage="true">
+    <whitelist processUncoveredFilesFromWhitelist="true">
       <directory suffix=".php">src</directory>
       <exclude>
        <file>src/Framework/Assert/Functions.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
   </testsuites>
 
   <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
+    <whitelist processUncoveredFilesFromWhitelist="true" enablePathCoverage="true">
       <directory suffix=".php">src</directory>
       <exclude>
        <file>src/Framework/Assert/Functions.php</file>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -35,6 +35,7 @@
     <xs:complexContent>
       <xs:extension base="filterType">
         <xs:attribute name="addUncoveredFilesFromWhitelist" default="false" type="xs:boolean"/>
+        <xs:attribute name="enablePathCoverage" default="true" type="xs:boolean"/>
         <xs:attribute name="processUncoveredFilesFromWhitelist" default="true" type="xs:boolean"/>
       </xs:extension>
     </xs:complexContent>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -35,7 +35,6 @@
     <xs:complexContent>
       <xs:extension base="filterType">
         <xs:attribute name="addUncoveredFilesFromWhitelist" default="false" type="xs:boolean"/>
-        <xs:attribute name="enablePathCoverage" default="true" type="xs:boolean"/>
         <xs:attribute name="processUncoveredFilesFromWhitelist" default="true" type="xs:boolean"/>
       </xs:extension>
     </xs:complexContent>
@@ -196,6 +195,7 @@
     <xs:attribute name="convertErrorsToExceptions" type="xs:boolean" default="true"/>
     <xs:attribute name="convertNoticesToExceptions" type="xs:boolean" default="true"/>
     <xs:attribute name="convertWarningsToExceptions" type="xs:boolean" default="true"/>
+    <xs:attribute name="enablePathCoverage" default="true" type="xs:boolean"/>
     <xs:attribute name="forceCoversAnnotation" type="xs:boolean" default="false"/>
     <xs:attribute name="mapTestClassNameToCoveredClassName" type="xs:boolean" default="false"/>
     <xs:attribute name="printerClass" type="xs:string" default="PHPUnit_TextUI_ResultPrinter"/>

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -965,7 +965,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $this->runtime->canCollectCodeCoverage()) {
                 $filterConfiguration                             = $arguments['configuration']->getFilterConfiguration();
                 $arguments['addUncoveredFilesFromWhitelist']     = $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist'];
-                $arguments['enablePathCoverage']                 = $filterConfiguration['whitelist']['enablePathCoverage'];
+                $arguments['enablePathCoverage']                 = $phpunitConfiguration['enablePathCoverage'];
                 $arguments['processUncoveredFilesFromWhitelist'] = $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist'];
 
                 foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -347,7 +347,8 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         if ($codeCoverageReports > 0) {
             $codeCoverage = new PHP_CodeCoverage(
                 null,
-                $this->codeCoverageFilter
+                $this->codeCoverageFilter,
+                $arguments['enablePathCoverage']
             );
 
             $codeCoverage->setAddUncoveredFilesFromWhitelist(
@@ -964,6 +965,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $this->runtime->canCollectCodeCoverage()) {
                 $filterConfiguration                             = $arguments['configuration']->getFilterConfiguration();
                 $arguments['addUncoveredFilesFromWhitelist']     = $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist'];
+                $arguments['enablePathCoverage']                 = $filterConfiguration['whitelist']['enablePathCoverage'];
                 $arguments['processUncoveredFilesFromWhitelist'] = $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist'];
 
                 foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
@@ -993,6 +995,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         }
 
         $arguments['addUncoveredFilesFromWhitelist']             = isset($arguments['addUncoveredFilesFromWhitelist'])             ? $arguments['addUncoveredFilesFromWhitelist']             : true;
+        $arguments['enablePathCoverage']                         = isset($arguments['enablePathCoverage'])                         ? $arguments['enablePathCoverage']                         : false;
         $arguments['processUncoveredFilesFromWhitelist']         = isset($arguments['processUncoveredFilesFromWhitelist'])         ? $arguments['processUncoveredFilesFromWhitelist']         : false;
         $arguments['backupGlobals']                              = isset($arguments['backupGlobals'])                              ? $arguments['backupGlobals']                              : null;
         $arguments['backupStaticAttributes']                     = isset($arguments['backupStaticAttributes'])                     ? $arguments['backupStaticAttributes']                     : null;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -25,6 +25,7 @@
  *          convertErrorsToExceptions="true"
  *          convertNoticesToExceptions="true"
  *          convertWarningsToExceptions="true"
+ *          enablePathCoverage="false"
  *          forceCoversAnnotation="false"
  *          mapTestClassNameToCoveredClassName="false"
  *          printerClass="PHPUnit_TextUI_ResultPrinter"
@@ -69,7 +70,6 @@
  *
  *   <filter>
  *     <whitelist addUncoveredFilesFromWhitelist="true"
- *                enablePathCoverage="false"
  *                processUncoveredFilesFromWhitelist="false">
  *       <directory suffix=".php">/path/to/files</directory>
  *       <file>/path/to/file</file>
@@ -208,7 +208,6 @@ class PHPUnit_Util_Configuration
     public function getFilterConfiguration()
     {
         $addUncoveredFilesFromWhitelist     = true;
-        $enablePathCoverage                 = false;
         $processUncoveredFilesFromWhitelist = false;
 
         $tmp = $this->xpath->query('filter/whitelist');
@@ -220,15 +219,6 @@ class PHPUnit_Util_Configuration
                         'addUncoveredFilesFromWhitelist'
                     ),
                     true
-                );
-            }
-
-            if ($tmp->item(0)->hasAttribute('enablePathCoverage')) {
-                $enablePathCoverage = $this->getBoolean(
-                    (string) $tmp->item(0)->getAttribute(
-                        'enablePathCoverage'
-                    ),
-                    false
                 );
             }
 
@@ -245,7 +235,6 @@ class PHPUnit_Util_Configuration
         return [
           'whitelist' => [
             'addUncoveredFilesFromWhitelist'     => $addUncoveredFilesFromWhitelist,
-            'enablePathCoverage'                 => $enablePathCoverage,
             'processUncoveredFilesFromWhitelist' => $processUncoveredFilesFromWhitelist,
             'include'                            => [
               'directory' => $this->readFilterDirectories(
@@ -614,6 +603,13 @@ class PHPUnit_Util_Configuration
             $result['convertWarningsToExceptions'] = $this->getBoolean(
                 (string) $root->getAttribute('convertWarningsToExceptions'),
                 true
+            );
+        }
+
+        if ($root->hasAttribute('enablePathCoverage')) {
+            $result['enablePathCoverage'] = $this->getBoolean(
+                (string) $root->getAttribute('enablePathCoverage'),
+                false
             );
         }
 

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -69,6 +69,7 @@
  *
  *   <filter>
  *     <whitelist addUncoveredFilesFromWhitelist="true"
+ *                enablePathCoverage="false"
  *                processUncoveredFilesFromWhitelist="false">
  *       <directory suffix=".php">/path/to/files</directory>
  *       <file>/path/to/file</file>
@@ -207,6 +208,7 @@ class PHPUnit_Util_Configuration
     public function getFilterConfiguration()
     {
         $addUncoveredFilesFromWhitelist     = true;
+        $enablePathCoverage                 = false;
         $processUncoveredFilesFromWhitelist = false;
 
         $tmp = $this->xpath->query('filter/whitelist');
@@ -218,6 +220,15 @@ class PHPUnit_Util_Configuration
                         'addUncoveredFilesFromWhitelist'
                     ),
                     true
+                );
+            }
+
+            if ($tmp->item(0)->hasAttribute('enablePathCoverage')) {
+                $enablePathCoverage = $this->getBoolean(
+                    (string) $tmp->item(0)->getAttribute(
+                        'enablePathCoverage'
+                    ),
+                    false
                 );
             }
 
@@ -234,6 +245,7 @@ class PHPUnit_Util_Configuration
         return [
           'whitelist' => [
             'addUncoveredFilesFromWhitelist'     => $addUncoveredFilesFromWhitelist,
+            'enablePathCoverage'                 => $enablePathCoverage,
             'processUncoveredFilesFromWhitelist' => $processUncoveredFilesFromWhitelist,
             'include'                            => [
               'directory' => $this->readFilterDirectories(

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -89,6 +89,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'whitelist' =>
             [
               'addUncoveredFilesFromWhitelist'     => true,
+              'enablePathCoverage'                 => false,
               'processUncoveredFilesFromWhitelist' => false,
               'include'                            =>
               [

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -89,7 +89,6 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'whitelist' =>
             [
               'addUncoveredFilesFromWhitelist'     => true,
-              'enablePathCoverage'                 => false,
               'processUncoveredFilesFromWhitelist' => false,
               'include'                            =>
               [
@@ -321,6 +320,7 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             'convertErrorsToExceptions'                  => true,
             'convertNoticesToExceptions'                 => true,
             'convertWarningsToExceptions'                => true,
+            'enablePathCoverage'                         => false,
             'forceCoversAnnotation'                      => false,
             'mapTestClassNameToCoveredClassName'         => false,
             'printerClass'                               => 'PHPUnit_TextUI_ResultPrinter',

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -47,6 +47,7 @@
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true"
+               enablePathCoverage="false"
                processUncoveredFilesFromWhitelist="false">
       <directory suffix=".php">/path/to/files</directory>
       <file>/path/to/file</file>

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -10,6 +10,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         enablePathCoverage="false"
          forceCoversAnnotation="false"
          mapTestClassNameToCoveredClassName="false"
          printerClass="PHPUnit_TextUI_ResultPrinter"
@@ -47,7 +48,6 @@
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true"
-               enablePathCoverage="false"
                processUncoveredFilesFromWhitelist="false">
       <directory suffix=".php">/path/to/files</directory>
       <file>/path/to/file</file>


### PR DESCRIPTION
Requires php-code-coverage v3.1 (https://github.com/sebastianbergmann/php-code-coverage/pull/400)

Turned off by default because is resource expensive and requires Xdebug >= 2.3.2
