### PR TITLE
Allow skipping of testcases that have have @expectedException annotation

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -917,7 +917,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         if (isset($e)) {
             $checkException = false;
 
-            if (is_string($this->expectedException)) {
+            if (!($e instanceof PHPUnit_Framework_SkippedTestError) && is_string($this->expectedException)) {
                 $checkException = true;
 
                 if ($e instanceof PHPUnit_Framework_Exception) {


### PR DESCRIPTION
This allows for something like:

``` php
/**
  * @expectedException \PHPUnit_Framework_Error_Warning
  */
function testSomething() {
     if (!version_compare(PHP_VERSION, '7.0.0', '<')) {
         $this->markTestSkipped("PHP < 7.0.0 is required");
     }
}
```

Currently it fails with:

`Failed asserting that exception of type "PHPUnit_Framework_SkippedTestError" matches expected exception "\PHPUnit_Framework_Error_Notice". Message was: "PHP < 7.0.0 is required"`
