### PR TITLE
Fix: Return early

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2844,17 +2844,19 @@ abstract class Assert
                 $classOrObject,
                 $attributeName
             );
-        } elseif (is_object($classOrObject)) {
+        }
+
+        if (is_object($classOrObject)) {
             return static::getObjectAttribute(
                 $classOrObject,
                 $attributeName
             );
-        } else {
-            throw InvalidArgumentHelper::factory(
-                1,
-                'class name or object'
-            );
         }
+
+        throw InvalidArgumentHelper::factory(
+            1,
+            'class name or object'
+        );
     }
 
     /**

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -64,9 +64,9 @@ class ArraySubset extends Constraint
 
         if ($this->strict) {
             return $other === $patched;
-        } else {
-            return $other == $patched;
         }
+
+        return $other == $patched;
     }
 
     /**

--- a/src/Framework/Constraint/ClassHasStaticAttribute.php
+++ b/src/Framework/Constraint/ClassHasStaticAttribute.php
@@ -35,9 +35,9 @@ class ClassHasStaticAttribute extends ClassHasAttribute
             $attribute = $class->getProperty($this->attributeName);
 
             return $attribute->isStatic();
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -53,7 +53,9 @@ class Count extends Constraint
     {
         if ($other instanceof Countable || is_array($other)) {
             return count($other);
-        } elseif ($other instanceof Traversable) {
+        }
+
+        if ($other instanceof Traversable) {
             if ($other instanceof IteratorAggregate) {
                 $iterator = $other->getIterator();
             } else {

--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -158,25 +158,25 @@ class IsEqual extends Constraint
         if (is_string($this->value)) {
             if (strpos($this->value, "\n") !== false) {
                 return 'is equal to <text>';
-            } else {
-                return sprintf(
-                    'is equal to <string:%s>',
-                    $this->value
-                );
-            }
-        } else {
-            if ($this->delta != 0) {
-                $delta = sprintf(
-                    ' with delta <%F>',
-                    $this->delta
-                );
             }
 
             return sprintf(
-                'is equal to %s%s',
-                $this->exporter->export($this->value),
-                $delta
+                'is equal to <string:%s>',
+                $this->value
             );
         }
+
+        if ($this->delta != 0) {
+            $delta = sprintf(
+                ' with delta <%F>',
+                $this->delta
+            );
+        }
+
+        return sprintf(
+            'is equal to %s%s',
+            $this->exporter->export($this->value),
+            $delta
+        );
     }
 }

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -128,9 +128,8 @@ class IsIdentical extends Constraint
         if (is_object($this->value)) {
             return 'is identical to an object of class "' .
                 get_class($this->value) . '"';
-        } else {
-            return 'is identical to ' .
-                $this->exporter->export($this->value);
         }
+
+        return 'is identical to ' . $this->exporter->export($this->value);
     }
 }

--- a/src/Framework/Constraint/StringContains.php
+++ b/src/Framework/Constraint/StringContains.php
@@ -54,9 +54,9 @@ class StringContains extends Constraint
     {
         if ($this->ignoreCase) {
             return mb_stripos($other, $this->string) !== false;
-        } else {
-            return mb_strpos($other, $this->string) !== false;
         }
+
+        return mb_strpos($other, $this->string) !== false;
     }
 
     /**

--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -75,7 +75,9 @@ class TraversableContains extends Constraint
             foreach ($other as $element) {
                 if ($this->checkForObjectIdentity && $element === $this->value) {
                     return true;
-                } elseif (!$this->checkForObjectIdentity && $element == $this->value) {
+                }
+
+                if (!$this->checkForObjectIdentity && $element == $this->value) {
                     return true;
                 }
             }
@@ -83,7 +85,9 @@ class TraversableContains extends Constraint
             foreach ($other as $element) {
                 if ($this->checkForNonObjectIdentity && $element === $this->value) {
                     return true;
-                } elseif (!$this->checkForNonObjectIdentity && $element == $this->value) {
+                }
+
+                if (!$this->checkForNonObjectIdentity && $element == $this->value) {
                     return true;
                 }
             }
@@ -101,9 +105,9 @@ class TraversableContains extends Constraint
     {
         if (is_string($this->value) && strpos($this->value, "\n") !== false) {
             return 'contains "' . $this->value . '"';
-        } else {
-            return 'contains ' . $this->exporter->export($this->value);
         }
+
+        return 'contains ' . $this->exporter->export($this->value);
     }
 
     /**

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -402,9 +402,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     {
         if ($withDataSet) {
             return $this->name . $this->getDataSetAsString(false);
-        } else {
-            return $this->name;
         }
+
+        return $this->name;
     }
 
     /**
@@ -459,9 +459,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     {
         if (!$this->outputBufferingActive) {
             return $this->output;
-        } else {
-            return ob_get_contents();
         }
+
+        return ob_get_contents();
     }
 
     /**
@@ -1115,9 +1115,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 }
 
                 return;
-            } else {
-                throw $e;
             }
+
+            throw $e;
         }
 
         if ($this->expectedException !== null) {

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -96,15 +96,20 @@ class TestFailure
             if (!empty($buffer)) {
                 $buffer = trim($buffer) . "\n";
             }
-        } elseif ($e instanceof Error) {
-            $buffer = $e->getMessage() . "\n";
-        } elseif ($e instanceof ExceptionWrapper) {
-            $buffer = $e->getClassName() . ': ' . $e->getMessage() . "\n";
-        } else {
-            $buffer = get_class($e) . ': ' . $e->getMessage() . "\n";
+
+            return $buffer;
+
         }
 
-        return $buffer;
+        if ($e instanceof Error) {
+            return $e->getMessage() . "\n";
+        }
+
+        if ($e instanceof ExceptionWrapper) {
+            return $e->getClassName() . ': ' . $e->getMessage() . "\n";
+        }
+
+        return get_class($e) . ': ' . $e->getMessage() . "\n";
     }
 
     /**

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -411,16 +411,16 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
     public function count($preferCache = false)
     {
         if ($preferCache && $this->cachedNumTests !== null) {
-            $numTests = $this->cachedNumTests;
-        } else {
-            $numTests = 0;
-
-            foreach ($this as $test) {
-                $numTests += count($test);
-            }
-
-            $this->cachedNumTests = $numTests;
+            return $this->cachedNumTests;
         }
+
+        $numTests = 0;
+
+        foreach ($this as $test) {
+            $numTests += count($test);
+        }
+
+        $this->cachedNumTests = $numTests;
 
         return $numTests;
     }
@@ -800,9 +800,9 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
     {
         if (isset($this->tests[$index])) {
             return $this->tests[$index];
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -173,9 +173,9 @@ class Command
 
             if ($exit) {
                 exit(TestRunner::SUCCESS_EXIT);
-            } else {
-                return TestRunner::SUCCESS_EXIT;
             }
+
+            return TestRunner::SUCCESS_EXIT;
         }
 
         if ($this->arguments['listSuites']) {
@@ -194,9 +194,9 @@ class Command
 
             if ($exit) {
                 exit(TestRunner::SUCCESS_EXIT);
-            } else {
-                return TestRunner::SUCCESS_EXIT;
             }
+
+            return TestRunner::SUCCESS_EXIT;
         }
 
         unset($this->arguments['test']);

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -121,11 +121,9 @@ class TestRunner extends BaseTestRunner
                 $test,
                 $arguments
             );
-        } else {
-            throw new Exception(
-                'No test case or test suite found.'
-            );
         }
+
+        throw new Exception('No test case or test suite found.');
     }
 
     /**

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -1008,7 +1008,9 @@ class Configuration
     {
         if (strtolower($value) == 'false') {
             return false;
-        } elseif (strtolower($value) == 'true') {
+        }
+
+        if (strtolower($value) == 'true') {
             return true;
         }
 

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -379,9 +379,13 @@ class TeamCity extends ResultPrinter
     {
         if (is_null($value)) {
             return 'null';
-        } elseif (is_bool($value)) {
+        }
+
+        if (is_bool($value)) {
             return $value == true ? 'true' : 'false';
-        } elseif (is_scalar($value)) {
+        }
+
+        if (is_scalar($value)) {
             return print_r($value, true);
         }
     }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -54,20 +54,22 @@ class Test
         if ($asString) {
             if ($test instanceof SelfDescribing) {
                 return $test->toString();
-            } else {
-                return get_class($test);
             }
-        } else {
-            if ($test instanceof TestCase) {
-                return [
-                    get_class($test), $test->getName()
-                ];
-            } elseif ($test instanceof SelfDescribing) {
-                return ['', $test->toString()];
-            } else {
-                return ['', get_class($test)];
-            }
+
+            return get_class($test);
         }
+
+        if ($test instanceof TestCase) {
+            return [
+                get_class($test), $test->getName()
+            ];
+        }
+
+        if ($test instanceof SelfDescribing) {
+            return ['', $test->toString()];
+        }
+
+        return ['', get_class($test)];
     }
 
     /**
@@ -775,21 +777,24 @@ class Test
     public static function getSize($className, $methodName)
     {
         $groups = array_flip(self::getGroups($className, $methodName));
-        $size   = self::UNKNOWN;
         $class  = new ReflectionClass($className);
 
         if (isset($groups['large']) ||
             (class_exists('PHPUnit\DbUnit\TestCase', false) &&
                 $class->isSubclassOf('PHPUnit\DbUnit\TestCase'))
         ) {
-            $size = self::LARGE;
-        } elseif (isset($groups['medium'])) {
-            $size = self::MEDIUM;
-        } elseif (isset($groups['small'])) {
-            $size = self::SMALL;
+            return self::LARGE;
         }
 
-        return $size;
+        if (isset($groups['medium'])) {
+            return self::MEDIUM;
+        }
+
+        if (isset($groups['small'])) {
+            return self::SMALL;
+        }
+
+        return self::UNKNOWN;
     }
 
     /**
@@ -811,9 +816,9 @@ class Test
             isset($annotations['method']['runInSeparateProcess'])
         ) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -907,25 +912,27 @@ class Test
             $methodName
         );
 
-        $result = null;
-
         if (isset($annotations['class'][$settingName])) {
             if ($annotations['class'][$settingName][0] == 'enabled') {
-                $result = true;
-            } elseif ($annotations['class'][$settingName][0] == 'disabled') {
-                $result = false;
+                return true;
+            }
+
+            if ($annotations['class'][$settingName][0] == 'disabled') {
+                return false;
             }
         }
 
         if (isset($annotations['method'][$settingName])) {
             if ($annotations['method'][$settingName][0] == 'enabled') {
-                $result = true;
-            } elseif ($annotations['method'][$settingName][0] == 'disabled') {
-                $result = false;
+                return true;
+            }
+
+            if ($annotations['method'][$settingName][0] == 'disabled') {
+                return false;
             }
         }
 
-        return $result;
+        return null;
     }
 
     /**

--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -106,12 +106,13 @@ class Xml
                         $message != '' ? "\n" . $message : ''
                     )
                 );
-            } else {
-                if ($message === '') {
-                    $message = 'Could not load XML for unknown reason';
-                }
-                throw new Exception($message);
             }
+
+            if ($message === '') {
+                $message = 'Could not load XML for unknown reason';
+            }
+
+            throw new Exception($message);
         }
 
         return $document;
@@ -264,10 +265,10 @@ class Xml
     {
         if (!self::isUtf8($string)) {
             if (function_exists('mb_convert_encoding')) {
-                $string = mb_convert_encoding($string, 'UTF-8');
-            } else {
-                $string = utf8_encode($string);
+                return mb_convert_encoding($string, 'UTF-8');
             }
+
+            return utf8_encode($string);
         }
 
         return $string;


### PR DESCRIPTION
This PR

* [x] removes useless `else` and `elseif` statements where we could `return` or `throw` early instead (or already are)