### PR TITLE
Render __FILE__ and __DIR__ in SKIPIF section

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -166,7 +166,8 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         if (isset($sections['SKIPIF'])) {
-            $jobResult = $this->phpUtil->runJob($sections['SKIPIF'], $settings);
+            $skipif    = $this->render($sections['SKIPIF']);
+            $jobResult = $this->phpUtil->runJob($skipif, $settings);
 
             if (!strncasecmp('skip', ltrim($jobResult['stdout']), 4)) {
                 if (preg_match('/^\s*skip\s*(.+)\s*/i', $jobResult['stdout'], $message)) {


### PR DESCRIPTION
This patch adds support for `__DIR__` and `__FILE__` in the `SKIPIF` section of phpt tests.

One use-case for this is including Composer's autoload.php in case you want to use `class_exists()` to check whether some specific package is installed.