### PR TITLE
compatibility with older version, allow NULL as message

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -467,7 +467,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     {
         $this->expectedException = $exception;
 
-        if ($message !== '') {
+        if ($message !== null && $message !== '') {
             $this->expectExceptionMessage($message);
         }
 

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -195,6 +195,28 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result->wasSuccessful());
     }
 
+    public function testExceptionWithEmptyMessage()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedException('RuntimeException', '');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testExceptionWithNullMessage()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->setExpectedException('RuntimeException', NULL);
+
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
     public function testExceptionWithMessage()
     {
         $test = new ThrowExceptionTestCase('test');


### PR DESCRIPTION
Real use case in zend-mail: https://github.com/zendframework/zend-mail/blob/master/test/Header/SenderTest.php#L50

For now, zend-mail test suite pass with 4.8 but fails with 5.2
This PR restore compatibility (even if this method is deprecated)
