### PR TITLE
Fix warning

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -286,19 +286,22 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
                         $arguments['configuration']->getFilename()
                     );
                 }
-
-                foreach ($arguments['loadedExtensions'] as $extension) {
-                    $this->writeMessage(
-                        'Extension',
-                        $extension
-                    );
+                if (isset($arguments['loadedExtensions'])) {
+                    foreach ($arguments['loadedExtensions'] as $extension) {
+                        $this->writeMessage(
+                            'Extension',
+                            $extension
+                        );
+                    }
                 }
 
-                foreach ($arguments['notLoadedExtensions'] as $extension) {
-                    $this->writeMessage(
-                        'Extension',
-                        $extension
-                    );
+                if (isset($arguments['notLoadedExtensions'])) {
+                    foreach ($arguments['notLoadedExtensions'] as $extension) {
+                        $this->writeMessage(
+                            'Extension',
+                            $extension
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
When locally installed phpunit and a composer version exist, using the
local installed version gives a warning about the variable not being set

Tested on Ubuntu 16.10 with local version 5.4.6  and composer version
5.7.5