### PR TITLE
Fix for Issue #2158

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -1,4 +1,6 @@
 <?php
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+
 if (!defined('STDOUT')) {
     // php://stdout does not obey output buffering. Any output would break
     // unserialization of child process results in the parent process.
@@ -32,7 +34,7 @@ function __phpunit_run_isolated_test()
 
     if ({collectCodeCoverageInformation}) {
         $result->setCodeCoverage(
-            new PHP_CodeCoverage(
+            new CodeCoverage(
                 null,
                 unserialize('{codeCoverageFilter}')
             )
@@ -79,9 +81,18 @@ if ('' !== $configurationFilePath) {
     unset($configuration);
 }
 
+function __phpunit_error_handler($errno, $errstr, $errfile, $errline, $errcontext)
+{
+   return true;
+}
+
+set_error_handler("__phpunit_error_handler");
+
 {constants}
 {included_files}
 {globals}
+
+restore_error_handler();
 
 if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
     require_once $GLOBALS['__PHPUNIT_BOOTSTRAP'];

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -1,6 +1,4 @@
 <?php
-use SebastianBergmann\CodeCoverage\CodeCoverage;
-
 if (!defined('STDOUT')) {
     // php://stdout does not obey output buffering. Any output would break
     // unserialization of child process results in the parent process.
@@ -34,7 +32,7 @@ function __phpunit_run_isolated_test()
 
     if ({collectCodeCoverageInformation}) {
         $result->setCodeCoverage(
-            new CodeCoverage(
+            new PHP_CodeCoverage(
                 null,
                 unserialize('{codeCoverageFilter}')
             )

--- a/tests/Regression/GitHub/2158.phpt
+++ b/tests/Regression/GitHub/2158.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#2158: Failure to run tests in separate processes if a file included into main process contains constant definition
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue2158Test';
+$_SERVER['argv'][3] = __DIR__ . '/2158/Issue2158Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %sMb
+
+OK (2 tests, 2 assertions)

--- a/tests/Regression/GitHub/2158/Issue2158Test.php
+++ b/tests/Regression/GitHub/2158/Issue2158Test.php
@@ -1,0 +1,23 @@
+<?php
+class Issue2158Test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Set constant in main process
+     */
+    public function testSomething()
+    {
+        include(__DIR__ . '/constant.inc');
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Constant defined previously in main process constant should be available and
+     * no errors should be yielded by reload of included files
+     *
+     * @runInSeparateProcess
+     */
+    public function testSomethingElse()
+    {
+        $this->assertTrue(defined('TEST_CONSTANT'));
+    }
+}

--- a/tests/Regression/GitHub/2158/constant.inc
+++ b/tests/Regression/GitHub/2158/constant.inc
@@ -1,0 +1,5 @@
+<?php
+
+define('TEST_CONSTANT', true);
+
+?>


### PR DESCRIPTION
Constant redefinition errors should be ignored when new separate process initialized by TestCaseMethod.dist.tpl . Any errors which may happen in included files are reported at the time of first include attempt so only errors which may be reported in TestCaseMethod.dist.tpl during constants and included files loading are those of global constants redefinitions and they may be safely ignored.
