### PR TITLE
Print stacktrace for throwables if expecting exception

### DIFF
--- a/src/Framework/Constraint/Exception.php
+++ b/src/Framework/Constraint/Exception.php
@@ -54,8 +54,7 @@ class PHPUnit_Framework_Constraint_Exception extends PHPUnit_Framework_Constrain
     {
         if ($other !== null) {
             $message = '';
-            $throwable = 'Throwable';
-            if ($other instanceof Exception || $other instanceof $throwable) {
+            if ($other instanceof Exception || $other instanceof Throwable) {
                 $message = '. Message was: "' . $other->getMessage() . '" at'
                         . "\n" . $other->getTraceAsString();
             }

--- a/src/Framework/Constraint/Exception.php
+++ b/src/Framework/Constraint/Exception.php
@@ -54,7 +54,8 @@ class PHPUnit_Framework_Constraint_Exception extends PHPUnit_Framework_Constrain
     {
         if ($other !== null) {
             $message = '';
-            if ($other instanceof Exception) {
+            $throwable = 'Throwable';
+            if ($other instanceof Exception || $other instanceof $throwable) {
                 $message = '. Message was: "' . $other->getMessage() . '" at'
                         . "\n" . $other->getTraceAsString();
             }

--- a/src/Framework/Constraint/Exception.php
+++ b/src/Framework/Constraint/Exception.php
@@ -56,7 +56,7 @@ class PHPUnit_Framework_Constraint_Exception extends PHPUnit_Framework_Constrain
             $message = '';
             if ($other instanceof Exception || $other instanceof Throwable) {
                 $message = '. Message was: "' . $other->getMessage() . '" at'
-                        . "\n" . $other->getTraceAsString();
+                        . "\n" . PHPUnit_Util_Filter::getFilteredStacktrace($other);
             }
 
             return sprintf(

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -23,7 +23,7 @@ class PHPUnit_Util_Filter
      *
      * @return string
      */
-    public static function getFilteredStacktrace(Exception $e, $asString = true)
+    public static function getFilteredStacktrace($e, $asString = true)
     {
         $prefix = false;
         $script = realpath($GLOBALS['_SERVER']['SCRIPT_NAME']);

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -3454,7 +3454,7 @@ EOF
     {
         $constraint = new PHPUnit_Framework_Constraint_Exception('FoobarException');
         $exception  = new DummyException('Test');
-        $stackTrace = $exception->getTraceAsString();
+        $stackTrace = PHPUnit_Util_Filter::getFilteredStacktrace($exception);
 
         try {
             $constraint->evaluate($exception);


### PR DESCRIPTION
There is no stacktrace printed when following conditions are met:
1. PHP version is 7.0 of greater
2. Exception is expected to be thrown from test method
3. PHP Error (former fatal) is thrown before expected exception 

For example, this code:

```
    /**
     * @expectedException InvalidArgumentException
     */
    public function testFatal() {
        getFatal();
        throw new InvalidArgumentException();
    }
```

will print:

```
PHPUnit 5.0.3-14-gd31d78c by Sebastian Bergmann and contributors.
F                                                                   1 / 1 (100%)
Time: 156 ms, Memory: 4.00Mb
There was 1 failure:
1) FatalTest::testFatal
Failed asserting that exception of type "Error" matches expected exception "InvalidArgumentException".
FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

And it will output stacktrace with my fix

```
PHPUnit 5.0.3-87-g62d33fb by Sebastian Bergmann and contributors.
F                                                                   1 / 1 (100%)
Time: 147 ms, Memory: 4.00Mb
There was 1 failure:
1) FatalTest::testFatal
Failed asserting that exception of type "Error" matches expected exception "InvalidArgumentException". Message was: "Call to undefined function getFatal()" at
#0 [internal function]: FatalTest->testFatal()
#1 /home/dev/phpunittest/vendor/phpunit/phpunit/src/Framework/TestCase.php(907): ReflectionMethod->invokeArgs(Object(FatalTest), Array)
#2 /home/dev/phpunittest/vendor/phpunit/phpunit/src/Framework/TestCase.php(770): PHPUnit_Framework_TestCase->runTest()
#3 /home/dev/phpunittest/vendor/phpunit/phpunit/src/Framework/TestResult.php(616): PHPUnit_Framework_TestCase->runBare()
#4 /home/dev/phpunittest/vendor/phpunit/phpunit/src/Framework/TestCase.php(726): PHPUnit_Framework_TestResult->run(Object(FatalTest))
#5 /home/dev/phpunittest/vendor/phpunit/phpunit/src/Framework/TestSuite.php(747): PHPUnit_Framework_TestCase->run(Object(PHPUnit_Framework_TestResult))
#6 /home/dev/phpunittest/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(425): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))
#7 /home/dev/phpunittest/vendor/phpunit/phpunit/src/TextUI/Command.php(154): PHPUnit_TextUI_TestRunner->doRun(Object(PHPUnit_Framework_TestSuite), Array)
#8 /home/dev/phpunittest/vendor/phpunit/phpunit/src/TextUI/Command.php(105): PHPUnit_TextUI_Command->run(Array, true)
#9 /home/dev/phpunittest/vendor/phpunit/phpunit/phpunit(47): PHPUnit_TextUI_Command::main()
#10 {main}.
```
