### PR TITLE
Feature suggestion: callNonPublicMethod()

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2369,4 +2369,26 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
         }
     }
+
+    /**
+     * Call a protected or private method on an object. Useful to unit test methods which are tagged as protected and
+     * private.
+     *
+     * @param mixed $object
+     * @param string $methodName
+     * @param array $methodArgs
+     * @return mixed
+     */
+    protected static function callNonPublicMethod($object, $methodName, $methodArgs = array())
+    {
+        $objectClassName = get_class($object);
+        $reflectionMethod = new \ReflectionMethod(
+            $objectClassName,
+            $methodName
+        );
+        // Coerce to being a public function.
+        $reflectionMethod->setAccessible(true);
+        $result = $reflectionMethod->invokeArgs($object, $methodArgs);
+        return $result;
+    }
 }


### PR DESCRIPTION
I realize you probably don't want to add this to the framework... but in my projects, I use this function _all the time_. 

In fact, I suspect that a lot of developers end up reluctantly setting functions to public because they don't have an easier way to test them from PHPUnit. In my opinion, this would be useful to a lot of other devs.
