### PR TITLE
Make consistent equal to

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -692,14 +692,18 @@ abstract class PHPUnit_Framework_Assert
      * @param mixed  $expected
      * @param mixed  $actual
      * @param string $message
+     * @param float  $delta
+     * @param int    $maxDepth
+     * @param bool   $canonicalize
+     * @param bool   $ignoreCase
      *
      * @since Method available since Release 3.1.0
      */
-    public static function assertGreaterThanOrEqual($expected, $actual, $message = '')
+    public static function assertGreaterThanOrEqual($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {
         static::assertThat(
             $actual,
-            static::greaterThanOrEqual($expected),
+            static::greaterThanOrEqual($expected, $delta, $maxDepth, $canonicalize, $ignoreCase),
             $message
         );
     }
@@ -762,12 +766,20 @@ abstract class PHPUnit_Framework_Assert
      * @param mixed  $expected
      * @param mixed  $actual
      * @param string $message
+     * @param float  $delta
+     * @param int    $maxDepth
+     * @param bool   $canonicalize
+     * @param bool   $ignoreCase
      *
      * @since Method available since Release 3.1.0
      */
-    public static function assertLessThanOrEqual($expected, $actual, $message = '')
+    public static function assertLessThanOrEqual($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {
-        static::assertThat($actual, static::lessThanOrEqual($expected), $message);
+        static::assertThat(
+            $actual,
+            static::lessThanOrEqual($expected, $delta, $maxDepth, $canonicalize, $ignoreCase),
+            $message
+        );
     }
 
     /**
@@ -2719,15 +2731,19 @@ abstract class PHPUnit_Framework_Assert
      * PHPUnit_Framework_Constraint_GreaterThan matcher object.
      *
      * @param mixed $value
+     * @param float $delta
+     * @param int   $maxDepth
+     * @param bool  $canonicalize
+     * @param bool  $ignoreCase
      *
      * @return PHPUnit_Framework_Constraint_Or
      *
      * @since Method available since Release 3.1.0
      */
-    public static function greaterThanOrEqual($value)
+    public static function greaterThanOrEqual($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {
         return static::logicalOr(
-            new PHPUnit_Framework_Constraint_IsEqual($value),
+            new PHPUnit_Framework_Constraint_IsEqual($value, $delta, $maxDepth, $canonicalize, $ignoreCase),
             new PHPUnit_Framework_Constraint_GreaterThan($value)
         );
     }
@@ -2843,15 +2859,19 @@ abstract class PHPUnit_Framework_Assert
      * PHPUnit_Framework_Constraint_LessThan matcher object.
      *
      * @param mixed $value
+     * @param float $delta
+     * @param int   $maxDepth
+     * @param bool  $canonicalize
+     * @param bool  $ignoreCase
      *
      * @return PHPUnit_Framework_Constraint_Or
      *
      * @since Method available since Release 3.1.0
      */
-    public static function lessThanOrEqual($value)
+    public static function lessThanOrEqual($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {
         return static::logicalOr(
-            new PHPUnit_Framework_Constraint_IsEqual($value),
+            new PHPUnit_Framework_Constraint_IsEqual($value, $delta, $maxDepth, $canonicalize, $ignoreCase),
             new PHPUnit_Framework_Constraint_LessThan($value)
         );
     }

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -860,6 +860,7 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
             [[3, 2, 1], [2, 3, 1], 0, true], // canonicalized comparison
             // floats
             [2.3, 2.5, 0.5],
+            [2.5, 2.3, 0.5],
             [[2.3], [2.5], 0.5],
             [[[2.3]], [[2.5]], 0.5],
             [new Struct(2.3), new Struct(2.5), 0.5],
@@ -2077,6 +2078,15 @@ XML;
     }
 
     /**
+     * @covers PHPUnit_Framework_Assert::assertGreaterThanOrEqual
+     * @dataProvider equalProvider
+     */
+    public function testGreaterThanOrEqualWithEqualArgs($a, $b, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
+    {
+        $this->assertGreaterThanOrEqual($a, $b, '', $delta, 10, $canonicalize, $ignoreCase);
+    }
+
+    /**
      * @covers PHPUnit_Framework_Assert::assertAttributeGreaterThanOrEqual
      */
     public function testAttributeGreaterThanOrEqual()
@@ -2146,6 +2156,15 @@ XML;
         }
 
         $this->fail();
+    }
+
+    /**
+     * @covers PHPUnit_Framework_Assert::assertLessThanOrEqual
+     * @dataProvider equalProvider
+     */
+    public function testLessThanOrEqualWithEqualArgs($a, $b, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
+    {
+        $this->assertLessThanOrEqual($a, $b, '', $delta, 10, $canonicalize, $ignoreCase);
     }
 
     /**


### PR DESCRIPTION
The methods greaterThanOrEqual and lessThanOrEqual had a different
definition of equal. This brings the signatures of the methods in line
and allows the deltas to be checked too.