### PR TITLE
Upgrade phpunit-selenium version on 4.8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -121,7 +121,7 @@
         <exec executable="${basedir}/build/tools/composer">
             <arg value="require"/>
             <arg value="phpunit/dbunit:~1.4"/>
-            <arg value="phpunit/phpunit-selenium:~1.4"/>
+            <arg value="phpunit/phpunit-selenium:~2"/>
             <arg value="phpunit/php-invoker:~1.1"/>
         </exec>
 


### PR DESCRIPTION
We're still using the old version of PHPUnit which integrates phpunit-selenium. 

I need some of the bug fixes that will be included in the future `2.x` branch release. 