### PR TITLE
Ensure the version library can correctly report the phpunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "sebastian/global-state": "^1.1",
         "sebastian/object-enumerator": "~2.0",
         "sebastian/resource-operations": "~1.0",
-        "sebastian/version": "~1.0|~2.0",
+        "sebastian/version": "~1.0.3|~2.0",
         "myclabs/deep-copy": "~1.3",
         "ext-dom": "*",
         "ext-json": "*",


### PR DESCRIPTION
There was a pretty significant [fix](https://github.com/sebastianbergmann/version/commit/1edc5b25589915d10a93fb11f7760d6283b52f95) to the version library, and if `1.0.0-1.0.2` is installed then phpunit does not report the correct version in some circumstances.

This pr declares the fix as a required dependency