### PR TITLE
Test with HHVM LTS, HHVM Current and in HHVM php7 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,46 @@
+# Use new Travis-CI container Infrastructure for faster builds
+sudo: false
+
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-
 matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm-3.12 # Current LTS version of HHVM
+        sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
+        dist: trusty
+        group: edge # Until the next update
+         env: HHVMPHP7="no"
+      - php: hhvm-3.12 # Current LTS version of HHVM with PHP7 mode
+        sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
+        dist: trusty
+        group: edge # until the next update
+        env: HHVMPHP7="yes"
+    - php: hhvm # Current version of HHVM (could be LTS or STS)
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      env: HHVMPHP7="no"
+    - php: hhvm # Current version of HHVM with PHP7 mode (could be LTS or STS)
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      env: HHVMPHP7="yes"
   allow_failures:
+    - php: hhvm-3.12
     - php: hhvm
-
-sudo: false
 
 before_install:
   - composer self-update
 
 install:
   - travis_retry composer install --no-interaction --prefer-source
+
+before_script:
+  - if [[ $HHVMPHP7 == "yes" ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
 
 script:
   - ./phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: hhvm-3.12 # Current LTS version of HHVM
-        sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
-        dist: trusty
-        group: edge # Until the next update
-         env: HHVMPHP7="no"
-      - php: hhvm-3.12 # Current LTS version of HHVM with PHP7 mode
-        sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
-        dist: trusty
-        group: edge # until the next update
-        env: HHVMPHP7="yes"
+      sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
+      dist: trusty
+      group: edge # Until the next update
+      env: HHVMPHP7="no"
+    - php: hhvm-3.12 # Current LTS version of HHVM with PHP7 mode
+      sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
+      dist: trusty
+      group: edge # until the next update
+      env: HHVMPHP7="yes"
     - php: hhvm # Current version of HHVM (could be LTS or STS)
       sudo: true
       dist: trusty
@@ -58,4 +58,4 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
-
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
       dist: trusty
       group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
       env: HHVMPHP7="yes"
     - php: hhvm # Current version of HHVM (could be LTS or STS)
       sudo: true
@@ -28,6 +32,10 @@ matrix:
       sudo: true
       dist: trusty
       group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
       env: HHVMPHP7="yes"
   allow_failures:
     - php: hhvm-3.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,3 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
-    

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
       sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
       dist: trusty
       group: edge # Until the next update
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
       env: HHVMPHP7="no"
     - php: hhvm-3.12 # Current LTS version of HHVM with PHP7 mode
       sudo: true # Travis-CI container Infrastructure doesn't support all available HHVM versions, so use Trusty
@@ -27,6 +31,10 @@ matrix:
       sudo: true
       dist: trusty
       group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
       env: HHVMPHP7="no"
     - php: hhvm # Current version of HHVM with PHP7 mode (could be LTS or STS)
       sudo: true
@@ -49,6 +57,7 @@ install:
 
 before_script:
   - if [[ $HHVMPHP7 == "yes" ]]; then echo hhvm.php7.all=1 >> /etc/hhvm/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'xdebug.enable = 1' >> /etc/hhvm/php.ini; fi # Extension xdebug is required
 
 script:
   - ./phpunit


### PR DESCRIPTION
New Testing options for HHVM
- [specific versions of HHVM LTS and Current](https://docs.travis-ci.com/user/languages/php#HHVM-versions)
- [HHVM in PHP7 mode](https://docs.hhvm.com/hhvm/configuration/INI-settings#php-7-settings)
