### PR TITLE
Allow throwing any Throwable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1783,13 +1783,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * @param Exception $exception
+     * @param Throwable|Exception $exception
      *
      * @return PHPUnit_Framework_MockObject_Stub_Exception
      *
      * @since  Method available since Release 3.1.0
      */
-    public static function throwException(Exception $exception)
+    public static function throwException($exception)
     {
         return new PHPUnit_Framework_MockObject_Stub_Exception($exception);
     }


### PR DESCRIPTION
Simple update related to https://github.com/sebastianbergmann/phpunit-mock-objects/pull/282 so instances of Error can also be thrown.
