### PR TITLE
Fix: Remove unused argument

### DIFF
--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -200,7 +200,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionWithEmptyMessage()
     {
         $test = new ThrowExceptionTestCase('test');
-        $test->expectException(RuntimeException::class, '');
+        $test->expectException(RuntimeException::class);
 
         $result = $test->run();
 
@@ -211,7 +211,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionWithNullMessage()
     {
         $test = new ThrowExceptionTestCase('test');
-        $test->expectException(RuntimeException::class, null);
+        $test->expectException(RuntimeException::class);
 
         $result = $test->run();
 


### PR DESCRIPTION
This PR

* [x] removes unused arguments from method calls in tests