### PR TITLE
Fix #2449: Warnings in Data Providers

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -457,10 +457,21 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
             } // TestCase($name, $data)
             else {
                 try {
+                    // We must set an error handler if we want to catch warnings
+                    // possibly thrown by our data provider.
+                    $oldErrorHandler = set_error_handler(
+                        ['PHPUnit_Util_ErrorHandler', 'handleError'],
+                        E_ALL | E_STRICT
+                    );
+
                     $data = PHPUnit_Util_Test::getProvidedData(
                         $className,
                         $name
                     );
+
+                    if ($oldErrorHandler !== null) {
+                        restore_error_handler();
+                    }
                 } catch (PHPUnit_Framework_IncompleteTestError $e) {
                     $message = sprintf(
                         'Test for %s::%s marked incomplete by data provider',


### PR DESCRIPTION
This is my first commit to this repository, so I'm not very familiar with the code base. I realize this might not be the best way to fix the problem and I'm open to other suggestions. Also looking for a little guidance on where best to add a unit test for this scenario. (Not sure if it should go in the github directory or somewhere else, or if there's a special test setup for data providers or failures.)

If a warning occurs in a data provider, we should let the user know
about it. We can do this by setting an error handler before getting data
from the data provider.

See the difference in behavior below:

## Before
```
$ ./phpunit --fail-on-warning FooBarTest.php
PHP Warning:  Missing argument 2 for FooBar::__construct(), called in
/home/mkasberg/github/phpunit/FooBarTest.php on line 31 and defined in
/home/mkasberg/github/phpunit/FooBarTest.php on line 5
PHP Stack trace:
PHP   1. {main}() /home/mkasberg/github/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main()/home/mkasberg/github/phpunit/phpunit:52
PHP   3. PHPUnit_TextUI_Command->run()/home/mkasberg/github/phpunit/src/TextUI/Command.php:118
PHP   4. PHPUnit_Runner_BaseTestRunner->getTest()/home/mkasberg/github/phpunit/src/TextUI/Command.php:140
PHP   5. PHPUnit_Framework_TestSuite->__construct()/home/mkasberg/github/phpunit/src/Runner/BaseTestRunner.php:100
PHP   6. PHPUnit_Framework_TestSuite->addTestMethod()/home/mkasberg/github/phpunit/src/Framework/TestSuite.php:170
PHP   7. PHPUnit_Framework_TestSuite::createTest()/home/mkasberg/github/phpunit/src/Framework/TestSuite.php:861
PHP   8. PHPUnit_Util_Test::getProvidedData()/home/mkasberg/github/phpunit/src/Framework/TestSuite.php:460
PHP   9. PHPUnit_Util_Test::getDataFromDataProviderAnnotation()/home/mkasberg/github/phpunit/src/Util/Test.php:394
PHP  10. ReflectionMethod->invoke()/home/mkasberg/github/phpunit/src/Util/Test.php:466
PHP  11. FooBarTest->provideTestData()/home/mkasberg/github/phpunit/src/Util/Test.php:466
PHP  12. FooBar->__construct()/home/mkasberg/github/phpunit/FooBarTest.php:31
PHPUnit 5.7.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.13-0ubuntu0.16.04.1 with Xdebug 2.4.0
Configuration: /home/mkasberg/github/phpunit/phpunit.xml

.                                                                   1 /1 (100%)

Time: 23 ms, Memory: 4.00MB

OK (1 test, 1 assertion)

$ echo $?
0
```

## After
```
$ ./phpunit --fail-on-warning FooBarTest.php
PHPUnit 5.7.8-1-g490c9d4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.13-0ubuntu0.16.04.1 with Xdebug 2.4.0
Configuration: /home/mkasberg/github/phpunit/phpunit.xml

W                                                                   1 /1 (100%)

Time: 26 ms, Memory: 4.00MB

There was 1 warning:

1) Warning
The data provider specified for FooBarTest::testConstructor is invalid.
Missing argument 2 for FooBar::__construct(), called in
/home/mkasberg/github/phpunit/FooBarTest.php on line 31 and defined

/home/mkasberg/github/phpunit/src/Framework/WarningTestCase.php:57
/home/mkasberg/github/phpunit/src/Framework/TestCase.php:972
/home/mkasberg/github/phpunit/src/Framework/TestResult.php:709
/home/mkasberg/github/phpunit/src/Framework/TestCase.php:927
/home/mkasberg/github/phpunit/src/Framework/TestSuite.php:739
/home/mkasberg/github/phpunit/src/Framework/TestSuite.php:739
/home/mkasberg/github/phpunit/src/TextUI/TestRunner.php:491
/home/mkasberg/github/phpunit/src/TextUI/Command.php:188
/home/mkasberg/github/phpunit/src/TextUI/Command.php:118
OK (1 test, 0 assertions)

$ echo $?
1
```