### PR TITLE
#2246 --fail-on-warning doesn't change status code

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -598,10 +598,6 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                     exit(self::FAILURE_EXIT);
                 }
 
-                if ($arguments['failOnWarning'] && $result->warningCount() > 0) {
-                    exit(self::FAILURE_EXIT);
-                }
-
                 exit(self::SUCCESS_EXIT);
             }
 
@@ -612,6 +608,12 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
             if ($result->failureCount() > 0) {
                 exit(self::FAILURE_EXIT);
             }
+
+            if ($arguments['failOnWarning'] && $result->warningCount() > 0) {
+                exit(self::FAILURE_EXIT);
+            }
+
+            exit(self::SUCCESS_EXIT);
         }
 
         return $result;


### PR DESCRIPTION
The conditional was unreachable due to the `$result->wasSuccessful()` conditional already checked internally if there were any warnings.

Original report: #2246 