### PR TITLE
Fix handling of Listener arguments (#1873)

### DIFF
--- a/src/Util/XML.php
+++ b/src/Util/XML.php
@@ -221,7 +221,7 @@ class Xml
                 $className = $element->getAttribute('class');
 
                 if ($element->hasChildNodes()) {
-                    $arguments       = $element->childNodes->item(1)->childNodes;
+                    $arguments       = $element->childNodes->item(0)->childNodes;
                     $constructorArgs = [];
 
                     foreach ($arguments as $argument) {

--- a/tests/Util/XmlTest.php
+++ b/tests/Util/XmlTest.php
@@ -89,4 +89,29 @@ class XmlTest extends TestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    public function testXmlToVariableCanHandleMultipleOfTheSameArgumentType()
+    {
+        $xml = '<object class="SampleClass"><arguments><string>a</string><string>b</string><string>c</string></arguments></object>';
+        $dom = new \DOMDocument();
+        $dom->loadXML($xml);
+
+        $expected = ['a' => 'a', 'b' => 'b', 'c' => 'c'];
+
+        $actual = Xml::xmlToVariable($dom->documentElement);
+
+        $this->assertSame($expected, (array) $actual);
+    }
+
+    public function testXmlToVariableCanConstructObjectsWithConstructorArgumentsRecursively()
+    {
+        $xml = '<object class="Exception"><arguments><string>one</string><integer>0</integer><object class="Exception"><arguments><string>two</string></arguments></object></arguments></object>';
+        $dom = new \DOMDocument();
+        $dom->loadXML($xml);
+
+        $actual = Xml::xmlToVariable($dom->documentElement);
+
+        $this->assertEquals('one', $actual->getMessage());
+        $this->assertEquals('two', $actual->getPrevious()->getMessage());
+    }
 }

--- a/tests/_files/SampleClass.php
+++ b/tests/_files/SampleClass.php
@@ -2,8 +2,8 @@
 class SampleClass
 {
     public $a;
-    protected $b;
-    protected $c;
+    public $b;
+    public $c;
 
     public function __construct($a, $b, $c)
     {


### PR DESCRIPTION
This is a proposed fix for #1873, it's technically a BC break but `PHPUnit\Util\Xml` is an internal PHPUnit class so I'm not sure how much that matters. I think backwards compatibility can be maintained by checking the length of `childNodes` and using the appropriate index, but didn't want to over-complicate the fix if it's not a concern.

The same fix works on 5.7 as well if you want me to open a separate PR for that branch.