### PR TITLE
#1912 add requirement for minimum extension version

### DIFF
--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -483,6 +483,17 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSkipsIfRequiresExtensionWithAMinimumVersion()
+    {
+        $test   = new RequirementsTest('testSpecificExtensionVersion');
+        $result = $test->run();
+
+        $this->assertEquals(
+            'Extension testExt 1.8.0 (or later) is required.',
+            $test->getStatusMessage()
+        );
+    }
+
     public function testSkipsProvidesMessagesForAllSkippingReasons()
     {
         $test   = new RequirementsTest('testAllPossibleRequirements');
@@ -495,7 +506,8 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
             'Function testFuncOne is required.' . PHP_EOL .
             'Function testFuncTwo is required.' . PHP_EOL .
             'Extension testExtOne is required.' . PHP_EOL .
-            'Extension testExtTwo is required.',
+            'Extension testExtTwo is required.' . PHP_EOL .
+            'Extension testExtThree 2.0 (or later) is required.',
             $test->getStatusMessage()
         );
     }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -165,9 +165,19 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
                 'extensions' => [
                   'testExtOne',
                   'testExtTwo',
+                  'testExtThree',
+                ],
+                'extension_versions' => [
+                    'testExtThree' => '2.0'
                 ]
               ]
-            ]
+            ],
+            ['testSpecificExtensionVersion',
+                [
+                    'extension_versions' => ['testExt' => '1.8.0'],
+                    'extensions' => ['testExt']
+                ]
+            ],
         ];
     }
 
@@ -225,6 +235,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
               'Function testFuncTwo is required.',
               'Extension testExtOne is required.',
               'Extension testExtTwo is required.',
+              'Extension testExtThree 2.0 (or later) is required.',
             ]],
         ];
     }

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -84,6 +84,7 @@ class RequirementsTest extends PHPUnit_Framework_TestCase
      * @requires function testFuncTwo
      * @requires extension testExtOne
      * @requires extension testExtTwo
+     * @requires extension testExtThree 2.0
      */
     public function testAllPossibleRequirements()
     {
@@ -144,5 +145,13 @@ class RequirementsTest extends PHPUnit_Framework_TestCase
      */
     public function testSpace()
     {
+    }
+
+    /**
+     * @requires extension testExt 1.8.0
+     */
+    public function testSpecificExtensionVersion()
+    {
+
     }
 }


### PR DESCRIPTION
I took a look at #1912 and wrote a pragmatic implementation that supports specifying the minimum version number for an extension.

I tried avoiding changes to the public API of `PHPUnit_Util_Test` and therefore added a new element to the array returned by `PHPUnit_Util_Test::getRequirements()` (which can still be considered a breaking change). It now includes the element `extension_versions`, that is being evaluated by `PHPUnit_Util_Test::getMissingRequirements`.

Example:

```
<?php

class FooTest extends PHPUnit_Framework_TestCase
{
    /**
     * @requires extension foo 2.2
     */
    public function testFoo()
    {
        $this->assertTrue(true);
    }
}
```

Output:

```
$ phpunit -v FooTest.php
(...)
There was 1 skipped test:

1) FooTest::testFoo
Extension foo 2.2 (or later) is required.
(...)
```

The message will be same if the extension is not present at all. 
