### PR TITLE
Fix count() typo

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -344,7 +344,7 @@ class PHPUnit_Util_Test
      */
     private static function parseAnnotationContent($message)
     {
-        if (strpos($message, '::') !== false && count(explode('::', $message) == 2)) {
+        if (strpos($message, '::') !== false && count(explode('::', $message)) == 2) {
             if (defined($message)) {
                 $message = constant($message);
             }


### PR DESCRIPTION
Discovered running tests w/ PHP 7.2-dev on master. Applied to 4.8 as that seemed to be the sensible thing to do.