### PR TITLE
TestCase - fix handling PHPUnit_Framework_Exception expectedException

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -925,7 +925,8 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
                 $reflector = new ReflectionClass($this->expectedException);
 
-                if ($this->expectedException == 'PHPUnit_Framework_Exception' ||
+                if ($this->expectedException === 'PHPUnit_Framework_Exception' ||
+                    $this->expectedException === '\PHPUnit_Framework_Exception' ||
                     $reflector->isSubclassOf('PHPUnit_Framework_Exception')) {
                     $checkException = true;
                 }


### PR DESCRIPTION
So, one may expect an exception.
Examples:

- `@expectedException Foo\Bar\Baz`
- `@expectedException \Foo\Bar\Baz`
which are the same. And both are handled the same way.

Currently, there is some movement to prefer later one, as it's problematic when one is requiring `LogicException` thinking he expects one from his imports, while in fact he is requiring one from global namespace.

For that, in some edge cases, one may do this:
`@expectedException \PHPUnit_Framework_Exception`
but it doesn't work.
This would:
`@expectedException PHPUnit_Framework_Exception`

------------------

This PR fixes that: