### PR TITLE
Make phpunit/php-code-coverage dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 
 install:
   - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable; fi
+  - if [[ "$DEPENDENCIES" = 'high-code-coverage' ]]; then travis_retry composer require --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable phpunit/php-code-coverage; fi
   - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable --prefer-lowest; fi
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ext-xml": "*",
         "myclabs/deep-copy": "^1.3",
         "phpspec/prophecy": "^1.7",
-        "phpunit/php-code-coverage": "^5.0",
         "phpunit/php-file-iterator": "^1.4",
         "phpunit/php-text-template": "^1.2",
         "phpunit/php-timer": "^1.0.6",
@@ -56,6 +55,7 @@
         "sort-packages": true
     },
     "suggest": {
+        "phpunit/php-code-coverage": "^5.0",
         "phpunit/php-invoker": "^1.1",
         "ext-xdebug": "*"
     },

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -91,10 +91,6 @@ class TestRunner extends BaseTestRunner
      */
     public function __construct(TestSuiteLoader $loader = null, CodeCoverageFilter $filter = null)
     {
-        if ($filter === null) {
-            $filter = new CodeCoverageFilter;
-        }
-
         $this->codeCoverageFilter = $filter;
         $this->loader             = $loader;
         $this->runtime            = new Runtime;
@@ -388,10 +384,16 @@ class TestRunner extends BaseTestRunner
             $codeCoverageReports = 0;
         }
 
-        if ($codeCoverageReports > 0 && !$this->runtime->canCollectCodeCoverage()) {
-            $this->writeMessage('Error', 'No code coverage driver is available');
+        if ($codeCoverageReports > 0) {
+            if (!class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
+                $this->writeMessage('Error', 'phpunit/php-code-coverage is not installed');
+                $codeCoverageReports = 0;
+            }
 
-            $codeCoverageReports = 0;
+            if (!$this->runtime->canCollectCodeCoverage()) {
+                $this->writeMessage('Error', 'No code coverage driver is available');
+                $codeCoverageReports = 0;
+            }
         }
 
         $this->printer->write("\n");
@@ -431,7 +433,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (isset($arguments['whitelist'])) {
-                $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
+                $codeCoverage->filter()->addDirectoryToWhitelist($arguments['whitelist']);
             }
 
             if (isset($arguments['configuration'])) {
@@ -446,7 +448,7 @@ class TestRunner extends BaseTestRunner
                 );
 
                 foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
-                    $this->codeCoverageFilter->addDirectoryToWhitelist(
+                    $codeCoverage->filter()->addDirectoryToWhitelist(
                         $dir['path'],
                         $dir['suffix'],
                         $dir['prefix']
@@ -454,11 +456,11 @@ class TestRunner extends BaseTestRunner
                 }
 
                 foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
-                    $this->codeCoverageFilter->addFileToWhitelist($file);
+                    $codeCoverage-filter()->addFileToWhitelist($file);
                 }
 
                 foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
-                    $this->codeCoverageFilter->removeDirectoryFromWhitelist(
+                    $codeCoverage->filter()->removeDirectoryFromWhitelist(
                         $dir['path'],
                         $dir['suffix'],
                         $dir['prefix']
@@ -466,11 +468,11 @@ class TestRunner extends BaseTestRunner
                 }
 
                 foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
-                    $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    $codeCoverage->filter()->removeFileFromWhitelist($file);
                 }
             }
 
-            if (!$this->codeCoverageFilter->hasWhitelist()) {
+            if (!$codeCoverage->filter()->hasWhitelist()) {
                 $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
 
                 $codeCoverageReports = 0;

--- a/tests/TextUI/code-coverage-not-installed.phpt
+++ b/tests/TextUI/code-coverage-not-installed.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout BankAccountTest ../_files/BankAccountTest.php
+--SKIPIF--
+<?php
+require __DIR__ . '/../bootstrap.php';
+if (class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
+    print 'skip: phpunit/php-code-coverage must not be installed.';
+}
+?>
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = 'BankAccountTest';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Error:         phpunit/php-code-coverage is not installed
+%A
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/tests/TextUI/disable-code-coverage-ignore.phpt
+++ b/tests/TextUI/disable-code-coverage-ignore.phpt
@@ -5,6 +5,11 @@ phpunit --colors=never --coverage-text=php://stdout --disable-coverage-ignore Ig
 if (!extension_loaded('xdebug')) {
     print 'skip: Extension xdebug is required.';
 }
+
+require __DIR__ . '/../bootstrap.php';
+if (!class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
+    print 'skip: phpunit/php-code-coverage is required.';
+}
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
If I check out PHPUnit and run `composer install`, the vendor folder uses 8 MB. If I remove the dependency on *phpunit/php-code-coverage*, the disk usage drops to 5.9 MB.

I propose making the dependency on *phpunit/php-code-coverage* optional, so that users must install it explicitly if they want to generate code coverage reports.

This will save bandwidth and build time, in particular in setups where you download the same files over and over again, e.g. when using PHPUnit to test your PHP project on Travis, or when building Docker images.