### PR TITLE
Allow directory traversal in FILE_EXTERNAL section

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -330,10 +330,8 @@ class PhptTestCase implements Test, SelfDescribing
 
         foreach ($allowExternalSections as $section) {
             if (isset($sections[$section . '_EXTERNAL'])) {
-                // do not allow directory traversal
-                $externalFilename = str_replace('..', '', trim($sections[$section . '_EXTERNAL']));
+                $externalFilename = trim($sections[$section . '_EXTERNAL']);
 
-                // only allow files from the test directory
                 if (!is_file($testDirectory . $externalFilename) || !is_readable($testDirectory . $externalFilename)) {
                     throw new Exception(
                         sprintf(


### PR DESCRIPTION
I don't know for what contrived reason relative paths were disabled, but if it's for "security" reasons, that's clearly complete nonsense.