### PR TITLE
Fix: Class names do not match actual case

### DIFF
--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -2637,7 +2637,7 @@ EOF
 
     public function testConstraintSplObjectStorageContains()
     {
-        $object     = new StdClass;
+        $object     = new stdClass;
         $constraint = new TraversableContains($object);
         $this->assertStringMatchesFormat('contains stdClass Object &%s ()', $constraint->toString());
 
@@ -2667,7 +2667,7 @@ EOF
 
     public function testConstraintSplObjectStorageContains2()
     {
-        $object     = new StdClass;
+        $object     = new stdClass;
         $constraint = new TraversableContains($object);
 
         try {

--- a/tests/Util/XMLTest.php
+++ b/tests/Util/XMLTest.php
@@ -83,7 +83,7 @@ class Util_XMLTest extends TestCase
             'c' => 'bar',
         ];
 
-        $actual = XML::xmlToVariable($dom->documentElement);
+        $actual = Xml::xmlToVariable($dom->documentElement);
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/_files/ClonedDependencyTest.php
+++ b/tests/_files/ClonedDependencyTest.php
@@ -7,7 +7,7 @@ class ClonedDependencyTest extends TestCase
 
     public static function setUpBeforeClass()
     {
-        self::$dependency = new StdClass;
+        self::$dependency = new stdClass;
     }
 
     public function testOne()

--- a/tests/_files/FailureTest.php
+++ b/tests/_files/FailureTest.php
@@ -15,10 +15,10 @@ class FailureTest extends TestCase
 
     public function testAssertObjectEqualsObject()
     {
-        $a      = new StdClass;
+        $a      = new stdClass;
         $a->foo = 'bar';
 
-        $b      = new StdClass;
+        $b      = new stdClass;
         $b->bar = 'foo';
 
         $this->assertEquals($a, $b, 'message');
@@ -56,12 +56,12 @@ class FailureTest extends TestCase
 
     public function testAssertObjectSameObject()
     {
-        $this->assertSame(new StdClass, new StdClass, 'message');
+        $this->assertSame(new stdClass, new stdClass, 'message');
     }
 
     public function testAssertObjectSameNull()
     {
-        $this->assertSame(new StdClass, null, 'message');
+        $this->assertSame(new stdClass, null, 'message');
     }
 
     public function testAssertFloatSameFloat()


### PR DESCRIPTION
This PR

* [x] fixes issues where the case of a class name does not match the actually referenced class name