### PR TITLE
Feature: Add to backupGlobalsBlacklist via annotations, XML config or command line option

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -76,6 +76,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     protected $backupGlobals = null;
 
     /**
+     * List of globals that should not be backed up when backupGlobals is enabled.
+     * 
      * @var array
      */
     protected $backupGlobalsBlacklist = [];

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1259,8 +1259,6 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
-     * Calling this method in setUp() has no effect!
-     *
      * @param bool $backupGlobals
      *
      * @since Method available since Release 3.3.0
@@ -1272,6 +1270,20 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         }
     }
 
+    /**
+     * Calling this method in setUp() has no effect!
+     *
+     * @param array $backupGlobalsBlacklist
+     */
+    public function setBackupGlobalsBlacklist(array $backupGlobalsBlacklist = [])
+    {
+        $this->backupGlobalsBlacklist = array_unique(
+                                            array_merge(
+                                                $this->backupGlobalsBlacklist,
+                                                $backupGlobalsBlacklist
+                                                )
+                                        );
+    }
     /**
      * Calling this method in setUp() has no effect!
      *

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -55,6 +55,8 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     protected $backupGlobals = null;
 
     /**
+     * List of globals that should not be backed up when backupGlobals is enabled.
+     * 
      * @var array
      */
     protected $backupGlobalsBlacklist = [];

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -55,6 +55,11 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
     protected $backupGlobals = null;
 
     /**
+     * @var array
+     */
+    protected $backupGlobalsBlacklist = [];
+
+    /**
      * Enable or disable the backup and restoration of static attributes.
      *
      * @var bool
@@ -575,6 +580,12 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
                                 );
                             }
 
+                            if ($backupSettings['backupGlobalsBlacklist'] !== []) {
+                                $_test->setBackupGlobalsBlacklist(
+                                    $backupSettings['backupGlobalsBlacklist']
+                                );
+                            }
+
                             if ($backupSettings['backupStaticAttributes'] !== null) {
                                 $_test->setBackupStaticAttributes(
                                     $backupSettings['backupStaticAttributes']
@@ -607,6 +618,12 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
 
             if ($backupSettings['backupGlobals'] !== null) {
                 $test->setBackupGlobals($backupSettings['backupGlobals']);
+            }
+
+            if ($backupSettings['backupGlobalsBlacklist'] !== []) {
+                $test->setBackupGlobalsBlacklist(
+                    $backupSettings['backupGlobalsBlacklist']
+                );
             }
 
             if ($backupSettings['backupStaticAttributes'] !== null) {
@@ -746,6 +763,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
                 $test instanceof self) {
                 $test->setbeStrictAboutChangesToGlobalState($this->beStrictAboutChangesToGlobalState);
                 $test->setBackupGlobals($this->backupGlobals);
+                $test->setBackupGlobalsBlacklist($this->backupGlobalsBlacklist);
                 $test->setBackupStaticAttributes($this->backupStaticAttributes);
                 $test->setRunTestInSeparateProcess($this->runTestInSeparateProcess);
             }
@@ -977,6 +995,14 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         if (is_null($this->backupGlobals) && is_bool($backupGlobals)) {
             $this->backupGlobals = $backupGlobals;
         }
+    }
+
+    /**
+     * @param array $backupGlobalsBlacklist
+     */
+    public function setBackupGlobalsBlacklist(array $backupGlobalsBlacklist = [])
+    {
+        $this->backupGlobalsBlacklist = $backupGlobalsBlacklist;
     }
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -555,6 +555,10 @@ class PHPUnit_TextUI_Command
                     $this->arguments['backupGlobals'] = false;
                     break;
 
+                case '--globals-backup-blacklist':
+                    $this->arguments['backupGlobalsBlacklist'] = explode(',', $option[1]);
+                    break;
+
                 case '--static-backup':
                     $this->arguments['backupStaticAttributes'] = true;
                     break;
@@ -1023,91 +1027,92 @@ Usage: phpunit [options] UnitTest [UnitTest.php]
 
 Code Coverage Options:
 
-  --coverage-clover <file>  Generate code coverage report in Clover XML format.
-  --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
-  --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Export PHP_CodeCoverage object to file.
-  --coverage-text=<file>    Generate code coverage report in text format.
-                            Default: Standard output.
-  --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
-  --whitelist <dir>         Whitelist <dir> for code coverage analysis.
-  --disable-coverage-ignore Disable annotations for ignoring code coverage.
+  --coverage-clover <file>    Generate code coverage report in Clover XML format.
+  --coverage-crap4j <file>    Generate code coverage report in Crap4J XML format.
+  --coverage-html <dir>       Generate code coverage report in HTML format.
+  --coverage-php <file>       Export PHP_CodeCoverage object to file.
+  --coverage-text=<file>      Generate code coverage report in text format.
+                              Default: Standard output.
+  --coverage-xml <dir>        Generate code coverage report in PHPUnit XML format.
+  --whitelist <dir>           Whitelist <dir> for code coverage analysis.
+  --disable-coverage-ignore   Disable annotations for ignoring code coverage.
 
 Logging Options:
 
-  --log-junit <file>        Log test execution in JUnit XML format to file.
-  --log-tap <file>          Log test execution in TAP format to file.
-  --log-teamcity <file>     Log test execution in TeamCity format to file.
-  --log-json <file>         Log test execution in JSON format.
-  --testdox-html <file>     Write agile documentation in HTML format to file.
-  --testdox-text <file>     Write agile documentation in Text format to file.
-  --testdox-xml <file>      Write agile documentation in XML format to file.
-  --reverse-list            Print defects in reverse order
+  --log-junit <file>          Log test execution in JUnit XML format to file.
+  --log-tap <file>            Log test execution in TAP format to file.
+  --log-teamcity <file>       Log test execution in TeamCity format to file.
+  --log-json <file>           Log test execution in JSON format.
+  --testdox-html <file>       Write agile documentation in HTML format to file.
+  --testdox-text <file>       Write agile documentation in Text format to file.
+  --testdox-xml <file>        Write agile documentation in XML format to file.
+  --reverse-list              Print defects in reverse order
 
 Test Selection Options:
 
-  --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
-  --group ...               Only runs tests from the specified group(s).
-  --exclude-group ...       Exclude tests from the specified group(s).
-  --list-groups             List available test groups.
-  --list-suites             List available test suites.
-  --test-suffix ...         Only search for test in files with specified
-                            suffix(es). Default: Test.php,.phpt
+  --filter <pattern>          Filter which tests to run.
+  --testsuite <pattern>       Filter which testsuite to run.
+  --group ...                 Only runs tests from the specified group(s).
+  --exclude-group ...         Exclude tests from the specified group(s).
+  --list-groups               List available test groups.
+  --list-suites               List available test suites.
+  --test-suffix ...           Only search for test in files with specified
+                              suffix(es). Default: Test.php,.phpt
 
 Test Execution Options:
 
-  --report-useless-tests    Be strict about tests that do not test anything.
-  --strict-coverage         Be strict about @covers annotation usage.
-  --strict-global-state     Be strict about changes to global state
-  --disallow-test-output    Be strict about output during tests.
-  --disallow-resource-usage Be strict about resource usage during small tests.
-  --enforce-time-limit      Enforce time limit based on test size.
-  --disallow-todo-tests     Disallow @todo-annotated tests.
+  --report-useless-tests      Be strict about tests that do not test anything.
+  --strict-coverage           Be strict about @covers annotation usage.
+  --strict-global-state       Be strict about changes to global state
+  --disallow-test-output      Be strict about output during tests.
+  --disallow-resource-usage   Be strict about resource usage during small tests.
+  --enforce-time-limit        Enforce time limit based on test size.
+  --disallow-todo-tests       Disallow @todo-annotated tests.
 
-  --process-isolation       Run each test in a separate PHP process.
-  --no-globals-backup       Do not backup and restore \$GLOBALS for each test.
-  --static-backup           Backup and restore static attributes for each test.
+  --process-isolation         Run each test in a separate PHP process.
+  --no-globals-backup         Do not backup and restore \$GLOBALS for each test.
+  --globals-backup-blacklist  List of globals to not backup.
+  --static-backup             Backup and restore static attributes for each test.
 
-  --colors=<flag>           Use colors in output ("never", "auto" or "always").
-  --columns <n>             Number of columns to use for progress output.
-  --columns max             Use maximum number of columns for progress output.
-  --stderr                  Write to STDERR instead of STDOUT.
-  --stop-on-error           Stop execution upon first error.
-  --stop-on-failure         Stop execution upon first error or failure.
-  --stop-on-warning         Stop execution upon first warning.
-  --stop-on-risky           Stop execution upon first risky test.
-  --stop-on-skipped         Stop execution upon first skipped test.
-  --stop-on-incomplete      Stop execution upon first incomplete test.
-  --fail-on-warning         Treat tests with warnings as failures.
-  --fail-on-risky           Treat risky tests as failures.
-  -v|--verbose              Output more verbose information.
-  --debug                   Display debugging information during test execution.
+  --colors=<flag>             Use colors in output ("never", "auto" or "always").
+  --columns <n>               Number of columns to use for progress output.
+  --columns max               Use maximum number of columns for progress output.
+  --stderr                    Write to STDERR instead of STDOUT.
+  --stop-on-error             Stop execution upon first error.
+  --stop-on-failure           Stop execution upon first error or failure.
+  --stop-on-warning           Stop execution upon first warning.
+  --stop-on-risky             Stop execution upon first risky test.
+  --stop-on-skipped           Stop execution upon first skipped test.
+  --stop-on-incomplete        Stop execution upon first incomplete test.
+  --fail-on-warning           Treat tests with warnings as failures.
+  --fail-on-risky             Treat risky tests as failures.
+  -v|--verbose                Output more verbose information.
+  --debug                     Display debugging information during test execution.
 
-  --loader <loader>         TestSuiteLoader implementation to use.
-  --repeat <times>          Runs the test(s) repeatedly.
-  --tap                     Report test execution progress in TAP format.
-  --teamcity                Report test execution progress in TeamCity format.
-  --testdox                 Report test execution progress in TestDox format.
-  --testdox-group           Only include tests from the specified group(s).
-  --testdox-exclude-group   Exclude tests from the specified group(s).
-  --printer <printer>       TestListener implementation to use.
+  --loader <loader>           TestSuiteLoader implementation to use.
+  --repeat <times>            Runs the test(s) repeatedly.
+  --tap                       Report test execution progress in TAP format.
+  --teamcity                  Report test execution progress in TeamCity format.
+  --testdox                   Report test execution progress in TestDox format.
+  --testdox-group             Only include tests from the specified group(s).
+  --testdox-exclude-group     Exclude tests from the specified group(s).
+  --printer <printer>         TestListener implementation to use.
 
 Configuration Options:
 
-  --bootstrap <file>        A "bootstrap" PHP file that is run before the tests.
-  -c|--configuration <file> Read configuration from XML file.
-  --no-configuration        Ignore default configuration file (phpunit.xml).
-  --no-coverage             Ignore code coverage configuration.
-  --include-path <path(s)>  Prepend PHP's include_path with given path(s).
-  -d key[=value]            Sets a php.ini value.
-  --generate-configuration  Generate configuration file with suggested settings.
+  --bootstrap <file>          A "bootstrap" PHP file that is run before the tests.
+  -c|--configuration <file>   Read configuration from XML file.
+  --no-configuration          Ignore default configuration file (phpunit.xml).
+  --no-coverage               Ignore code coverage configuration.
+  --include-path <path(s)>    Prepend PHP's include_path with given path(s).
+  -d key[=value]              Sets a php.ini value.
+  --generate-configuration    Generate configuration file with suggested settings.
 
 Miscellaneous Options:
 
-  -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
-  --atleast-version <min>   Checks that version is greater than min and exits.
+  -h|--help                   Prints this usage information.
+  --version                   Prints the version and exits.
+  --atleast-version <min>     Checks that version is greater than min and exits.
 
 EOT;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -172,6 +172,11 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             $suite->setBackupGlobals(false);
         }
 
+        if (is_array($arguments['backupGlobalsBlacklist']) &&
+                $arguments['backupGlobalsBlacklist'] !== []) {
+            $suite->setBackupGlobalsBlacklist($arguments['backupGlobalsBlacklist']);
+        }
+
         if ($arguments['backupStaticAttributes'] === true) {
             $suite->setBackupStaticAttributes(true);
         }
@@ -460,6 +465,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
 
         if ($suite instanceof PHPUnit_Framework_TestSuite) {
             $suite->setRunTestInSeparateProcess($arguments['processIsolation']);
+            $suite->setBackupGlobalsBlacklist($arguments['backupGlobalsBlacklist']);
         }
 
         $suite->run($result);
@@ -876,6 +882,12 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                 $arguments['excludeGroups'] = array_diff($groupConfiguration['exclude'], $groupCliArgs);
             }
 
+            $backupGlobalsBlacklist = $arguments['configuration']->getBackupGlobalsBlacklistConfiguration();
+            if ($backupGlobalsBlacklist !== [] &&
+                !isset($arguments['backupGlobalsBlacklist'])) {
+                $arguments['backupGlobalsBlacklist'] = $backupGlobalsBlacklist;
+            }
+
             foreach ($arguments['configuration']->getListenerConfiguration() as $listener) {
                 if (!class_exists($listener['class'], false) &&
                     $listener['file'] !== '') {
@@ -1039,6 +1051,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         $arguments['addUncoveredFilesFromWhitelist']                  = isset($arguments['addUncoveredFilesFromWhitelist'])                  ? $arguments['addUncoveredFilesFromWhitelist']                  : true;
         $arguments['processUncoveredFilesFromWhitelist']              = isset($arguments['processUncoveredFilesFromWhitelist'])              ? $arguments['processUncoveredFilesFromWhitelist']              : false;
         $arguments['backupGlobals']                                   = isset($arguments['backupGlobals'])                                   ? $arguments['backupGlobals']                                   : null;
+        $arguments['backupGlobalsBlacklist']                          = isset($arguments['backupGlobalsBlacklist'])                          ? $arguments['backupGlobalsBlacklist']                          : [];
         $arguments['backupStaticAttributes']                          = isset($arguments['backupStaticAttributes'])                          ? $arguments['backupStaticAttributes']                          : null;
         $arguments['beStrictAboutChangesToGlobalState']               = isset($arguments['beStrictAboutChangesToGlobalState'])               ? $arguments['beStrictAboutChangesToGlobalState']               : null;
         $arguments['cacheTokens']                                     = isset($arguments['cacheTokens'])                                     ? $arguments['cacheTokens']                                     : false;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -58,6 +58,10 @@
  *       <exclude>/path/to/files/exclude</exclude>
  *     </testsuite>
  *   </testsuites>
+ *   
+ *   <backupglobalsblacklist>
+ *     <name>server_config</name>
+ *   </backupglobalsblacklist>
  *
  *   <groups>
  *     <include>
@@ -276,6 +280,22 @@ class PHPUnit_Util_Configuration
     public function getGroupConfiguration()
     {
         return $this->parseGroupConfiguration('groups');
+    }
+
+    /**
+     * Returns the configuration for backup globals blacklist
+     *
+     * @return array
+     */
+    public function getBackupGlobalsBlacklistConfiguration()
+    {
+        $backupGlobalsBlacklist = [];
+
+        foreach ($this->xpath->query('backupglobalsblacklist/name') as $name) {
+            $backupGlobalsBlacklist[] = $name->textContent;
+        }
+
+        return $backupGlobalsBlacklist;
     }
 
     /**

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -498,7 +498,6 @@ class PHPUnit_Util_Test
                 $dataSet = json_decode($candidateRow, true);
 
                 if (json_last_error() != JSON_ERROR_NONE) {
-
                     throw new PHPUnit_Framework_Exception(
                         'The dataset for the @testWith annotation cannot be parsed: ' . json_last_error_msg()
                     );
@@ -632,6 +631,10 @@ class PHPUnit_Util_Test
               $methodName,
               'backupGlobals'
           ),
+          'backupGlobalsBlacklist' => self::getBackupGlobalsBlacklist(
+              $className,
+              $methodName
+          ),
           'backupStaticAttributes' => self::getBooleanAnnotationSetting(
               $className,
               $methodName,
@@ -671,6 +674,37 @@ class PHPUnit_Util_Test
         }
 
         return array_unique($dependencies);
+    }
+
+    /**
+     * Returns the backup globals blacklist for a test class or method.
+     *
+     * @param string $className
+     * @param string $methodName
+     *
+     * @return array
+     */
+    public static function getBackupGlobalsBlacklist($className, $methodName)
+    {
+        $annotations = self::parseTestMethodAnnotations(
+            $className,
+            $methodName
+        );
+
+        $backupGlobalsBlacklist = [];
+
+        if (isset($annotations['class']['backupGlobalsBlacklist'])) {
+            $backupGlobalsBlacklist = $annotations['class']['backupGlobalsBlacklist'];
+        }
+
+        if (isset($annotations['method']['backupGlobalsBlacklist'])) {
+            $backupGlobalsBlacklist = array_merge(
+                $backupGlobalsBlacklist,
+                $annotations['method']['backupGlobalsBlacklist']
+            );
+        }
+
+        return array_unique($backupGlobalsBlacklist);
     }
 
     /**

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -21,6 +21,7 @@ $_SERVER['f']  = 'f';
 $_FILES['g']   = 'g';
 $_REQUEST['h'] = 'h';
 $GLOBALS['i']  = 'i';
+$GLOBALS['yu'] = 'yu';
 
 /**
  * @since      Class available since Release 2.0.0
@@ -29,7 +30,6 @@ $GLOBALS['i']  = 'i';
 class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
 {
     protected $backupGlobalsBlacklist = ['i', 'singleton'];
-
     /**
      * Used be testStaticAttributesBackupPre
      */
@@ -310,6 +310,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
 
     /**
      * @backupGlobals enabled
+     * @backupGlobalsBlacklist yu
      */
     public function testGlobalsBackupPre()
     {
@@ -327,6 +328,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('h', $_REQUEST['h']);
         $this->assertEquals('i', $i);
         $this->assertEquals('i', $GLOBALS['i']);
+        $this->assertEquals('yu', $GLOBALS['yu']);
 
         $GLOBALS['a']   = 'aa';
         $GLOBALS['foo'] = 'bar';
@@ -338,6 +340,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $_FILES['g']    = 'gg';
         $_REQUEST['h']  = 'hh';
         $GLOBALS['i']   = 'ii';
+        $GLOBALS['yu']  = 'yun';
 
         $this->assertEquals('aa', $a);
         $this->assertEquals('aa', $GLOBALS['a']);
@@ -351,6 +354,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hh', $_REQUEST['h']);
         $this->assertEquals('ii', $i);
         $this->assertEquals('ii', $GLOBALS['i']);
+        $this->assertEquals('yun', $GLOBALS['yu']);
     }
 
     public function testGlobalsBackupPost()
@@ -369,6 +373,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('h', $_REQUEST['h']);
         $this->assertEquals('ii', $i);
         $this->assertEquals('ii', $GLOBALS['i']);
+        $this->assertEquals('yun', $GLOBALS['yu']);
 
         $this->assertArrayNotHasKey('foo', $GLOBALS);
     }

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -14,88 +14,89 @@ Usage: phpunit [options] UnitTest [UnitTest.php]
 
 Code Coverage Options:
 
-  --coverage-clover <file>  Generate code coverage report in Clover XML format.
-  --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
-  --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Export PHP_CodeCoverage object to file.
-  --coverage-text=<file>    Generate code coverage report in text format.
-                            Default: Standard output.
-  --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
-  --whitelist <dir>         Whitelist <dir> for code coverage analysis.
-  --disable-coverage-ignore Disable annotations for ignoring code coverage.
+  --coverage-clover <file>    Generate code coverage report in Clover XML format.
+  --coverage-crap4j <file>    Generate code coverage report in Crap4J XML format.
+  --coverage-html <dir>       Generate code coverage report in HTML format.
+  --coverage-php <file>       Export PHP_CodeCoverage object to file.
+  --coverage-text=<file>      Generate code coverage report in text format.
+                              Default: Standard output.
+  --coverage-xml <dir>        Generate code coverage report in PHPUnit XML format.
+  --whitelist <dir>           Whitelist <dir> for code coverage analysis.
+  --disable-coverage-ignore   Disable annotations for ignoring code coverage.
 
 Logging Options:
 
-  --log-junit <file>        Log test execution in JUnit XML format to file.
-  --log-tap <file>          Log test execution in TAP format to file.
-  --log-teamcity <file>     Log test execution in TeamCity format to file.
-  --log-json <file>         Log test execution in JSON format.
-  --testdox-html <file>     Write agile documentation in HTML format to file.
-  --testdox-text <file>     Write agile documentation in Text format to file.
-  --testdox-xml <file>      Write agile documentation in XML format to file.
-  --reverse-list            Print defects in reverse order
+  --log-junit <file>          Log test execution in JUnit XML format to file.
+  --log-tap <file>            Log test execution in TAP format to file.
+  --log-teamcity <file>       Log test execution in TeamCity format to file.
+  --log-json <file>           Log test execution in JSON format.
+  --testdox-html <file>       Write agile documentation in HTML format to file.
+  --testdox-text <file>       Write agile documentation in Text format to file.
+  --testdox-xml <file>        Write agile documentation in XML format to file.
+  --reverse-list              Print defects in reverse order
 
 Test Selection Options:
 
-  --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
-  --group ...               Only runs tests from the specified group(s).
-  --exclude-group ...       Exclude tests from the specified group(s).
-  --list-groups             List available test groups.
-  --list-suites             List available test suites.
-  --test-suffix ...         Only search for test in files with specified
-                            suffix(es). Default: Test.php,.phpt
+  --filter <pattern>          Filter which tests to run.
+  --testsuite <pattern>       Filter which testsuite to run.
+  --group ...                 Only runs tests from the specified group(s).
+  --exclude-group ...         Exclude tests from the specified group(s).
+  --list-groups               List available test groups.
+  --list-suites               List available test suites.
+  --test-suffix ...           Only search for test in files with specified
+                              suffix(es). Default: Test.php,.phpt
 
 Test Execution Options:
 
-  --report-useless-tests    Be strict about tests that do not test anything.
-  --strict-coverage         Be strict about @covers annotation usage.
-  --strict-global-state     Be strict about changes to global state
-  --disallow-test-output    Be strict about output during tests.
-  --disallow-resource-usage Be strict about resource usage during small tests.
-  --enforce-time-limit      Enforce time limit based on test size.
-  --disallow-todo-tests     Disallow @todo-annotated tests.
+  --report-useless-tests      Be strict about tests that do not test anything.
+  --strict-coverage           Be strict about @covers annotation usage.
+  --strict-global-state       Be strict about changes to global state
+  --disallow-test-output      Be strict about output during tests.
+  --disallow-resource-usage   Be strict about resource usage during small tests.
+  --enforce-time-limit        Enforce time limit based on test size.
+  --disallow-todo-tests       Disallow @todo-annotated tests.
 
-  --process-isolation       Run each test in a separate PHP process.
-  --no-globals-backup       Do not backup and restore $GLOBALS for each test.
-  --static-backup           Backup and restore static attributes for each test.
+  --process-isolation         Run each test in a separate PHP process.
+  --no-globals-backup         Do not backup and restore $GLOBALS for each test.
+  --globals-backup-blacklist  List of globals to not backup.
+  --static-backup             Backup and restore static attributes for each test.
 
-  --colors=<flag>           Use colors in output ("never", "auto" or "always").
-  --columns <n>             Number of columns to use for progress output.
-  --columns max             Use maximum number of columns for progress output.
-  --stderr                  Write to STDERR instead of STDOUT.
-  --stop-on-error           Stop execution upon first error.
-  --stop-on-failure         Stop execution upon first error or failure.
-  --stop-on-warning         Stop execution upon first warning.
-  --stop-on-risky           Stop execution upon first risky test.
-  --stop-on-skipped         Stop execution upon first skipped test.
-  --stop-on-incomplete      Stop execution upon first incomplete test.
-  --fail-on-warning         Treat tests with warnings as failures.
-  --fail-on-risky           Treat risky tests as failures.
-  -v|--verbose              Output more verbose information.
-  --debug                   Display debugging information during test execution.
+  --colors=<flag>             Use colors in output ("never", "auto" or "always").
+  --columns <n>               Number of columns to use for progress output.
+  --columns max               Use maximum number of columns for progress output.
+  --stderr                    Write to STDERR instead of STDOUT.
+  --stop-on-error             Stop execution upon first error.
+  --stop-on-failure           Stop execution upon first error or failure.
+  --stop-on-warning           Stop execution upon first warning.
+  --stop-on-risky             Stop execution upon first risky test.
+  --stop-on-skipped           Stop execution upon first skipped test.
+  --stop-on-incomplete        Stop execution upon first incomplete test.
+  --fail-on-warning           Treat tests with warnings as failures.
+  --fail-on-risky             Treat risky tests as failures.
+  -v|--verbose                Output more verbose information.
+  --debug                     Display debugging information during test execution.
 
-  --loader <loader>         TestSuiteLoader implementation to use.
-  --repeat <times>          Runs the test(s) repeatedly.
-  --tap                     Report test execution progress in TAP format.
-  --teamcity                Report test execution progress in TeamCity format.
-  --testdox                 Report test execution progress in TestDox format.
-  --testdox-group           Only include tests from the specified group(s).
-  --testdox-exclude-group   Exclude tests from the specified group(s).
-  --printer <printer>       TestListener implementation to use.
+  --loader <loader>           TestSuiteLoader implementation to use.
+  --repeat <times>            Runs the test(s) repeatedly.
+  --tap                       Report test execution progress in TAP format.
+  --teamcity                  Report test execution progress in TeamCity format.
+  --testdox                   Report test execution progress in TestDox format.
+  --testdox-group             Only include tests from the specified group(s).
+  --testdox-exclude-group     Exclude tests from the specified group(s).
+  --printer <printer>         TestListener implementation to use.
 
 Configuration Options:
 
-  --bootstrap <file>        A "bootstrap" PHP file that is run before the tests.
-  -c|--configuration <file> Read configuration from XML file.
-  --no-configuration        Ignore default configuration file (phpunit.xml).
-  --no-coverage             Ignore code coverage configuration.
-  --include-path <path(s)>  Prepend PHP's include_path with given path(s).
-  -d key[=value]            Sets a php.ini value.
-  --generate-configuration  Generate configuration file with suggested settings.
+  --bootstrap <file>          A "bootstrap" PHP file that is run before the tests.
+  -c|--configuration <file>   Read configuration from XML file.
+  --no-configuration          Ignore default configuration file (phpunit.xml).
+  --no-coverage               Ignore code coverage configuration.
+  --include-path <path(s)>    Prepend PHP's include_path with given path(s).
+  -d key[=value]              Sets a php.ini value.
+  --generate-configuration    Generate configuration file with suggested settings.
 
 Miscellaneous Options:
 
-  -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
-  --atleast-version <min>   Checks that version is greater than min and exits.
+  -h|--help                   Prints this usage information.
+  --version                   Prints the version and exits.
+  --atleast-version <min>     Checks that version is greater than min and exits.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -15,88 +15,89 @@ Usage: phpunit [options] UnitTest [UnitTest.php]
 
 Code Coverage Options:
 
-  --coverage-clover <file>  Generate code coverage report in Clover XML format.
-  --coverage-crap4j <file>  Generate code coverage report in Crap4J XML format.
-  --coverage-html <dir>     Generate code coverage report in HTML format.
-  --coverage-php <file>     Export PHP_CodeCoverage object to file.
-  --coverage-text=<file>    Generate code coverage report in text format.
-                            Default: Standard output.
-  --coverage-xml <dir>      Generate code coverage report in PHPUnit XML format.
-  --whitelist <dir>         Whitelist <dir> for code coverage analysis.
-  --disable-coverage-ignore Disable annotations for ignoring code coverage.
+  --coverage-clover <file>    Generate code coverage report in Clover XML format.
+  --coverage-crap4j <file>    Generate code coverage report in Crap4J XML format.
+  --coverage-html <dir>       Generate code coverage report in HTML format.
+  --coverage-php <file>       Export PHP_CodeCoverage object to file.
+  --coverage-text=<file>      Generate code coverage report in text format.
+                              Default: Standard output.
+  --coverage-xml <dir>        Generate code coverage report in PHPUnit XML format.
+  --whitelist <dir>           Whitelist <dir> for code coverage analysis.
+  --disable-coverage-ignore   Disable annotations for ignoring code coverage.
 
 Logging Options:
 
-  --log-junit <file>        Log test execution in JUnit XML format to file.
-  --log-tap <file>          Log test execution in TAP format to file.
-  --log-teamcity <file>     Log test execution in TeamCity format to file.
-  --log-json <file>         Log test execution in JSON format.
-  --testdox-html <file>     Write agile documentation in HTML format to file.
-  --testdox-text <file>     Write agile documentation in Text format to file.
-  --testdox-xml <file>      Write agile documentation in XML format to file.
-  --reverse-list            Print defects in reverse order
+  --log-junit <file>          Log test execution in JUnit XML format to file.
+  --log-tap <file>            Log test execution in TAP format to file.
+  --log-teamcity <file>       Log test execution in TeamCity format to file.
+  --log-json <file>           Log test execution in JSON format.
+  --testdox-html <file>       Write agile documentation in HTML format to file.
+  --testdox-text <file>       Write agile documentation in Text format to file.
+  --testdox-xml <file>        Write agile documentation in XML format to file.
+  --reverse-list              Print defects in reverse order
 
 Test Selection Options:
 
-  --filter <pattern>        Filter which tests to run.
-  --testsuite <pattern>     Filter which testsuite to run.
-  --group ...               Only runs tests from the specified group(s).
-  --exclude-group ...       Exclude tests from the specified group(s).
-  --list-groups             List available test groups.
-  --list-suites             List available test suites.
-  --test-suffix ...         Only search for test in files with specified
-                            suffix(es). Default: Test.php,.phpt
+  --filter <pattern>          Filter which tests to run.
+  --testsuite <pattern>       Filter which testsuite to run.
+  --group ...                 Only runs tests from the specified group(s).
+  --exclude-group ...         Exclude tests from the specified group(s).
+  --list-groups               List available test groups.
+  --list-suites               List available test suites.
+  --test-suffix ...           Only search for test in files with specified
+                              suffix(es). Default: Test.php,.phpt
 
 Test Execution Options:
 
-  --report-useless-tests    Be strict about tests that do not test anything.
-  --strict-coverage         Be strict about @covers annotation usage.
-  --strict-global-state     Be strict about changes to global state
-  --disallow-test-output    Be strict about output during tests.
-  --disallow-resource-usage Be strict about resource usage during small tests.
-  --enforce-time-limit      Enforce time limit based on test size.
-  --disallow-todo-tests     Disallow @todo-annotated tests.
+  --report-useless-tests      Be strict about tests that do not test anything.
+  --strict-coverage           Be strict about @covers annotation usage.
+  --strict-global-state       Be strict about changes to global state
+  --disallow-test-output      Be strict about output during tests.
+  --disallow-resource-usage   Be strict about resource usage during small tests.
+  --enforce-time-limit        Enforce time limit based on test size.
+  --disallow-todo-tests       Disallow @todo-annotated tests.
 
-  --process-isolation       Run each test in a separate PHP process.
-  --no-globals-backup       Do not backup and restore $GLOBALS for each test.
-  --static-backup           Backup and restore static attributes for each test.
+  --process-isolation         Run each test in a separate PHP process.
+  --no-globals-backup         Do not backup and restore $GLOBALS for each test.
+  --globals-backup-blacklist  List of globals to not backup.
+  --static-backup             Backup and restore static attributes for each test.
 
-  --colors=<flag>           Use colors in output ("never", "auto" or "always").
-  --columns <n>             Number of columns to use for progress output.
-  --columns max             Use maximum number of columns for progress output.
-  --stderr                  Write to STDERR instead of STDOUT.
-  --stop-on-error           Stop execution upon first error.
-  --stop-on-failure         Stop execution upon first error or failure.
-  --stop-on-warning         Stop execution upon first warning.
-  --stop-on-risky           Stop execution upon first risky test.
-  --stop-on-skipped         Stop execution upon first skipped test.
-  --stop-on-incomplete      Stop execution upon first incomplete test.
-  --fail-on-warning         Treat tests with warnings as failures.
-  --fail-on-risky           Treat risky tests as failures.
-  -v|--verbose              Output more verbose information.
-  --debug                   Display debugging information during test execution.
+  --colors=<flag>             Use colors in output ("never", "auto" or "always").
+  --columns <n>               Number of columns to use for progress output.
+  --columns max               Use maximum number of columns for progress output.
+  --stderr                    Write to STDERR instead of STDOUT.
+  --stop-on-error             Stop execution upon first error.
+  --stop-on-failure           Stop execution upon first error or failure.
+  --stop-on-warning           Stop execution upon first warning.
+  --stop-on-risky             Stop execution upon first risky test.
+  --stop-on-skipped           Stop execution upon first skipped test.
+  --stop-on-incomplete        Stop execution upon first incomplete test.
+  --fail-on-warning           Treat tests with warnings as failures.
+  --fail-on-risky             Treat risky tests as failures.
+  -v|--verbose                Output more verbose information.
+  --debug                     Display debugging information during test execution.
 
-  --loader <loader>         TestSuiteLoader implementation to use.
-  --repeat <times>          Runs the test(s) repeatedly.
-  --tap                     Report test execution progress in TAP format.
-  --teamcity                Report test execution progress in TeamCity format.
-  --testdox                 Report test execution progress in TestDox format.
-  --testdox-group           Only include tests from the specified group(s).
-  --testdox-exclude-group   Exclude tests from the specified group(s).
-  --printer <printer>       TestListener implementation to use.
+  --loader <loader>           TestSuiteLoader implementation to use.
+  --repeat <times>            Runs the test(s) repeatedly.
+  --tap                       Report test execution progress in TAP format.
+  --teamcity                  Report test execution progress in TeamCity format.
+  --testdox                   Report test execution progress in TestDox format.
+  --testdox-group             Only include tests from the specified group(s).
+  --testdox-exclude-group     Exclude tests from the specified group(s).
+  --printer <printer>         TestListener implementation to use.
 
 Configuration Options:
 
-  --bootstrap <file>        A "bootstrap" PHP file that is run before the tests.
-  -c|--configuration <file> Read configuration from XML file.
-  --no-configuration        Ignore default configuration file (phpunit.xml).
-  --no-coverage             Ignore code coverage configuration.
-  --include-path <path(s)>  Prepend PHP's include_path with given path(s).
-  -d key[=value]            Sets a php.ini value.
-  --generate-configuration  Generate configuration file with suggested settings.
+  --bootstrap <file>          A "bootstrap" PHP file that is run before the tests.
+  -c|--configuration <file>   Read configuration from XML file.
+  --no-configuration          Ignore default configuration file (phpunit.xml).
+  --no-coverage               Ignore code coverage configuration.
+  --include-path <path(s)>    Prepend PHP's include_path with given path(s).
+  -d key[=value]              Sets a php.ini value.
+  --generate-configuration    Generate configuration file with suggested settings.
 
 Miscellaneous Options:
 
-  -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
-  --atleast-version <min>   Checks that version is greater than min and exits.
+  -h|--help                   Prints this usage information.
+  --version                   Prints the version and exits.
+  --atleast-version <min>     Checks that version is greater than min and exits.


### PR DESCRIPTION
This PR adds the ability for users to set backupGlobalsBlacklist three ways:
- _@backupGlobalsBlacklist_ annotation for a class or method
- _--globals-backup-blacklist_ command line option
- _backupglobalsblacklist_ XML configuration.

I added new assertions to the existing _testGlobalsBackupPost_ and _testGlobalsBackupPre_ methods to cover this new feature.  If there is another test that would be useful for this feature or if docs need to be updated with this PR, please let me know and I'll be happy to update those as well.
