### PR TITLE
'data set #' breaks TAP format when line ends with a directive

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2086,7 +2086,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
         if (!empty($this->data)) {
             if (is_int($this->dataName)) {
-                $buffer .= sprintf(' with data set #%d', $this->dataName);
+                $buffer .= sprintf(' with data set %d', $this->dataName);
             } else {
                 $buffer .= sprintf(' with data set "%s"', $this->dataName);
             }


### PR DESCRIPTION
Noticed when using the Jenkins TAP plugin, any 'TODO' directives will be lost and the line will be truncated after the '#'. [Here](http://scratch.linuxplicable.org/before.png) is the output for the current stable PHPUnit, and [here](http://scratch.linuxplicable.org/after.png) is the output in a version with this patch applied.

A workaround is to have your dataProvider functions return arrays with non-integer keys, but as this appears to breach the [TAP 13 format](http://testanything.org/tap-version-13-specification.html)...

> Any text after the test number but before a # is the description of the test point.

...then it seems to be a bug. I'm not certain about how to make this only apply to TAP output.
