### PR TITLE
Add 'it_' and 'its_' as test method prefixes

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -899,8 +899,12 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
      */
     public static function isTestMethod(ReflectionMethod $method)
     {
-        if (strpos($method->name, 'test') === 0) {
-            return true;
+        $testMethodPrefixes = ['test', 'it_', 'its_'];
+
+        foreach ($testMethodPrefixes as $prefix) {
+            if (strpos($method->name, $prefix) === 0) {
+                return true;
+            }
         }
 
         // @scenario on TestCase::testMethod()


### PR DESCRIPTION
I like to write the name of my test methods in a BDD way:

``` php
function it_sends_messages()
{
    // ...
}
```

Instead of:

``` php
function testSendMessage()
{
    // ...
}
```

Currently I have to add the `@test` annotation to all my test methods.
This PR adds support for methods starting with  `it_` and `its_` to be recognized as test methods.
