### PR TITLE
Fix: Remove unused paramater from method signature

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1676,13 +1676,12 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * @param bool   $callOriginalConstructor
      * @param bool   $callOriginalClone
      * @param bool   $callAutoload
-     * @param bool   $cloneArguments
      *
      * @return object
      *
      * @throws Exception
      */
-    protected function getObjectForTrait($traitName, array $arguments = [], $traitClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false)
+    protected function getObjectForTrait($traitName, array $arguments = [], $traitClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true)
     {
         return $this->getMockObjectGenerator()->getObjectForTrait(
             $traitName,
@@ -1690,8 +1689,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $traitClassName,
             $callOriginalConstructor,
             $callOriginalClone,
-            $callAutoload,
-            $cloneArguments
+            $callAutoload
         );
     }
 


### PR DESCRIPTION
This PR

* [x] removes an unused parameter from a method signature