### PR TITLE
Throw exception when @testWith annotation contains invalid datasets

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -469,9 +469,15 @@ class PHPUnit_Util_Test
             $data              = array();
             foreach (explode("\n", $annotationContent) as $candidateRow) {
                 $candidateRow = trim($candidateRow);
+                if ($candidateRow[0] !== '[') {
+                    break;
+                }
                 $dataSet      = json_decode($candidateRow, true);
                 if (json_last_error() != JSON_ERROR_NONE) {
-                    break;
+                    $error = function_exists('json_last_error_msg') ? json_last_error_msg() : json_last_error();
+                    throw new PHPUnit_Framework_Exception(
+                        'The dataset for the @testWith annotation cannot be parsed: '.$error
+                    );
                 }
                 $data[] = $dataSet;
             }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -346,10 +346,22 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     {
         $this->setExpectedExceptionRegExp(
             'PHPUnit_Framework_Exception',
-            '/^The dataset for the @testWith annotation cannot be parsed.$/'
+            '/^The dataset for the @testWith annotation cannot be parsed:/'
         );
         PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
                                                            * @testWith [s]
+                                                           */');
+    }
+
+    public function testTestWithThrowsProperExceptionIfMultiLineDatasetCannotBeParsed()
+    {
+        $this->setExpectedExceptionRegExp(
+            'PHPUnit_Framework_Exception',
+            '/^The dataset for the @testWith annotation cannot be parsed:/'
+        );
+        PHPUnit_Util_Test::getDataFromTestWithAnnotation('/**
+                                                           * @testWith ["valid"]
+                                                           *           [invalid]
                                                            */');
     }
 


### PR DESCRIPTION
The existing code was silently ignoring invalid JSON if it had
found at least one valid dataset. It was using this behaviour
to detect the end of the @testWith annotation (see for eg the
testTestWithSimpleTextAfter test, which fails if a simple
throw on invalid JSON is used).

This fix treats a line as being part of the @testWith if it begins
with a `[` character - since all datasets are required to be JSON
arrays this should be reliable.

It can then reliably throw if invalid JSON is found for any of the
datasets.
