### PR TITLE
Fixed #2431 - ArrayAccess support missing in assertArraySubset

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -62,14 +62,14 @@ abstract class PHPUnit_Framework_Assert
      */
     public static function assertArraySubset($subset, $array, $strict = false, $message = '')
     {
-        if (!is_array($subset)) {
+        if (!(is_array($subset) || $subset instanceof ArrayAccess)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
                 1,
                 'array or ArrayAccess'
             );
         }
 
-        if (!is_array($array)) {
+        if (!(is_array($array) || $array instanceof ArrayAccess)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
                 2,
                 'array or ArrayAccess'

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -49,6 +49,16 @@ class PHPUnit_Framework_Constraint_ArraySubset extends PHPUnit_Framework_Constra
      */
     protected function matches($other)
     {
+        //type cast $other & $this->subset as an array to allow 
+        //support in standard array functions.
+        if($other instanceof ArrayAccess) {
+            $other = (array) $other;
+        }
+
+        if($this->subset instanceof ArrayAccess) {
+            $this->subset = (array) $this->subset;
+        }
+
         $patched = array_replace_recursive($other, $this->subset);
 
         if ($this->strict) {

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -182,6 +182,11 @@ class Framework_AssertTest extends PHPUnit_Framework_TestCase
         $this->assertArraySubset(['a' => 'item a', 'c' => ['a2' => 'item a2']], $array);
         $this->assertArraySubset(['a' => 'item a', 'd' => ['a2' => ['b3' => 'item b3']]], $array);
 
+        $arrayAccessData = new ArrayObject($array);
+
+        $this->assertArraySubset(['a' => 'item a', 'c' => ['a2' => 'item a2']], $arrayAccessData);
+        $this->assertArraySubset(['a' => 'item a', 'd' => ['a2' => ['b3' => 'item b3']]], $arrayAccessData);
+
         try {
             $this->assertArraySubset(['a' => 'bad value'], $array);
         } catch (PHPUnit_Framework_AssertionFailedError $e) {


### PR DESCRIPTION
Fixes #2431 - Added `ArrayAccess` support to assertArraySubset