### PR TITLE
Add ability to set custom filename rewrite callbacks

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -356,8 +356,13 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         foreach ($this->foundClasses as $i => $className) {
             if (preg_match($shortnameRegEx, $className)) {
                 $class = new ReflectionClass($className);
+                $classFile = $class->getFileName();
 
-                if ($class->getFileName() == $filename) {
+                if ($restoreCallback = PHPUnit_Util_Fileloader::getFilenameRestoreCallback()) {
+                    $classFile = $restoreCallback($classFile);
+                }
+
+                if ($classFile == $filename) {
                     $newClasses = [$className];
                     unset($this->foundClasses[$i]);
                     break;

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -63,6 +63,10 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
                 $class     = new ReflectionClass($loadedClass);
                 $classFile = $class->getFileName();
 
+                if ($restoreCallback = PHPUnit_Util_Fileloader::getFilenameRestoreCallback()) {
+                    $classFile = $restoreCallback($classFile);
+                }
+
                 if ($class->isSubclassOf($testCaseClass) &&
                     !$class->isAbstract()) {
                     $suiteClassName = $loadedClass;
@@ -91,8 +95,13 @@ class PHPUnit_Runner_StandardTestSuiteLoader implements PHPUnit_Runner_TestSuite
 
         if (class_exists($suiteClassName, false)) {
             $class = new ReflectionClass($suiteClassName);
+            $classFile = $class->getFileName();
 
-            if ($class->getFileName() == realpath($suiteClassFile)) {
+            if ($restoreCallback = PHPUnit_Util_Fileloader::getFilenameRestoreCallback()) {
+                $classFile = $restoreCallback($classFile);
+            }
+
+            if ($classFile == realpath($suiteClassFile)) {
                 return $class;
             }
         }

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -15,6 +15,17 @@
  */
 class PHPUnit_Util_Filter
 {
+    private static $custom_stacktrace_callback;
+
+    /**
+     * Set custom stack trace callback that can deal with rewritten files and extra stack trace lines
+     * @param callable $callback (Exception $e, $asString = true): string
+     */
+    public static function setCustomStackTraceCallback(Callable $callback)
+    {
+        self::$custom_stacktrace_callback = $callback;
+    }
+
     /**
      * Filters stack frames from PHPUnit classes.
      *
@@ -25,6 +36,10 @@ class PHPUnit_Util_Filter
      */
     public static function getFilteredStacktrace($e, $asString = true)
     {
+        if ($stackTraceCb = self::$custom_stacktrace_callback) {
+            return $stackTraceCb($e, $asString);
+        }
+
         $prefix = false;
         $script = realpath($GLOBALS['_SERVER']['SCRIPT_NAME']);
 


### PR DESCRIPTION
We implemented "soft mocks" project that is intended to be able to replace runkit and uopz. We do it by rewriting code "on the fly".

Project: https://github.com/badoo/soft-mocks

We used Soft Mocks to rewrite our tests (60k tests) so that PHP7 is supported on our website.

Here is the suggested patch to be able to use Soft Mocks with phpunit.
