### PR TITLE
Place assertJsonFileEqualsJsonFile() before assertJsonFileNotEqualsJsonFile()

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2080,35 +2080,6 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
-     * Asserts that two JSON files are not equal.
-     *
-     * @param string $expectedFile
-     * @param string $actualFile
-     * @param string $message
-     */
-    public static function assertJsonFileNotEqualsJsonFile($expectedFile, $actualFile, $message = '')
-    {
-        self::assertFileExists($expectedFile, $message);
-        self::assertFileExists($actualFile, $message);
-
-        $actualJson   = file_get_contents($actualFile);
-        $expectedJson = file_get_contents($expectedFile);
-
-        self::assertJson($expectedJson, $message);
-        self::assertJson($actualJson, $message);
-
-        // call constraint
-        $constraintExpected = new PHPUnit_Framework_Constraint_JsonMatches(
-            $expectedJson
-        );
-
-        $constraintActual = new PHPUnit_Framework_Constraint_JsonMatches($actualJson);
-
-        self::assertThat($expectedJson, new PHPUnit_Framework_Constraint_Not($constraintActual), $message);
-        self::assertThat($actualJson, new PHPUnit_Framework_Constraint_Not($constraintExpected), $message);
-    }
-
-    /**
      * Asserts that two JSON files are equal.
      *
      * @param string $expectedFile
@@ -2135,6 +2106,35 @@ abstract class PHPUnit_Framework_Assert
 
         self::assertThat($expectedJson, $constraintActual, $message);
         self::assertThat($actualJson, $constraintExpected, $message);
+    }
+
+    /**
+     * Asserts that two JSON files are not equal.
+     *
+     * @param string $expectedFile
+     * @param string $actualFile
+     * @param string $message
+     */
+    public static function assertJsonFileNotEqualsJsonFile($expectedFile, $actualFile, $message = '')
+    {
+        self::assertFileExists($expectedFile, $message);
+        self::assertFileExists($actualFile, $message);
+
+        $actualJson   = file_get_contents($actualFile);
+        $expectedJson = file_get_contents($expectedFile);
+
+        self::assertJson($expectedJson, $message);
+        self::assertJson($actualJson, $message);
+
+        // call constraint
+        $constraintExpected = new PHPUnit_Framework_Constraint_JsonMatches(
+            $expectedJson
+        );
+
+        $constraintActual = new PHPUnit_Framework_Constraint_JsonMatches($actualJson);
+
+        self::assertThat($expectedJson, new PHPUnit_Framework_Constraint_Not($constraintActual), $message);
+        self::assertThat($actualJson, new PHPUnit_Framework_Constraint_Not($constraintExpected), $message);
     }
 
     /**


### PR DESCRIPTION
All 'negative' ('not') assert methods are placed after the 'positive' assert methods, but `assertJsonFileNotEqualsJsonFile()` was placed before `assertJsonFileEqualsJsonFile()`.
This PR fixes this minor imperfection.
