### PR TITLE
Fix multi data generators when using iterator or yield

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -379,8 +379,8 @@ class PHPUnit_Util_Test
      * @param string $className
      * @param string $methodName
      *
-     * @return array|Iterator when a data provider is specified and exists
-     *                        null           when no data provider is specified
+     * @return array When a data provider is specified and exists
+     *         null  When no data provider is specified
      *
      * @throws PHPUnit_Framework_Exception
      *
@@ -401,10 +401,6 @@ class PHPUnit_Util_Test
         }
 
         if ($data !== null) {
-            if (is_object($data)) {
-                $data = iterator_to_array($data);
-            }
-
             foreach ($data as $key => $value) {
                 if (!is_array($value)) {
                     throw new PHPUnit_Framework_Exception(
@@ -476,6 +472,9 @@ class PHPUnit_Util_Test
                 }
 
                 if (is_array($data)) {
+                    $result = array_merge($result, $data);
+                } elseif ($data instanceof \Iterator) {
+                    $data = iterator_to_array($data);
                     $result = array_merge($result, $data);
                 }
             }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -432,10 +432,38 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
 
     /**
      * Check if all data providers are being merged.
+     *
+     * @covers PHPUnit_Util_Test::getDataFromDataProviderAnnotation
      */
     public function testMultipleDataProviders()
     {
         $dataSets = PHPUnit_Util_Test::getProvidedData('MultipleDataProviderTest', 'testOne');
+
+        $this->assertEquals(9, count($dataSets));
+
+        $aCount = 0;
+        $bCount = 0;
+        $cCount = 0;
+
+        for ($i = 0; $i < 9; $i++) {
+            $aCount += $dataSets[$i][0] != null ? 1 : 0;
+            $bCount += $dataSets[$i][1] != null ? 1 : 0;
+            $cCount += $dataSets[$i][2] != null ? 1 : 0;
+        }
+
+        $this->assertEquals(3, $aCount);
+        $this->assertEquals(3, $bCount);
+        $this->assertEquals(3, $cCount);
+    }
+
+    /**
+     * Check with a multiple yield / iterator data providers.
+     *
+     * @covers PHPUnit_Util_Test::getDataFromDataProviderAnnotation
+     */
+    public function testMultipleYieldIteratorDataProviders()
+    {
+        $dataSets = PHPUnit_Util_Test::getProvidedData('MultipleDataProviderTest', 'testTwo');
 
         $this->assertEquals(9, count($dataSets));
 

--- a/tests/_files/MultipleDataProviderTest.php
+++ b/tests/_files/MultipleDataProviderTest.php
@@ -10,6 +10,15 @@ class MultipleDataProviderTest extends PHPUnit_Framework_TestCase
     {
     }
 
+    /**
+     * @dataProvider providerD
+     * @dataProvider providerE
+     * @dataProvider providerF
+     */
+    public function testTwo()
+    {
+    }
+
     public static function providerA()
     {
         return [
@@ -35,5 +44,32 @@ class MultipleDataProviderTest extends PHPUnit_Framework_TestCase
             [null, null, 'ok'],
             [null, null, 'ok']
         ];
+    }
+
+    public static function providerD()
+    {
+        yield ['ok', null, null];
+        yield ['ok', null, null];
+        yield ['ok', null, null];
+    }
+
+    public static function providerE()
+    {
+        yield [null, 'ok', null];
+        yield [null, 'ok', null];
+        yield [null, 'ok', null];
+    }
+
+    public static function providerF()
+    {
+        $object = new ArrayObject(
+            [
+                [null, null, 'ok'],
+                [null, null, 'ok'],
+                [null, null, 'ok']
+            ]
+        );
+
+        return $object->getIterator();
     }
 }


### PR DESCRIPTION
When we use "yield" or "iterator" into data generator, for the moment we have a problem for the actual implementation of multiple data generators.
The proposal fix this problem.
