### PR TITLE
Set prepend-autoloader to false in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "phpdocumentor/reflection-docblock": "3.0.2"
     },
     "config": {
+        "prepend-autoloader": false,
         "platform": {
             "php": "5.6.0"
         }


### PR DESCRIPTION
This should allow e.g. symfony/yaml users to test their code with the latest version of the component, whereas today the phar users are forced to whatever version is bundled inside it.
