### PR TITLE
Issue #2002 - Fix skipped test name in JSON log output

### DIFF
--- a/src/Util/Log/JSON.php
+++ b/src/Util/Log/JSON.php
@@ -212,7 +212,7 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
             array(
             'event'   => 'test',
             'suite'   => $this->currentTestSuiteName,
-            'test'    => $this->currentTestName,
+            'test'    => PHPUnit_Util_Test::describe($test),
             'status'  => $status,
             'time'    => $time,
             'trace'   => $trace,


### PR DESCRIPTION
[4.8]  Fix the issue where skipped tests have an incorrect name in JSON log output.
