### PR TITLE
Add support for multiple data providers

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -434,41 +434,48 @@ class PHPUnit_Util_Test
      */
     private static function getDataFromDataProviderAnnotation($docComment, $className, $methodName)
     {
-        if (preg_match(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
-            $dataProviderMethodNameNamespace = explode('\\', $matches[1]);
-            $leaf                            = explode('::', array_pop($dataProviderMethodNameNamespace));
-            $dataProviderMethodName          = array_pop($leaf);
+        if (preg_match_all(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
+            $result = array();
+            foreach ($matches[1] as $match) {
+                $dataProviderMethodNameNamespace = explode('\\', $match);
+                $leaf                            = explode('::', array_pop($dataProviderMethodNameNamespace));
+                $dataProviderMethodName          = array_pop($leaf);
 
-            if (!empty($dataProviderMethodNameNamespace)) {
-                $dataProviderMethodNameNamespace = implode('\\', $dataProviderMethodNameNamespace) . '\\';
-            } else {
-                $dataProviderMethodNameNamespace = '';
+                if (!empty($dataProviderMethodNameNamespace)) {
+                    $dataProviderMethodNameNamespace = implode('\\', $dataProviderMethodNameNamespace) . '\\';
+                } else {
+                    $dataProviderMethodNameNamespace = '';
+                }
+
+                if (!empty($leaf)) {
+                    $dataProviderClassName = $dataProviderMethodNameNamespace . array_pop($leaf);
+                } else {
+                    $dataProviderClassName = $className;
+                }
+
+                $dataProviderClass  = new ReflectionClass($dataProviderClassName);
+                $dataProviderMethod = $dataProviderClass->getMethod(
+                    $dataProviderMethodName
+                );
+
+                if ($dataProviderMethod->isStatic()) {
+                    $object = null;
+                } else {
+                    $object = $dataProviderClass->newInstance();
+                }
+
+                if ($dataProviderMethod->getNumberOfParameters() == 0) {
+                    $data = $dataProviderMethod->invoke($object);
+                } else {
+                    $data = $dataProviderMethod->invoke($object, $methodName);
+                }
+
+                if (is_array($data)) {
+                    $result = array_merge($result, $data);
+                }
             }
 
-            if (!empty($leaf)) {
-                $dataProviderClassName = $dataProviderMethodNameNamespace . array_pop($leaf);
-            } else {
-                $dataProviderClassName = $className;
-            }
-
-            $dataProviderClass  = new ReflectionClass($dataProviderClassName);
-            $dataProviderMethod = $dataProviderClass->getMethod(
-                $dataProviderMethodName
-            );
-
-            if ($dataProviderMethod->isStatic()) {
-                $object = null;
-            } else {
-                $object = $dataProviderClass->newInstance();
-            }
-
-            if ($dataProviderMethod->getNumberOfParameters() == 0) {
-                $data = $dataProviderMethod->invoke($object);
-            } else {
-                $data = $dataProviderMethod->invoke($object, $methodName);
-            }
-
-            return $data;
+            return $result;
         }
     }
 

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -431,6 +431,30 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Check if all data providers are being merged.
+     */
+    public function testMultipleDataProviders()
+    {
+        $dataSets = PHPUnit_Util_Test::getProvidedData('MultipleDataProviderTest', 'testOne');
+
+        $this->assertEquals(9, count($dataSets));
+
+        $aCount = 0;
+        $bCount = 0;
+        $cCount = 0;
+
+        for ($i = 0; $i < 9; $i++) {
+            $aCount += $dataSets[$i][0] != null ? 1 : 0;
+            $bCount += $dataSets[$i][1] != null ? 1 : 0;
+            $cCount += $dataSets[$i][2] != null ? 1 : 0;
+        }
+
+        $this->assertEquals(3, $aCount);
+        $this->assertEquals(3, $bCount);
+        $this->assertEquals(3, $cCount);
+    }
+
+    /**
      * @covers PHPUnit_Util_Test::getDataFromTestWithAnnotation
      */
     public function testTestWithEmptyAnnotation()

--- a/tests/_files/MultipleDataProviderTest.php
+++ b/tests/_files/MultipleDataProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+class MultipleDataProviderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider providerA
+     * @dataProvider providerB
+     * @dataProvider providerC
+     */
+    public function testOne()
+    {
+    }
+
+    public static function providerA()
+    {
+        return [
+            ['ok', null, null],
+            ['ok', null, null],
+            ['ok', null, null]
+        ];
+    }
+
+    public static function providerB()
+    {
+        return [
+            [null, 'ok', null],
+            [null, 'ok', null],
+            [null, 'ok', null]
+        ];
+    }
+
+    public static function providerC()
+    {
+        return [
+            [null, null, 'ok'],
+            [null, null, 'ok'],
+            [null, null, 'ok']
+        ];
+    }
+}


### PR DESCRIPTION
This patch will make phpunit merge the data from multiple data providers and use them in the test. 

![example](https://cloud.githubusercontent.com/assets/11317458/16173575/b9869a82-357b-11e6-9103-acc7d4e9ab52.png)
