### PR TITLE
bugfix for PHPUnit\Framework\Exception call in tests

### DIFF
--- a/src/Framework/Constraint/Callback.php
+++ b/src/Framework/Constraint/Callback.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Util\InvalidArgumentHelper;
 
 /**
@@ -22,7 +22,7 @@ class Callback extends Constraint
     /**
      * @param callable $callback
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($callback)
     {

--- a/src/Framework/Constraint/ExceptionMessageRegularExpression.php
+++ b/src/Framework/Constraint/ExceptionMessageRegularExpression.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Util\RegularExpression;
 
 /**
@@ -34,7 +34,7 @@ class ExceptionMessageRegularExpression extends Constraint
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
-     * @param Exception $other
+     * @param PHPUnitException $other
      *
      * @return bool
      */
@@ -43,7 +43,7 @@ class ExceptionMessageRegularExpression extends Constraint
         $match = RegularExpression::safeMatch($this->expectedMessageRegExp, $other->getMessage());
 
         if (false === $match) {
-            throw new Exception(
+            throw new PHPUnitException(
                 "Invalid expected exception message regex given: '{$this->expectedMessageRegExp}'"
             );
         }

--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Util\InvalidArgumentHelper;
 use SebastianBergmann;
@@ -62,7 +62,7 @@ class IsEqual extends Constraint
      * @param bool  $canonicalize
      * @param bool  $ignoreCase
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {

--- a/src/Framework/Constraint/IsType.php
+++ b/src/Framework/Constraint/IsType.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Constraint that asserts that the value it is evaluated for is of a
@@ -60,14 +60,14 @@ class IsType extends Constraint
     /**
      * @param string $type
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($type)
     {
         parent::__construct();
 
         if (!isset($this->types[$type])) {
-            throw new Exception(
+            throw new PHPUnitException(
                 sprintf(
                     'Type specified for PHPUnit\Framework\Constraint\IsType <%s> ' .
                     'is not a valid type.',

--- a/src/Framework/Constraint/LogicalAnd.php
+++ b/src/Framework/Constraint/LogicalAnd.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\ExpectationFailedException;
 
 /**
@@ -30,7 +30,7 @@ class LogicalAnd extends Constraint
     /**
      * @param Constraint[] $constraints
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function setConstraints(array $constraints)
     {
@@ -38,7 +38,7 @@ class LogicalAnd extends Constraint
 
         foreach ($constraints as $constraint) {
             if (!($constraint instanceof Constraint)) {
-                throw new Exception(
+                throw new PHPUnitException(
                     'All parameters to ' . __CLASS__ .
                     ' must be a constraint object.'
                 );

--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Util\InvalidArgumentHelper;
 use SplObjectStorage;
 
@@ -39,7 +39,7 @@ class TraversableContains extends Constraint
      * @param bool  $checkForObjectIdentity
      * @param bool  $checkForNonObjectIdentity
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($value, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
     {

--- a/src/Framework/Error/Error.php
+++ b/src/Framework/Error/Error.php
@@ -10,12 +10,12 @@
 
 namespace PHPUnit\Framework\Error;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Wrapper for PHP errors.
  */
-class Error extends Exception
+class Error extends PHPUnitException
 {
     /**
      * Constructor.

--- a/src/Runner/BaseTestRunner.php
+++ b/src/Runner/BaseTestRunner.php
@@ -10,7 +10,7 @@
 namespace PHPUnit\Runner;
 
 use File_Iterator_Facade;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Test;
 use ReflectionClass;
@@ -72,7 +72,7 @@ abstract class BaseTestRunner
                 $suiteClassName,
                 $suiteClassFile
             );
-        } catch (Exception $e) {
+        } catch (PHPUnitException $e) {
             $this->runFailed($e->getMessage());
 
             return;
@@ -104,7 +104,7 @@ abstract class BaseTestRunner
         } catch (ReflectionException $e) {
             try {
                 $test = new TestSuite($testClass);
-            } catch (Exception $e) {
+            } catch (PHPUnitException $e) {
                 $test = new TestSuite;
                 $test->setName($suiteClassName);
             }

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Runner;
 use PHP_Timer;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\IncompleteTestError;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\Test;
@@ -70,7 +70,7 @@ class PhptTestCase implements Test, SelfDescribing
      * @param string             $filename
      * @param AbstractPhpProcess $phpUtil
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($filename, $phpUtil = null)
     {
@@ -79,7 +79,7 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         if (!is_file($filename)) {
-            throw new Exception(
+            throw new PHPUnitException(
                 sprintf(
                     'File "%s" does not exist.',
                     $filename
@@ -269,7 +269,7 @@ class PhptTestCase implements Test, SelfDescribing
     /**
      * @return array
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     private function parse()
     {
@@ -316,7 +316,7 @@ class PhptTestCase implements Test, SelfDescribing
 
                 continue;
             } elseif (empty($section)) {
-                throw new Exception('Invalid PHPT file');
+                throw new PHPUnitException('Invalid PHPT file');
             }
 
             $sections[$section] .= $line;
@@ -336,7 +336,7 @@ class PhptTestCase implements Test, SelfDescribing
 
                 // only allow files from the test directory
                 if (!is_file($testDirectory . $externalFilename) || !is_readable($testDirectory . $externalFilename)) {
-                    throw new Exception(
+                    throw new PHPUnitException(
                         sprintf(
                             'Could not load --%s-- %s for PHPT file',
                             $section . '_EXTERNAL',
@@ -380,12 +380,12 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         if (!$isValid) {
-            throw new Exception('Invalid PHPT file');
+            throw new PHPUnitException('Invalid PHPT file');
         }
 
         foreach ($unsupportedSections as $section) {
             if (isset($sections[$section])) {
-                throw new Exception(
+                throw new PHPUnitException(
                     'PHPUnit does not support this PHPT file'
                 );
             }

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Runner;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Util\Fileloader;
 use PHPUnit\Util\Filesystem;
@@ -26,7 +26,7 @@ class StandardTestSuiteLoader implements TestSuiteLoader
      *
      * @return ReflectionClass
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function load($suiteClassName, $suiteClassFile = '')
     {
@@ -105,7 +105,7 @@ class StandardTestSuiteLoader implements TestSuiteLoader
             }
         }
 
-        throw new Exception(
+        throw new PHPUnitException(
             sprintf(
                 "Class '%s' could not be found in '%s'.",
                 $suiteClassName,

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -11,7 +11,7 @@
 namespace PHPUnit\TextUI;
 
 use File_Iterator_Facade;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestListener;
@@ -204,7 +204,7 @@ class Command
 
         try {
             $result = $runner->doRun($suite, $this->arguments, $exit);
-        } catch (Exception $e) {
+        } catch (PHPUnitException $e) {
             print $e->getMessage() . "\n";
         }
 
@@ -290,7 +290,7 @@ class Command
                 'd:c:hv',
                 array_keys($this->longOptions)
             );
-        } catch (Exception $t) {
+        } catch (PHPUnitException $t) {
             $this->showError($t->getMessage());
         }
 
@@ -909,7 +909,7 @@ class Command
     {
         try {
             Fileloader::checkAndLoad($filename);
-        } catch (Exception $e) {
+        } catch (PHPUnitException $e) {
             $this->showError($e->getMessage());
         }
     }

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -12,7 +12,7 @@ namespace PHPUnit\TextUI;
 
 use PHP_Timer;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\TestResult;
@@ -138,7 +138,7 @@ class ResultPrinter extends Printer implements TestListener
      * @param int|string $numberOfColumns
      * @param bool       $reverse
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($out = null, $verbose = false, $colors = self::COLOR_DEFAULT, $debug = false, $numberOfColumns = 80, $reverse = false)
     {

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -12,7 +12,7 @@ namespace PHPUnit\TextUI;
 
 use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\Error\Warning;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestListener;
@@ -106,7 +106,7 @@ class TestRunner extends BaseTestRunner
      *
      * @return TestResult
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public static function run($test, array $arguments = [])
     {
@@ -122,7 +122,7 @@ class TestRunner extends BaseTestRunner
                 $arguments
             );
         } else {
-            throw new Exception(
+            throw new PHPUnitException(
                 'No test case or test suite found.'
             );
         }
@@ -889,7 +889,7 @@ class TestRunner extends BaseTestRunner
                 }
 
                 if (!class_exists($listener['class'])) {
-                    throw new Exception(
+                    throw new PHPUnitException(
                         sprintf(
                             'Class "%s" does not exist',
                             $listener['class']
@@ -900,7 +900,7 @@ class TestRunner extends BaseTestRunner
                 $listenerClass = new ReflectionClass($listener['class']);
 
                 if (!$listenerClass->implementsInterface(TestListener::class)) {
-                    throw new Exception(
+                    throw new PHPUnitException(
                         sprintf(
                             'Class "%s" does not implement the PHPUnit\Framework\TestListener interface',
                             $listener['class']

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Util;
 use DOMElement;
 use DOMXPath;
 use File_Iterator_Facade;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\TextUI\ResultPrinter;
 
@@ -185,7 +185,7 @@ class Configuration
         $realpath = realpath($filename);
 
         if ($realpath === false) {
-            throw new Exception(
+            throw new PHPUnitException(
                 sprintf(
                     'Could not read "%s".',
                     $filename

--- a/src/Util/Fileloader.php
+++ b/src/Util/Fileloader.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Utility methods to load PHP sourcefiles.
@@ -24,14 +24,14 @@ class Fileloader
      *
      * @return string
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public static function checkAndLoad($filename)
     {
         $includePathFilename = stream_resolve_include_path($filename);
 
         if (!$includePathFilename || !is_readable($includePathFilename)) {
-            throw new Exception(
+            throw new PHPUnitException(
                 sprintf('Cannot open file "%s".' . "\n", $filename)
             );
         }

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\SyntheticError;
 
 /**
@@ -20,8 +20,8 @@ class Filter
     /**
      * Filters stack frames from PHPUnit classes.
      *
-     * @param Exception $e
-     * @param bool      $asString
+     * @param \Exception $e
+     * @param bool       $asString
      *
      * @return string
      */
@@ -44,7 +44,7 @@ class Filter
             $eTrace = $e->getSyntheticTrace();
             $eFile  = $e->getSyntheticFile();
             $eLine  = $e->getSyntheticLine();
-        } elseif ($e instanceof Exception) {
+        } elseif ($e instanceof PHPUnitException) {
             $eTrace = $e->getSerializableTrace();
             $eFile  = $e->getFile();
             $eLine  = $e->getLine();

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Command-line options parsing class.
@@ -82,7 +82,7 @@ class Getopt
             if (($spec = strstr($short_options, $opt)) === false ||
                 $arg[$i] == ':'
             ) {
-                throw new Exception(
+                throw new PHPUnitException(
                     "unrecognized option -- $opt"
                 );
             }
@@ -99,7 +99,7 @@ class Getopt
                         break;
                     } elseif (list(, $opt_arg) = each($args)) {
                     } else {
-                        throw new Exception(
+                        throw new PHPUnitException(
                             "option requires an argument -- $opt"
                         );
                     }
@@ -136,7 +136,7 @@ class Getopt
             if ($opt_rest != '' && $opt[0] != '=' && $i + 1 < $count &&
                 $opt == substr($long_options[$i + 1], 0, $opt_len)
             ) {
-                throw new Exception(
+                throw new PHPUnitException(
                     "option --$opt is ambiguous"
                 );
             }
@@ -146,13 +146,13 @@ class Getopt
                     if (!strlen($opt_arg) &&
                         !(list(, $opt_arg) = each($args))
                     ) {
-                        throw new Exception(
+                        throw new PHPUnitException(
                             "option --$opt requires an argument"
                         );
                     }
                 }
             } elseif ($opt_arg) {
-                throw new Exception(
+                throw new PHPUnitException(
                     "option --$opt doesn't allow an argument"
                 );
             }
@@ -163,6 +163,6 @@ class Getopt
             return;
         }
 
-        throw new Exception("unrecognized option --$opt");
+        throw new PHPUnitException("unrecognized option --$opt");
     }
 }

--- a/src/Util/InvalidArgumentHelper.php
+++ b/src/Util/InvalidArgumentHelper.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Factory for PHPUnit_Framework_Exception objects that are used to describe
@@ -22,13 +22,13 @@ class InvalidArgumentHelper
      * @param string $type
      * @param mixed  $value
      *
-     * @return Exception
+     * @return PHPUnitException
      */
     public static function factory($argument, $type, $value = null)
     {
         $stack = debug_backtrace(false);
 
-        return new Exception(
+        return new PHPUnitException(
             sprintf(
                 'Argument #%d%sof %s::%s() must be a %s',
                 $argument,

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -11,7 +11,7 @@
 namespace PHPUnit\Util\Log;
 
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Framework\TestSuite;
@@ -184,7 +184,7 @@ class TeamCity extends ResultPrinter
         }
     }
 
-    public function printIgnoredTest($testName, Exception $e)
+    public function printIgnoredTest($testName, \Exception $e)
     {
         $this->printEvent(
             'testIgnored',
@@ -328,15 +328,15 @@ class TeamCity extends ResultPrinter
     }
 
     /**
-     * @param Exception $e
+     * @param \Exception $e
      *
      * @return string
      */
-    private static function getMessage(Exception $e)
+    private static function getMessage(\Exception $e)
     {
         $message = '';
 
-        if (!$e instanceof Exception) {
+        if (!$e instanceof PHPUnitException) {
             if (strlen(get_class($e)) != 0) {
                 $message = $message . get_class($e);
             }
@@ -350,11 +350,11 @@ class TeamCity extends ResultPrinter
     }
 
     /**
-     * @param Exception $e
+     * @param \Exception $e
      *
      * @return string
      */
-    private static function getDetails(Exception $e)
+    private static function getDetails(\Exception $e)
     {
         $stackTrace = Filter::getFilteredStacktrace($e);
         $previous   = $e->getPrevious();

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Util\PHP;
 
 use __PHP_Incomplete_Class;
 use ErrorException;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestFailure;
 use PHPUnit\Framework\Test;
@@ -68,7 +68,7 @@ abstract class AbstractPhpProcess
      *
      * Then $stderrRedirection is TRUE, STDERR is redirected to STDOUT.
      *
-     * @throws Exception
+     * @throws PHPUnitException
      *
      * @param bool $stderrRedirection
      */
@@ -190,7 +190,7 @@ abstract class AbstractPhpProcess
      * @param Test       $test
      * @param TestResult $result
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function runTestJob($job, Test $test, TestResult $result)
     {
@@ -250,7 +250,7 @@ abstract class AbstractPhpProcess
      *
      * @return array
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     abstract public function runJob($job, array $settings = []);
 
@@ -285,7 +285,7 @@ abstract class AbstractPhpProcess
         if (!empty($stderr)) {
             $result->addError(
                 $test,
-                new Exception(trim($stderr)),
+                new PHPUnitException(trim($stderr)),
                 $time
             );
         } else {
@@ -305,7 +305,7 @@ abstract class AbstractPhpProcess
 
                 $result->addError(
                     $test,
-                    new Exception(trim($stdout), 0, $e),
+                    new PHPUnitException(trim($stdout), 0, $e),
                     $time
                 );
             }
@@ -387,7 +387,7 @@ abstract class AbstractPhpProcess
      *
      * @param TestFailure $error
      *
-     * @return Exception
+     * @return PHPUnitException
      *
      * @see    https://github.com/sebastianbergmann/phpunit/issues/74
      */

--- a/src/Util/PHP/DefaultPhpProcess.php
+++ b/src/Util/PHP/DefaultPhpProcess.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util\PHP;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Default utility for PHP sub-processes.
@@ -34,7 +34,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
      *
      * @return array
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function runJob($job, array $settings = [])
     {
@@ -42,7 +42,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
             if (!($this->tempFile = tempnam(sys_get_temp_dir(), 'PHPUnit')) ||
                 file_put_contents($this->tempFile, $job) === false
             ) {
-                throw new Exception(
+                throw new PHPUnitException(
                     'Unable to write temporary file'
                 );
             }
@@ -71,7 +71,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
      *
      * @return array
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     protected function runProcess($job, $settings)
     {
@@ -104,7 +104,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
         );
 
         if (!is_resource($process)) {
-            throw new Exception(
+            throw new PHPUnitException(
                 'Unable to spawn worker process'
             );
         }
@@ -129,7 +129,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
                     break;
                 } elseif ($n === 0) {
                     proc_terminate($process, 9);
-                    throw new Exception(sprintf('Job execution aborted after %d seconds', $this->timeout));
+                    throw new PHPUnitException(sprintf('Job execution aborted after %d seconds', $this->timeout));
                 } elseif ($n > 0) {
                     foreach ($r as $pipe) {
                         $pipeOffset = 0;
@@ -196,7 +196,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
      * @param resource $pipe
      * @param string   $job
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     protected function process($pipe, $job)
     {

--- a/src/Util/PHP/WindowsPhpProcess.php
+++ b/src/Util/PHP/WindowsPhpProcess.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util\PHP;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Windows utility for PHP sub-processes.
@@ -26,7 +26,7 @@ class WindowsPhpProcess extends DefaultPhpProcess
     protected function getHandles()
     {
         if (false === $stdout_handle = tmpfile()) {
-            throw new Exception(
+            throw new PHPUnitException(
                 'A temporary file could not be created; verify that your TEMP environment variable is writable'
             );
         }

--- a/src/Util/Printer.php
+++ b/src/Util/Printer.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util;
 
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 
 /**
  * Utility class that can print to STDOUT or write to a file.
@@ -38,7 +38,7 @@ class Printer
      *
      * @param mixed $out
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public function __construct($out = null)
     {
@@ -48,7 +48,7 @@ class Printer
                     $out = explode(':', str_replace('socket://', '', $out));
 
                     if (count($out) != 2) {
-                        throw new Exception;
+                        throw new PHPUnitException;
                     }
 
                     $this->out = fsockopen($out[0], $out[1]);

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -11,7 +11,7 @@ namespace PHPUnit\Util;
 
 use Iterator;
 use PHPUnit\Framework\CodeCoverageException;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\InvalidCoversTargetException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\SelfDescribing;
@@ -391,7 +391,7 @@ class Test
      * @return array When a data provider is specified and exists
      *         null  When no data provider is specified
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     public static function getProvidedData($className, $methodName)
     {
@@ -411,7 +411,7 @@ class Test
         if ($data !== null) {
             foreach ($data as $key => $value) {
                 if (!is_array($value)) {
-                    throw new Exception(
+                    throw new PHPUnitException(
                         sprintf(
                             'Data set %s is invalid.',
                             is_int($key) ? '#' . $key : '"' . $key . '"'
@@ -434,7 +434,7 @@ class Test
      * @return array|Iterator when a data provider is specified and exists
      *                        null           when no data provider is specified
      *
-     * @throws Exception
+     * @throws PHPUnitException
      */
     private static function getDataFromDataProviderAnnotation($docComment, $className, $methodName)
     {
@@ -497,7 +497,7 @@ class Test
      * @return array when @testWith annotation is defined
      *               null  when @testWith annotation is omitted
      *
-     * @throws Exception when @testWith annotation is defined but cannot be parsed
+     * @throws PHPUnitException when @testWith annotation is defined but cannot be parsed
      */
     public static function getDataFromTestWithAnnotation($docComment)
     {
@@ -518,7 +518,7 @@ class Test
                 $dataSet = json_decode($candidateRow, true);
 
                 if (json_last_error() != JSON_ERROR_NONE) {
-                    throw new Exception(
+                    throw new PHPUnitException(
                         'The dataset for the @testWith annotation cannot be parsed: ' . json_last_error_msg()
                     );
                 }
@@ -527,7 +527,7 @@ class Test
             }
 
             if (!$data) {
-                throw new Exception('The dataset for the @testWith annotation cannot be parsed.');
+                throw new PHPUnitException('The dataset for the @testWith annotation cannot be parsed.');
             }
 
             return $data;

--- a/src/Util/TestDox/XmlResultPrinter.php
+++ b/src/Util/TestDox/XmlResultPrinter.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Util\TestDox;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\TestListener;
@@ -41,7 +41,7 @@ class XmlResultPrinter extends Printer implements TestListener
     private $prettifier;
 
     /**
-     * @var Exception
+     * @var PHPUnitException
      */
     private $exception;
 
@@ -215,7 +215,7 @@ class XmlResultPrinter extends Printer implements TestListener
         }
 
         if ($this->exception !== null) {
-            if ($this->exception instanceof Exception) {
+            if ($this->exception instanceof PHPUnitException) {
                 $steps = $this->exception->getSerializableTrace();
             } else {
                 $steps = $this->exception->getTrace();

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -14,7 +14,7 @@ use DOMDocument;
 use DOMElement;
 use DOMNode;
 use DOMText;
-use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Exception as PHPUnitException;
 use ReflectionClass;
 
 /**
@@ -51,11 +51,11 @@ class Xml
         }
 
         if (!is_string($actual)) {
-            throw new Exception('Could not load XML from ' . gettype($actual));
+            throw new PHPUnitException('Could not load XML from ' . gettype($actual));
         }
 
         if ($actual === '') {
-            throw new Exception('Could not load XML from empty string');
+            throw new PHPUnitException('Could not load XML from empty string');
         }
 
         // Required for XInclude on Windows.
@@ -99,7 +99,7 @@ class Xml
 
         if ($loaded === false || ($strict && $message !== '')) {
             if ($filename !== '') {
-                throw new Exception(
+                throw new PHPUnitException(
                     sprintf(
                         'Could not load "%s".%s',
                         $filename,
@@ -110,7 +110,7 @@ class Xml
                 if ($message === '') {
                     $message = 'Could not load XML for unknown reason';
                 }
-                throw new Exception($message);
+                throw new PHPUnitException($message);
             }
         }
 
@@ -134,7 +134,7 @@ class Xml
         error_reporting($reporting);
 
         if ($contents === false) {
-            throw new Exception(
+            throw new PHPUnitException(
                 sprintf(
                     'Could not read "%s".',
                     $filename


### PR DESCRIPTION
i get with PHPUnit 6.0.2 following error `PHP Fatal error:  Cannot use PHPUnit\Framework\Exception as Exception because the name is already in use`

file 
phpunit\src\Framework\Constraint\IsEqual.php on line 12

so i changed all parts to the alias `PHPUnitException`

i changed also some parts in `PHPUnit\Util\Log\TeamCity` that there should be `\Exception` and not the internal `PHPUnitException`.