### PR TITLE
Missing regression test for @dataProvider

### DIFF
--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -11,6 +11,7 @@
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeAndAfterTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeClassAndAfterClassTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'TestWithTest.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'BeforeClassWithOnlyDataProviderTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderSkippedTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'DataProviderIncompleteTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'InheritedTestCase.php';
@@ -48,6 +49,7 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
         $suite->addTest(new self('testOneTestCase'));
         $suite->addTest(new self('testShadowedTests'));
         $suite->addTest(new self('testBeforeClassAndAfterClassAnnotations'));
+        $suite->addTest(new self('testBeforeClassWithDataProviders'));
         $suite->addTest(new self('testBeforeAnnotation'));
         $suite->addTest(new self('testTestWithAnnotation'));
         $suite->addTest(new self('testSkippedTestDataProvider'));
@@ -168,6 +170,19 @@ class Framework_SuiteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, BeforeClassAndAfterClassTest::$beforeClassWasRun, '@beforeClass method was not run once for the whole suite.');
         $this->assertEquals(1, BeforeClassAndAfterClassTest::$afterClassWasRun, '@afterClass method was not run once for the whole suite.');
+    }
+
+    public function testBeforeClassWithDataProviders()
+    {
+        $suite = new PHPUnit_Framework_TestSuite(
+            'BeforeClassWithOnlyDataProviderTest'
+        );
+
+        BeforeClassWithOnlyDataProviderTest::resetProperties();
+        $suite->run($this->result);
+
+        $this->assertTrue(BeforeClassWithOnlyDataProviderTest::$setUpBeforeClassWasCalled, "setUpBeforeClass method was not run.");
+        $this->assertTrue(BeforeClassWithOnlyDataProviderTest::$beforeClassWasCalled, "@beforeClass method was not run.");
     }
 
     public function testBeforeAnnotation()

--- a/tests/_files/BeforeClassWithOnlyDataProviderTest.php
+++ b/tests/_files/BeforeClassWithOnlyDataProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+class BeforeClassWithOnlyDataProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public static $setUpBeforeClassWasCalled;
+    public static $beforeClassWasCalled;
+
+    public static function resetProperties()
+    {
+        self::$setUpBeforeClassWasCalled = false;
+        self::$beforeClassWasCalled = false;
+    }
+
+    public static function setUpBeforeClass()
+    {
+        self::$setUpBeforeClassWasCalled = true;
+    }
+
+    /**
+     * @beforeClass
+     */
+    public static function someAnnotatedSetupMethod()
+    {
+        self::$beforeClassWasCalled = true;
+    }
+
+    public function dummyProvider()
+    {
+        return array(array(1));
+    }
+
+    /**
+     * @dataProvider dummyProvider
+     * delete annotation to fail test case
+     */
+    public function testDummy()
+    {
+        $this->assertFalse(false);
+    }
+}


### PR DESCRIPTION
Adds a missing regression test for the combination `beforeClass` and `@dataProvider`, which was affected by a bug (https://github.com/sebastianbergmann/phpunit/issues/1295) which was solved but not covered by a new test.
