### PR TITLE
Adding test defining issue #2013

### DIFF
--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -42,6 +42,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
         $suite->addTest(new self('testInheritedTests'));
         $suite->addTest(new self('testNoTestCases'));
         $suite->addTest(new self('testNoTestCaseClass'));
+        $suite->addTest(new self('testPhpInternalClassNameSuit'));
         $suite->addTest(new self('testNotExistingTestCase'));
         $suite->addTest(new self('testNotPublicTestCase'));
         $suite->addTest(new self('testNotVoidTestCase'));
@@ -100,7 +101,15 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
      */
     public function testNoTestCaseClass()
     {
-        $suite = new PHPUnit_Framework_TestSuite('NoTestCaseClass');
+        new PHPUnit_Framework_TestSuite('NoTestCaseClass');
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testPhpInternalClassNameSuit()
+    {
+        new PHPUnit_Framework_TestSuite('Directory');
     }
 
     public function testNotExistingTestCase()


### PR DESCRIPTION
_Added test for test suit name "Directory".
*_Indicated the use of PHP internal classes being treated the same way
as using a test suit by the name of an existing class that does not
subclass PHPUnit_Framework_TestCase.
