### PR TITLE
Add support for [optional] operators in @requires and @extension annotations

### DIFF
--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -431,7 +431,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
-            'PHPUnit 1111111 (or later) is required.',
+            'PHPUnit >= 1111111 is required.',
             $test->getStatusMessage()
         );
     }
@@ -443,7 +443,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
-            'PHP 9999999 (or later) is required.',
+            'PHP >= 9999999 is required.',
             $test->getStatusMessage()
         );
     }
@@ -489,7 +489,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $result = $test->run();
 
         $this->assertEquals(
-            'Extension testExt 1.8.0 (or later) is required.',
+            'Extension testExt >= 1.8.0 is required.',
             $test->getStatusMessage()
         );
     }
@@ -500,14 +500,14 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $result = $test->run();
 
         $this->assertEquals(
-            'PHP 99-dev (or later) is required.' . PHP_EOL .
-            'PHPUnit 9-dev (or later) is required.' . PHP_EOL .
+            'PHP >= 99-dev is required.' . PHP_EOL .
+            'PHPUnit >= 9-dev is required.' . PHP_EOL .
             'Operating system matching /DOESNOTEXIST/i is required.' . PHP_EOL .
             'Function testFuncOne is required.' . PHP_EOL .
             'Function testFuncTwo is required.' . PHP_EOL .
             'Extension testExtOne is required.' . PHP_EOL .
             'Extension testExtTwo is required.' . PHP_EOL .
-            'Extension testExtThree 2.0 (or later) is required.',
+            'Extension testExtThree >= 2.0 is required.',
             $test->getStatusMessage()
         );
     }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -135,13 +135,16 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['testOne',    []],
-            ['testTwo',    ['PHPUnit'    => '1.0']],
-            ['testThree',  ['PHP'        => '2.0']],
-            ['testFour',   ['PHPUnit'    => '2.0', 'PHP' => '1.0']],
-            ['testFive',   ['PHP'        => '5.4.0RC6']],
-            ['testSix',    ['PHP'        => '5.4.0-alpha1']],
-            ['testSeven',  ['PHP'        => '5.4.0beta2']],
-            ['testEight',  ['PHP'        => '5.4-dev']],
+            ['testTwo',    ['PHPUnit'    => ['version' => '1.0', 'operator' => '']]],
+            ['testThree',  ['PHP'        => ['version' => '2.0', 'operator' => '']]],
+            ['testFour',   [
+                'PHPUnit'    => ['version' => '2.0', 'operator' => ''],
+                'PHP' => ['version' => '1.0', 'operator' => '']]
+            ],
+            ['testFive',   ['PHP'        => ['version' => '5.4.0RC6', 'operator' => '']]],
+            ['testSix',    ['PHP'        => ['version' => '5.4.0-alpha1', 'operator' => '']]],
+            ['testSeven',  ['PHP'        => ['version' => '5.4.0beta2', 'operator' => '']]],
+            ['testEight',  ['PHP'        => ['version' => '5.4-dev', 'operator' => '']]],
             ['testNine',   ['functions'  => ['testFunc']]],
             ['testTen',    ['extensions' => ['testExt']]],
             ['testEleven', ['OS'         => '/Linux/i']],
@@ -155,8 +158,8 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
             [
               'testAllPossibleRequirements',
               [
-                'PHP'       => '99-dev',
-                'PHPUnit'   => '9-dev',
+                'PHP'       => ['version' => '99-dev', 'operator' => ''],
+                'PHPUnit'   => ['version' => '9-dev', 'operator' => ''],
                 'OS'        => '/DOESNOTEXIST/i',
                 'functions' => [
                   'testFuncOne',
@@ -168,14 +171,152 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
                   'testExtThree',
                 ],
                 'extension_versions' => [
-                    'testExtThree' => '2.0'
+                    'testExtThree' => ['version' => '2.0', 'operator' => '']
                 ]
               ]
             ],
             ['testSpecificExtensionVersion',
                 [
-                    'extension_versions' => ['testExt' => '1.8.0'],
+                    'extension_versions' => ['testExt' => ['version' => '1.8.0', 'operator' => '']],
                     'extensions'         => ['testExt']
+                ]
+            ],
+            ['testPHPVersionOperatorLessThan',
+                [
+                    'PHP' => ['version' => '5.4', 'operator' => '<']
+                ]
+            ],
+            ['testPHPVersionOperatorLessThanEquals',
+                [
+                    'PHP' => ['version' => '5.4', 'operator' => '<=']
+                ]
+            ],
+            ['testPHPVersionOperatorGreaterThan',
+                [
+                    'PHP' => ['version' => '99', 'operator' => '>']
+                ]
+            ],
+            ['testPHPVersionOperatorGreaterThanEquals',
+                [
+                    'PHP' => ['version' => '99', 'operator' => '>=']
+                ]
+            ],
+            ['testPHPVersionOperatorEquals',
+                [
+                    'PHP' => ['version' => '5.4', 'operator' => '=']
+                ]
+            ],
+            ['testPHPVersionOperatorDoubleEquals',
+                [
+                    'PHP' => ['version' => '5.4', 'operator' => '==']
+                ]
+            ],
+            ['testPHPVersionOperatorBangEquals',
+                [
+                    'PHP' => ['version' => '99', 'operator' => '!=']
+                ]
+            ],
+            ['testPHPVersionOperatorNotEquals',
+                [
+                    'PHP' => ['version' => '99', 'operator' => '<>']
+                ]
+            ],
+            ['testPHPVersionOperatorNoSpace',
+                [
+                    'PHP' => ['version' => '99', 'operator' => '>=']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorLessThan',
+                [
+                    'PHPUnit' => ['version' => '1.0', 'operator' => '<']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorLessThanEquals',
+                [
+                    'PHPUnit' => ['version' => '1.0', 'operator' => '<=']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorGreaterThan',
+                [
+                    'PHPUnit' => ['version' => '99', 'operator' => '>']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorGreaterThanEquals',
+                [
+                    'PHPUnit' => ['version' => '99', 'operator' => '>=']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorEquals',
+                [
+                    'PHPUnit' => ['version' => '1.0', 'operator' => '=']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorDoubleEquals',
+                [
+                    'PHPUnit' => ['version' => '1.0', 'operator' => '==']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorBangEquals',
+                [
+                    'PHPUnit' => ['version' => '99', 'operator' => '!=']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorNotEquals',
+                [
+                    'PHPUnit' => ['version' => '99', 'operator' => '<>']
+                ]
+            ],
+            ['testPHPUnitVersionOperatorNoSpace',
+                [
+                    'PHPUnit' => ['version' => '99', 'operator' => '>=']
+                ]
+            ],
+            ['testExtensionVersionOperatorLessThanEquals',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '1.0', 'operator' => '<=']]
+                ]
+            ],
+            ['testExtensionVersionOperatorGreaterThan',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '99', 'operator' => '>']]
+                ]
+            ],
+            ['testExtensionVersionOperatorGreaterThanEquals',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '99', 'operator' => '>=']]
+                ]
+            ],
+            ['testExtensionVersionOperatorEquals',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '1.0', 'operator' => '=']]
+                ]
+            ],
+            ['testExtensionVersionOperatorDoubleEquals',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '1.0', 'operator' => '==']]
+                ]
+            ],
+            ['testExtensionVersionOperatorBangEquals',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '99', 'operator' => '!=']]
+                ]
+            ],
+            ['testExtensionVersionOperatorNotEquals',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '99', 'operator' => '<>']]
+                ]
+            ],
+            ['testExtensionVersionOperatorNoSpace',
+                [
+                    'extensions' => ['testExtOne'],
+                    'extension_versions' => ['testExtOne' => ['version' => '99', 'operator' => '>=']]
                 ]
             ],
         ];
@@ -187,8 +328,8 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     public function testGetRequirementsMergesClassAndMethodDocBlocks()
     {
         $expectedAnnotations = [
-            'PHP'       => '5.4',
-            'PHPUnit'   => '3.7',
+            'PHP'       => ['version' => '5.4', 'operator' => ''],
+            'PHPUnit'   => ['version' => '3.7', 'operator' => ''],
             'OS'        => '/WINNT/i',
             'functions' => [
               'testFuncClass',
@@ -224,19 +365,40 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
             ['testOne',            []],
             ['testNine',           ['Function testFunc is required.']],
             ['testTen',            ['Extension testExt is required.']],
-            ['testAlwaysSkip',     ['PHPUnit 1111111 (or later) is required.']],
-            ['testAlwaysSkip2',    ['PHP 9999999 (or later) is required.']],
+            ['testAlwaysSkip',     ['PHPUnit >= 1111111 is required.']],
+            ['testAlwaysSkip2',    ['PHP >= 9999999 is required.']],
             ['testAlwaysSkip3',    ['Operating system matching /DOESNOTEXIST/i is required.']],
             ['testAllPossibleRequirements', [
-              'PHP 99-dev (or later) is required.',
-              'PHPUnit 9-dev (or later) is required.',
+              'PHP >= 99-dev is required.',
+              'PHPUnit >= 9-dev is required.',
               'Operating system matching /DOESNOTEXIST/i is required.',
               'Function testFuncOne is required.',
               'Function testFuncTwo is required.',
               'Extension testExtOne is required.',
               'Extension testExtTwo is required.',
-              'Extension testExtThree 2.0 (or later) is required.',
+              'Extension testExtThree >= 2.0 is required.',
             ]],
+            ['testPHPVersionOperatorLessThan', ['PHP < 5.4 is required.']],
+            ['testPHPVersionOperatorLessThanEquals', ['PHP <= 5.4 is required.']],
+            ['testPHPVersionOperatorGreaterThan', ['PHP > 99 is required.']],
+            ['testPHPVersionOperatorGreaterThanEquals', ['PHP >= 99 is required.']],
+            ['testPHPVersionOperatorNoSpace', ['PHP >= 99 is required.']],
+            ['testPHPVersionOperatorEquals', ['PHP = 5.4 is required.']],
+            ['testPHPVersionOperatorDoubleEquals', ['PHP == 5.4 is required.']],
+            ['testPHPUnitVersionOperatorLessThan', ['PHPUnit < 1.0 is required.']],
+            ['testPHPUnitVersionOperatorLessThanEquals', ['PHPUnit <= 1.0 is required.']],
+            ['testPHPUnitVersionOperatorGreaterThan', ['PHPUnit > 99 is required.']],
+            ['testPHPUnitVersionOperatorGreaterThanEquals', ['PHPUnit >= 99 is required.']],
+            ['testPHPUnitVersionOperatorEquals', ['PHPUnit = 1.0 is required.']],
+            ['testPHPUnitVersionOperatorDoubleEquals', ['PHPUnit == 1.0 is required.']],
+            ['testPHPUnitVersionOperatorNoSpace', ['PHPUnit >= 99 is required.']],
+            ['testExtensionVersionOperatorLessThan', ['Extension testExtOne < 1.0 is required.']],
+            ['testExtensionVersionOperatorLessThanEquals', ['Extension testExtOne <= 1.0 is required.']],
+            ['testExtensionVersionOperatorGreaterThan', ['Extension testExtOne > 99 is required.']],
+            ['testExtensionVersionOperatorGreaterThanEquals', ['Extension testExtOne >= 99 is required.']],
+            ['testExtensionVersionOperatorEquals', ['Extension testExtOne = 1.0 is required.']],
+            ['testExtensionVersionOperatorDoubleEquals', ['Extension testExtOne == 1.0 is required.']],
+            ['testExtensionVersionOperatorNoSpace', ['Extension testExtOne >= 99 is required.']],
         ];
     }
 

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -153,4 +153,193 @@ class RequirementsTest extends PHPUnit_Framework_TestCase
     public function testSpecificExtensionVersion()
     {
     }
+
+    /**
+     * @requires PHP < 5.4
+     */
+    public function testPHPVersionOperatorLessThan()
+    {
+    }
+
+    /**
+     * @requires PHP <= 5.4
+     */
+    public function testPHPVersionOperatorLessThanEquals()
+    {
+    }
+
+    /**
+     * @requires PHP > 99
+     */
+    public function testPHPVersionOperatorGreaterThan()
+    {
+    }
+
+    /**
+     * @requires PHP >= 99
+     */
+    public function testPHPVersionOperatorGreaterThanEquals()
+    {
+    }
+
+    /**
+     * @requires PHP = 5.4
+     */
+    public function testPHPVersionOperatorEquals()
+    {
+    }
+
+    /**
+     * @requires PHP == 5.4
+     */
+    public function testPHPVersionOperatorDoubleEquals()
+    {
+    }
+
+    /**
+     * @requires PHP != 99
+     */
+    public function testPHPVersionOperatorBangEquals()
+    {
+    }
+
+    /**
+     * @requires PHP <> 99
+     */
+    public function testPHPVersionOperatorNotEquals()
+    {
+    }
+
+    /**
+     * @requires PHP >=99
+     */
+    public function testPHPVersionOperatorNoSpace()
+    {
+    }
+
+    /**
+     * @requires PHPUnit < 1.0
+     */
+    public function testPHPUnitVersionOperatorLessThan()
+    {
+    }
+
+    /**
+     * @requires PHPUnit <= 1.0
+     */
+    public function testPHPUnitVersionOperatorLessThanEquals()
+    {
+    }
+
+    /**
+     * @requires PHPUnit > 99
+     */
+    public function testPHPUnitVersionOperatorGreaterThan()
+    {
+    }
+
+    /**
+     * @requires PHPUnit >= 99
+     */
+    public function testPHPUnitVersionOperatorGreaterThanEquals()
+    {
+    }
+
+    /**
+     * @requires PHPUnit = 1.0
+     */
+    public function testPHPUnitVersionOperatorEquals()
+    {
+    }
+
+    /**
+     * @requires PHPUnit == 1.0
+     */
+    public function testPHPUnitVersionOperatorDoubleEquals()
+    {
+    }
+
+    /**
+     * @requires PHPUnit != 99
+     */
+    public function testPHPUnitVersionOperatorBangEquals()
+    {
+    }
+
+    /**
+     * @requires PHPUnit <> 99
+     */
+    public function testPHPUnitVersionOperatorNotEquals()
+    {
+    }
+
+    /**
+     * @requires PHPUnit >=99
+     */
+    public function testPHPUnitVersionOperatorNoSpace()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne < 1.0
+     */
+    public function testExtensionVersionOperatorLessThan()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne <= 1.0
+     */
+    public function testExtensionVersionOperatorLessThanEquals()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne > 99
+     */
+    public function testExtensionVersionOperatorGreaterThan()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne >= 99
+     */
+    public function testExtensionVersionOperatorGreaterThanEquals()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne = 1.0
+     */
+    public function testExtensionVersionOperatorEquals()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne == 1.0
+     */
+    public function testExtensionVersionOperatorDoubleEquals()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne != 99
+     */
+    public function testExtensionVersionOperatorBangEquals()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne <> 99
+     */
+    public function testExtensionVersionOperatorNotEquals()
+    {
+    }
+
+    /**
+     * @requires extension testExtOne >=99
+     */
+    public function testExtensionVersionOperatorNoSpace()
+    {
+    }
 }


### PR DESCRIPTION
This adds support for optional operators in both `@requires` for PHP and PHPUnit, as well as for `@extension`.

Default is `>=` and the `version_compare` has been negated to account for that (previously was `<`) — this is so that the error message
makes sense (`PHP >= 7.0.0 is required` vs `PHP < 7.0.0 is required`) without needed to juggle based on the operator.

I can add the ability to change the operators to words e.g.:
- `>` becomes `PHP 7.0.0 or older is not supported`
- `>=` becomes `PHP 7.0.0 or greater is required` 
- `<` becomes `PHP 7.0.0 or greater is not supported`
- `<=` becomes `PHP 7.0.0 or older is required`
- `=` and `==` becomes `PHP 7.0.0 is required`
- `!=` and `<>` becomes `PHP 7.0.0 is not supported`

Refs #1984
