### PR TITLE
Fixes #2308

### DIFF
--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -82,9 +82,10 @@ class PHPUnit_Framework_Constraint_IsIdentical extends PHPUnit_Framework_Constra
                 $f = new SebastianBergmann\Comparator\ComparisonFailure(
                     $this->value,
                     $other,
-                    $this->value,
-                    $other
+                    sprintf("'%s'", $this->value),
+                    sprintf("'%s'", $other)
                 );
+
             }
 
             $this->fail($other, $description, $f);

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -1146,8 +1146,8 @@ Failed asserting that two strings are identical.
 --- Expected
 +++ Actual
 @@ @@
--a
-+b
+-'a'
++'b'
 
 EOF
               ,

--- a/tests/Regression/GitHub/503.phpt
+++ b/tests/Regression/GitHub/503.phpt
@@ -25,7 +25,8 @@ Failed asserting that two strings are identical.
 +++ Actual
 @@ @@
  #Warning: Strings contain different line endings!
- foo
+ 'foo
+ '
 
 %s:%i
 

--- a/tests/TextUI/failure-isolation.phpt
+++ b/tests/TextUI/failure-isolation.phpt
@@ -103,8 +103,8 @@ Failed asserting that two strings are identical.
 --- Expected
 +++ Actual
 @@ @@
--foo
-+bar
+-'foo'
++'bar'
 
 %s:%i
 

--- a/tests/TextUI/failure-reverse-list.phpt
+++ b/tests/TextUI/failure-reverse-list.phpt
@@ -53,8 +53,8 @@ Failed asserting that two strings are identical.
 --- Expected
 +++ Actual
 @@ @@
--foo
-+bar
+-'foo'
++'bar'
 
 %s:%d
 

--- a/tests/TextUI/failure.phpt
+++ b/tests/TextUI/failure.phpt
@@ -102,8 +102,8 @@ Failed asserting that two strings are identical.
 --- Expected
 +++ Actual
 @@ @@
--foo
-+bar
+-'foo'
++'bar'
 
 %s:%i
 


### PR DESCRIPTION
Add quotes around multi line strings when using assertSame similar to
the ones which are there for assertEquals

Sorry had to make a new PR, old one wouldnt open due to force pushing

The behavior isnt identical between same and equals (same gives a warning about line endings for example) but the quotes are more clear

Fixed all failing tests