### PR TITLE
Fixes #1961 - XSD schema in 5.x does not validate

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -12,14 +12,9 @@
     </xs:annotation>
   </xs:element>
   <xs:complexType name="filtersType">
-    <xs:choice>
-      <xs:sequence>
-        <xs:element name="whitelist" type="whiteListType" minOccurs="0"/>
-      </xs:sequence>
-      <xs:sequence>
-        <xs:element name="whitelist" type="whiteListType"/>
-      </xs:sequence>
-    </xs:choice>
+    <xs:sequence>
+      <xs:element name="whitelist" type="whiteListType" minOccurs="0"/>
+    </xs:sequence>
   </xs:complexType>
   <xs:complexType name="filterType">
     <xs:sequence>


### PR DESCRIPTION
Tests are mostly to show the issue and the fact that validating with DOMDocument and XMLReader isn't showing the problem.
