### PR TITLE
Constants in expectedException annotations …

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1120,7 +1120,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     $this->assertThat(
                         $e,
                         new PHPUnit_Framework_Constraint_ExceptionMessage(
-                            $this->expectedExceptionMessage
+                            defined($this->expectedExceptionMessage) ? constant($this->expectedExceptionMessage) : $this->expectedExceptionMessage
                         )
                     );
                 }
@@ -1130,17 +1130,22 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     $this->assertThat(
                         $e,
                         new PHPUnit_Framework_Constraint_ExceptionMessageRegExp(
-                            $this->expectedExceptionMessageRegExp
+                            defined($this->expectedExceptionMessageRegExp) ? constant($this->expectedExceptionMessageRegExp) : $this->expectedExceptionMessageRegExp
                         )
                     );
                 }
 
                 if ($this->expectedExceptionCode !== null) {
+                    $code = $this->expectedExceptionCode;
+                    if (is_numeric($code)) {
+                        $code = (int) $code;
+                    } elseif (is_string($code) && defined($code)) {
+                        $code = (int) constant($code);
+                    }
+
                     $this->assertThat(
                         $e,
-                        new PHPUnit_Framework_Constraint_ExceptionCode(
-                            $this->expectedExceptionCode
-                        )
+                        new PHPUnit_Framework_Constraint_ExceptionCode($code)
                     );
                 }
 

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -318,29 +318,17 @@ class PHPUnit_Util_Test
             if (isset($matches[2])) {
                 $message = trim($matches[2]);
             } elseif (isset($annotations['method']['expectedExceptionMessage'])) {
-                $message = self::parseAnnotationContent(
-                    $annotations['method']['expectedExceptionMessage'][0]
-                );
+                $message = $annotations['method']['expectedExceptionMessage'][0];
             }
 
             if (isset($annotations['method']['expectedExceptionMessageRegExp'])) {
-                $messageRegExp = self::parseAnnotationContent(
-                    $annotations['method']['expectedExceptionMessageRegExp'][0]
-                );
+                $messageRegExp = $annotations['method']['expectedExceptionMessageRegExp'][0];
             }
 
             if (isset($matches[3])) {
                 $code = $matches[3];
             } elseif (isset($annotations['method']['expectedExceptionCode'])) {
-                $code = self::parseAnnotationContent(
-                    $annotations['method']['expectedExceptionCode'][0]
-                );
-            }
-
-            if (is_numeric($code)) {
-                $code = (int) $code;
-            } elseif (is_string($code) && defined($code)) {
-                $code = (int) constant($code);
+                $code = $annotations['method']['expectedExceptionCode'][0];
             }
 
             return [
@@ -349,28 +337,6 @@ class PHPUnit_Util_Test
         }
 
         return false;
-    }
-
-    /**
-     * Parse annotation content to use constant/class constant values
-     *
-     * Constants are specified using a starting '@'. For example: @ClassName::CONST_NAME
-     *
-     * If the constant is not found the string is used as is to ensure maximum BC.
-     *
-     * @param string $message
-     *
-     * @return string
-     */
-    private static function parseAnnotationContent($message)
-    {
-        if (strpos($message, '::') !== false && count(explode('::', $message) == 2)) {
-            if (defined($message)) {
-                $message = constant($message);
-            }
-        }
-
-        return $message;
     }
 
     /**

--- a/tests/Regression/GitHub/2317.phpt
+++ b/tests/Regression/GitHub/2317.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-2317: @expectedExceptionCode should support locally defined global constants
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = 'Issue2317Test';
+$_SERVER['argv'][4] = __DIR__ . '/2317/Issue2317Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 2 assertions)

--- a/tests/Regression/GitHub/2317/Issue2317Test.php
+++ b/tests/Regression/GitHub/2317/Issue2317Test.php
@@ -1,0 +1,13 @@
+<?php
+class Issue2317Test extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Exception
+     * @expectedExceptionCode LOCALLY_DEFINED_CONSTANT
+     */
+    public function testWorks()
+    {
+        define('LOCALLY_DEFINED_CONSTANT', 1);
+        throw new Exception('Message', LOCALLY_DEFINED_CONSTANT);
+    }
+}

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -72,7 +72,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertArraySubset(
-          ['class' => 'Class', 'code' => ExceptionTest::ERROR_CODE, 'message' => ExceptionTest::ERROR_MESSAGE],
+          ['class' => 'Class', 'code' => 'ExceptionTest::ERROR_CODE', 'message' => 'ExceptionTest::ERROR_MESSAGE'],
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testNine')
         );
 
@@ -82,7 +82,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertArraySubset(
-          ['class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE],
+          ['class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::ERROR_CODE', 'message' => 'My\Space\ExceptionNamespaceTest::ERROR_MESSAGE'],
           PHPUnit_Util_Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstants')
         );
 
@@ -109,7 +109,7 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertArraySubset(
-          ['message_regex' => '#regex#'],
+          ['message_regex' => 'ExceptionTest::ERROR_MESSAGE_REGEX'],
           PHPUnit_Util_Test::getExpectedException('ExceptionTest', 'testWithRegexMessageFromClassConstant')
         );
 


### PR DESCRIPTION
…should be evaluated at assertion time, not at annotation parsing time, Issue #2317

This PR has modification of existing tests. In my view such modifications are warranted.
