### PR TITLE
Fix throwing Prophet error

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1004,7 +1004,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         if ($this->prophet !== null) {
             try {
                 $this->prophet->checkPredictions();
-            } catch (Throwable $t) {
+            } catch (Throwable $e) {
                 /* Intentionally left empty */
             } catch (Exception $e) {
                 /* Intentionally left empty */


### PR DESCRIPTION
This simple fix allows to throw Prophet predictions exceptions.

Btw, very similar error is in current dev version https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L1002
