### PR TITLE
Assertion support within outputCallback

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -944,10 +944,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         if (!isset($e) || $e instanceof PHPUnit_Framework_RiskyTestError) {
             try {
                 if ($this->outputCallback !== false) {
-                    $this->output = call_user_func_array(
-                        $this->outputCallback,
-                        [$this->output]
-                    );
+                    $this->output = ($this->outputCallback)($this->output);
                 }
 
                 $this->outputCallback = false;

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -932,6 +932,40 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             $this->statusMessage = $_e->getMessage();
         }
 
+        try {
+            $this->stopOutputBuffering();
+        } catch (PHPUnit_Framework_RiskyTestError $_e) {
+            if (!isset($e)) {
+                $e = $_e;
+            }
+        }
+
+        // Perform assertion on output.
+        if (!isset($e) || $e instanceof PHPUnit_Framework_RiskyTestError) {
+            try {
+                if ($this->outputCallback !== false) {
+                    $this->output = call_user_func_array(
+                        $this->outputCallback,
+                        [$this->output]
+                    );
+                }
+
+                $this->outputCallback = false;
+
+                if ($this->outputExpectedRegex !== null) {
+                    $this->assertRegExp($this->outputExpectedRegex, $this->output);
+                }
+
+                if ($this->outputExpectedString !== null) {
+                    $this->assertEquals($this->outputExpectedString, $this->output);
+                }
+            } catch (Throwable $_e) {
+                $e = $_e;
+            } catch (Exception $_e) {
+                $e = $_e;
+            }
+        }
+
         // Clean up the mock objects.
         $this->mockObjects = [];
         $this->prophet     = null;
@@ -960,14 +994,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             }
         }
 
-        try {
-            $this->stopOutputBuffering();
-        } catch (PHPUnit_Framework_RiskyTestError $_e) {
-            if (!isset($e)) {
-                $e = $_e;
-            }
-        }
-
         clearstatcache();
 
         if ($currentWorkingDirectory != getcwd()) {
@@ -986,21 +1012,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         // Clean up locale settings.
         foreach ($this->locale as $category => $locale) {
             setlocale($category, $locale);
-        }
-
-        // Perform assertion on output.
-        if (!isset($e)) {
-            try {
-                if ($this->outputExpectedRegex !== null) {
-                    $this->assertRegExp($this->outputExpectedRegex, $this->output);
-                } elseif ($this->outputExpectedString !== null) {
-                    $this->assertEquals($this->outputExpectedString, $this->output);
-                }
-            } catch (Throwable $_e) {
-                $e = $_e;
-            } catch (Exception $_e) {
-                $e = $_e;
-            }
         }
 
         // Workaround for missing "finally".
@@ -2243,17 +2254,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
             );
         }
 
-        $output = ob_get_contents();
-
-        if ($this->outputCallback === false) {
-            $this->output = $output;
-        } else {
-            $this->output = call_user_func_array(
-                $this->outputCallback,
-                [$output]
-            );
-        }
-
+        $this->output = ob_get_contents();
         ob_end_clean();
 
         $this->outputBufferingActive = false;

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -451,6 +451,42 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($result->wasSuccessful());
     }
 
+    public function testSetOutputCallbackAssertSameFooActualFoo()
+    {
+        $test   = new OutputTestCase('testSetOutputCallbackAssertSameFooActualFoo');
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testSetOutputCallbackAssertSameFooActualBar()
+    {
+        $test   = new OutputTestCase('testSetOutputCallbackAssertSameFooActualBar');
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertFalse($result->wasSuccessful());
+    }
+
+    public function testMultipleExpectOutputFooActualFoo()
+    {
+        $test   = new OutputTestCase('testMultipleExpectOutputFooActualFoo');
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertFalse($result->wasSuccessful());
+    }
+
+    public function testSetOutputCallbackAssertSetUp()
+    {
+        $test   = new OutputTestCase('testSetOutputCallbackAssertSetUp');
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
     public function testSkipsIfRequiresHigherVersionOfPHPUnit()
     {
         $test   = new RequirementsTest('testAlwaysSkip');

--- a/tests/_files/OutputTestCase.php
+++ b/tests/_files/OutputTestCase.php
@@ -1,6 +1,18 @@
 <?php
 class OutputTestCase extends PHPUnit_Framework_TestCase
 {
+    public $setUp = false;
+
+    public function setUp()
+    {
+        $this->setUp = true;
+    }
+
+    protected function tearDown()
+    {
+        $this->setUp = false;
+    }
+
     public function testExpectOutputStringFooActualFoo()
     {
         $this->expectOutputString('foo');
@@ -23,5 +35,40 @@ class OutputTestCase extends PHPUnit_Framework_TestCase
     {
         $this->expectOutputRegex('/foo/');
         print 'bar';
+    }
+
+    public function testSetOutputCallbackAssertSameFooActualFoo()
+    {
+        $this->setOutputCallback(function ($output) {
+            $this->assertSame('foo', $output);
+        });
+        print 'foo';
+    }
+
+    public function testSetOutputCallbackAssertSameFooActualBar()
+    {
+        $this->setOutputCallback(function ($output) {
+            $this->assertSame('foo', $output);
+        });
+        print 'bar';
+    }
+
+    public function testMultipleExpectOutputFooActualFoo()
+    {
+        $this->expectOutputRegex('/foo/');
+        $this->expectOutputString('foo');
+        $this->setOutputCallback(function ($output) {
+            $this->assertSame('<info>foo</info>', $output);
+
+            return strip_tags($output);
+        });
+        print '<info>foo</info>';
+    }
+
+    public function testSetOutputCallbackAssertSetUp()
+    {
+        $this->setOutputCallback(function () {
+            $this->assertTrue($this->setUp);
+        });
     }
 }


### PR DESCRIPTION
I need to test the output of my sut, unfortunately, however, `setOutputCallback` is quite limited.
Therefore, the following doesn't work as expected:

``` php
class UseCaseTest extends \PHPUnit_Framework_TestCase
{
    protected $directory = false;

    protected function setUp()
    {
        // create a temp directory
        $this->directory = ...;
    }

    protected function tearDown()
    {
        // remove the temp directory
        ...
        $this->directory = false;
    }

    public function testFileCreated()
    {
        $this->setOutputCallback(function ($output) {
            // assert file creation
            preg_match( '/Created: (?P<path>.*)/', $output, $matches);
            $this->assertFileExists($this->directory.'/'.$matches['path']);
        });

        // sut
        touch($this->directory.'/foo.txt');
        print 'Created: foo.txt';
    }
}
```

The main issues are:
1. the outputCallback is called after `tearDown`, thus `foo.txt` is already removed
2. the outputCallback is called within `stopOutputBuffering`, thus assertions aren't handled the right way
