### PR TITLE
Fix: assertCount will no longer cause a rewind error when given a generator (as per #2149)

### DIFF
--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of PHPUnit.
  *
@@ -7,11 +8,13 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace PHPUnit\Framework\Constraint;
 
 use Countable;
 use IteratorAggregate;
 use Traversable;
+use Generator;
 
 /**
  */
@@ -60,11 +63,15 @@ class Count extends Constraint
                 $iterator = $other;
             }
 
-            $key   = $iterator->key();
+            if ($iterator instanceof Generator) {
+                return $this->getCountOfGenerator($iterator);
+            }
+
+            $key = $iterator->key();
             $count = iterator_count($iterator);
 
-            // manually rewind $iterator to previous key, since iterator_count
-            // moves pointer
+            // Manually rewind $iterator to previous key, since iterator_count
+            // moves pointer.
             if ($key !== null) {
                 $iterator->rewind();
                 while ($iterator->valid() && $key !== $iterator->key()) {
@@ -77,7 +84,24 @@ class Count extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the total number of iterations from a generator.
+     * This will fully exhaust the generator.
+     *
+     * @param Generator $generator
+     *
+     * @return int
+     */
+    protected function getCountOfGenerator(Generator $generator)
+    {
+        for ($count = 0; $generator->valid(); $generator->next()) {
+            $count += 1;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/tests/Framework/Constraint/CountTest.php
+++ b/tests/Framework/Constraint/CountTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of PHPUnit.
  *
@@ -21,7 +22,7 @@ class CountTest extends TestCase
         $this->assertTrue($countConstraint->evaluate([], '', true));
 
         $countConstraint = new Count(2);
-        $it              = new TestIterator([1, 2]);
+        $it = new TestIterator([1, 2]);
         $this->assertTrue($countConstraint->evaluate($it, '', true));
     }
 
@@ -57,5 +58,37 @@ class CountTest extends TestCase
         $it->next();
         $countConstraint->evaluate($it, '', true);
         $this->assertFalse($it->valid());
+    }
+
+    public function testCountGeneratorsDoNotRewind()
+    {
+        $generatorMaker = new TestGeneratorMaker();
+
+        $countConstraint = new Count(3);
+
+        $generator = $generatorMaker->create([1, 2, 3]);
+        $this->assertEquals(1, $generator->current());
+        $countConstraint->evaluate($generator, '', true);
+        $this->assertEquals(null, $generator->current());
+
+        $countConstraint = new Count(2);
+
+        $generator = $generatorMaker->create([1, 2, 3]);
+        $this->assertEquals(1, $generator->current());
+        $generator->next();
+        $this->assertEquals(2, $generator->current());
+        $countConstraint->evaluate($generator, '', true);
+        $this->assertEquals(null, $generator->current());
+
+        $countConstraint = new Count(1);
+
+        $generator = $generatorMaker->create([1, 2, 3]);
+        $this->assertEquals(1, $generator->current());
+        $generator->next();
+        $this->assertEquals(2, $generator->current());
+        $generator->next();
+        $this->assertEquals(3, $generator->current());
+        $countConstraint->evaluate($generator, '', true);
+        $this->assertEquals(null, $generator->current());
     }
 }

--- a/tests/_files/TestGeneratorMaker.php
+++ b/tests/_files/TestGeneratorMaker.php
@@ -1,0 +1,11 @@
+<?php
+
+class TestGeneratorMaker
+{
+    public function create($array = [])
+    {
+        foreach ($array as $key => $value) {
+            yield $key => $value;
+        }
+    }
+}


### PR DESCRIPTION
Hi, first attempt at a pull request, attempting to tackle #2149!

The issue was found to be in two areas in Framework\Constraint\Count::getCountOf:

1. Firstly, where a generator had already been iterated at least once, `iterator_count()` attempted to rewind the generator object which fired off the error.
2. Secondly, where a generator had not been iterated through at all, after the `iterator_count()` call exhausted it, the method would then attempt to rewind the generator object to set it back to the original position, also causing the error.

The fix attempts to get around this by looping through the generator itself and counting up the times it was iterated. Non-generators are not affected by this change.

A new test was added to cover both a fresh generator and a generator which had been partially exhausted already.

The caveats from this are that the generator will always be fully exhausted as a result of the assertion, and that counting a partially exhausted generator will only be able to return the count from its current position to the end.

Feedback is appreciated!