### PR TITLE
Always write the template in order to make it easier to debug isolation mode

### DIFF
--- a/src/Util/PHP/Default.php
+++ b/src/Util/PHP/Default.php
@@ -16,6 +16,11 @@
 class PHPUnit_Util_PHP_Default extends PHPUnit_Util_PHP
 {
     /**
+     * @var string
+     */
+    private $tempFile;
+
+    /**
      * Runs a single job (PHP code) using a separate PHP process.
      *
      * @param string $job
@@ -68,6 +73,17 @@ class PHPUnit_Util_PHP_Default extends PHPUnit_Util_PHP
      */
     protected function process($pipe, $job)
     {
+        if (!($this->tempFile = tempnam(sys_get_temp_dir(), 'PHPUnit')) ||
+          file_put_contents($this->tempFile, $job) === false) {
+            throw new PHPUnit_Framework_Exception(
+              'Unable to write temporary file'
+            );
+        }
+
+        fwrite(
+          $pipe,
+          '<?php require_once ' . var_export($this->tempFile, true) .  '; ?>'
+        );
         fwrite($pipe, $job);
     }
 
@@ -76,5 +92,6 @@ class PHPUnit_Util_PHP_Default extends PHPUnit_Util_PHP
      */
     protected function cleanup()
     {
+        unlink($this->tempFile);
     }
 }

--- a/src/Util/PHP/Default.php
+++ b/src/Util/PHP/Default.php
@@ -84,7 +84,6 @@ class PHPUnit_Util_PHP_Default extends PHPUnit_Util_PHP
           $pipe,
           '<?php require_once ' . var_export($this->tempFile, true) .  '; ?>'
         );
-        fwrite($pipe, $job);
     }
 
     /**

--- a/src/Util/PHP/Windows.php
+++ b/src/Util/PHP/Windows.php
@@ -15,10 +15,6 @@
  */
 class PHPUnit_Util_PHP_Windows extends PHPUnit_Util_PHP_Default
 {
-    /**
-     * @var string
-     */
-    private $tempFile;
 
     /**
      * {@inheritdoc}
@@ -67,36 +63,5 @@ class PHPUnit_Util_PHP_Windows extends PHPUnit_Util_PHP_Default
         $this->cleanup();
 
         return ['stdout' => $stdout, 'stderr' => $stderr];
-    }
-
-    /**
-     * @param resource $pipe
-     * @param string   $job
-     *
-     * @throws PHPUnit_Framework_Exception
-     *
-     * @since  Method available since Release 3.5.12
-     */
-    protected function process($pipe, $job)
-    {
-        if (!($this->tempFile = tempnam(sys_get_temp_dir(), 'PHPUnit')) ||
-            file_put_contents($this->tempFile, $job) === false) {
-            throw new PHPUnit_Framework_Exception(
-                'Unable to write temporary file'
-            );
-        }
-
-        fwrite(
-            $pipe,
-            '<?php require_once ' . var_export($this->tempFile, true) .  '; ?>'
-        );
-    }
-
-    /**
-     * @since Method available since Release 3.5.12
-     */
-    protected function cleanup()
-    {
-        unlink($this->tempFile);
     }
 }


### PR DESCRIPTION
Rebase of https://github.com/sebastianbergmann/phpunit/pull/1942

 Debugging the isolation mode can be tricky as xdebug doesn't help you
with the initial $job piped into the php process.

As solution this PR uses the same technique as the windows util,
which is dumping the template into a temporary file and include it from there.
