### PR TITLE
Fix #2437: Show previous exceptions as well

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Util\Log;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Framework\TestSuite;
@@ -357,14 +358,16 @@ class TeamCity extends ResultPrinter
     private static function getDetails(Exception $e)
     {
         $stackTrace = Filter::getFilteredStacktrace($e);
-        $previous   = $e->getPrevious();
+        $previous   = $e instanceof ExceptionWrapper ?
+            $e->getPreviousWrapped() : $e->getPrevious();
 
         while ($previous) {
             $stackTrace .= "\nCaused by\n" .
                 TestFailure::exceptionToString($previous) . "\n" .
                 Filter::getFilteredStacktrace($previous);
 
-            $previous = $previous->getPrevious();
+            $previous = $previous instanceof ExceptionWrapper ?
+                $previous->getPreviousWrapped() : $previous->getPrevious();
         }
 
         return ' ' . str_replace("\n", "\n ", $stackTrace);

--- a/tests/TextUI/teamcity-inner-exceptions.phpt
+++ b/tests/TextUI/teamcity-inner-exceptions.phpt
@@ -1,0 +1,39 @@
+--TEST--
+phpunit --teamcity ExceptionStackTest ../_files/ExceptionStackTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--teamcity';
+$_SERVER['argv'][3] = 'ExceptionStackTest';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/ExceptionStackTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='ExceptionStackTest' locationHint='php_qn://%s/tests/_files/ExceptionStackTest.php::\ExceptionStackTest' flowId='%d']
+
+##teamcity[testStarted name='testPrintingChildException' locationHint='php_qn://%s/tests/_files/ExceptionStackTest.php::\ExceptionStackTest::testPrintingChildException' flowId='%d']
+
+##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n )|n' details=' %s/tests/_files/ExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n  )|n |n %s/tests/_files/ExceptionStackTest.php:10|n ' flowId='%d']
+
+##teamcity[testFinished name='testPrintingChildException' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testNestedExceptions' locationHint='php_qn://%s/tests/_files/ExceptionStackTest.php::\ExceptionStackTest::testNestedExceptions' flowId='%d']
+
+##teamcity[testFailed name='testNestedExceptions' message='One' details=' %s/tests/_files/ExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s/tests/_files/ExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s/tests/_files/ExceptionStackTest.php:20|n ' flowId='%d']
+
+##teamcity[testFinished name='testNestedExceptions' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='ExceptionStackTest' flowId='%d']
+
+
+Time: %s, Memory: %s
+
+
+ERRORS!
+Tests: 2, Assertions: 1, Errors: 2.


### PR DESCRIPTION
This is the fix for #2437 (Show previous exceptions as well).

To extract all inner exceptions TeamCity printer should use `getPreviousWrapped()` method instead of `getPrevious()` for `ExceptionWrapper`.