### PR TITLE
fix for missing loggerType coverage-xml in .xsd

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -117,6 +117,7 @@
           <xs:enumeration value="coverage-text"/>
           <xs:enumeration value="coverage-clover"/>
           <xs:enumeration value="coverage-crap4j"/>
+          <xs:enumeration value="coverage-xml"/>
           <xs:enumeration value="json"/>
           <xs:enumeration value="plain"/>
           <xs:enumeration value="tap"/>


### PR DESCRIPTION
added missing loggerType coverage-xml to phpunit.xsd file
