### PR TITLE
Fix TestResult::wasSuccessful to not base on warnings

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -1239,7 +1239,7 @@ class PHPUnit_Framework_TestResult implements Countable
      */
     public function wasSuccessful()
     {
-        return empty($this->errors) && empty($this->failures) && empty($this->warnings);
+        return empty($this->errors) && empty($this->failures);
     }
 
     /**


### PR DESCRIPTION
Closes #2246 

Relates to #2357, #2409

According to comment in https://github.com/sebastianbergmann/phpunit/pull/2409 fix `wasSuccessful` implementation