### PR TITLE
Fix: Remove useless condition

### DIFF
--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -172,14 +172,7 @@ class GlobalState
      */
     protected static function getSuperGlobalArrays()
     {
-        if (ini_get('register_long_arrays') == '1') {
-            return array_merge(
-                self::$superGlobalArrays,
-                self::$superGlobalArraysLong
-            );
-        } else {
-            return self::$superGlobalArrays;
-        }
+        return self::$superGlobalArrays;
     }
 
     protected static function exportVariable($variable)


### PR DESCRIPTION
This PR

* [x] removes a useless condition

💁‍♂️ For reference, see http://php.net/manual/en/ini.core.php#ini.register-long-arrays:

>**Warning**
>This feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.