### PR TITLE
Fixed incompatibility with HHVM in PHP7 mode.

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2187,9 +2187,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      */
     protected function onNotSuccessfulTest($e)
     {
-        $expected = PHP_MAJOR_VERSION >= 7 ? 'Throwable' : 'Exception';
-
-        if ($e instanceof $expected) {
+        if ($e instanceof Throwable || $e instanceof Exception) {
             throw $e;
         }
 


### PR DESCRIPTION
See also facebook/hhvm#7537.

HHVM has a "PHP7 mode" that can be enabled with an INI setting. Currently PHPUnit skipped tests (and probably other features) do not work in this mode because of an HHVM incompatibility involving `instanceof` used with a variable containing `'Throwable'` as the type.

I realize that you could simply wait until HHVM addresses this issue, but hopefully you will consider accepting this PR in any case, as it will allow PHPUnit to function correctly on older versions of HHVM that are unlikely to be patched.