### PR TITLE
Fix DirectoryNotIsWriteable calling itself

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1052,7 +1052,7 @@ abstract class PHPUnit_Framework_Assert
     public static function assertDirectoryNotIsWritable($directory, $message = '')
     {
         self::assertDirectoryExists($directory, $message);
-        self::assertDirectoryNotIsWritable($directory, $message);
+        self::assertNotIsWritable($directory, $message);
     }
 
     /**


### PR DESCRIPTION
Small copy/paste error or IDE auto-complete issue. Let's always blame auto-complete.