### PR TITLE
Rollback version of DbUnit for PHP 5.3

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -91,7 +91,7 @@
         <exec executable="php">
             <arg value="composer.phar"/>
             <arg value="require"/>
-            <arg value="phpunit/dbunit:~2.0.2"/>
+            <arg value="phpunit/dbunit:~1.4"/>
             <arg value="phpunit/phpunit-selenium:~1.4"/>
             <arg value="phpunit/php-invoker:~1.1"/>
         </exec>
@@ -208,8 +208,9 @@
         </copy>
 
         <copy todir="${basedir}/build/phar/dbunit">
-            <fileset dir="${basedir}/vendor/phpunit/dbunit/src">
+            <fileset dir="${basedir}/vendor/phpunit/dbunit/PHPUnit">
                 <include name="**/*.php" />
+                <exclude name="**/Autoload.*" />
             </fileset>
         </copy>
 


### PR DESCRIPTION
It's revert to part of 54ee96a

DbUnit ~2.0 is supporting PHP version >= 5.4.
DbUnit ~2.0 is using array-short-syntax (`[]`), case PHP 5.3, it's occurred syntax error.
PHPUnit 4.8.17 bundles DbUnit 2.0.2..

PHPUnit 4.8 supports PHP version >= 5.3 now.

Hope to continue using DbUnit 1.4 **for PHP 5.3 user**
(I think something is not one's real intention, too..)

or PHPUnit over then 4.8.16 will be not supporting PHP 5.3?
