### PR TITLE
Ability to --list-suites for a given configuration

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -21,6 +21,7 @@ class PHPUnit_TextUI_Command
      */
     protected $arguments = [
         'listGroups'              => false,
+        'listSuites'              => false,
         'loader'                  => null,
         'useDefaultConfiguration' => true
     ];
@@ -57,6 +58,7 @@ class PHPUnit_TextUI_Command
         'help'                    => null,
         'include-path='           => null,
         'list-groups'             => null,
+        'list-suites'             => null,
         'loader='                 => null,
         'log-json='               => null,
         'log-junit='              => null,
@@ -146,6 +148,27 @@ class PHPUnit_TextUI_Command
 
             foreach ($groups as $group) {
                 print " - $group\n";
+            }
+
+            if ($exit) {
+                exit(PHPUnit_TextUI_TestRunner::SUCCESS_EXIT);
+            } else {
+                return PHPUnit_TextUI_TestRunner::SUCCESS_EXIT;
+            }
+        }
+
+        if ($this->arguments['listSuites']) {
+            $this->printVersionString();
+
+            print "Available test suite(s):\n";
+
+            $configuration = PHPUnit_Util_Configuration::getInstance(
+                $this->arguments['configuration']
+            );
+
+            $suiteNames = $configuration->getTestSuiteNames();
+            foreach ($suiteNames as $suiteName) {
+                print " - $suiteName\n";
             }
 
             if ($exit) {
@@ -408,6 +431,10 @@ class PHPUnit_TextUI_Command
 
                 case '--list-groups':
                     $this->arguments['listGroups'] = true;
+                    break;
+
+                case '--list-suites':
+                    $this->arguments['listSuites'] = true;
                     break;
 
                 case '--printer':
@@ -1024,6 +1051,7 @@ Test Selection Options:
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.
+  --list-suites             List available test suites.
   --test-suffix ...         Only search for test in files with specified
                             suffix(es). Default: Test.php,.phpt
 

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -866,6 +866,21 @@ class PHPUnit_Util_Configuration
     }
 
     /**
+     * Returns the test suite names from the configuration.
+     *
+     * @return array
+     */
+    public function getTestSuiteNames()
+    {
+        $names = [];
+        $nodes = $this->xpath->query('*/testsuite');
+        foreach ($nodes as $node) {
+            $names[] = $node->getAttribute('name');
+        }
+        return $names;
+    }
+
+    /**
      * @param DOMElement $testSuiteNode
      *
      * @return PHPUnit_Framework_TestSuite

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -42,6 +42,7 @@ Test Selection Options:
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.
+  --list-suites             List available test suites.
   --test-suffix ...         Only search for test in files with specified
                             suffix(es). Default: Test.php,.phpt
 

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -43,6 +43,7 @@ Test Selection Options:
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.
+  --list-suites             List available test suites.
   --test-suffix ...         Only search for test in files with specified
                             suffix(es). Default: Test.php,.phpt
 

--- a/tests/TextUI/list-suites.phpt
+++ b/tests/TextUI/list-suites.phpt
@@ -1,0 +1,16 @@
+--TEST--
+phpunit --list-suites --configuration=__DIR__.'/../_files/configuration.suites.xml'
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--list-suites';
+$_SERVER['argv'][2] = '--configuration';
+$_SERVER['argv'][3] = __DIR__.'/../_files/configuration.suites.xml';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Available test suite(s):
+ - Suite One
+ - Suite Two

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -460,4 +460,18 @@ class Util_ConfigurationTest extends PHPUnit_Framework_TestCase
             $actualConfiguration->getTestSuiteConfiguration()
         );
     }
+
+    /**
+     * @covers PHPUnit_Util_Configuration::getTestSuiteNames
+     */
+    public function testGetTestSuiteNamesReturnsTheNamesIfDefined()
+    {
+        $configuration = PHPUnit_Util_Configuration::getInstance(
+            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.suites.xml'
+        );
+
+        $names = $configuration->getTestSuiteNames();
+
+        $this->assertEquals(['Suite One', 'Suite Two'], $names);
+    }
 }

--- a/tests/_files/configuration.suites.xml
+++ b/tests/_files/configuration.suites.xml
@@ -1,0 +1,6 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="Suite One"></testsuite>
+        <testsuite name="Suite Two"></testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Taken from --list-groups as having the same functionality for suites is
helpful, and stops the need to constantly either grep'ing the phpunit.xml
file or opening it to find the suites available to run

Makes sense to have list-suites if list-groups is there, as both are then options you can use to limit the tests being group via --group --testsuite
