### PR TITLE
Fix: Remove useless return statements

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -384,8 +384,6 @@ class TeamCity extends ResultPrinter
         } elseif (is_scalar($value)) {
             return print_r($value, true);
         }
-
-        return;
     }
 
     /**

--- a/tests/_files/NonStatic.php
+++ b/tests/_files/NonStatic.php
@@ -3,6 +3,5 @@ class NonStatic
 {
     public function suite()
     {
-        return;
     }
 }


### PR DESCRIPTION
This PR

* [x] removes useless `return` statements