### PR TITLE
Upgrade Prophecy to work with PHP 7 Scalar Type Hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/php-code-coverage": "~3.0",
         "phpunit/php-timer": ">=1.0.6",
         "phpunit/phpunit-mock-objects": ">=3.0.5",
-        "phpspec/prophecy": "^1.3.1",
+        "phpspec/prophecy": "^1.5.0",
         "symfony/yaml": "~2.1|~3.0",
         "sebastian/comparator": "~1.1",
         "sebastian/diff": "~1.2",


### PR DESCRIPTION
When using the prophecy version provided by PHPUnit we are not able to use PHP 7 due to a bug related to scalar type hints:

https://github.com/phpspec/prophecy/commit/3355f3a58d1ba1f1ea3b423e43a982ad040e2697
