### PR TITLE
[refactor] Separate TeamCity specific operations from Printer

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -11,14 +11,12 @@
 namespace PHPUnit\Util\Log;
 
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Test;
 use PHPUnit\TextUI\ResultPrinter;
-use SebastianBergmann\Comparator\ComparisonFailure;
 
 /**
  * A TestListener that generates a logfile of the test execution using the
@@ -101,37 +99,7 @@ class TeamCity extends ResultPrinter
      */
     public function addFailure(Test $test, AssertionFailedError $e, $time)
     {
-        $parameters = [
-            'name'    => $test->getName(),
-            'message' => self::getMessage($e),
-            'details' => self::getDetails($e),
-        ];
-
-        if ($e instanceof ExpectationFailedException) {
-            $comparisonFailure = $e->getComparisonFailure();
-
-            if ($comparisonFailure instanceof ComparisonFailure) {
-                $expectedString = $comparisonFailure->getExpectedAsString();
-
-                if (is_null($expectedString) || empty($expectedString)) {
-                    $expectedString = self::getPrimitiveValueAsString($comparisonFailure->getExpected());
-                }
-
-                $actualString = $comparisonFailure->getActualAsString();
-
-                if (is_null($actualString) || empty($actualString)) {
-                    $actualString = self::getPrimitiveValueAsString($comparisonFailure->getActual());
-                }
-
-                if (!is_null($actualString) && !is_null($expectedString)) {
-                    $parameters['type']     = 'comparisonFailure';
-                    $parameters['actual']   = $actualString;
-                    $parameters['expected'] = $expectedString;
-                }
-            }
-        }
-
-        $this->printEvent('testFailed', $parameters);
+        $this->testFailed($test, $e);
     }
 
     /**
@@ -281,5 +249,4 @@ class TeamCity extends ResultPrinter
             ]
         );
     }
-
 }

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -61,14 +61,7 @@ class TeamCity extends ResultPrinter
      */
     public function addError(Test $test, \Exception $e, $time)
     {
-        $this->printEvent(
-            'testFailed',
-            [
-                'name'    => $test->getName(),
-                'message' => self::getMessage($e),
-                'details' => self::getDetails($e),
-            ]
-        );
+        $this->testFailed($test, $e);
     }
 
     /**

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -184,11 +184,7 @@ class TeamCity extends ResultPrinter
      */
     public function startTestSuite(TestSuite $suite)
     {
-        if (stripos(ini_get('disable_functions'), 'getmypid') === false) {
-            $this->flowId = getmypid();
-        } else {
-            $this->flowId = false;
-        }
+        $this->getFlowId();
 
         if (!$this->isSummaryTestCountPrinted) {
             $this->isSummaryTestCountPrinted = true;
@@ -287,16 +283,5 @@ class TeamCity extends ResultPrinter
             ]
         );
     }
-
-
-
-
-
-
-
-
-
-
-
 
 }

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -97,7 +97,7 @@ class TeamCity extends ResultPrinter
      */
     public function addIncompleteTest(Test $test, \Exception $e, $time)
     {
-        $this->printIgnoredTest($test->getName(), $e);
+        $this->testIgnored($test->getName(), $e);
     }
 
     /**
@@ -124,10 +124,10 @@ class TeamCity extends ResultPrinter
         $testName = $test->getName();
         if ($this->startedTestName != $testName) {
             $this->startTest($test);
-            $this->printIgnoredTest($testName, $e);
+            $this->testIgnored($testName, $e);
             $this->endTest($test, $time);
         } else {
-            $this->printIgnoredTest($testName, $e);
+            $this->testIgnored($testName, $e);
         }
     }
 

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -156,13 +156,13 @@ class TeamCity extends ResultPrinter
         $parameters = ['name' => $suiteName];
 
         if (class_exists($suiteName, false)) {
-            $fileName                   = self::getFileName($suiteName);
+            $fileName                   = $this->getFileName($suiteName);
             $parameters['locationHint'] = "php_qn://$fileName::\\$suiteName";
         } else {
             $split = preg_split('/::/', $suiteName);
 
             if (count($split) == 2 && method_exists($split[0], $split[1])) {
-                $fileName                   = self::getFileName($split[0]);
+                $fileName                   = $this->getFileName($split[0]);
                 $parameters['locationHint'] = "php_qn://$fileName::\\$suiteName";
                 $parameters['name']         = $split[1];
             }
@@ -210,7 +210,7 @@ class TeamCity extends ResultPrinter
 
         if ($test instanceof TestCase) {
             $className              = get_class($test);
-            $fileName               = self::getFileName($className);
+            $fileName               = $this->getFileName($className);
             $params['locationHint'] = "php_qn://$fileName::\\$className::$testName";
         }
 

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -73,14 +73,7 @@ class TeamCity extends ResultPrinter
      */
     public function addWarning(Test $test, Warning $e, $time)
     {
-        $this->printEvent(
-            'testFailed',
-            [
-                'name'    => $test->getName(),
-                'message' => self::getMessage($e),
-                'details' => self::getDetails($e)
-            ]
-        );
+        $this->testFailed($test, $e);
     }
 
     /**

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -141,7 +141,7 @@ class TeamCity extends ResultPrinter
         if (!$this->isSummaryTestCountPrinted) {
             $this->isSummaryTestCountPrinted = true;
 
-            $this->printEvent(
+            $this->message(
                 'testCount',
                 ['count' => count($suite)]
             );
@@ -168,7 +168,7 @@ class TeamCity extends ResultPrinter
             }
         }
 
-        $this->printEvent('testSuiteStarted', $parameters);
+        $this->message('testSuiteStarted', $parameters);
     }
 
     /**
@@ -194,7 +194,7 @@ class TeamCity extends ResultPrinter
             }
         }
 
-        $this->printEvent('testSuiteFinished', $parameters);
+        $this->message('testSuiteFinished', $parameters);
     }
 
     /**
@@ -214,7 +214,7 @@ class TeamCity extends ResultPrinter
             $params['locationHint'] = "php_qn://$fileName::\\$className::$testName";
         }
 
-        $this->printEvent('testStarted', $params);
+        $this->message('testStarted', $params);
     }
 
     /**
@@ -227,7 +227,7 @@ class TeamCity extends ResultPrinter
     {
         parent::endTest($test, $time);
 
-        $this->printEvent(
+        $this->message(
             'testFinished',
             [
                 'name'     => $test->getName(),

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -184,8 +184,6 @@ class TeamCity extends ResultPrinter
      */
     public function startTestSuite(TestSuite $suite)
     {
-        $this->getFlowId();
-
         if (!$this->isSummaryTestCountPrinted) {
             $this->isSummaryTestCountPrinted = true;
 

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -19,6 +19,14 @@ use ReflectionClass;
 
 trait TeamCityUtils
 {
+    /**
+     * The flow identifier is a unique identifier of the messages flow in a build used to
+     * distinguish separate processes running in parallel.
+     *
+     * @see https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-MessageFlowId
+     *
+     * @return bool|int
+     */
     protected function getFlowId()
     {
         if (stripos(ini_get('disable_functions'), 'getmypid') !== false) {
@@ -29,6 +37,9 @@ trait TeamCityUtils
     }
 
     /**
+     * Applies formatting rules to an exception for use in the `message`
+     * attribute of a `testFailed` TeamCity service message.
+     *
      * @param Exception $e
      *
      * @return string
@@ -51,6 +62,9 @@ trait TeamCityUtils
     }
 
     /**
+     * Applies formatting rules to an exception for use in the `details`
+     * attribute of a `testFailed` TeamCity service message.
+     *
      * @param Exception $e
      *
      * @return string
@@ -117,6 +131,12 @@ trait TeamCityUtils
         return $fileName;
     }
 
+    /**
+     * Writes a `testIgnored` service message to the TeamCity build log.
+     *
+     * @param           $testName
+     * @param Exception $e
+     */
     public function testIgnored($testName, Exception $e)
     {
         $this->message(
@@ -155,10 +175,12 @@ trait TeamCityUtils
     }
 
     /**
+     * Writes a `testFailed` service message to the TeamCity build log.
+     *
      * @param Test                            $test
      * @param \Exception $e
      */
-    protected function testFailed(Test $test, \Exception $e): void
+    protected function testFailed(Test $test, \Exception $e)
     {
         $parameters = [
             'name' => $test->getName(),

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -142,8 +142,8 @@ trait TeamCityUtils
     {
         $this->write("\n##teamcity[$eventName");
 
-        if ($this->flowId) {
-            $params['flowId'] = $this->flowId;
+        if ($flowId = $this->getFlowId()) {
+            $params['flowId'] = $flowId;
         }
 
         foreach ($params as $key => $value) {

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -72,7 +72,7 @@ trait TeamCityUtils
     protected function getDetails(Exception $e)
     {
         $stackTrace = Filter::getFilteredStacktrace($e);
-        $previous = $e->getPrevious();
+        $previous   = $e->getPrevious();
 
         while ($previous) {
             $stackTrace .= "\nCaused by\n" .
@@ -126,7 +126,7 @@ trait TeamCityUtils
     protected function getFileName($className)
     {
         $reflectionClass = new ReflectionClass($className);
-        $fileName = $reflectionClass->getFileName();
+        $fileName        = $reflectionClass->getFileName();
 
         return $fileName;
     }
@@ -142,7 +142,7 @@ trait TeamCityUtils
         $this->message(
             'testIgnored',
             [
-                'name' => $testName,
+                'name'    => $testName,
                 'message' => self::getMessage($e),
                 'details' => self::getDetails($e),
             ]
@@ -177,13 +177,13 @@ trait TeamCityUtils
     /**
      * Writes a `testFailed` service message to the TeamCity build log.
      *
-     * @param Test                            $test
+     * @param Test       $test
      * @param \Exception $e
      */
     protected function testFailed(Test $test, \Exception $e)
     {
         $parameters = [
-            'name' => $test->getName(),
+            'name'    => $test->getName(),
             'message' => $this->getMessage($e),
             'details' => $this->getDetails($e),
         ];
@@ -205,8 +205,8 @@ trait TeamCityUtils
                 }
 
                 if (!is_null($actualString) && !is_null($expectedString)) {
-                    $parameters['type'] = 'comparisonFailure';
-                    $parameters['actual'] = $actualString;
+                    $parameters['type']     = 'comparisonFailure';
+                    $parameters['actual']   = $actualString;
                     $parameters['expected'] = $expectedString;
                 }
             }

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -119,7 +119,7 @@ trait TeamCityUtils
 
     public function printIgnoredTest($testName, Exception $e)
     {
-        $this->printEvent(
+        $this->message(
             'testIgnored',
             [
                 'name' => $testName,
@@ -130,18 +130,23 @@ trait TeamCityUtils
     }
 
     /**
-     * @param string $eventName
-     * @param array  $params
+     * Represents a low-level mechanism for writing TeamCity Service Messages
+     * to output.
+     *
+     * @see https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
+     * 
+     * @param string $name
+     * @param array  $attributes
      */
-    protected function printEvent($eventName, $params = [])
+    protected function message($name, $attributes = [])
     {
-        $this->write("\n##teamcity[$eventName");
+        $this->write("\n##teamcity[$name");
 
         if ($flowId = $this->getFlowId()) {
-            $params['flowId'] = $flowId;
+            $attributes['flowId'] = $flowId;
         }
 
-        foreach ($params as $key => $value) {
+        foreach ($attributes as $key => $value) {
             $escapedValue = self::escapeValue($value);
             $this->write(" $key='$escapedValue'");
         }
@@ -185,6 +190,6 @@ trait TeamCityUtils
             }
         }
 
-        $this->printEvent('testFailed', $parameters);
+        $this->message('testFailed', $parameters);
     }
 }

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -22,6 +22,17 @@ trait TeamCityUtils
      */
     private $flowId;
 
+    protected function getFlowId()
+    {
+        if (stripos(ini_get('disable_functions'), 'getmypid') === false) {
+            $this->flowId = getmypid();
+        } else {
+            $this->flowId = false;
+        }
+
+        return $this->flowId;
+    }
+
     /**
      * @param Exception $e
      *

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -143,8 +143,8 @@ trait TeamCityUtils
             'testIgnored',
             [
                 'name'    => $testName,
-                'message' => self::getMessage($e),
-                'details' => self::getDetails($e),
+                'message' => $this->getMessage($e),
+                'details' => $this->getDetails($e),
             ]
         );
     }
@@ -167,7 +167,7 @@ trait TeamCityUtils
         }
 
         foreach ($attributes as $key => $value) {
-            $escapedValue = self::escapeValue($value);
+            $escapedValue = $this->escapeValue($value);
             $this->write(" $key='$escapedValue'");
         }
 
@@ -195,13 +195,13 @@ trait TeamCityUtils
                 $expectedString = $comparisonFailure->getExpectedAsString();
 
                 if (is_null($expectedString) || empty($expectedString)) {
-                    $expectedString = self::getPrimitiveValueAsString($comparisonFailure->getExpected());
+                    $expectedString = $this->getPrimitiveValueAsString($comparisonFailure->getExpected());
                 }
 
                 $actualString = $comparisonFailure->getActualAsString();
 
                 if (is_null($actualString) || empty($actualString)) {
-                    $actualString = self::getPrimitiveValueAsString($comparisonFailure->getActual());
+                    $actualString = $this->getPrimitiveValueAsString($comparisonFailure->getActual());
                 }
 
                 if (!is_null($actualString) && !is_null($expectedString)) {

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -17,20 +17,13 @@ use ReflectionClass;
 
 trait TeamCityUtils
 {
-    /**
-     * @var string
-     */
-    private $flowId;
-
     protected function getFlowId()
     {
-        if (stripos(ini_get('disable_functions'), 'getmypid') === false) {
-            $this->flowId = getmypid();
-        } else {
-            $this->flowId = false;
+        if (stripos(ini_get('disable_functions'), 'getmypid') !== false) {
+            return false;
         }
 
-        return $this->flowId;
+        return getmypid();
     }
 
     /**

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -117,7 +117,7 @@ trait TeamCityUtils
         return $fileName;
     }
 
-    public function printIgnoredTest($testName, Exception $e)
+    public function testIgnored($testName, Exception $e)
     {
         $this->message(
             'testIgnored',
@@ -134,7 +134,7 @@ trait TeamCityUtils
      * to output.
      *
      * @see https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity
-     * 
+     *
      * @param string $name
      * @param array  $attributes
      */

--- a/src/Util/Log/TeamCityUtils.php
+++ b/src/Util/Log/TeamCityUtils.php
@@ -1,0 +1,145 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\Log;
+
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Util\Filter;
+use ReflectionClass;
+
+trait TeamCityUtils
+{
+    /**
+     * @var string
+     */
+    private $flowId;
+
+    /**
+     * @param Exception $e
+     *
+     * @return string
+     */
+    protected function getMessage(Exception $e)
+    {
+        $message = '';
+
+        if (!$e instanceof Exception) {
+            if (strlen(get_class($e)) != 0) {
+                $message = $message . get_class($e);
+            }
+
+            if (strlen($message) != 0 && strlen($e->getMessage()) != 0) {
+                $message = $message . ' : ';
+            }
+        }
+
+        return $message . $e->getMessage();
+    }
+
+    /**
+     * @param Exception $e
+     *
+     * @return string
+     */
+    protected function getDetails(Exception $e)
+    {
+        $stackTrace = Filter::getFilteredStacktrace($e);
+        $previous = $e->getPrevious();
+
+        while ($previous) {
+            $stackTrace .= "\nCaused by\n" .
+            TestFailure::exceptionToString($previous) . "\n" .
+            Filter::getFilteredStacktrace($previous);
+
+            $previous = $previous->getPrevious();
+        }
+
+        return ' ' . str_replace("\n", "\n ", $stackTrace);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function getPrimitiveValueAsString($value)
+    {
+        if (is_null($value)) {
+            return 'null';
+        } elseif (is_bool($value)) {
+            return $value == true ? 'true' : 'false';
+        } elseif (is_scalar($value)) {
+            return print_r($value, true);
+        }
+    }
+
+    /**
+     * @param  $text
+     *
+     * @return string
+     */
+    protected function escapeValue($text)
+    {
+        $text = str_replace('|', '||', $text);
+        $text = str_replace("'", "|'", $text);
+        $text = str_replace("\n", '|n', $text);
+        $text = str_replace("\r", '|r', $text);
+        $text = str_replace(']', '|]', $text);
+        $text = str_replace('[', '|[', $text);
+
+        return $text;
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return string
+     */
+    protected function getFileName($className)
+    {
+        $reflectionClass = new ReflectionClass($className);
+        $fileName = $reflectionClass->getFileName();
+
+        return $fileName;
+    }
+
+    public function printIgnoredTest($testName, Exception $e)
+    {
+        $this->printEvent(
+            'testIgnored',
+            [
+                'name' => $testName,
+                'message' => self::getMessage($e),
+                'details' => self::getDetails($e),
+            ]
+        );
+    }
+
+    /**
+     * @param string $eventName
+     * @param array  $params
+     */
+    protected function printEvent($eventName, $params = [])
+    {
+        $this->write("\n##teamcity[$eventName");
+
+        if ($this->flowId) {
+            $params['flowId'] = $this->flowId;
+        }
+
+        foreach ($params as $key => $value) {
+            $escapedValue = self::escapeValue($value);
+            $this->write(" $key='$escapedValue'");
+        }
+
+        $this->write("]\n");
+    }
+}

--- a/tests/TextUI/teamcity-exception-no-message.phpt
+++ b/tests/TextUI/teamcity-exception-no-message.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit ExceptionInTest ../_files/ExceptionInTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--teamcity';
+$_SERVER['argv'][3] = 'ExceptionInTest';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/ExceptionInTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+##teamcity[testCount count='1' flowId='%d']
+
+##teamcity[testSuiteStarted name='ExceptionInTest' locationHint='php_qn://%s/tests/_files/ExceptionInTest.php::\ExceptionInTest' flowId='%d']
+
+##teamcity[testStarted name='testSomething' locationHint='php_qn://%s/tests/_files/ExceptionInTest.php::\ExceptionInTest::testSomething' flowId='%d']
+
+##teamcity[testFailed name='testSomething' message='' details=' /%s/tests/_files/ExceptionInTest.php:%d|n ' flowId='%d']
+
+##teamcity[testFinished name='testSomething' duration='%s' flowId='%d']
+
+##teamcity[testSuiteFinished name='ExceptionInTest' flowId='%d']
+
+
+Time: %s, Memory: %s
+
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/TextUI/teamcity-failure.phpt
+++ b/tests/TextUI/teamcity-failure.phpt
@@ -1,0 +1,105 @@
+--TEST--
+phpunit FailureTest ../_files/FailureTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--teamcity';
+$_SERVER['argv'][3] = 'FailureTest';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/FailureTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+##teamcity[testCount count='13' flowId='%d']
+
+##teamcity[testSuiteStarted name='FailureTest' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest' flowId='%d']
+
+##teamcity[testStarted name='testAssertArrayEqualsArray' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertArrayEqualsArray' flowId='%d']
+
+##teamcity[testFailed name='testAssertArrayEqualsArray' message='message|nFailed asserting that two arrays are equal.' details=' /%s/tests/_files/FailureTest.php:8|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertArrayEqualsArray' duration='50' flowId='%d']
+
+##teamcity[testStarted name='testAssertIntegerEqualsInteger' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertIntegerEqualsInteger' flowId='%d']
+
+##teamcity[testFailed name='testAssertIntegerEqualsInteger' message='message|nFailed asserting that 2 matches expected 1.' details=' %s/tests/_files/FailureTest.php:13|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertIntegerEqualsInteger' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertObjectEqualsObject' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertObjectEqualsObject' flowId='%d']
+
+##teamcity[testFailed name='testAssertObjectEqualsObject' message='message|nFailed asserting that two objects are equal.' details=' %s/tests/_files/FailureTest.php:24|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertObjectEqualsObject' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertNullEqualsString' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertNullEqualsString' flowId='%d']
+
+##teamcity[testFailed name='testAssertNullEqualsString' message='message|nFailed asserting that |'bar|' matches expected null.' details=' %s/tests/_files/FailureTest.php:29|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertNullEqualsString' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertStringEqualsString' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertStringEqualsString' flowId='%d']
+
+##teamcity[testFailed name='testAssertStringEqualsString' message='message|nFailed asserting that two strings are equal.' details=' %s/tests/_files/FailureTest.php:34|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertStringEqualsString' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertTextEqualsText' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertTextEqualsText' flowId='%d']
+
+##teamcity[testFailed name='testAssertTextEqualsText' message='message|nFailed asserting that two strings are equal.' details=' %s/tests/_files/FailureTest.php:39|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertTextEqualsText' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertStringMatchesFormat' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertStringMatchesFormat' flowId='%d']
+
+##teamcity[testFailed name='testAssertStringMatchesFormat' message='message|nFailed asserting that string matches format description.|n--- Expected|n+++ Actual|n@@ @@|n-*%s*|n+**|n' details=' %s/tests/_files/FailureTest.php:44|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertStringMatchesFormat' duration='10' flowId='%d']
+
+##teamcity[testStarted name='testAssertNumericEqualsNumeric' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertNumericEqualsNumeric' flowId='%d']
+
+##teamcity[testFailed name='testAssertNumericEqualsNumeric' message='message|nFailed asserting that 2 matches expected 1.' details=' %s/tests/_files/FailureTest.php:49|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertNumericEqualsNumeric' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertTextSameText' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertTextSameText' flowId='%d']
+
+##teamcity[testFailed name='testAssertTextSameText' message='message|nFailed asserting that two strings are identical.' details=' %s/tests/_files/FailureTest.php:54|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertTextSameText' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertObjectSameObject' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertObjectSameObject' flowId='%d']
+
+##teamcity[testFailed name='testAssertObjectSameObject' message='message|nFailed asserting that two variables reference the same object.' details=' %s/tests/_files/FailureTest.php:59|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertObjectSameObject' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertObjectSameNull' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertObjectSameNull' flowId='%d']
+
+##teamcity[testFailed name='testAssertObjectSameNull' message='message|nFailed asserting that null is identical to an object of class "stdClass".' details=' %s/tests/_files/FailureTest.php:64|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertObjectSameNull' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertFloatSameFloat' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertFloatSameFloat' flowId='%d']
+
+##teamcity[testFailed name='testAssertFloatSameFloat' message='message|nFailed asserting that 1.5 is identical to 1.0.' details=' %s/tests/_files/FailureTest.php:69|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertFloatSameFloat' duration='0' flowId='%d']
+
+##teamcity[testStarted name='testAssertStringMatchesFormatFile' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertStringMatchesFormatFile' flowId='%d']
+
+##teamcity[testFailed name='testAssertStringMatchesFormatFile' message='Failed asserting that string matches format description.|n--- Expected|n+++ Actual|n@@ @@|n-FOO|n-|n+...BAR...|n' details=' %s/tests/_files/FailureTest.php:75|n ' flowId='%d']
+
+##teamcity[testFinished name='testAssertStringMatchesFormatFile' duration='0' flowId='%d']
+
+##teamcity[testSuiteFinished name='FailureTest' flowId='%d']
+
+
+Time: %s, Memory: %s
+
+
+FAILURES!
+Tests: 13, Assertions: 14, Failures: 13.

--- a/tests/TextUI/teamcity-failure.phpt
+++ b/tests/TextUI/teamcity-failure.phpt
@@ -21,79 +21,79 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testFailed name='testAssertArrayEqualsArray' message='message|nFailed asserting that two arrays are equal.' details=' /%s/tests/_files/FailureTest.php:8|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertArrayEqualsArray' duration='50' flowId='%d']
+##teamcity[testFinished name='testAssertArrayEqualsArray' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertIntegerEqualsInteger' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertIntegerEqualsInteger' flowId='%d']
 
 ##teamcity[testFailed name='testAssertIntegerEqualsInteger' message='message|nFailed asserting that 2 matches expected 1.' details=' %s/tests/_files/FailureTest.php:13|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertIntegerEqualsInteger' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertIntegerEqualsInteger' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertObjectEqualsObject' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertObjectEqualsObject' flowId='%d']
 
 ##teamcity[testFailed name='testAssertObjectEqualsObject' message='message|nFailed asserting that two objects are equal.' details=' %s/tests/_files/FailureTest.php:24|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertObjectEqualsObject' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertObjectEqualsObject' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertNullEqualsString' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertNullEqualsString' flowId='%d']
 
 ##teamcity[testFailed name='testAssertNullEqualsString' message='message|nFailed asserting that |'bar|' matches expected null.' details=' %s/tests/_files/FailureTest.php:29|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertNullEqualsString' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertNullEqualsString' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertStringEqualsString' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertStringEqualsString' flowId='%d']
 
 ##teamcity[testFailed name='testAssertStringEqualsString' message='message|nFailed asserting that two strings are equal.' details=' %s/tests/_files/FailureTest.php:34|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertStringEqualsString' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertStringEqualsString' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertTextEqualsText' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertTextEqualsText' flowId='%d']
 
 ##teamcity[testFailed name='testAssertTextEqualsText' message='message|nFailed asserting that two strings are equal.' details=' %s/tests/_files/FailureTest.php:39|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertTextEqualsText' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertTextEqualsText' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertStringMatchesFormat' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertStringMatchesFormat' flowId='%d']
 
 ##teamcity[testFailed name='testAssertStringMatchesFormat' message='message|nFailed asserting that string matches format description.|n--- Expected|n+++ Actual|n@@ @@|n-*%s*|n+**|n' details=' %s/tests/_files/FailureTest.php:44|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertStringMatchesFormat' duration='10' flowId='%d']
+##teamcity[testFinished name='testAssertStringMatchesFormat' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertNumericEqualsNumeric' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertNumericEqualsNumeric' flowId='%d']
 
 ##teamcity[testFailed name='testAssertNumericEqualsNumeric' message='message|nFailed asserting that 2 matches expected 1.' details=' %s/tests/_files/FailureTest.php:49|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertNumericEqualsNumeric' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertNumericEqualsNumeric' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertTextSameText' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertTextSameText' flowId='%d']
 
 ##teamcity[testFailed name='testAssertTextSameText' message='message|nFailed asserting that two strings are identical.' details=' %s/tests/_files/FailureTest.php:54|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertTextSameText' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertTextSameText' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertObjectSameObject' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertObjectSameObject' flowId='%d']
 
 ##teamcity[testFailed name='testAssertObjectSameObject' message='message|nFailed asserting that two variables reference the same object.' details=' %s/tests/_files/FailureTest.php:59|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertObjectSameObject' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertObjectSameObject' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertObjectSameNull' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertObjectSameNull' flowId='%d']
 
 ##teamcity[testFailed name='testAssertObjectSameNull' message='message|nFailed asserting that null is identical to an object of class "stdClass".' details=' %s/tests/_files/FailureTest.php:64|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertObjectSameNull' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertObjectSameNull' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertFloatSameFloat' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertFloatSameFloat' flowId='%d']
 
 ##teamcity[testFailed name='testAssertFloatSameFloat' message='message|nFailed asserting that 1.5 is identical to 1.0.' details=' %s/tests/_files/FailureTest.php:69|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertFloatSameFloat' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertFloatSameFloat' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testAssertStringMatchesFormatFile' locationHint='php_qn://%s/tests/_files/FailureTest.php::\FailureTest::testAssertStringMatchesFormatFile' flowId='%d']
 
 ##teamcity[testFailed name='testAssertStringMatchesFormatFile' message='Failed asserting that string matches format description.|n--- Expected|n+++ Actual|n@@ @@|n-FOO|n-|n+...BAR...|n' details=' %s/tests/_files/FailureTest.php:75|n ' flowId='%d']
 
-##teamcity[testFinished name='testAssertStringMatchesFormatFile' duration='0' flowId='%d']
+##teamcity[testFinished name='testAssertStringMatchesFormatFile' duration='%d' flowId='%d']
 
 ##teamcity[testSuiteFinished name='FailureTest' flowId='%d']
 


### PR DESCRIPTION
Related: #2537 

This work refactors the current `TeamCity` result printer to distinguish methods used for writing the build log from the interface inherited from `Printer` and `TestListener` through extending `ResultPrinter`. A test was added to cover the current behaviour of `master` when a failure occurs during a test-suite. I used the existing `FailureTest` and also created a new `ExceptionInTest` test case.

This work is in progress towards the goals of #2537 and is mostly structural in nature. No logical changes are intended in this work. I am simply separating concerns and renaming a few methods to better match TeamCity documentation. 