### PR TITLE
Fixes --filter

### DIFF
--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -53,7 +53,7 @@ class PHPUnit_Util_ErrorHandler
 
         self::$errorStack[] = [$errno, $errstr, $errfile, $errline];
 
-        $trace = debug_backtrace(false);
+        $trace = debug_backtrace(0);
         array_shift($trace);
 
         foreach ($trace as $frame) {

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -114,7 +114,7 @@ class PHPUnit_Util_Getopt
         $count   = count($long_options);
         $list    = explode('=', $arg);
         $opt     = $list[0];
-        $opt_arg = null;
+        $opt_arg = '';
 
         if (count($list) > 1) {
             $opt_arg = $list[1];


### PR DESCRIPTION
Fixes --filter option since migration to strict types. Right now this code is emitting type errors:
- `strlen` expects a string
- `debug_backtrace` expects an int not bool
