### PR TITLE
Allow to filter for multiple test suites

### DIFF
--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -140,6 +140,8 @@
  */
 class PHPUnit_Util_Configuration
 {
+    const TEST_SUITE_FILTER_SEPARATOR = ',';
+
     private static $instances = [];
 
     protected $document;
@@ -899,9 +901,10 @@ class PHPUnit_Util_Configuration
         }
 
         $fileIteratorFacade = new File_Iterator_Facade;
+        $testSuiteFilter    = $testSuiteFilter ? explode(self::TEST_SUITE_FILTER_SEPARATOR, $testSuiteFilter) : [];
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
-            if ($testSuiteFilter && $directoryNode->parentNode->getAttribute('name') != $testSuiteFilter) {
+            if (!empty($testSuiteFilter) && !in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
                 continue;
             }
 


### PR DESCRIPTION
This change allows users to run pass multiple test suites on the option `testsuite`.
e.g.: `--testsuite one,two`.

I didn't add any unit test since I couldn't find any test that uses the `$testSuiteFilter`, definitely you guys can help me to do it so.