### PR TITLE
Fix: Use class keyword instead of string literals

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1067,9 +1067,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
                 $reflector = new ReflectionClass($this->expectedException);
 
-                if ($this->expectedException === 'PHPUnit\Framework\Exception' ||
-                    $this->expectedException === '\PHPUnit\Framework\Exception' ||
-                    $reflector->isSubclassOf('PHPUnit\Framework\Exception')
+                if ($this->expectedException === Exception::class ||
+                    $this->expectedException === Exception::class ||
+                    $reflector->isSubclassOf(Exception::class)
                 ) {
                     $checkException = true;
                 }

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -633,7 +633,7 @@ class TestResult implements Countable
 
         if ($this->convertErrorsToExceptions) {
             $oldErrorHandler = set_error_handler(
-                ['PHPUnit\Util\ErrorHandler', 'handleError'],
+                [\PHPUnit\Util\ErrorHandler::class, 'handleError'],
                 E_ALL | E_STRICT
             );
 

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -86,14 +86,14 @@ class Framework_AssertTest extends TestCase
     {
         $test = [new Book, new Book];
 
-        $this->assertContainsOnlyInstancesOf('Book', $test);
-        $this->assertContainsOnlyInstancesOf('stdClass', [new stdClass()]);
+        $this->assertContainsOnlyInstancesOf(Book::class, $test);
+        $this->assertContainsOnlyInstancesOf(stdClass::class, [new stdClass()]);
 
         $test2 = [new Author('Test')];
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertContainsOnlyInstancesOf('Book', $test2);
+        $this->assertContainsOnlyInstancesOf(Book::class, $test2);
     }
 
     public function testAssertArrayHasKeyThrowsExceptionForInvalidFirstArgument()
@@ -184,7 +184,7 @@ class Framework_AssertTest extends TestCase
 
     public function testAssertArraySubsetWithStrictCheckAndObjects()
     {
-        $obj       = new \stdClass;
+        $obj       = new stdClass;
         $reference = &$obj;
         $array     = ['a' => $obj];
 
@@ -192,7 +192,7 @@ class Framework_AssertTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertArraySubset(['a' => new \stdClass], $array, true);
+        $this->assertArraySubset(['a' => new stdClass], $array, true);
     }
 
     /**
@@ -1622,11 +1622,11 @@ XML;
 
     public function testReadAttribute2()
     {
-        $this->assertEquals('foo', $this->readAttribute('ClassWithNonPublicAttributes', 'publicStaticAttribute'));
-        $this->assertEquals('bar', $this->readAttribute('ClassWithNonPublicAttributes', 'protectedStaticAttribute'));
-        $this->assertEquals('baz', $this->readAttribute('ClassWithNonPublicAttributes', 'privateStaticAttribute'));
-        $this->assertEquals('foo', $this->readAttribute('ClassWithNonPublicAttributes', 'protectedStaticParentAttribute'));
-        $this->assertEquals('foo', $this->readAttribute('ClassWithNonPublicAttributes', 'privateStaticParentAttribute'));
+        $this->assertEquals('foo', $this->readAttribute(ClassWithNonPublicAttributes::class, 'publicStaticAttribute'));
+        $this->assertEquals('bar', $this->readAttribute(ClassWithNonPublicAttributes::class, 'protectedStaticAttribute'));
+        $this->assertEquals('baz', $this->readAttribute(ClassWithNonPublicAttributes::class, 'privateStaticAttribute'));
+        $this->assertEquals('foo', $this->readAttribute(ClassWithNonPublicAttributes::class, 'protectedStaticParentAttribute'));
+        $this->assertEquals('foo', $this->readAttribute(ClassWithNonPublicAttributes::class, 'privateStaticParentAttribute'));
     }
 
     public function testReadAttribute3()
@@ -1654,7 +1654,7 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->readAttribute('stdClass', '2');
+        $this->readAttribute(stdClass::class, '2');
     }
 
     public function testGetStaticAttributeRaisesExceptionForInvalidFirstArgument()
@@ -1675,21 +1675,21 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->getStaticAttribute('stdClass', null);
+        $this->getStaticAttribute(stdClass::class, null);
     }
 
     public function testGetStaticAttributeRaisesExceptionForInvalidSecondArgument2()
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->getStaticAttribute('stdClass', '0');
+        $this->getStaticAttribute(stdClass::class, '0');
     }
 
     public function testGetStaticAttributeRaisesExceptionForInvalidSecondArgument3()
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->getStaticAttribute('stdClass', 'foo');
+        $this->getStaticAttribute(stdClass::class, 'foo');
     }
 
     public function testGetObjectAttributeRaisesExceptionForInvalidFirstArgument()
@@ -1928,56 +1928,56 @@ XML;
 
     public function testAssertPublicStaticAttributeEquals()
     {
-        $this->assertAttributeEquals('foo', 'publicStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeEquals('foo', 'publicStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertAttributeEquals('bar', 'publicStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeEquals('bar', 'publicStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertPublicStaticAttributeNotEquals()
     {
-        $this->assertAttributeNotEquals('bar', 'publicStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeNotEquals('bar', 'publicStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertAttributeNotEquals('foo', 'publicStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeNotEquals('foo', 'publicStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertProtectedStaticAttributeEquals()
     {
-        $this->assertAttributeEquals('bar', 'protectedStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeEquals('bar', 'protectedStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertAttributeEquals('foo', 'protectedStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeEquals('foo', 'protectedStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertProtectedStaticAttributeNotEquals()
     {
-        $this->assertAttributeNotEquals('foo', 'protectedStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeNotEquals('foo', 'protectedStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertAttributeNotEquals('bar', 'protectedStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeNotEquals('bar', 'protectedStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertPrivateStaticAttributeEquals()
     {
-        $this->assertAttributeEquals('baz', 'privateStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeEquals('baz', 'privateStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertAttributeEquals('foo', 'privateStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeEquals('foo', 'privateStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertPrivateStaticAttributeNotEquals()
     {
-        $this->assertAttributeNotEquals('foo', 'privateStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeNotEquals('foo', 'privateStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertAttributeNotEquals('baz', 'privateStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertAttributeNotEquals('baz', 'privateStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertClassHasAttributeThrowsException()
@@ -1998,7 +1998,7 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->assertClassHasAttribute('1', 'ClassWithNonPublicAttributes');
+        $this->assertClassHasAttribute('1', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertClassNotHasAttributeThrowsException()
@@ -2019,7 +2019,7 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->assertClassNotHasAttribute('1', 'ClassWithNonPublicAttributes');
+        $this->assertClassNotHasAttribute('1', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertClassHasStaticAttributeThrowsException()
@@ -2040,7 +2040,7 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->assertClassHasStaticAttribute('1', 'ClassWithNonPublicAttributes');
+        $this->assertClassHasStaticAttribute('1', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertClassNotHasStaticAttributeThrowsException()
@@ -2061,7 +2061,7 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->assertClassNotHasStaticAttribute('1', 'ClassWithNonPublicAttributes');
+        $this->assertClassNotHasStaticAttribute('1', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertObjectHasAttributeThrowsException()
@@ -2082,7 +2082,7 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->assertObjectHasAttribute('1', 'ClassWithNonPublicAttributes');
+        $this->assertObjectHasAttribute('1', ClassWithNonPublicAttributes::class);
     }
 
     public function testAssertObjectNotHasAttributeThrowsException()
@@ -2103,43 +2103,43 @@ XML;
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        $this->assertObjectNotHasAttribute('1', 'ClassWithNonPublicAttributes');
+        $this->assertObjectNotHasAttribute('1', ClassWithNonPublicAttributes::class);
     }
 
     public function testClassHasPublicAttribute()
     {
-        $this->assertClassHasAttribute('publicAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassHasAttribute('publicAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertClassHasAttribute('attribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassHasAttribute('attribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testClassNotHasPublicAttribute()
     {
-        $this->assertClassNotHasAttribute('attribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassNotHasAttribute('attribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertClassNotHasAttribute('publicAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassNotHasAttribute('publicAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testClassHasPublicStaticAttribute()
     {
-        $this->assertClassHasStaticAttribute('publicStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassHasStaticAttribute('publicStaticAttribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertClassHasStaticAttribute('attribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassHasStaticAttribute('attribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testClassNotHasPublicStaticAttribute()
     {
-        $this->assertClassNotHasStaticAttribute('attribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassNotHasStaticAttribute('attribute', ClassWithNonPublicAttributes::class);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertClassNotHasStaticAttribute('publicStaticAttribute', 'ClassWithNonPublicAttributes');
+        $this->assertClassNotHasStaticAttribute('publicStaticAttribute', ClassWithNonPublicAttributes::class);
     }
 
     public function testObjectHasPublicAttribute()
@@ -2344,7 +2344,7 @@ XML;
 
     public function testAssertThatContainsOnlyInstancesOf()
     {
-        $this->assertThat([new Book], $this->containsOnlyInstancesOf('Book'));
+        $this->assertThat([new Book], $this->containsOnlyInstancesOf(Book::class));
     }
 
     public function testAssertThatArrayHasKey()
@@ -2996,11 +2996,11 @@ XML;
 
     public function testAssertInstanceOf()
     {
-        $this->assertInstanceOf('stdClass', new stdClass);
+        $this->assertInstanceOf(stdClass::class, new stdClass);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertInstanceOf('Exception', new stdClass);
+        $this->assertInstanceOf(\Exception::class, new stdClass);
     }
 
     public function testAssertInstanceOfThrowsExceptionForInvalidArgument()
@@ -3015,16 +3015,16 @@ XML;
         $o    = new stdClass;
         $o->a = new stdClass;
 
-        $this->assertAttributeInstanceOf('stdClass', 'a', $o);
+        $this->assertAttributeInstanceOf(stdClass::class, 'a', $o);
     }
 
     public function testAssertNotInstanceOf()
     {
-        $this->assertNotInstanceOf('Exception', new stdClass);
+        $this->assertNotInstanceOf(\Exception::class, new stdClass);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertNotInstanceOf('stdClass', new stdClass);
+        $this->assertNotInstanceOf(stdClass::class, new stdClass);
     }
 
     public function testAssertNotInstanceOfThrowsExceptionForInvalidArgument()
@@ -3039,7 +3039,7 @@ XML;
         $o    = new stdClass;
         $o->a = new stdClass;
 
-        $this->assertAttributeNotInstanceOf('Exception', 'a', $o);
+        $this->assertAttributeNotInstanceOf(\Exception::class, 'a', $o);
     }
 
     public function testAssertInternalType()

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -1092,14 +1092,14 @@ EOF
 
     public function testConstraintIsInstanceOf()
     {
-        $constraint = Assert::isInstanceOf('Exception');
+        $constraint = Assert::isInstanceOf(Exception::class);
 
         $this->assertFalse($constraint->evaluate(new stdClass, '', true));
-        $this->assertTrue($constraint->evaluate(new \Exception, '', true));
+        $this->assertTrue($constraint->evaluate(new Exception, '', true));
         $this->assertEquals('is instance of class "Exception"', $constraint->toString());
         $this->assertCount(1, $constraint);
 
-        $interfaceConstraint = Assert::isInstanceOf('Countable');
+        $interfaceConstraint = Assert::isInstanceOf(Countable::class);
         $this->assertFalse($interfaceConstraint->evaluate(new stdClass, '', true));
         $this->assertTrue($interfaceConstraint->evaluate(new ArrayObject, '', true));
         $this->assertEquals('is instance of interface "Countable"', $interfaceConstraint->toString());
@@ -1124,7 +1124,7 @@ EOF
 
     public function testConstraintIsInstanceOf2()
     {
-        $constraint = Assert::isInstanceOf('Exception');
+        $constraint = Assert::isInstanceOf(Exception::class);
 
         try {
             $constraint->evaluate(new stdClass, 'custom message');
@@ -1147,7 +1147,7 @@ EOF
     public function testConstraintIsNotInstanceOf()
     {
         $constraint = Assert::logicalNot(
-          PHPUnit\Framework\Assert::isInstanceOf('stdClass')
+          PHPUnit\Framework\Assert::isInstanceOf(stdClass::class)
         );
 
         $this->assertFalse($constraint->evaluate(new stdClass, '', true));
@@ -1176,7 +1176,7 @@ EOF
     public function testConstraintIsNotInstanceOf2()
     {
         $constraint = Assert::logicalNot(
-          PHPUnit\Framework\Assert::isInstanceOf('stdClass')
+          PHPUnit\Framework\Assert::isInstanceOf(stdClass::class)
         );
 
         try {
@@ -1573,7 +1573,7 @@ EOF
         $constraint = Assert::callback($callback);
         $this->assertTrue($constraint->evaluate(false,  '', true));
 
-        $callback   = ['Framework_ConstraintTest', 'staticCallbackReturningTrue'];
+        $callback   = [Framework_ConstraintTest::class, 'staticCallbackReturningTrue'];
         $constraint = Assert::callback($callback);
         $this->assertTrue($constraint->evaluate(null, '', true));
 
@@ -1683,13 +1683,13 @@ EOF
     {
         $constraint = Assert::classHasAttribute('privateAttribute');
 
-        $this->assertTrue($constraint->evaluate('ClassWithNonPublicAttributes', '', true));
-        $this->assertFalse($constraint->evaluate('stdClass', '', true));
+        $this->assertTrue($constraint->evaluate(ClassWithNonPublicAttributes::class, '', true));
+        $this->assertFalse($constraint->evaluate(stdClass::class, '', true));
         $this->assertEquals('has attribute "privateAttribute"', $constraint->toString());
         $this->assertCount(1, $constraint);
 
         try {
-            $constraint->evaluate('stdClass');
+            $constraint->evaluate(stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
               <<<EOF
@@ -1711,7 +1711,7 @@ EOF
         $constraint = Assert::classHasAttribute('privateAttribute');
 
         try {
-            $constraint->evaluate('stdClass', 'custom message');
+            $constraint->evaluate(stdClass::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(<<<EOF
 custom message
@@ -1734,13 +1734,13 @@ EOF
           PHPUnit\Framework\Assert::classHasAttribute('privateAttribute')
         );
 
-        $this->assertTrue($constraint->evaluate('stdClass', '', true));
-        $this->assertFalse($constraint->evaluate('ClassWithNonPublicAttributes', '', true));
+        $this->assertTrue($constraint->evaluate(stdClass::class, '', true));
+        $this->assertFalse($constraint->evaluate(ClassWithNonPublicAttributes::class, '', true));
         $this->assertEquals('does not have attribute "privateAttribute"', $constraint->toString());
         $this->assertCount(1, $constraint);
 
         try {
-            $constraint->evaluate('ClassWithNonPublicAttributes');
+            $constraint->evaluate(ClassWithNonPublicAttributes::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
               <<<EOF
@@ -1764,7 +1764,7 @@ EOF
         );
 
         try {
-            $constraint->evaluate('ClassWithNonPublicAttributes', 'custom message');
+            $constraint->evaluate(ClassWithNonPublicAttributes::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(<<<EOF
 custom message
@@ -1785,13 +1785,13 @@ EOF
     {
         $constraint = Assert::classHasStaticAttribute('privateStaticAttribute');
 
-        $this->assertTrue($constraint->evaluate('ClassWithNonPublicAttributes', '', true));
-        $this->assertFalse($constraint->evaluate('stdClass', '', true));
+        $this->assertTrue($constraint->evaluate(ClassWithNonPublicAttributes::class, '', true));
+        $this->assertFalse($constraint->evaluate(stdClass::class, '', true));
         $this->assertEquals('has static attribute "privateStaticAttribute"', $constraint->toString());
         $this->assertCount(1, $constraint);
 
         try {
-            $constraint->evaluate('stdClass');
+            $constraint->evaluate(stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
               <<<EOF
@@ -1813,7 +1813,7 @@ EOF
         $constraint = Assert::classHasStaticAttribute('foo');
 
         try {
-            $constraint->evaluate('stdClass', 'custom message');
+            $constraint->evaluate(stdClass::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(<<<EOF
 custom message
@@ -1836,13 +1836,13 @@ EOF
           PHPUnit\Framework\Assert::classHasStaticAttribute('privateStaticAttribute')
         );
 
-        $this->assertTrue($constraint->evaluate('stdClass', '', true));
-        $this->assertFalse($constraint->evaluate('ClassWithNonPublicAttributes', '', true));
+        $this->assertTrue($constraint->evaluate(stdClass::class, '', true));
+        $this->assertFalse($constraint->evaluate(ClassWithNonPublicAttributes::class, '', true));
         $this->assertEquals('does not have static attribute "privateStaticAttribute"', $constraint->toString());
         $this->assertCount(1, $constraint);
 
         try {
-            $constraint->evaluate('ClassWithNonPublicAttributes');
+            $constraint->evaluate(ClassWithNonPublicAttributes::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
               <<<EOF
@@ -1866,7 +1866,7 @@ EOF
         );
 
         try {
-            $constraint->evaluate('ClassWithNonPublicAttributes', 'custom message');
+            $constraint->evaluate(ClassWithNonPublicAttributes::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(<<<EOF
 custom message

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -64,9 +64,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testAddTestSuite()
     {
-        $suite = new TestSuite(
-            'OneTestCase'
-        );
+        $suite = new TestSuite(OneTestCase::class);
 
         $suite->run($this->result);
 
@@ -75,9 +73,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testInheritedTests()
     {
-        $suite = new TestSuite(
-            'InheritedTestCase'
-        );
+        $suite = new TestSuite(InheritedTestCase::class);
 
         $suite->run($this->result);
 
@@ -87,9 +83,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testNoTestCases()
     {
-        $suite = new TestSuite(
-            'NoTestCases'
-        );
+        $suite = new TestSuite(NoTestCases::class);
 
         $suite->run($this->result);
 
@@ -103,7 +97,7 @@ class Framework_SuiteTest extends TestCase
     {
         $this->expectException(PHPUnit\Framework\Exception::class);
 
-        new TestSuite('NoTestCaseClass');
+        new TestSuite(NoTestCaseClass::class);
     }
 
     public function testNotExistingTestCase()
@@ -119,27 +113,21 @@ class Framework_SuiteTest extends TestCase
 
     public function testNotPublicTestCase()
     {
-        $suite = new TestSuite(
-            'NotPublicTestCase'
-        );
+        $suite = new TestSuite(NotPublicTestCase::class);
 
         $this->assertCount(2, $suite);
     }
 
     public function testNotVoidTestCase()
     {
-        $suite = new TestSuite(
-            'NotVoidTestCase'
-        );
+        $suite = new TestSuite(NotVoidTestCase::class);
 
         $this->assertCount(1, $suite);
     }
 
     public function testOneTestCase()
     {
-        $suite = new TestSuite(
-            'OneTestCase'
-        );
+        $suite = new TestSuite(OneTestCase::class);
 
         $suite->run($this->result);
 
@@ -151,9 +139,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testShadowedTests()
     {
-        $suite = new TestSuite(
-            'OverrideTestCase'
-        );
+        $suite = new TestSuite(OverrideTestCase::class);
 
         $suite->run($this->result);
 
@@ -162,9 +148,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testBeforeClassAndAfterClassAnnotations()
     {
-        $suite = new TestSuite(
-            'BeforeClassAndAfterClassTest'
-        );
+        $suite = new TestSuite(BeforeClassAndAfterClassTest::class);
 
         BeforeClassAndAfterClassTest::resetProperties();
         $suite->run($this->result);
@@ -175,9 +159,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testBeforeClassWithDataProviders()
     {
-        $suite = new TestSuite(
-            'BeforeClassWithOnlyDataProviderTest'
-        );
+        $suite = new TestSuite(BeforeClassWithOnlyDataProviderTest::class);
 
         BeforeClassWithOnlyDataProviderTest::resetProperties();
         $suite->run($this->result);
@@ -188,9 +170,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testBeforeAnnotation()
     {
-        $test = new TestSuite(
-            'BeforeAndAfterTest'
-        );
+        $test = new TestSuite(BeforeAndAfterTest::class);
 
         BeforeAndAfterTest::resetProperties();
         $result = $test->run();
@@ -201,9 +181,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testTestWithAnnotation()
     {
-        $test = new TestSuite(
-            'TestWithTest'
-        );
+        $test = new TestSuite(TestWithTest::class);
 
         BeforeAndAfterTest::resetProperties();
         $result = $test->run();
@@ -213,7 +191,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testSkippedTestDataProvider()
     {
-        $suite = new TestSuite('DataProviderSkippedTest');
+        $suite = new TestSuite(DataProviderSkippedTest::class);
 
         $suite->run($this->result);
 
@@ -236,7 +214,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testIncompleteTestDataProvider()
     {
-        $suite = new TestSuite('DataProviderIncompleteTest');
+        $suite = new TestSuite(DataProviderIncompleteTest::class);
 
         $suite->run($this->result);
 
@@ -246,9 +224,7 @@ class Framework_SuiteTest extends TestCase
 
     public function testRequirementsBeforeClassHook()
     {
-        $suite = new TestSuite(
-            'RequirementsClassBeforeClassHookTest'
-        );
+        $suite = new TestSuite(RequirementsClassBeforeClassHookTest::class);
 
         $suite->run($this->result);
 

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -169,7 +169,7 @@ class Framework_TestCaseTest extends TestCase
     public function testNoArgTestCasePasses()
     {
         $result = new TestResult;
-        $t      = new TestSuite('NoArgTestCaseTest');
+        $t      = new TestSuite(NoArgTestCaseTest::class);
 
         $t->run($result);
 

--- a/tests/Regression/GitHub/1351/Issue1351Test.php
+++ b/tests/Regression/GitHub/1351/Issue1351Test.php
@@ -17,7 +17,7 @@ class Issue1351Test extends TestCase
     public function testFailurePost()
     {
         $this->assertNull($this->instance);
-        $this->assertFalse(class_exists('ChildProcessClass1351', false), 'ChildProcessClass1351 is not loaded.');
+        $this->assertFalse(class_exists(ChildProcessClass1351::class, false), 'ChildProcessClass1351 is not loaded.');
     }
 
     /**
@@ -36,7 +36,7 @@ class Issue1351Test extends TestCase
     public function testExceptionPost()
     {
         $this->assertNull($this->instance);
-        $this->assertFalse(class_exists('ChildProcessClass1351', false), 'ChildProcessClass1351 is not loaded.');
+        $this->assertFalse(class_exists(ChildProcessClass1351::class, false), 'ChildProcessClass1351 is not loaded.');
     }
 
     public function testPhpCoreLanguageException()

--- a/tests/Regression/Trac/783/ChildSuite.php
+++ b/tests/Regression/Trac/783/ChildSuite.php
@@ -9,8 +9,8 @@ class ChildSuite
     public static function suite()
     {
         $suite = new TestSuite('Child');
-        $suite->addTestSuite('OneTest');
-        $suite->addTestSuite('TwoTest');
+        $suite->addTestSuite(OneTest::class);
+        $suite->addTestSuite(TwoTest::class);
 
         return $suite;
     }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -33,68 +33,68 @@ class Util_TestTest extends TestCase
     {
         $this->assertArraySubset(
           ['class' => 'FooBarBaz', 'code' => null, 'message' => ''],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testOne')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testOne')
         );
 
         $this->assertArraySubset(
           ['class' => 'Foo_Bar_Baz', 'code' => null, 'message' => ''],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testTwo')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testTwo')
         );
 
         $this->assertArraySubset(
-          ['class' => 'Foo\Bar\Baz', 'code' => null, 'message' => ''],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testThree')
+          ['class' => \Foo\Bar\Baz::class, 'code' => null, 'message' => ''],
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testThree')
         );
 
         $this->assertArraySubset(
           ['class' => 'ほげ', 'code' => null, 'message' => ''],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testFour')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testFour')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => 1234, 'message' => 'Message'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testFive')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testFive')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => 1234, 'message' => 'Message'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testSix')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testSix')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => 'ExceptionCode', 'message' => 'Message'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testSeven')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testSeven')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => 0, 'message' => 'Message'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testEight')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testEight')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => ExceptionTest::ERROR_CODE, 'message' => ExceptionTest::ERROR_MESSAGE],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testNine')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testNine')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => null, 'message' => ''],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testSingleLine')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testSingleLine')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => My\Space\ExceptionNamespaceTest::ERROR_CODE, 'message' => My\Space\ExceptionNamespaceTest::ERROR_MESSAGE],
-          \PHPUnit\Util\Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testConstants')
+          \PHPUnit\Util\Test::getExpectedException(My\Space\ExceptionNamespaceTest::class, 'testConstants')
         );
 
         // Ensure the Class::CONST expression is only evaluated when the constant really exists
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => 'ExceptionTest::UNKNOWN_CODE_CONSTANT', 'message' => 'ExceptionTest::UNKNOWN_MESSAGE_CONSTANT'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testUnknownConstants')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testUnknownConstants')
         );
 
         $this->assertArraySubset(
           ['class' => 'Class', 'code' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_CODE_CONSTANT', 'message' => 'My\Space\ExceptionNamespaceTest::UNKNOWN_MESSAGE_CONSTANT'],
-          \PHPUnit\Util\Test::getExpectedException('My\Space\ExceptionNamespaceTest', 'testUnknownConstants')
+          \PHPUnit\Util\Test::getExpectedException(My\Space\ExceptionNamespaceTest::class, 'testUnknownConstants')
         );
     }
 
@@ -102,17 +102,17 @@ class Util_TestTest extends TestCase
     {
         $this->assertArraySubset(
           ['message_regex' => '#regex#'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testWithRegexMessage')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testWithRegexMessage')
         );
 
         $this->assertArraySubset(
           ['message_regex' => '#regex#'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testWithRegexMessageFromClassConstant')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testWithRegexMessageFromClassConstant')
         );
 
         $this->assertArraySubset(
           ['message_regex' => 'ExceptionTest::UNKNOWN_MESSAGE_REGEX_CONSTANT'],
-          \PHPUnit\Util\Test::getExpectedException('ExceptionTest', 'testWithUnknowRegexMessageFromClassConstant')
+          \PHPUnit\Util\Test::getExpectedException(ExceptionTest::class, 'testWithUnknowRegexMessageFromClassConstant')
         );
     }
 
@@ -123,7 +123,7 @@ class Util_TestTest extends TestCase
     {
         $this->assertEquals(
             $result,
-            \PHPUnit\Util\Test::getRequirements('RequirementsTest', $test)
+            \PHPUnit\Util\Test::getRequirements(RequirementsTest::class, $test)
         );
     }
 
@@ -336,7 +336,7 @@ class Util_TestTest extends TestCase
 
         $this->assertEquals(
             $expectedAnnotations,
-            \PHPUnit\Util\Test::getRequirements('RequirementsClassDocBlockTest', 'testMethod')
+            \PHPUnit\Util\Test::getRequirements(RequirementsClassDocBlockTest::class, 'testMethod')
         );
     }
 
@@ -347,7 +347,7 @@ class Util_TestTest extends TestCase
     {
         $this->assertEquals(
             $result,
-            \PHPUnit\Util\Test::getMissingRequirements('RequirementsTest', $test)
+            \PHPUnit\Util\Test::getMissingRequirements(RequirementsTest::class, $test)
         );
     }
 
@@ -425,7 +425,7 @@ class Util_TestTest extends TestCase
      */
     public function testMultipleDataProviders()
     {
-        $dataSets = \PHPUnit\Util\Test::getProvidedData('MultipleDataProviderTest', 'testOne');
+        $dataSets = \PHPUnit\Util\Test::getProvidedData(MultipleDataProviderTest::class, 'testOne');
 
         $this->assertCount(9, $dataSets);
 
@@ -446,7 +446,7 @@ class Util_TestTest extends TestCase
 
     public function testMultipleYieldIteratorDataProviders()
     {
-        $dataSets = \PHPUnit\Util\Test::getProvidedData('MultipleDataProviderTest', 'testTwo');
+        $dataSets = \PHPUnit\Util\Test::getProvidedData(MultipleDataProviderTest::class, 'testTwo');
 
         $this->assertEquals(9, count($dataSets));
 
@@ -710,7 +710,7 @@ class Util_TestTest extends TestCase
                 TEST_FILES_PATH . 'NamespaceCoveredFunction.php' => range(4, 7)
             ],
             \PHPUnit\Util\Test::getLinesToBeCovered(
-                'CoverageNamespacedFunctionTest',
+                CoverageNamespacedFunctionTest::class,
                 'testFunc'
             )
         );

--- a/tests/_files/DependencyTestSuite.php
+++ b/tests/_files/DependencyTestSuite.php
@@ -7,8 +7,8 @@ class DependencyTestSuite
     {
         $suite = new TestSuite('Test Dependencies');
 
-        $suite->addTestSuite('DependencySuccessTest');
-        $suite->addTestSuite('DependencyFailureTest');
+        $suite->addTestSuite(DependencySuccessTest::class);
+        $suite->addTestSuite(DependencyFailureTest::class);
 
         return $suite;
     }

--- a/tests/_files/StopOnWarningTestSuite.php
+++ b/tests/_files/StopOnWarningTestSuite.php
@@ -7,8 +7,8 @@ class StopOnWarningTestSuite
     {
         $suite = new TestSuite('Test Warnings');
 
-        $suite->addTestSuite('NoTestCases');
-        $suite->addTestSuite('CoverageClassTest');
+        $suite->addTestSuite(NoTestCases::class);
+        $suite->addTestSuite(CoverageClassTest::class);
 
         return $suite;
     }


### PR DESCRIPTION
This PR

* [x] makes use of the `class` keyword instead of referencing class names via string literals