### PR TITLE
Backport expectException() to 4.8

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -457,7 +457,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * @param string $exceptionMessage
      * @param int    $exceptionCode
      *
-     * @since  Method available since Release 3.2.0
+     * @since      Method available since Release 3.2.0
+     * @deprecated Method deprecated since Release 5.2.0
      */
     public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
     {
@@ -467,11 +468,74 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @param string $exception
+     *
+     * @since Method available since Release 5.2.0
+     */
+    public function expectException($exception)
+    {
+        if (!is_string($exception)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->expectedException = $exception;
+    }
+
+    /**
+     * @param int|string $code
+     *
+     * @throws PHPUnit_Framework_Exception
+     *
+     * @since Method available since Release 5.2.0
+     */
+    public function expectExceptionCode($code)
+    {
+        if (!is_int($code) && !is_string($code)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'integer or string');
+        }
+
+        $this->expectedExceptionCode = $code;
+    }
+
+    /**
+     * @param string $message
+     *
+     * @throws PHPUnit_Framework_Exception
+     *
+     * @since Method available since Release 5.2.0
+     */
+    public function expectExceptionMessage($message)
+    {
+        if (!is_string($message)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->expectedExceptionMessage = $message;
+    }
+
+    /**
+     * @param string $messageRegExp
+     *
+     * @throws PHPUnit_Framework_Exception
+     *
+     * @since Method available since Release 5.2.0
+     */
+    public function expectExceptionMessageRegExp($messageRegExp)
+    {
+        if (!is_string($messageRegExp)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->expectedExceptionMessageRegExp = $messageRegExp;
+    }
+
+    /**
      * @param mixed  $exceptionName
      * @param string $exceptionMessageRegExp
      * @param int    $exceptionCode
      *
-     * @since Method available since Release 4.3.0
+     * @since      Method available since Release 4.3.0
+     * @deprecated Method deprecated since Release 5.6.0
      */
     public function setExpectedExceptionRegExp($exceptionName, $exceptionMessageRegExp = '', $exceptionCode = null)
     {

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -195,10 +195,33 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result->wasSuccessful());
     }
 
+    public function testExceptionBackport()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->expectException('RuntimeException');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
     public function testExceptionWithMessage()
     {
         $test = new ThrowExceptionTestCase('test');
         $test->setExpectedException('RuntimeException', 'A runtime error occurred');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, count($result));
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testExceptionWithMessageBackport()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->expectException('RuntimeException');
+        $test->expectExceptionMessage('A runtime error occurred');
 
         $result = $test->run();
 
@@ -221,6 +244,21 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testExceptionWithWrongMessageBackport()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->expectException('RuntimeException');
+        $test->expectExceptionMessage('A logic error occurred');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, $result->failureCount());
+        $this->assertEquals(1, count($result));
+        $this->assertEquals(
+            "Failed asserting that exception message 'A runtime error occurred' contains 'A logic error occurred'.",
+            $test->getStatusMessage()
+        );
+    }
     public function testExceptionWithRegexpMessage()
     {
         $test = new ThrowExceptionTestCase('test');
@@ -256,6 +294,39 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $test->setExpectedExceptionRegExp('RuntimeException', '#runtime .*? occurred/'); // wrong delimiter
 
         $result = $test->run();
+
+        $this->assertEquals(
+            "Invalid expected exception message regex given: '#runtime .*? occurred/'",
+            $test->getStatusMessage()
+        );
+    }
+
+    public function testExceptionWithWrongRegexpMessageBackport()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->expectException('RuntimeException');
+        $test->expectExceptionMessageRegExp('/logic .*? occurred/');
+
+        $result = $test->run();
+
+        $this->assertEquals(1, $result->failureCount());
+        $this->assertEquals(1, count($result));
+        $this->assertEquals(
+            "Failed asserting that exception message 'A runtime error occurred' matches '/logic .*? occurred/'.",
+            $test->getStatusMessage()
+        );
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_ExceptionMessageRegExp
+     */
+    public function testExceptionWithInvalidRegexpMessageBackport()
+    {
+        $test = new ThrowExceptionTestCase('test');
+        $test->expectException('RuntimeException');
+        $test->expectExceptionMessageRegExp('#runtime .*? occurred/');
+
+        $test->run();
 
         $this->assertEquals(
             "Invalid expected exception message regex given: '#runtime .*? occurred/'",


### PR DESCRIPTION
Libraries and products that support PHP 5.5 has a dependency on PHPUnit 4.

This patch will help migrating to latest version PHPUnit.
