### PR TITLE
Better normalization of WSDL URL for getMockFromWsdl

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1591,7 +1591,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     protected function getMockFromWsdl($wsdlFile, $originalClassName = '', $mockClassName = '', array $methods = [], $callOriginalConstructor = true, array $options = [])
     {
         if ($originalClassName === '') {
-            $originalClassName = str_replace('.wsdl', '', basename($wsdlFile));
+            $originalClassName = pathinfo(basename(parse_url($wsdlFile)['path']), PATHINFO_FILENAME);
         }
 
         if (!class_exists($originalClassName)) {


### PR DESCRIPTION
Fixes generation of PHP class name from URL with:
 - any file extension postfix
 - query params
Fixes https://github.com/sebastianbergmann/phpunit/issues/2573