### PR TITLE
Test & Fix for Windows Spaces

### DIFF
--- a/src/Util/PHP/Windows.php
+++ b/src/Util/PHP/Windows.php
@@ -33,4 +33,9 @@ class PHPUnit_Util_PHP_Windows extends PHPUnit_Util_PHP_Default
             1 => $stdout_handle
         ];
     }
+
+    public function getCommand(array $settings, $file = null)
+    {
+        return '"' . parent::getCommand($settings, $file) . '"';
+    }
 }

--- a/tests/Util/WindowsTest.php
+++ b/tests/Util/WindowsTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * @author     Jessica Mauerhan <jessicamauerhan@gmail.com>
+ * @copyright  Sebastian Bergmann <sebastian@phpunit.de>
+ * @license    http://www.opensource.org/licenses/BSD-3-Clause  The BSD 3-Clause License
+ *
+ * @link       http://www.phpunit.de/
+ * @covers     PHPUnit_Util_PHP
+ */
+class PHPUnit_Util_PHP_WindowsTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetCommandShouldReturnCommandCompletelySurroundedByQuotes()
+    {
+        /**
+         * On windows, if the command is: "C:\Program Files (x86)\PHP\php.exe"
+         * And this string is passed into proc_open, which runProcess does,
+         * Windows will complain:
+         *   'C:\Program' is not recognized as an internal or external command,
+         *   operable program or batch file.
+         *
+         * Using an extra set of double quotes around the entire command fixes this.
+         * Source: https://bugs.php.net/bug.php?id=49139
+         **/
+        $windows = new PHPUnit_Util_PHP_Windows();
+
+        $expectedCommandFormat = '""%s""';
+        $actualCommand = $windows->getCommand([]);
+
+        $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);
+    }
+}

--- a/tests/Util/WindowsTest.php
+++ b/tests/Util/WindowsTest.php
@@ -18,7 +18,7 @@
  */
 class PHPUnit_Util_PHP_WindowsTest extends PHPUnit_Framework_TestCase
 {
-    public function testGetCommandShouldReturnCommandCompletelySurroundedByQuotes()
+    public function testGetCommandShouldReturnCommandCompletelySurroundedByQuotesWhenSpacesExistInBinary()
     {
         /**
          * On windows, if the command is: "C:\Program Files (x86)\PHP\php.exe"
@@ -30,11 +30,26 @@ class PHPUnit_Util_PHP_WindowsTest extends PHPUnit_Framework_TestCase
          * Using an extra set of double quotes around the entire command fixes this.
          * Source: https://bugs.php.net/bug.php?id=49139
          **/
-        $windows = new PHPUnit_Util_PHP_Windows();
 
-        $expectedCommandFormat = '""%s""';
-        $actualCommand = $windows->getCommand([]);
+        $binary = '"C:\Program Files (x86)\PHP\php.exe"';
+        $runtime = $this->createMock('SebastianBergmann\Environment\Runtime');
+        $runtime->method('getBinary')
+            ->willReturn($binary);
 
-        $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);
+        $windows = new PHPUnit_Util_PHP_Windows_Stub($runtime);
+
+        $file = 'foo.php';
+
+        $actualCommand = $windows->getCommand([], $file);
+        $expectedCommand = '""C:\Program Files (x86)\PHP\php.exe" -f "foo.php""';
+        $this->assertEquals($expectedCommand, $actualCommand);
+    }
+}
+
+Class PHPUnit_Util_PHP_Windows_Stub extends PHPUnit_Util_PHP_Windows
+{
+    public function __construct($runtime)
+    {
+        $this->runtime = $runtime;
     }
 }

--- a/tests/Util/WindowsTest.php
+++ b/tests/Util/WindowsTest.php
@@ -38,10 +38,8 @@ class PHPUnit_Util_PHP_WindowsTest extends PHPUnit_Framework_TestCase
 
         $windows = new PHPUnit_Util_PHP_Windows_Stub($runtime);
 
-        $file = 'foo.php';
-
-        $actualCommand = $windows->getCommand([], $file);
-        $expectedCommand = '""C:\Program Files (x86)\PHP\php.exe" -f "foo.php""';
+        $actualCommand = $windows->getCommand([]);
+        $expectedCommand = '""C:\Program Files (x86)\PHP\php.exe""';
         $this->assertEquals($expectedCommand, $actualCommand);
     }
 }


### PR DESCRIPTION
I noticed when running a test as an isolated process on Windows 10, there is an error: "'C:\Program' is not recognized as an internal or external command, operable program or batch file." I researched this and found it is an issue with proc_open and spaces, and the solution for Windows is to add a set of double quotes around the entire command. 

Source: https://bugs.php.net/bug.php?id=49139

I manually tested this, and created a unit test as well. 
