### PR TITLE
using the curl instead of wget cmd

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -40,7 +40,7 @@ unset($file);
 if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     fwrite(STDERR,
         'You need to set up the project dependencies using the following commands:' . PHP_EOL .
-        'wget http://getcomposer.org/composer.phar' . PHP_EOL .
+        'curl -sS http://getcomposer.org/composer.phar | php' . PHP_EOL .
         'php composer.phar install' . PHP_EOL
     );
 


### PR DESCRIPTION
# Change log
- modify the downloading composer description.

In my opinion, using ```curl ``` command is a proper way to download composer.
Using ```wget ``` command will have the SSL issue and ```curl ``` command can checkout the php settings.