### PR TITLE
Cache dependencies, resulting in faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,15 @@ matrix:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 before_install:
   - composer self-update
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - ./phpunit


### PR DESCRIPTION
This way, dependencies will be loaded from cache all next builds against the same branch (unless there is a newer version, it will be loaded and cached again). This will result in faster builds, as cloning is quite slow.
