### PR TITLE
Fixed php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "irc": "irc://irc.freenode.net/phpunit"
     },
     "require": {
-        "php": "~5.3.3|~5.4|~5.5|~5.6",
+        "php": "^5.3.3",
         "phpunit/php-file-iterator": "~1.4",
         "phpunit/php-text-template": "~1.2",
         "phpunit/php-code-coverage": "~2.1",


### PR DESCRIPTION
`~5.4` already includes all 5.x versions greater or equal to 5.4.0, so `~5.5` means nothing since it's a subset of `~5.4`.

`^5.3.3` is probably the shortest way to express what you want here.
