### PR TITLE
Fix UTF-8 strings support in assertContains and assertNotContains

### DIFF
--- a/src/Framework/Constraint/StringContains.php
+++ b/src/Framework/Constraint/StringContains.php
@@ -12,8 +12,8 @@
  * Constraint that asserts that the string it is evaluated for contains
  * a given string.
  *
- * Uses strpos() to find the position of the string in the input, if not found
- * the evaluation fails.
+ * Uses mb_strpos() to find the position of the string in the input, if not
+ * found the evaluation fails.
  *
  * The sub-string is passed in the constructor.
  *
@@ -54,9 +54,9 @@ class PHPUnit_Framework_Constraint_StringContains extends PHPUnit_Framework_Cons
     protected function matches($other)
     {
         if ($this->ignoreCase) {
-            return stripos($other, $this->string) !== false;
+            return mb_stripos($other, $this->string) !== false;
         } else {
-            return strpos($other, $this->string) !== false;
+            return mb_strpos($other, $this->string) !== false;
         }
     }
 
@@ -68,7 +68,7 @@ class PHPUnit_Framework_Constraint_StringContains extends PHPUnit_Framework_Cons
     public function toString()
     {
         if ($this->ignoreCase) {
-            $string = strtolower($this->string);
+            $string = mb_strtolower($this->string);
         } else {
             $string = $this->string;
         }

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -473,6 +473,39 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::assertContains
+     */
+    public function testAssertStringContainsStringForUtf8()
+    {
+        $this->assertContains('oryginał', 'oryginał');
+
+        try {
+            $this->assertContains('ORYGINAŁ', 'oryginał');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertContains
+     */
+    public function testAssertStringContainsStringForUtf8WhenIgnoreCase()
+    {
+        $this->assertContains('oryginał', 'oryginał', '', true);
+        $this->assertContains('ORYGINAŁ', 'oryginał', '', true);
+
+        try {
+            $this->assertContains('foo', 'oryginał', '', true);
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
      * @covers            PHPUnit_Framework_Assert::assertNotContains
      * @expectedException PHPUnit_Framework_Exception
      */
@@ -562,6 +595,36 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
 
         try {
             $this->assertNotContains('foo', 'foo');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertNotContains
+     */
+    public function testAssertStringNotContainsStringForUtf8()
+    {
+        $this->assertNotContains('ORYGINAŁ', 'oryginał');
+
+        try {
+            $this->assertNotContains('oryginał', 'oryginał');
+        } catch (PHPUnit_Framework_AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertNotContains
+     */
+    public function testAssertStringNotContainsStringForUtf8WhenIgnoreCase()
+    {
+        try {
+            $this->assertNotContains('ORYGINAŁ', 'oryginał', '', true);
         } catch (PHPUnit_Framework_AssertionFailedError $e) {
             return;
         }
@@ -3445,7 +3508,9 @@ XML;
     {
         $this->assertThat(
             null,
-            $this->callback(function ($other) { return true; })
+            $this->callback(function ($other) {
+                return true;
+            })
         );
     }
 

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -2740,6 +2740,74 @@ EOF
     /**
      * @covers PHPUnit_Framework_Constraint_StringContains
      * @covers PHPUnit_Framework_Assert::stringContains
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintStringContainsWhenIgnoreCase()
+    {
+        $constraint = PHPUnit_Framework_Assert::stringContains('oryginał', true);
+
+        $this->assertFalse($constraint->evaluate('oryginal', '', true));
+        $this->assertTrue($constraint->evaluate('ORYGINAŁ', '', true));
+        $this->assertTrue($constraint->evaluate('oryginał', '', true));
+        $this->assertEquals('contains "oryginał"', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('oryginal');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that 'oryginal' contains "oryginał".
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_StringContains
+     * @covers PHPUnit_Framework_Assert::stringContains
+     * @covers PHPUnit_Framework_Constraint::count
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintStringContainsForUtf8StringWhenNotIgnoreCase()
+    {
+        $constraint = PHPUnit_Framework_Assert::stringContains('oryginał', false);
+
+        $this->assertFalse($constraint->evaluate('oryginal', '', true));
+        $this->assertFalse($constraint->evaluate('ORYGINAŁ', '', true));
+        $this->assertTrue($constraint->evaluate('oryginał', '', true));
+        $this->assertEquals('contains "oryginał"', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('oryginal');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that 'oryginal' contains "oryginał".
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_StringContains
+     * @covers PHPUnit_Framework_Assert::stringContains
      * @covers PHPUnit_Framework_TestFailure::exceptionToString
      */
     public function testConstraintStringContains2()
@@ -2793,6 +2861,80 @@ Failed asserting that 'barfoobar' does not contain "foo".
 EOF
               ,
               PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_StringContains
+     * @covers PHPUnit_Framework_Constraint_Not
+     * @covers PHPUnit_Framework_Assert::stringContains
+     * @covers PHPUnit_Framework_Assert::logicalNot
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintStringNotContainsWhenIgnoreCase()
+    {
+        $constraint = PHPUnit_Framework_Assert::logicalNot(
+            PHPUnit_Framework_Assert::stringContains('oryginał')
+        );
+
+        $this->assertTrue($constraint->evaluate('original', '', true));
+        $this->assertFalse($constraint->evaluate('ORYGINAŁ', '', true));
+        $this->assertFalse($constraint->evaluate('oryginał', '', true));
+        $this->assertEquals('does not contain "oryginał"', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('ORYGINAŁ');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that 'ORYGINAŁ' does not contain "oryginał".
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Constraint_StringContains
+     * @covers PHPUnit_Framework_Constraint_Not
+     * @covers PHPUnit_Framework_Assert::stringContains
+     * @covers PHPUnit_Framework_Assert::logicalNot
+     * @covers PHPUnit_Framework_TestFailure::exceptionToString
+     */
+    public function testConstraintStringNotContainsForUtf8StringWhenNotIgnoreCase()
+    {
+        $constraint = PHPUnit_Framework_Assert::logicalNot(
+            PHPUnit_Framework_Assert::stringContains('oryginał', false)
+        );
+
+        $this->assertTrue($constraint->evaluate('original', '', true));
+        $this->assertTrue($constraint->evaluate('ORYGINAŁ', '', true));
+        $this->assertFalse($constraint->evaluate('oryginał', '', true));
+        $this->assertEquals('does not contain "oryginał"', $constraint->toString());
+        $this->assertEquals(1, count($constraint));
+
+        try {
+            $constraint->evaluate('oryginał');
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that 'oryginał' does not contain "oryginał".
+
+EOF
+                ,
+                PHPUnit_Framework_TestFailure::exceptionToString($e)
             );
 
             return;


### PR DESCRIPTION
The problem is that PHPUnit_Framework_Constraint_StringContains uses `stripos` and `strpos` functions instead of multibyte counterparts so before this change running:

``` php
$this->assertContains('Oryginał', 'ORYGINAŁ', '', true);
```

will assert `false` instead of `true` so you might get into trouble.

This is especially dangerous when you use `assertNotContains` because:

``` php
$this->assertNotContains('Oryginał', 'ORYGINAŁ', '', true);
```

will assert to `true` instead of `false` and your test will pass although your application might be broken.
