### PR TITLE
Feature Getopt refactoring each

### DIFF
--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -90,20 +90,17 @@ class Getopt
             }
 
             if (strlen($spec) > 1 && $spec[1] == ':') {
-                if (strlen($spec) > 2 && $spec[2] == ':') {
-                    if ($i + 1 < $argLen) {
-                        $opts[] = [$opt, substr($arg, $i + 1)];
-                        break;
-                    }
-                } else {
-                    if ($i + 1 < $argLen) {
-                        $opts[] = [$opt, substr($arg, $i + 1)];
-                        break;
-                    } elseif (false === $opt_arg = next($args)) {
+                if ($i + 1 < $argLen) {
+                    $opts[] = [$opt, substr($arg, $i + 1)];
+                    break;
+                }
+                if (!(strlen($spec) > 2 && $spec[2] == ':')) {
+                    if (false === $opt_arg = current($args)) {
                         throw new Exception(
                             "option requires an argument -- $opt"
                         );
                     }
+                    next($args);
                 }
             }
 
@@ -145,11 +142,12 @@ class Getopt
             if (substr($long_opt, -1) == '=') {
                 if (substr($long_opt, -2) != '==') {
                     if (!strlen($opt_arg)) {
-                        if (false === $opt_arg = next($args)) {
+                        if (false === $opt_arg = current($args)) {
                             throw new Exception(
                                 "option --$opt requires an argument"
                             );
                         }
+                        next($args);
                     }
                 }
             } elseif ($opt_arg) {

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -36,7 +36,9 @@ class Getopt
         reset($args);
         array_map('trim', $args);
 
-        while (list($i, $arg) = @each($args)) {
+        while (false !== $arg = current($args)) {
+            $i = key($args);
+            next($args);
             if ($arg == '') {
                 continue;
             }
@@ -97,8 +99,7 @@ class Getopt
                     if ($i + 1 < $argLen) {
                         $opts[] = [$opt, substr($arg, $i + 1)];
                         break;
-                    } elseif (list(, $opt_arg) = @each($args)) {
-                    } else {
+                    } elseif (false === $opt_arg = next($args)) {
                         throw new Exception(
                             "option requires an argument -- $opt"
                         );
@@ -143,12 +144,12 @@ class Getopt
 
             if (substr($long_opt, -1) == '=') {
                 if (substr($long_opt, -2) != '==') {
-                    if (!strlen($opt_arg) &&
-                        !(list(, $opt_arg) = @each($args))
-                    ) {
-                        throw new Exception(
-                            "option --$opt requires an argument"
-                        );
+                    if (!strlen($opt_arg)) {
+                        if (false === $opt_arg = next($args)) {
+                            throw new Exception(
+                                "option --$opt requires an argument"
+                            );
+                        }
                     }
                 }
             } elseif ($opt_arg) {

--- a/tests/Util/GetoptTest.php
+++ b/tests/Util/GetoptTest.php
@@ -163,4 +163,50 @@ class Util_GetoptTest extends TestCase
 
         Getopt::getopt($args, '', ['foo']);
     }
+
+    public function testItHandlesLongParametesWithValues()
+    {
+        $command = 'command parameter-0 --exec parameter-1 --conf config.xml --optn parameter-2 --optn=content-of-o parameter-n';
+        $args    = explode(' ', $command);
+        unset($args[0]);
+        $expected = [
+            [
+                ['--exec', null],
+                ['--conf', 'config.xml'],
+                ['--optn', null],
+                ['--optn', 'content-of-o'],
+            ],
+            [
+                'parameter-0',
+                'parameter-1',
+                'parameter-2',
+                'parameter-n',
+            ],
+        ];
+        $actual = Getopt::getopt($args, '', ['exec', 'conf=', 'optn==']);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testItHandlesShortParametesWithValues()
+    {
+        $command = 'command parameter-0 -x parameter-1 -c config.xml -o parameter-2 -ocontent-of-o parameter-n';
+        $args    = explode(' ', $command);
+        unset($args[0]);
+        $expected = [
+            [
+                ['x', null],
+                ['c', 'config.xml'],
+                ['o', null],
+                ['o', 'content-of-o'],
+            ],
+            [
+                'parameter-0',
+                'parameter-1',
+                'parameter-2',
+                'parameter-n',
+            ],
+        ];
+        $actual = Getopt::getopt($args, 'xc:o::');
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/Util/GetoptTest.php
+++ b/tests/Util/GetoptTest.php
@@ -59,4 +59,108 @@ class Util_GetoptTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testShortOptionUnrecognizedException()
+    {
+        $args = [
+            'command',
+            'myArgument',
+            '-v',
+        ];
+
+        $this->expectException(PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessage('unrecognized option -- v');
+
+        Getopt::getopt($args, '');
+    }
+
+    public function testShortOptionRequiresAnArgumentException()
+    {
+        $args = [
+            'command',
+            'myArgument',
+            '-f',
+        ];
+
+        $this->expectException(PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessage('option requires an argument -- f');
+
+        Getopt::getopt($args, 'f:');
+    }
+
+    public function testShortOptionHandleAnOptionalValue()
+    {
+        $args = [
+            'command',
+            'myArgument',
+            '-f',
+        ];
+        $actual   = Getopt::getopt($args, 'f::');
+        $expected = [
+            [
+                [
+                    'f',
+                    null,
+                ],
+            ],
+            [
+                'myArgument',
+            ],
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testLongOptionIsAmbiguousException()
+    {
+        $args = [
+            'command',
+            '--col',
+        ];
+
+        $this->expectException(PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessage('option --col is ambiguous');
+
+        Getopt::getopt($args, '', ['columns', 'colors']);
+    }
+
+    public function testLongOptionUnrecognizedException()
+    {
+        // the exception 'unrecognized option --option' is not thrown
+        // if the there are not defined extended options
+        $args = [
+            'command',
+            '--foo',
+        ];
+
+        $this->expectException(PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessage('unrecognized option --foo');
+
+        Getopt::getopt($args, '', ['colors']);
+    }
+
+    public function testLongOptionRequiresAnArgumentException()
+    {
+        $args = [
+            'command',
+            '--foo',
+        ];
+
+        $this->expectException(PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessage('option --foo requires an argument');
+
+        Getopt::getopt($args, '', ['foo=']);
+    }
+
+    public function testLongOptionDoesNotAllowAnArgumentException()
+    {
+        $args = [
+            'command',
+            '--foo=bar',
+        ];
+
+        $this->expectException(PHPUnit\Framework\Exception::class);
+        $this->expectExceptionMessage("option --foo doesn't allow an argument");
+
+        Getopt::getopt($args, '', ['foo']);
+    }
 }


### PR DESCRIPTION
This solves PHPUnit\Util\Getopt uses deprecated each() function #2472.

It is a simple refactory to avoid using `each()` function based on `current()` and `next()`.
It includes more tests to verify how `Getopt::getopt` works.

Thanks for your great work and reviewing this PR.