### PR TITLE
redirect to locally composer installed phpunit version

### DIFF
--- a/build/binary-phar-autoload.php.in
+++ b/build/binary-phar-autoload.php.in
@@ -20,6 +20,15 @@ if (__FILE__ == realpath($GLOBALS['_SERVER']['SCRIPT_NAME'])) {
     $execute = false;
 }
 
+if (file_exists('./vendor/phpunit/phpunit/phpunit') && file_exists($auto='./vendor/autoload.php')) {
+  echo "\n==== Redirecting to composer installed version in vendor/phpunit ====\n\n";
+  define ('PHPUNIT_COMPOSER_INSTALL', realpath($auto));
+  require PHPUNIT_COMPOSER_INSTALL;
+  PHPUnit_TextUI_Command::main();
+  exit(0);
+}
+unset($auto);
+
 define('__PHPUNIT_PHAR__', str_replace(DIRECTORY_SEPARATOR, '/', __FILE__));
 define('__PHPUNIT_PHAR_ROOT__', 'phar://___PHAR___');
 

--- a/phpunit
+++ b/phpunit
@@ -27,15 +27,21 @@ if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');
 }
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
-    if (file_exists($file)) {
-        define('PHPUNIT_COMPOSER_INSTALL', $file);
-
-        break;
+if (file_exists($path='./vendor/phpunit/phpunit/phpunit') && file_exists($auto='./vendor/autoload.php')) {
+    if (__FILE__ != realpath($path)) {
+        echo "\n==== Redirecting to composer installed version in vendor/phpunit ====\n\n";
+    }
+    define ('PHPUNIT_COMPOSER_INSTALL', realpath($auto));
+} else {
+    foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+        if (file_exists($file)) {
+            define('PHPUNIT_COMPOSER_INSTALL', $file);
+            break;
+        }
     }
 }
 
-unset($file);
+unset($file, $path, $auto);
 
 if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     fwrite(STDERR,


### PR DESCRIPTION
In some project:

```
$ vendor/bin/phpunit 
PHPUnit 5.3.5 by Sebastian Bergmann and contributors.
...

$ ~/.composer/vendor/bin/phpunit

==== Redirecting to composer installed version in vendor/phpunit ====

PHPUnit 5.3.5 by Sebastian Bergmann and contributors.
...

$ /work/GIT/phpunit/build/phpunit-nightly.phar

==== Redirecting to composer installed version in vendor/phpunit ====

PHPUnit 5.3.5 by Sebastian Bergmann and contributors.
...
```
