### PR TITLE
Log more information about failures in JSON output

### DIFF
--- a/src/Util/Log/JSON.php
+++ b/src/Util/Log/JSON.php
@@ -43,7 +43,7 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
             'error',
             $time,
             PHPUnit_Util_Filter::getFilteredStacktrace($e, false),
-            $e->getMessage(),
+            PHPUnit_Framework_TestFailure::exceptionToString($e),
             $test
         );
 
@@ -65,7 +65,7 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
             'warning',
             $time,
             PHPUnit_Util_Filter::getFilteredStacktrace($e, false),
-            $e->getMessage(),
+            PHPUnit_Framework_TestFailure::exceptionToString($e),
             $test
         );
 
@@ -85,7 +85,7 @@ class PHPUnit_Util_Log_JSON extends PHPUnit_Util_Printer implements PHPUnit_Fram
             'fail',
             $time,
             PHPUnit_Util_Filter::getFilteredStacktrace($e, false),
-            $e->getMessage(),
+            PHPUnit_Framework_TestFailure::exceptionToString($e),
             $test
         );
 


### PR DESCRIPTION
Current JSON logger doesn't log comparison information when there is a failure on assertEquals. This will add logging of comparison diffs.
