### PR TITLE
fix readme contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Alternatively, you may use [Composer](https://getcomposer.org/) to download and 
 
 ## Contribute
 
-Please refer to [CONTRIBUTING.md](https://github.com/sebastianbergmann/phpunit/blob/master/CONTRIBUTING.md) for information on how to contribute to PHPUnit and its related projects.
+Please refer to [CONTRIBUTING.md](https://github.com/sebastianbergmann/phpunit/blob/master/.github/CONTRIBUTING.md) for information on how to contribute to PHPUnit and its related projects.
 
 ## List of Contributors
 


### PR DESCRIPTION
The `README.md` contributing link is broken since `CONTRIBUTING.md` was moved to the `.github` directory.