### PR TITLE
[6.0][BC] Add classes needed by Symfony's PHPUnit Bridge

### DIFF
--- a/src/BackwardCompatibility/AssertionFailedError.php
+++ b/src/BackwardCompatibility/AssertionFailedError.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\AssertionFailedError;
+
+class PHPUnit_Framework_AssertionFailedError extends AssertionFailedError
+{
+}

--- a/src/BackwardCompatibility/Command.php
+++ b/src/BackwardCompatibility/Command.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\TextUI\Command;
+
+class PHPUnit_TextUI_Command extends Command
+{
+}

--- a/src/BackwardCompatibility/ErrorHandler.php
+++ b/src/BackwardCompatibility/ErrorHandler.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Util\ErrorHandler;
+
+class PHPUnit_Util_ErrorHandler extends ErrorHandler
+{
+}

--- a/src/BackwardCompatibility/FrameworkTest.php
+++ b/src/BackwardCompatibility/FrameworkTest.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\Test;
+
+interface PHPUnit_Framework_Test extends Test
+{
+}

--- a/src/BackwardCompatibility/TestRunner.php
+++ b/src/BackwardCompatibility/TestRunner.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\TextUI\TestRunner;
+
+class PHPUnit_TextUI_TestRunner extends TestRunner
+{
+}

--- a/src/BackwardCompatibility/TestSuite.php
+++ b/src/BackwardCompatibility/TestSuite.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestSuite;
+
+class PHPUnit_Framework_TestSuite extends TestSuite
+{
+}

--- a/src/BackwardCompatibility/UtilTest.php
+++ b/src/BackwardCompatibility/UtilTest.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Util\Test;
+
+class PHPUnit_Util_Test extends Test
+{
+}


### PR DESCRIPTION
This PR stems from symfony/symfony#21125 which underlined the need for further BC support in the 6.0 release to avoid issues in their PHPUnit bridge.

This PR adds the needed classes. I had some doubts about the file naming, since there were 2 file with the `Test` name. I chose to use the latest part of the namespace as a distinguer, so:

 * `UtilTest.php` for class `PHPUnit\Util\Test`
 * `FrameworkTest.php` for interface `PHPUnit\Framework\Test`