### PR TITLE
Add type parameter to Teamcity service message

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -121,6 +121,7 @@ class PHPUnit_Util_Log_TeamCity extends PHPUnit_TextUI_ResultPrinter
                 }
 
                 if (!is_null($actualString) && !is_null($expectedString)) {
+                    $parameters['type']     = 'comparisonFailure';
                     $parameters['actual']   = $actualString;
                     $parameters['expected'] = $expectedString;
                 }


### PR DESCRIPTION
According to [Teamcity documentation](https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests): 

> actual and expected attributes can only be used together with type='comparisonFailure to report comparison failure. The values will be used when opening the test in the IDE.

This request adds type='comparisonFailure' where it's necessary.
