### PR TITLE
Allow `createPartialMock()` to not mock any methods.

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1574,7 +1574,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     ->disableOriginalClone()
                     ->disableArgumentCloning()
                     ->disallowMockingUnknownTypes()
-                    ->setMethods($methods)
+                    ->setMethods(empty($methods) ? null : $methods)
                     ->getMock();
     }
 

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -609,6 +609,15 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($mock->bar());
     }
 
+    public function testCreatePartialMockCanMockNoMethods()
+    {
+        /** @var Mockable $mock */
+        $mock = $this->createPartialMock(Mockable::class, []);
+
+        $this->assertTrue($mock->foo());
+        $this->assertTrue($mock->bar());
+    }
+
     public function testCreateMockSkipsConstructor()
     {
         /** @var Mockable $mock */


### PR DESCRIPTION
Right now, `createPartialMock($class, [])` does the same thing as `createMock($class)`; it mocks all methods. This is somewhat counter-intuitive and caused by the API of the mock builder, where calling `setMethods(null)` has the expected effect.

As a first idea, I allowed passing `null` as a parameter value for consistency. But there is no need for `createPartialMock` to return a complete one - `createMock` already does that. `[]` also expresses the meaning better than `null` (“exactly these methods”). As a bonus, the method signature doesn’t change.

Test included.
