### PR TITLE
All listeners should be called before/after test

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -363,8 +363,17 @@ class PHPUnit_Framework_TestResult implements Countable
             $this->topTestSuite = $suite;
         }
 
+        $exception = null;
         foreach ($this->listeners as $listener) {
-            $listener->startTestSuite($suite);
+            try {
+                $listener->startTestSuite($suite);
+            } catch (\Exception $e) {
+                $exception = $exception ?: $e;
+            }
+        }
+
+        if ($exception) {
+            throw $exception;
         }
     }
 
@@ -377,8 +386,17 @@ class PHPUnit_Framework_TestResult implements Countable
      */
     public function endTestSuite(PHPUnit_Framework_TestSuite $suite)
     {
+        $exception = null;
         foreach ($this->listeners as $listener) {
-            $listener->endTestSuite($suite);
+            try {
+                $listener->endTestSuite($suite);
+            } catch (\Exception $e) {
+                $exception = $exception ?: $e;
+            }
+        }
+
+        if ($exception) {
+            throw $exception;
         }
     }
 
@@ -392,8 +410,17 @@ class PHPUnit_Framework_TestResult implements Countable
         $this->lastTestFailed = false;
         $this->runTests      += count($test);
 
+        $exception = null;
         foreach ($this->listeners as $listener) {
-            $listener->startTest($test);
+            try {
+                $listener->startTest($test);
+            } catch (\Exception $e) {
+                $exception = $exception ?: $e;
+            }
+        }
+
+        if ($exception) {
+            throw $exception;
         }
     }
 
@@ -405,8 +432,17 @@ class PHPUnit_Framework_TestResult implements Countable
      */
     public function endTest(PHPUnit_Framework_Test $test, $time)
     {
+        $exception = null;
         foreach ($this->listeners as $listener) {
-            $listener->endTest($test, $time);
+            try {
+                $listener->endTest($test, $time);
+            } catch (\Exception $e) {
+                $exception = $exception ?: $e;
+            }
+        }
+
+        if ($exception) {
+            throw $exception;
         }
 
         if (!$this->lastTestFailed && $test instanceof PHPUnit_Framework_TestCase) {


### PR DESCRIPTION
When listener fails with an exception e.g. cannot connect to selenium server, no additional listeners, like HTML report will be triggered. All listeners should be called and when necessary, exception will be
triggered.

This is the fastest solution I came up with. I think better will be to catch exceptions and throw some listener exception with all exceptions that occurred. I can do that change too, let me know if that will be good to implement.

This change should fix this problem in Codeception https://github.com/Codeception/Codeception/issues/3653 . The problem is that the code is dependent on the actual order of registered listeners. When first listener fails and the last is HTML output, for that it will not call startTest event.