### PR TITLE
Issue #2273 option --testsuite <pattern> accepts regex to match testsuites

### DIFF
--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -917,7 +917,10 @@ class PHPUnit_Util_Configuration
         $fileIteratorFacade = new File_Iterator_Facade;
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
-            if ($testSuiteFilter && $directoryNode->parentNode->getAttribute('name') != $testSuiteFilter) {
+            if ($testSuiteFilter && !PHPUnit_Util_Regex::pregMatchSafe(
+                    PHPUnit_Util_Regex::unifyExpression($testSuiteFilter),
+                    $directoryNode->parentNode->getAttribute('name')
+            )) {
                 continue;
             }
 
@@ -965,7 +968,10 @@ class PHPUnit_Util_Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
-            if ($testSuiteFilter && $fileNode->parentNode->getAttribute('name') != $testSuiteFilter) {
+            if ($testSuiteFilter && !PHPUnit_Util_Regex::pregMatchSafe(
+                    PHPUnit_Util_Regex::unifyExpression($testSuiteFilter),
+                    $fileNode->parentNode->getAttribute('name')
+                )) {
                 continue;
             }
 

--- a/src/Util/Regex.php
+++ b/src/Util/Regex.php
@@ -15,6 +15,7 @@
  */
 class PHPUnit_Util_Regex
 {
+
     public static function pregMatchSafe($pattern, $subject, $matches = null, $flags = 0, $offset = 0)
     {
         $handler_terminator = PHPUnit_Util_ErrorHandler::handleErrorOnce(E_WARNING);
@@ -22,5 +23,42 @@ class PHPUnit_Util_Regex
         $handler_terminator(); // cleaning
 
         return $match;
+    }
+
+    /**
+     * Check if expression starts and end with '/'. If not, {@see pregMatchSafe} will not match, i.e.:
+     * static::pregMatchSafe('unit|functional', 'unit') => false
+     * static::pregMatchSafe('/unit|functional/', 'functional') => 1
+     *
+     * @param string $anExpression
+     *
+     * @return string
+     */
+    public static function unifyExpression($anExpression)
+    {
+        $unifiedExpression = '';
+        $regexBoundingChar = '/';
+        $expressionLength  = strlen($anExpression);
+
+        if (!$expressionLength) {
+            return $unifiedExpression;
+        }
+
+        if ($anExpression[0] !== $regexBoundingChar) {
+            $unifiedExpression .= $regexBoundingChar;
+        }
+        $unifiedExpression .= $anExpression;
+
+        /**
+         * Check if in one of the last 4 chars a '/' is present.
+         * There are few flags in regex which can be added on
+         * the very end of the expression. For more details please
+         * refer to the Regex documentation.
+         */
+        if (!static::pregMatchSafe('/\/[igm]{0,3}$/i', $anExpression, null, PREG_OFFSET_CAPTURE, 1)) {
+            $unifiedExpression .= $regexBoundingChar;
+        }
+
+        return $unifiedExpression;
     }
 }

--- a/tests/Regression/GitHub/2273.phpt
+++ b/tests/Regression/GitHub/2273.phpt
@@ -1,0 +1,21 @@
+--TEST--
+#2273: --testsuite <pattern> is not an actual pattern filter
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = __DIR__ . '/2273/phpunit.xml';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+%s
+%s
+
+....                                                                  2 / 2 (100%)
+
+%s
+
+OK (2 tests, 2 assertions)

--- a/tests/Regression/GitHub/2273/Issue2273MultiTestSuiteTest.php
+++ b/tests/Regression/GitHub/2273/Issue2273MultiTestSuiteTest.php
@@ -1,0 +1,21 @@
+<?php
+
+class Issue2273MultiTestSuiteTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $_SERVER['argv']    = [];
+        $_SERVER['argv'][1] = '--configuration';
+        $_SERVER['argv'][2] = __DIR__ . '/testData/phpunit.xml';
+        $_SERVER['argv'][3] = '--testsuite=unit|integration';
+    }
+
+    /**
+     * @test
+     */
+    public function iShouldRunAllTestsFromAllRequiredSuites()
+    {
+        PHPUnit_TextUI_Command::main(true);
+    }
+
+}

--- a/tests/Regression/GitHub/2273/Issue2273ParamsTest.php
+++ b/tests/Regression/GitHub/2273/Issue2273ParamsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+class Issue2273ParamsTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $_SERVER['argv'][1] = '--configuration';
+        $_SERVER['argv'][2] = __DIR__ . '/testData/phpunit.xml';
+        $_SERVER['argv'][3] = '--testsuite=unit|integration';
+    }
+
+    /**
+     * @test
+     */
+    public function iShouldBeAbleToRetrieveValidScriptParams()
+    {
+        $expectedParam = '--testsuite=unit|integration';
+        $strictCompare = true;
+        $this->assertTrue(in_array($expectedParam, $_SERVER['argv'], $strictCompare));
+
+        $configFilePath = $_SERVER['argv'][2];
+        $this->assertFileExists($configFilePath);
+    }
+
+    /**
+     * @test
+     */
+    public function configFileShouldContainValidTestSuites()
+    {
+        $expectedSuites = ['unit', 'integration'];
+        $configuration = $this->getUtilConfiguration();
+        $this->assertSame($expectedSuites, $configuration->getTestSuiteNames());
+    }
+
+    private function getUtilConfiguration()
+    {
+        $configFilePath = $_SERVER['argv'][2];
+
+        return PHPUnit_Util_Configuration::getInstance($configFilePath);
+    }
+}

--- a/tests/Regression/GitHub/2273/phpunit.xml
+++ b/tests/Regression/GitHub/2273/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+         backupGlobals="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <file>Issue2273ParamsTest.php</file>
+            <file>Issue2273MultiTestSuiteTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Regression/GitHub/2273/testData/phpunit.xml
+++ b/tests/Regression/GitHub/2273/testData/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         backupGlobals="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/unit_tests
+            </directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/integration_tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Regression/GitHub/2273/testData/tests/integration_tests/DummyIntegrationTest.php
+++ b/tests/Regression/GitHub/2273/testData/tests/integration_tests/DummyIntegrationTest.php
@@ -1,0 +1,12 @@
+<?php
+
+class Issue2273_testData_tests_integration_tests_DummyIntegrationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function dummyTest()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Regression/GitHub/2273/testData/tests/unit_tests/DummyUnitTest.php
+++ b/tests/Regression/GitHub/2273/testData/tests/unit_tests/DummyUnitTest.php
@@ -1,0 +1,11 @@
+<?php
+class Issue2273_testData_tests_unit_tests_DummyUnitTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function dummyTest()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Util/RegexTest.php
+++ b/tests/Util/RegexTest.php
@@ -32,6 +32,21 @@ class Util_RegexTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function expressionUnifierChecksDataProvider()
+    {
+        return [
+          ['a', '/a/'],
+          ['/a', '/a/'],
+          ['a/', '/a/'],
+          ['a/a', '/a/a/'],
+          ['a/i', '/a/i'],
+          ['a/g', '/a/g'],
+          ['a/m', '/a/m'],
+          ['a/mig', '/a/mig'],
+          ['(a|b|c)', '/(a|b|c)/'],
+        ];
+    }
+
     /**
      * @dataProvider validRegexpProvider
      * @covers       PHPUnit_Util_Regex::pregMatchSafe
@@ -48,5 +63,17 @@ class Util_RegexTest extends PHPUnit_Framework_TestCase
     public function testInvalidRegex($pattern, $subject)
     {
         $this->assertFalse(PHPUnit_Util_Regex::pregMatchSafe($pattern, $subject));
+    }
+
+    /**
+     * @param string $examinedExpression
+     * @param string $expectedExpression
+     *
+     * @dataProvider expressionUnifierChecksDataProvider
+     * @covers PHPUnit_Util_Regex::unifyExpression
+     */
+    public function testItShouldUnifyProvidedStringToRegexCompatible($examinedExpression, $expectedExpression)
+    {
+        $this->assertSame($expectedExpression, PHPUnit_Util_Regex::unifyExpression($examinedExpression));
     }
 }


### PR DESCRIPTION
Fix/new feature of Issue #2273 option --testsuite <pattern> accepts regex to match testsuites:
Added functional tests to check if solution is working
Added unit tests for new methods
Changed the `PHPUnit_Util_Configuration` class to handle regex match for testsuites.
