### PR TITLE
Make getDataFromDataProviderAnnotation aware of generators.

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -470,6 +470,12 @@ class PHPUnit_Util_Test
                     $data = $dataProviderMethod->invoke($object, $methodName);
                 }
 
+                if ($data instanceof Generator) {
+                    foreach ($data as $test) {
+                        $result[] = $test;
+                    }
+                }
+
                 if (is_array($data)) {
                     $result = array_merge($result, $data);
                 }


### PR DESCRIPTION
This method was skipping generators as mentioned in the issue #2380 which
would cause tests to fail.