### PR TITLE
Fix: Remove unused local variables

### DIFF
--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -173,7 +173,7 @@ class Framework_SuiteTest extends TestCase
         $test = new TestSuite(BeforeAndAfterTest::class);
 
         BeforeAndAfterTest::resetProperties();
-        $result = $test->run();
+        $test->run();
 
         $this->assertEquals(2, BeforeAndAfterTest::$beforeWasRun);
         $this->assertEquals(2, BeforeAndAfterTest::$afterWasRun);

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -109,7 +109,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionInSetUp()
     {
         $test   = new ExceptionInSetUpTest('testSomething');
-        $result = $test->run();
+        $test->run();
 
         $this->assertTrue($test->setUp);
         $this->assertFalse($test->assertPreConditions);
@@ -121,7 +121,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionInAssertPreConditions()
     {
         $test   = new ExceptionInAssertPreConditionsTest('testSomething');
-        $result = $test->run();
+        $test->run();
 
         $this->assertTrue($test->setUp);
         $this->assertTrue($test->assertPreConditions);
@@ -133,7 +133,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionInTest()
     {
         $test   = new ExceptionInTest('testSomething');
-        $result = $test->run();
+        $test->run();
 
         $this->assertTrue($test->setUp);
         $this->assertTrue($test->assertPreConditions);
@@ -145,7 +145,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionInAssertPostConditions()
     {
         $test   = new ExceptionInAssertPostConditionsTest('testSomething');
-        $result = $test->run();
+        $test->run();
 
         $this->assertTrue($test->setUp);
         $this->assertTrue($test->assertPreConditions);
@@ -157,7 +157,7 @@ class Framework_TestCaseTest extends TestCase
     public function testExceptionInTearDown()
     {
         $test   = new ExceptionInTearDownTest('testSomething');
-        $result = $test->run();
+        $test->run();
 
         $this->assertTrue($test->setUp);
         $this->assertTrue($test->assertPreConditions);
@@ -503,7 +503,7 @@ class Framework_TestCaseTest extends TestCase
     public function testSkipsIfRequiresNonExistingExtension()
     {
         $test   = new RequirementsTest('testTen');
-        $result = $test->run();
+        $test->run();
 
         $this->assertEquals(
             'Extension testExt is required.',
@@ -514,7 +514,7 @@ class Framework_TestCaseTest extends TestCase
     public function testSkipsIfRequiresExtensionWithAMinimumVersion()
     {
         $test   = new RequirementsTest('testSpecificExtensionVersion');
-        $result = $test->run();
+        $test->run();
 
         $this->assertEquals(
             'Extension testExt >= 1.8.0 is required.',
@@ -525,7 +525,7 @@ class Framework_TestCaseTest extends TestCase
     public function testSkipsProvidesMessagesForAllSkippingReasons()
     {
         $test   = new RequirementsTest('testAllPossibleRequirements');
-        $result = $test->run();
+        $test->run();
 
         $this->assertEquals(
             'PHP >= 99-dev is required.' . PHP_EOL .


### PR DESCRIPTION
This PR

* [x] removes unused local variables