### PR TITLE
Fix: Remove import for undefined class

### DIFF
--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -12,7 +12,6 @@ namespace PHPUnit\Framework\Constraint;
 
 use Countable;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\SebastianBergmann;
 use PHPUnit\Framework\SelfDescribing;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Exporter\Exporter;
@@ -92,9 +91,9 @@ abstract class Constraint implements Countable, SelfDescribing
     /**
      * Throws an exception for the given compared value and test description
      *
-     * @param mixed                                          $other             Evaluated value or object.
-     * @param string                                         $description       Additional information about the test
-     * @param SebastianBergmann\Comparator\ComparisonFailure $comparisonFailure
+     * @param mixed             $other             Evaluated value or object.
+     * @param string            $description       Additional information about the test
+     * @param ComparisonFailure $comparisonFailure
      *
      * @throws ExpectationFailedException
      */


### PR DESCRIPTION
This PR

* [x] removes an import for an undefined class and fixes a related docblock