### PR TITLE
Fix docs and message because assertArraySubset() does not support ArrayAccess

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -65,14 +65,14 @@ abstract class PHPUnit_Framework_Assert
         if (!is_array($subset)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
                 1,
-                'array or ArrayAccess'
+                'array'
             );
         }
 
         if (!is_array($array)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
                 2,
-                'array or ArrayAccess'
+                'array'
             );
         }
 

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -19,7 +19,7 @@
 class PHPUnit_Framework_Constraint_ArraySubset extends PHPUnit_Framework_Constraint
 {
     /**
-     * @var array|ArrayAccess
+     * @var array
      */
     protected $subset;
 
@@ -29,8 +29,8 @@ class PHPUnit_Framework_Constraint_ArraySubset extends PHPUnit_Framework_Constra
     protected $strict;
 
     /**
-     * @param array|ArrayAccess $subset
-     * @param bool              $strict Check for object identity
+     * @param array $subset
+     * @param bool  $strict Check for object identity
      */
     public function __construct($subset, $strict = false)
     {
@@ -43,7 +43,7 @@ class PHPUnit_Framework_Constraint_ArraySubset extends PHPUnit_Framework_Constra
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
-     * @param array|ArrayAccess $other Array or ArrayAccess object to evaluate.
+     * @param array $other Array to evaluate.
      *
      * @return bool
      */

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -265,7 +265,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
      * @covers PHPUnit_Framework_Assert::assertArraySubset
      * @covers PHPUnit_Framework_Constraint_ArraySubset
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessage array or ArrayAccess
+     * @expectedExceptionMessage array
      * @dataProvider assertArraySubsetInvalidArgumentProvider
      */
     public function testAssertArraySubsetRaisesExceptionForInvalidArguments($partial, $subject)


### PR DESCRIPTION
Exception message and docblocks state that `assertArraySubset()` accepts objects implementing `ArrayAccess` as well, however it actually does not. This PR only updates the docblocks, exception messages and corresponding test to match the actual behavior.
