### PR TITLE
Implement PHPUnit\Framework\TestCase::getCurrentProviderDataSet()

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2101,6 +2101,17 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         return $buffer;
     }
 
+
+    /**
+     * Gets the data set of a TestCase.
+     *
+     * @return array
+     */
+    protected function getCurrentProviderDataSet()
+    {
+        return $this->data;
+    }
+
     /**
      * Creates a default TestResult object.
      *


### PR DESCRIPTION
Having access to the providers data, one can create mocks in the setUp() according to the given data.
Currently we only have access to the data in string form. 
