### PR TITLE
Fix failOnWarning doesn't work

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -619,7 +619,7 @@ class PHPUnit_TextUI_TestRunner extends PHPUnit_Runner_BaseTestRunner
         }
 
         if ($exit) {
-            if ($result->wasSuccessful()) {
+            if ($result->wasSuccessful(false)) {
                 if ($arguments['failOnRisky'] && !$result->allHarmless()) {
                     exit(self::FAILURE_EXIT);
                 }


### PR DESCRIPTION
`wasSuccessful` shouldn't check warnings because `warningCount` checked inside condition body.

According to changes from #2446 fix