### PR TITLE
Fix default of backupGlobals and beStrictAboutTestsThatDoNotTestAnything in xsd

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -185,7 +185,7 @@
     <xs:attributeGroup ref="configAttributeGroup"/>
   </xs:complexType>
   <xs:attributeGroup name="configAttributeGroup">
-    <xs:attribute name="backupGlobals" type="xs:boolean" default="true"/>
+    <xs:attribute name="backupGlobals" type="xs:boolean" default="false"/>
     <xs:attribute name="backupStaticAttributes" type="xs:boolean" default="false"/>
     <xs:attribute name="bootstrap" type="xs:anyURI"/>
     <xs:attribute name="cacheTokens" type="xs:boolean"/>
@@ -209,7 +209,7 @@
     <xs:attribute name="beStrictAboutChangesToGlobalState" type="xs:boolean" default="false"/>
     <xs:attribute name="beStrictAboutOutputDuringTests" type="xs:boolean" default="false"/>
     <xs:attribute name="beStrictAboutResourceUsageDuringSmallTests" type="xs:boolean" default="false"/>
-    <xs:attribute name="beStrictAboutTestsThatDoNotTestAnything" type="xs:boolean" default="false"/>
+    <xs:attribute name="beStrictAboutTestsThatDoNotTestAnything" type="xs:boolean" default="true"/>
     <xs:attribute name="beStrictAboutTodoAnnotatedTests" type="xs:boolean" default="false"/>
     <xs:attribute name="beStrictAboutCoversAnnotation" type="xs:boolean" default="false"/>
     <xs:attribute name="enforceTimeLimit" type="xs:boolean" default="false"/>


### PR DESCRIPTION
Those have been changed in #2190 and #2189