### PR TITLE
Fix #2256 Invalid utf8 causing partially missing output

### DIFF
--- a/src/Util/Printer.php
+++ b/src/Util/Printer.php
@@ -128,7 +128,7 @@ class PHPUnit_Util_Printer
             }
         } else {
             if (PHP_SAPI != 'cli' && PHP_SAPI != 'phpdbg') {
-                $buffer = htmlspecialchars($buffer);
+                $buffer = htmlspecialchars($buffer, ENT_SUBSTITUTE);
             }
 
             print $buffer;


### PR DESCRIPTION
Added ENT_SUBSTITUTE parameter to htmlspecialchars in Printer->write, so invalid characters are replaced with a substitution character instead of returning empty string.
