### PR TITLE
Extend test util annotation loader with trait annotations

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -545,7 +545,12 @@ class PHPUnit_Util_Test
     {
         if (!isset(self::$annotationCache[$className])) {
             $class                             = new ReflectionClass($className);
-            self::$annotationCache[$className] = self::parseAnnotations($class->getDocComment());
+            $traits                            = $class->getTraits();
+            $annotations                       = [];
+            foreach($traits as $trait) {
+                 $annotations = array_merge($annotations, self::parseAnnotations($trait->getDocComment()));
+            }
+            self::$annotationCache[$className] = array_merge($annotations, self::parseAnnotations($class->getDocComment()));
         }
 
         if (!empty($methodName) && !isset(self::$annotationCache[$className . '::' . $methodName])) {

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -877,4 +877,29 @@ class Util_TestTest extends PHPUnit_Framework_TestCase
           ]
         ];
     }
+
+    public function testParseTestMethodAnnotationsIncorporatesTraits()
+    {
+        $result = PHPUnit_Util_Test::parseTestMethodAnnotations(ParseTestMethodAnnotationsMock::class);
+
+        $this->assertArrayHasKey('class', $result);
+        $this->assertArrayHasKey('method', $result);
+        $this->assertArrayHasKey('theClassAnnotation', $result['class']);
+        $this->assertArrayHasKey('theTraitAnnotation', $result['class']);
+    }
+}
+
+/**
+ * @theClassAnnotation
+ */
+class ParseTestMethodAnnotationsMock {
+    use ParseTestMethodAnnotationsTrait;
+}
+
+/**
+ * @theTraitAnnotation
+ */
+trait ParseTestMethodAnnotationsTrait
+{
+
 }


### PR DESCRIPTION
Hi,

In our project we use `PHUnit_Framework_TestCase` in combination with various Traits that provide the Application Kernel, the Connection, the Container or even a Mink or Web Access Adapter. Since the app is partly legacy and partly modern, we have to run a bunch of tests in a seperate process and a few others not. Currently we add the appropriate annotations to each test class, an error prone process.

This PR would allow us to use annotations on the traits to set the correct run time environment.