### PR TITLE
fix prettifier for trivial test name: test

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -85,6 +85,10 @@ class PHPUnit_Util_TestDox_NamePrettifier
             $name = substr($name, 4);
         }
 
+        if (strlen($name) == 0) {
+            return $buffer;
+        }
+
         $name[0] = strtoupper($name[0]);
 
         if (strpos($name, '_') !== false) {

--- a/tests/Util/TestDox/NamePrettifierTest.php
+++ b/tests/Util/TestDox/NamePrettifierTest.php
@@ -67,6 +67,7 @@ class Util_TestDox_NamePrettifierTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('This is a test', $this->namePrettifier->prettifyTestMethod('this_is_a_test'));
         $this->assertEquals('Foo for bar is 0', $this->namePrettifier->prettifyTestMethod('testFooForBarIs0'));
         $this->assertEquals('Foo for baz is 1', $this->namePrettifier->prettifyTestMethod('testFooForBazIs1'));
+        $this->assertEquals('', $this->namePrettifier->prettifyTestMethod('test'));
     }
 
     /**


### PR DESCRIPTION
hi,

phpunit 5.2.10 (7467a57b055985529d356746fc03c8ed3c3be520) introduced a side-effect which could lead to a crash.

In case a test method name equals 'test', php crashes with an "Uninitialized string offset" notice.

Feel free to ignore/close this in case this behaviour is discouraged.

BR
Valentin
