### PR TITLE
Bumping dependency to php-code-coverage to properly support PHP 7 tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.6",
+        "php": "^5.6 || ^7.0",
         "phpunit/php-file-iterator": "~1.4",
         "phpunit/php-text-template": "~1.2",
-        "phpunit/php-code-coverage": "~3.2",
+        "phpunit/php-code-coverage": "^3.2.1",
         "phpunit/php-timer": ">=1.0.6",
         "phpunit/phpunit-mock-objects": ">=3.0.5",
         "phpspec/prophecy": "^1.3.1",


### PR DESCRIPTION
This issue surfaces as a transitive dependency issue as per https://github.com/sebastianbergmann/php-code-coverage/pull/423

Note: sorry for the horrible branch names, but I can't get to clone the repo from the hotel wifi connection :-|
