### PR TITLE
Declare PHPUnit\Framework\TestCase abstract like its parent to fix warning

### DIFF
--- a/src/ForwardCompatibility/TestCase.php
+++ b/src/ForwardCompatibility/TestCase.php
@@ -12,6 +12,6 @@ namespace PHPUnit\Framework;
 
 use PHPUnit_Framework_TestCase;
 
-class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends PHPUnit_Framework_TestCase
 {
 }


### PR DESCRIPTION
When creating a test case that extends from PHPUnit\Framework\TestCase, a warning is generated because PHPUnit\Framework\TestCase is not declared abstract like it's parent:

```
PHPUnit 5.5.5 by Sebastian Bergmann and contributors.

W.........                                                        10 / 10 (100%)

Time: 203 ms, Memory: 6.50MB

There was 1 warning:

1) Warning
No tests found in class "PHPUnit\Framework\TestCase".

```

This fixes that.
