### PR TITLE
Feature defaultTestSuite

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -230,6 +230,7 @@
     <xs:attribute name="timeoutForLargeTests" type="xs:integer" default="60"/>
     <xs:attribute name="testSuiteLoaderClass" type="xs:string" default="PHPUnit_Runner_StandardTestSuiteLoader"/>
     <xs:attribute name="testSuiteLoaderFile" type="xs:anyURI"/>
+    <xs:attribute name="defaultTestSuite" type="xs:string" default=""/>
     <xs:attribute name="verbose" type="xs:boolean" default="false"/>
     <xs:attribute name="stderr" type="xs:boolean" default="false"/>
     <xs:attribute name="reverseDefectList" type="xs:boolean" default="false"/>

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -769,7 +769,7 @@ class Command
                     $file
                 );
             }
-            
+
             if (!isset($this->arguments['testsuite']) && isset($phpunitConfiguration['defaultTestSuite'])) {
                 $this->arguments['testsuite'] = $phpunitConfiguration['defaultTestSuite'];
             }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -769,6 +769,10 @@ class Command
                     $file
                 );
             }
+            
+            if (!isset($this->arguments['testsuite']) && isset($phpunitConfiguration['defaultTestSuite'])) {
+                $this->arguments['testsuite'] = $phpunitConfiguration['defaultTestSuite'];
+            }
 
             if (!isset($this->arguments['test'])) {
                 $testSuite = $configuration->getTestSuiteConfiguration(isset($this->arguments['testsuite']) ? $this->arguments['testsuite'] : null);

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -46,6 +46,7 @@ use PHPUnit\TextUI\ResultPrinter;
  *          extensionsDirectory="tools/phpunit.d"
  *          printerClass="PHPUnit\TextUI\ResultPrinter"
  *          testSuiteLoaderClass="PHPUnit\Runner\StandardTestSuiteLoader"
+ *          defaultTestSuite=""
  *          beStrictAboutChangesToGlobalState="false"
  *          beStrictAboutCoversAnnotation="false"
  *          beStrictAboutOutputDuringTests="false"
@@ -713,6 +714,12 @@ class Configuration
             );
         }
 
+        if ($root->hasAttribute('defaultTestSuite')) {
+            $result['defaultTestSuite'] = (string) $root->getAttribute(
+                'defaultTestSuite'
+            );
+        }
+        
         if ($root->getAttribute('testSuiteLoaderFile')) {
             $result['testSuiteLoaderFile'] = $this->toAbsolutePath(
                 (string) $root->getAttribute('testSuiteLoaderFile')

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -719,7 +719,7 @@ class Configuration
                 'defaultTestSuite'
             );
         }
-        
+
         if ($root->getAttribute('testSuiteLoaderFile')) {
             $result['testSuiteLoaderFile'] = $this->toAbsolutePath(
                 (string) $root->getAttribute('testSuiteLoaderFile')

--- a/tests/TextUI/defaulttestsuite-using-testsuite.phpt
+++ b/tests/TextUI/defaulttestsuite-using-testsuite.phpt
@@ -1,0 +1,17 @@
+--TEST--
+phpunit --testdox --configuration=__DIR__.'/../_files/configuration.defaulttestsuite.xml' --testsuite 'First'
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--testdox';
+$_SERVER['argv'][2] = '--configuration';
+$_SERVER['argv'][3] = __DIR__.'/../_files/configuration.defaulttestsuite.xml';
+$_SERVER['argv'][4] = '--testsuite';
+$_SERVER['argv'][5] = 'First';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+DummyFoo
+ [x] Foo equals foo

--- a/tests/TextUI/defaulttestsuite.phpt
+++ b/tests/TextUI/defaulttestsuite.phpt
@@ -1,0 +1,15 @@
+--TEST--
+phpunit --testdox --configuration=__DIR__.'/../_files/configuration.defaulttestsuite.xml'
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--testdox';
+$_SERVER['argv'][2] = '--configuration';
+$_SERVER['argv'][3] = __DIR__.'/../_files/configuration.defaulttestsuite.xml';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+DummyBar
+ [x] Bar equals bar

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -437,7 +437,7 @@ class Util_ConfigurationTest extends TestCase
         );
 
         $config = $configuration->getTestSuiteConfiguration();
-        $tests = $config->tests();
+        $tests  = $config->tests();
 
         $this->assertEquals(1, count($tests));
     }

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -319,6 +319,7 @@ class Util_ConfigurationTest extends TestCase
             'extensionsDirectory'                        => '/tmp',
             'printerClass'                               => 'PHPUnit\TextUI\ResultPrinter',
             'testSuiteLoaderClass'                       => 'PHPUnit\Runner\StandardTestSuiteLoader',
+            'defaultTestSuite'                           => 'My Test Suite',
             'verbose'                                    => false,
             'timeoutForSmallTests'                       => 1,
             'timeoutForMediumTests'                      => 10,

--- a/tests/_files/DummyBarTest.php
+++ b/tests/_files/DummyBarTest.php
@@ -1,5 +1,12 @@
 <?php
-
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 use PHPUnit\Framework\TestCase;
 
 class DummyBarTest extends TestCase

--- a/tests/_files/DummyBarTest.php
+++ b/tests/_files/DummyBarTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DummyBarTest extends TestCase
+{
+    public function testBarEqualsBar()
+    {
+        $this->assertEquals('Bar', 'Bar');
+    }
+}

--- a/tests/_files/DummyFooTest.php
+++ b/tests/_files/DummyFooTest.php
@@ -1,5 +1,12 @@
 <?php
-
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 use PHPUnit\Framework\TestCase;
 
 class DummyFooTest extends TestCase

--- a/tests/_files/DummyFooTest.php
+++ b/tests/_files/DummyFooTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DummyFooTest extends TestCase
+{
+    public function testFooEqualsFoo()
+    {
+        $this->assertEquals('Foo', 'Foo');
+    }
+}

--- a/tests/_files/configuration.defaulttestsuite.xml
+++ b/tests/_files/configuration.defaulttestsuite.xml
@@ -1,0 +1,10 @@
+<phpunit defaultTestSuite="Second">
+    <testsuites>
+        <testsuite name="First">
+            <file>../_files/DummyFooTest.php</file>
+        </testsuite>
+        <testsuite name="Second">
+            <file>../_files/DummyBarTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -18,6 +18,7 @@
          extensionsDirectory="/tmp"
          printerClass="PHPUnit\TextUI\ResultPrinter"
          testSuiteLoaderClass="PHPUnit\Runner\StandardTestSuiteLoader"
+         defaultTestSuite="My Test Suite"
          beStrictAboutChangesToGlobalState="false"
          beStrictAboutOutputDuringTests="false"
          beStrictAboutResourceUsageDuringSmallTests="false"

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -18,6 +18,7 @@
          extensionsDirectory="/tmp"
          printerClass="PHPUnit\TextUI\ResultPrinter"
          testSuiteLoaderClass="PHPUnit\Runner\StandardTestSuiteLoader"
+         defaultTestSuite="My Test Suite"
          beStrictAboutChangesToGlobalState="false"
          beStrictAboutOutputDuringTests="false"
          beStrictAboutResourceUsageDuringSmallTests="false"


### PR DESCRIPTION
This PR add an attribute `defaultTestSuite` to xml configuration root node and behave as if was set in the parameter `--testsuite` in the command line, the last one has priority.

Related issue #1844, closed due version change.

This is useful to run only the testsuite set in the xml attribute when no parameter --testsuite is set. The defaultTestSuite attribute is only used when --testsuite is not set. This does not introduce any compatibility breaks with current version.

It follows the php-cs-fixer code style and changes are tested.

Changes:
- `src/TextUI/Command.php`: Add defaultTestSuite default value as empty string, 
- `src/Util/Configuration.php`: Use if attribute defaultTestSuite is set and testsuite is not set
- `tests/_files/configuration.xml` and `tests/_files/configuration_xinclude.xml`: Change to be included in current tests

Add files:
- `tests/TextUI/defaulttestsuite.phpt`: Test that defaultTestSuite attribute is used
- `tests/TextUI/defaulttestsuite-using-testsuite.phpt`: Test that defaultTestSuite attribute is overriden
- `tests/_files/configuration.defaulttestsuite.xml`: Configuration file with the attribute defaultTestSuite set
- `tests/_files/DummyBarTest.php` and `tests/_files/DummyFooTest.php`: Files related in the configuration file.

Thanks for your great work on phpunit and checking this PR and feedback.