### PR TITLE
Throw InvalidCoversTargetException for extended covers tags

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -971,6 +971,18 @@ class PHPUnit_Util_Test
             $classes = [$element];
 
             if ($extended) {
+                if (!class_exists($element) &&
+                    !interface_exists($element) &&
+                    !trait_exists($element)) {
+                    throw new PHPUnit_Framework_InvalidCoversTargetException(
+                        sprintf(
+                            'Trying to @cover or @use not existing class or ' .
+                            'interface "%s".',
+                            $element
+                        )
+                    );
+                }
+
                 $classes = array_merge(
                     $classes,
                     class_implements($element),

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -465,6 +465,19 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers            PHPUnit_Util_Test::getLinesToBeCovered
+     * @covers            PHPUnit_Util_Test::getLinesToBeCoveredOrUsed
+     * @covers            PHPUnit_Util_Test::resolveElementToReflectionObjects
+     * @expectedException PHPUnit_Framework_CodeCoverageException
+     */
+    public function testGetLinesToBeCovered5()
+    {
+        PHPUnit_Util_Test::getLinesToBeCovered(
+            'NotExistingCoveredElementTest', 'testFour'
+        );
+    }
+
+    /**
      * @covers PHPUnit_Util_Test::getLinesToBeCovered
      * @covers PHPUnit_Util_Test::getLinesToBeCoveredOrUsed
      */

--- a/tests/_files/NotExistingCoveredElementTest.php
+++ b/tests/_files/NotExistingCoveredElementTest.php
@@ -21,4 +21,11 @@ class NotExistingCoveredElementTest extends PHPUnit_Framework_TestCase
     public function testThree()
     {
     }
+
+    /**
+     * @covers NotExistingClass<extended>
+     */
+    public function testFour()
+    {
+    }
 }


### PR DESCRIPTION
When an invalid class is given in `@covers` tag with `<extended>` no exception is thrown.

This causes a warning to be triggered:

```
class_implements(): Class NotExistingClass does not exist and could not be loaded
```

Also see: https://github.com/ockcyp/covers-validator/issues/5
Thanks @willemstuursma for finding it out
