### PR TITLE
Allow users to define a test suite with one file, no directories

### DIFF
--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -955,7 +955,7 @@ class Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
-            if ($testSuiteFilter && $fileNode->parentNode->getAttribute('name') != $testSuiteFilter) {
+            if (!empty($testSuiteFilter) && !in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
                 continue;
             }
 

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -428,4 +428,16 @@ class Util_ConfigurationTest extends TestCase
 
         $this->assertEquals(['Suite One', 'Suite Two'], $names);
     }
+
+    public function testTestSuiteConfigurationForASingleFileInASuite()
+    {
+        $configuration = Configuration::getInstance(
+            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.one-file-suite.xml'
+        );
+
+        $config = $configuration->getTestSuiteConfiguration();
+        $tests = $config->tests();
+
+        $this->assertEquals(1, count($tests));
+    }
 }

--- a/tests/_files/configuration.one-file-suite.xml
+++ b/tests/_files/configuration.one-file-suite.xml
@@ -1,0 +1,7 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="One File Suite">
+            <file>../../tests/TextUI/debug.phpt</file>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
testSuiteFilter is an array, but for the file config aspect, it isn't
being treated as such. This means if you define a test suite with one file, it isn't finding any tests, which is incorrect.