### PR TITLE
Bugfix/dataprovider uncloneable object #2382

### DIFF
--- a/tests/Regression/GitHub/2382.phpt
+++ b/tests/Regression/GitHub/2382.phpt
@@ -1,0 +1,19 @@
+--TEST--
+#2382: Data Providers throw error with uncloneable object
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue2382Test';
+$_SERVER['argv'][3] = __DIR__ . '/2382/Issue2382Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/Regression/GitHub/2382/Issue2382Test.php
+++ b/tests/Regression/GitHub/2382/Issue2382Test.php
@@ -1,0 +1,23 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class Issue2382Test extends TestCase
+{
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testOne($test)
+    {
+        $this->assertInstanceOf(\Exception::class, $test);
+    }
+
+    public function dataProvider()
+    {
+        return [
+            [
+                $this->getMockBuilder(\Exception::class)->getMock()
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
added a check, if its allowed to clone the object

https://github.com/sebastianbergmann/phpunit/issues/2382