### PR TITLE
Allow specifying methods to mock using createMock()

### DIFF
--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -10,6 +10,7 @@
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'NoArgTestCaseTest.php';
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Singleton.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Mockable.php';
 
 $GLOBALS['a']  = 'a';
 $_ENV['b']     = 'b';
@@ -580,5 +581,38 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
     {
         $o = new ClassWithScalarTypeDeclarations;
         $o->foo(null, null);
+    }
+
+    public function testCreateMockFromClassName()
+    {
+        $mock = $this->createMock(Mockable::class);
+
+        $this->assertInstanceOf(Mockable::class, $mock);
+        $this->assertInstanceOf(PHPUnit_Framework_MockObject_MockObject::class, $mock);
+    }
+
+    public function testCreateMockMocksAllMethods()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createMock(Mockable::class);
+
+        $this->assertNull($mock->foo());
+    }
+
+    public function testCreateMockSkipsConstructor()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createMock(Mockable::class);
+
+        $this->assertFalse($mock->constructorCalled);
+    }
+
+    public function testCreateMockDisablesOriginalClone()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createMock(Mockable::class);
+
+        $cloned = clone $mock;
+        $this->assertFalse($cloned->cloned);
     }
 }

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -615,4 +615,39 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $cloned = clone $mock;
         $this->assertFalse($cloned->cloned);
     }
+
+    public function testCreateMockWithMockedMethods()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createMock(Mockable::class, [
+            'foo' => 'bar',
+        ]);
+
+        $this->assertEquals('bar', $mock->foo());
+    }
+
+    public function testCreateMockWithMockedMethodsUsingClosure()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createMock(Mockable::class, [
+            'foo' => function () {
+                return 1 + 2;
+            },
+        ]);
+
+        $this->assertEquals(3, $mock->foo());
+    }
+
+    public function testCreateMockWithMockedMethodsUsingException()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createMock(Mockable::class, [
+            'foo' => new Exception('There was an error'),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('There was an error');
+        $mock->foo();
+    }
+
 }

--- a/tests/_files/Mockable.php
+++ b/tests/_files/Mockable.php
@@ -1,0 +1,21 @@
+<?php
+class Mockable
+{
+    public $constructorCalled = false;
+    public $cloned = false;
+
+    public function __construct()
+    {
+        $this->constructorCalled = false;
+    }
+
+    public function foo()
+    {
+        return true;
+    }
+
+    public function __clone()
+    {
+        $this->cloned = true;
+    }
+}


### PR DESCRIPTION
Pull request based on #2191 (simple tests additions)

---

With this addition it is now possible to quickly mock methods when creating a mock without having to go through the mock builder. This is intended to provide a simpler solution for 80% of the use cases.

Users can provide an array indexed by the method name. Values of the array can be:
- anything other than a `Closure` and an `Exception`, in which case the value will be returned when the method is called:

``` php
$mock = $this->createMock(MyClass::class, [
    'sayHello' => 'Hello',
]);

echo $mock->sayHello(); // Hello world!

// Shortcut for
$mock = $this->createMock(MyClass::class);
$mock->expect($this->any())
    ->method('sayHello')
    ->willReturn('Hello');
```
- a `Closure`, in which case the value returned by the closure will be returned when the method is called:

``` php
$mock = $this->createMock(MyClass::class, [
    'sayHello' => function ($name) {
        return 'Hello ' . $name;
    },
]);
echo $mock->sayHello('Bob'); // Hello Bob
```
- an `Exception`, in which case the exception will be thrown when the method is called:

``` php
$mock = $this->createMock(MyClass::class, [
    'sayHello' => new RuntimeException('Ouch'),
]);
$mock->sayHello(); // RuntimeException is thrown
```

It's important to note these helpers are completely optional and do not prevent using the more advanced API for mocks. For example it's possible to combine simple method mocks plus advanced mocking on other methods:

``` php
$mock = $this->createMock('MyClass', [
    'sayHello' => 'hello',
]);

$mock->expects($this->once())
    ->method('sayGoodbye')
    ->willReturn('Goodbye');
```

This feature is a port of the [mnapoli/phpunit-easymock](https://github.com/mnapoli/phpunit-easymock) package. I wrote and used this package for a year and it's very helpful. The introduction of the new `createMock()` method in PHPUnit 5.4 made this possible because of the lack of extra arguments to `createMock()` (contrary to `getMock()`), hopefully this can be merged and help future users.

PS: I'm more than willing to contribute documentation if this gets accepted.
