### PR TITLE
Marking failed unit test red

### DIFF
--- a/src/Util/TestDox/ResultPrinter/Text.php
+++ b/src/Util/TestDox/ResultPrinter/Text.php
@@ -36,10 +36,10 @@ class PHPUnit_Util_TestDox_ResultPrinter_Text extends PHPUnit_Util_TestDox_Resul
         if ($success) {
             $this->write(' [x] ');
         } else {
-            $this->write(' [ ] ');
+            $this->write("\033[31m [ ] ");
         }
 
-        $this->write($name . "\n");
+        $this->write($name . "\033[0m\n");
     }
 
     /**


### PR DESCRIPTION
In `Testdox` it is pretty hard to spot the failed tests, as they are just missing the x. Making the text red makes them easy to spot.
