### PR TITLE
Implementation of --only-print-tests

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -1015,6 +1015,28 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     }
 
     /**
+     * Returns a (recursively) calculated array of tests for this test suite.
+     *
+     * @return array
+     *
+     * @since  Method available since Release ...
+     */
+    public function asTestArray()
+    {
+        $list = array();
+
+        foreach ($this->tests() as $test) {
+            if ($test instanceof PHPUnit_Framework_TestSuite) {
+                $list = array_merge($list, $test->asTestArray());
+            } else {
+                $list[] = $test;
+            }
+        }
+
+        return $list;
+    }
+
+    /**
      * Template Method that is called before the tests
      * of this test suite are run.
      *

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -35,6 +35,7 @@ class PHPUnit_TextUI_Command
      */
     protected $longOptions = [
         'atleast-version='        => null,
+        'only-print-tests'        => null,
         'bootstrap='              => null,
         'colors=='                => null,
         'columns='                => null,
@@ -143,6 +144,20 @@ class PHPUnit_TextUI_Command
 
             foreach ($groups as $group) {
                 print " - $group\n";
+            }
+
+            if ($exit) {
+                exit(PHPUnit_TextUI_TestRunner::SUCCESS_EXIT);
+            } else {
+                return PHPUnit_TextUI_TestRunner::SUCCESS_EXIT;
+            }
+        }
+
+        if (!empty($this->arguments['onlyPrintTests'])) {
+            $processedSuite = $suite->asTestArray();
+
+            foreach ($processedSuite as $no => $test) {
+                echo ($no + 1) . '. ' . get_class($test) . '::' . $test->getName() . "\n";
             }
 
             if ($exit) {
@@ -521,6 +536,10 @@ class PHPUnit_TextUI_Command
                         ? PHPUnit_TextUI_TestRunner::SUCCESS_EXIT
                         : PHPUnit_TextUI_TestRunner::FAILURE_EXIT
                     );
+                    break;
+
+                case '--only-print-tests':
+                    $this->arguments['onlyPrintTests'] = true;
                     break;
 
                 case '--version':
@@ -1056,6 +1075,7 @@ Miscellaneous Options:
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
   --atleast-version <min>   Checks that version is greater than min and exits.
+  --only-print-tests        Prints all available test names in order without executing them.
 
 EOT;
 

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -96,3 +96,4 @@ Miscellaneous Options:
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
   --atleast-version <min>   Checks that version is greater than min and exits.
+  --only-print-tests        Prints all available test names in order without executing them.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -97,3 +97,4 @@ Miscellaneous Options:
   -h|--help                 Prints this usage information.
   --version                 Prints the version and exits.
   --atleast-version <min>   Checks that version is greater than min and exits.
+  --only-print-tests        Prints all available test names in order without executing them.


### PR DESCRIPTION
Let's say I'm running phpunit locally, and lines like these appear:

```
...............I.....IIIIIIIIIIIIIIII.......SSS........I...  1770 / 10237 ( 17%)
.IFF............III..SSSSSSSSSSSSSSSSSSSS..................  1829 / 10237 ( 17%)
```

This parameter offers a good way to find the failing tests in the range 1770±5. This would allow the developer to address the UT failures in advance without waiting for phpunit to finish and show the report of the failing tests.

Example usage:

```
boro@bor0:~/dev/phpunit$ ./phpunit --only-print-tests | head -n 123 | tail -n 3
121. Framework_AssertTest::testAssertEqualsFails with data set #30
122. Framework_AssertTest::testAssertEqualsFails with data set #31
123. Framework_AssertTest::testAssertEqualsFails with data set #32
boro@bor0:~/dev/phpunit$ 
```

In general, to display the nth test ±x, the formula would be `x + n` for head, and `2x + 1` for tail.

Also possibly addresses https://github.com/sebastianbergmann/phpunit/issues/1993.
