### PR TITLE
add File and Directory constraints and assertions

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -900,6 +900,162 @@ abstract class PHPUnit_Framework_Assert
     }
 
     /**
+     * Asserts that a file/dir is readable.
+     *
+     * @param string $filename
+     * @param string $message
+     */
+    public static function assertIsReadable($filename, $message = '')
+    {
+        if (!is_string($filename)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_IsReadable;
+
+        static::assertThat($filename, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a file/dir exists and is not readable.
+     *
+     * @param string $filename
+     * @param string $message
+     */
+    public static function assertNotIsReadable($filename, $message = '')
+    {
+        if (!is_string($filename)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_Not(
+            new PHPUnit_Framework_Constraint_IsReadable
+        );
+
+        static::assertThat($filename, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a file/dir exists and is writable.
+     *
+     * @param string $filename
+     * @param string $message
+     */
+    public static function assertIsWritable($filename, $message = '')
+    {
+        if (!is_string($filename)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_IsWritable;
+
+        static::assertThat($filename, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a file/dir exists and is not writable.
+     *
+     * @param string $filename
+     * @param string $message
+     */
+    public static function assertNotIsWritable($filename, $message = '')
+    {
+        if (!is_string($filename)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_Not(
+            new PHPUnit_Framework_Constraint_IsWritable
+        );
+
+        static::assertThat($filename, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a directory exists.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryExists($directory, $message = '')
+    {
+        if (!is_string($directory)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_DirectoryExists;
+
+        static::assertThat($directory, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a directory does not exist.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryNotExists($directory, $message = '')
+    {
+        if (!is_string($directory)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $constraint = new PHPUnit_Framework_Constraint_Not(
+            new PHPUnit_Framework_Constraint_DirectoryExists
+        );
+
+        static::assertThat($directory, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a directory exists and is readable.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryIsReadable($directory, $message = '')
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertIsReadable($directory, $message);
+    }
+
+    /**
+     * Asserts that a directory exists and is not readable.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryNotIsReadable($directory, $message = '')
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertNotIsReadable($directory, $message);
+    }
+
+    /**
+     * Asserts that a directory exists and is writable.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryIsWritable($directory, $message = '')
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertIsWritable($directory, $message);
+    }
+
+    /**
+     * Asserts that a directory exists and is not writable.
+     *
+     * @param string $directory
+     * @param string $message
+     */
+    public static function assertDirectoryNotIsWritable($directory, $message = '')
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertDirectoryNotIsWritable($directory, $message);
+    }
+
+    /**
      * Asserts that a file exists.
      *
      * @param string $filename
@@ -937,6 +1093,54 @@ abstract class PHPUnit_Framework_Assert
         );
 
         static::assertThat($filename, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a file exists and is readable.
+     *
+     * @param string $file
+     * @param string $message
+     */
+    public static function assertFileIsReadable($file, $message = '')
+    {
+        self::assertFileExists($file, $message);
+        self::assertIsReadable($file, $message);
+    }
+
+    /**
+     * Asserts that a file exists and is not readable.
+     *
+     * @param string $file
+     * @param string $message
+     */
+    public static function assertFileNotIsReadable($file, $message = '')
+    {
+        self::assertFileExists($file, $message);
+        self::assertNotIsReadable($file, $message);
+    }
+
+    /**
+     * Asserts that a file exists and is writable.
+     *
+     * @param string $file
+     * @param string $message
+     */
+    public static function assertFileIsWritable($file, $message = '')
+    {
+        self::assertFileExists($file, $message);
+        self::assertIsWritable($file, $message);
+    }
+
+    /**
+     * Asserts that a file exists and is not writable.
+     *
+     * @param string $file
+     * @param string $message
+     */
+    public static function assertFileNotIsWritable($file, $message = '')
+    {
+        self::assertFileExists($file, $message);
+        self::assertNotIsWritable($file, $message);
     }
 
     /**
@@ -2451,6 +2655,36 @@ abstract class PHPUnit_Framework_Assert
     public static function isEmpty()
     {
         return new PHPUnit_Framework_Constraint_IsEmpty;
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_IsWritable matcher object.
+     *
+     * @return PHPUnit_Framework_Constraint_IsWritable
+     */
+    public static function isWritable()
+    {
+        return new PHPUnit_Framework_Constraint_IsWritable;
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_IsReadable matcher object.
+     *
+     * @return PHPUnit_Framework_Constraint_IsReadable
+     */
+    public static function isReadable()
+    {
+        return new PHPUnit_Framework_Constraint_IsReadable;
+    }
+
+    /**
+     * Returns a PHPUnit_Framework_Constraint_DirectoryExists matcher object.
+     *
+     * @return PHPUnit_Framework_Constraint_DirectoryExists
+     */
+    public static function directoryExists()
+    {
+        return new PHPUnit_Framework_Constraint_DirectoryExists;
     }
 
     /**

--- a/src/Framework/Constraint/DirectoryExists.php
+++ b/src/Framework/Constraint/DirectoryExists.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Constraint that checks if the directory(name) that it is evaluated for exists.
+ *
+ * The file path to check is passed as $other in evaluate().
+ */
+class PHPUnit_Framework_Constraint_DirectoryExists extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return is_dir($other);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other Evaluated value or object.
+     *
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return sprintf(
+            'directory "%s" exists',
+            $other
+        );
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'directory exists';
+    }
+}

--- a/src/Framework/Constraint/IsReadable.php
+++ b/src/Framework/Constraint/IsReadable.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Constraint that checks if the file/dir(name) that it is evaluated for is readable.
+ *
+ * The file path to check is passed as $other in evaluate().
+ */
+class PHPUnit_Framework_Constraint_IsReadable extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return is_readable($other);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other Evaluated value or object.
+     *
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return sprintf(
+            '"%s" is readable',
+            $other
+        );
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'is readable';
+    }
+}

--- a/src/Framework/Constraint/IsWritable.php
+++ b/src/Framework/Constraint/IsWritable.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Constraint that checks if the file/dir(name) that it is evaluated for is writable.
+ *
+ * The file path to check is passed as $other in evaluate().
+ */
+class PHPUnit_Framework_Constraint_IsWritable extends PHPUnit_Framework_Constraint
+{
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return is_writable($other);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other Evaluated value or object.
+     *
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return sprintf(
+            '"%s" is writable',
+            $other
+        );
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'is writable';
+    }
+}

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -1341,6 +1341,220 @@ XML;
     }
 
     /**
+     * @covers            PHPUnit_Framework_Assert::assertIsReadable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertIsReadableThrowsException()
+    {
+        $this->assertIsReadable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertIsReadable
+     */
+    public function testAssertIsReadable()
+    {
+        $this->assertIsReadable(__FILE__);
+
+        try {
+            $this->assertIsReadable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertNotIsReadable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertNotIsReadableThrowsException()
+    {
+        $this->assertNotIsReadable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertNotIsReadable
+     */
+    public function testAssertNotIsReadable()
+    {
+        try {
+            $this->assertNotIsReadable(__FILE__);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertIsWritable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertIsWritableThrowsException()
+    {
+        $this->assertIsWritable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertIsWritable
+     */
+    public function testAssertIsWritable()
+    {
+        $this->assertIsWritable(__FILE__);
+
+        try {
+            $this->assertIsWritable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertNotIsWritable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertNotIsWritableThrowsException()
+    {
+        $this->assertNotIsWritable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertNotIsWritable
+     */
+    public function testAssertNotIsWritable()
+    {
+        try {
+            $this->assertNotIsWritable(__FILE__);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryExists
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryExistsThrowsException()
+    {
+        $this->assertDirectoryExists(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryExists
+     */
+    public function testAssertDirectoryExists()
+    {
+        $this->assertDirectoryExists(__DIR__);
+
+        try {
+            $this->assertDirectoryExists(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryNotExists
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryNotExistsThrowsException()
+    {
+        $this->assertDirectoryNotExists(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryNotExists
+     */
+    public function testAssertDirectoryNotExists()
+    {
+        $this->assertDirectoryNotExists(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+
+        try {
+            $this->assertDirectoryNotExists(__DIR__);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryIsReadable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryIsReadableThrowsException()
+    {
+        $this->assertDirectoryIsReadable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryIsReadable
+     */
+    public function testAssertDirectoryIsReadable()
+    {
+        $this->assertDirectoryIsReadable(__DIR__);
+
+        try {
+            $this->assertDirectoryIsReadable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryNotIsReadable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryNotIsReadableThrowsException()
+    {
+        $this->assertDirectoryNotIsReadable(null);
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryIsWritable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryIsWritableThrowsException()
+    {
+        $this->assertDirectoryIsWritable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertDirectoryIsWritable
+     */
+    public function testAssertDirectoryIsWritable()
+    {
+        $this->assertDirectoryIsWritable(__DIR__);
+
+        try {
+            $this->assertDirectoryIsWritable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertDirectoryNotIsWritable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertDirectoryNotIsWritableThrowsException()
+    {
+        $this->assertDirectoryNotIsWritable(null);
+    }
+
+    /**
      * @covers            PHPUnit_Framework_Assert::assertFileExists
      * @expectedException PHPUnit_Framework_Exception
      */
@@ -1388,6 +1602,74 @@ XML;
         }
 
         $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertFileIsReadable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertFileIsReadableThrowsException()
+    {
+        $this->assertFileIsReadable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertFileIsReadable
+     */
+    public function testAssertFileIsReadable()
+    {
+        $this->assertFileIsReadable(__FILE__);
+
+        try {
+            $this->assertFileIsReadable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertFileNotIsReadable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertFileNotIsReadableThrowsException()
+    {
+        $this->assertFileNotIsReadable(null);
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertFileIsWritable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertFileIsWritableThrowsException()
+    {
+        $this->assertFileIsWritable(null);
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertFileIsWritable
+     */
+    public function testAssertFileIsWritable()
+    {
+        $this->assertFileIsWritable(__FILE__);
+
+        try {
+            $this->assertFileIsWritable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers            PHPUnit_Framework_Assert::assertFileNotIsWritable
+     * @expectedException PHPUnit_Framework_Exception
+     */
+    public function testAssertFileNotIsWritableThrowsException()
+    {
+        $this->assertFileNotIsWritable(null);
     }
 
     /**

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -139,6 +139,102 @@ EOF
     }
 
     /**
+     * @covers PHPUnit_Framework_Constraint_IsReadable
+     * @covers PHPUnit_Framework_Assert::isReadable
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintIsReadable()
+    {
+        $constraint = PHPUnit_Framework_Assert::isReadable();
+
+        $this->assertFalse($constraint->evaluate('foo', '', true));
+        $this->assertEquals('is readable', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('foo');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that "foo" is readable.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_IsWritable
+     * @covers PHPUnit_Framework_Assert::isWritable
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintIsWritable()
+    {
+        $constraint = PHPUnit_Framework_Assert::isWritable();
+
+        $this->assertFalse($constraint->evaluate('foo', '', true));
+        $this->assertEquals('is writable', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('foo');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that "foo" is writable.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_DirectoryExists
+     * @covers PHPUnit_Framework_Assert::directoryExists
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintDirectoryExists()
+    {
+        $constraint = PHPUnit_Framework_Assert::directoryExists();
+
+        $this->assertFalse($constraint->evaluate('foo', '', true));
+        $this->assertEquals('directory exists', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('foo');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that directory "foo" exists.
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers PHPUnit_Framework_Constraint_FileExists
      * @covers PHPUnit_Framework_Assert::fileExists
      * @covers PHPUnit_Framework_Constraint::count


### PR DESCRIPTION
add Constraints:
- PHPUnit_Framework_Constraint_DirectoryExists
- PHPUnit_Framework_Constraint_IsReadable
- PHPUnit_Framework_Constraint_IsWritable

add Assertions:
- assertIsReadable
- assertNotIsReadable
- assertIsWritable
- assertNotIsWritable
- assertDirectoryExists
- assertDirectoryNotExists
- assertDirectoryIsReadable
- assertDirectoryNotIsReadable
- assertDirectoryIsWritable
- assertDirectoryNotIsWritable
- assertFileIsReadable
- assertFileNotIsReadable
- assertFileIsWritable
- assertFileNotIsWritable

added tests to completely cover the constraints, and tests to cover most of the assertions... however it will be difficult/impossible to completely test some of the assertions without using a virtual filesystem. how do you feel about my inclusion of `mikey179/vfsStream` or a similar package for this purpose?
