### PR TITLE
Fix duplicated keys in nested XML arrays (#525)

### DIFF
--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -200,17 +200,20 @@ class PHPUnit_Util_XML
             case 'array':
                 $variable = [];
 
-                foreach ($element->getElementsByTagName('element') as $element) {
-                    $item = $element->childNodes->item(0);
+                foreach ($element->childNodes as $entry) {
+                    if (!$entry instanceof DOMElement || $entry->tagName !== 'element') {
+                        continue;
+                    }
+                    $item = $entry->childNodes->item(0);
 
                     if ($item instanceof DOMText) {
-                        $item = $element->childNodes->item(1);
+                        $item = $entry->childNodes->item(1);
                     }
 
                     $value = self::xmlToVariable($item);
 
-                    if ($element->hasAttribute('key')) {
-                        $variable[(string) $element->getAttribute('key')] = $value;
+                    if ($entry->hasAttribute('key')) {
+                        $variable[(string) $entry->getAttribute('key')] = $value;
                     } else {
                         $variable[] = $value;
                     }

--- a/tests/Util/XMLTest.php
+++ b/tests/Util/XMLTest.php
@@ -73,4 +73,22 @@ class Util_XMLTest extends PHPUnit_Framework_TestCase
     {
         PHPUnit_Util_XML::load(false);
     }
+
+    public function testNestedXmlToVariable()
+    {
+        $xml = '<array><element key="a"><array><element key="b"><string>foo</string></element></array></element><element key="c"><string>bar</string></element></array>';
+        $dom = new DOMDocument();
+        $dom->loadXML($xml);
+
+        $expected = [
+            'a' => [
+                'b' => 'foo',
+            ],
+            'c' => 'bar',
+        ];
+
+        $actual = PHPUnit_Util_XML::xmlToVariable($dom->documentElement);
+
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
At the moment nested arrays in XML configuration files are parsed incorrectly because `DOMElement::getElementsByTagName` not only returns immediate children but all descendants.

Example:
```
<array>
    <element key="a">
        <array>
            <element key="b">
                <string>foo</string>
            </element>
        </array>
    </element>
    <element key="c">
        <string>bar</string>
    </element>
</array>
```
```php
array (
  'a' => array (
    'b' => 'foo',
  ),
  'b' => 'foo', // duplicated
  'c' => 'bar',
)
```