### PR TITLE
Fix #2584: wrong path to eval-stdin.php

### DIFF
--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -225,7 +225,7 @@ abstract class AbstractPhpProcess
             if ($file) {
                 $command .= '-e ' . escapeshellarg($file);
             } else {
-                $command .= escapeshellarg(__DIR__ . '/PHP/eval-stdin.php');
+                $command .= escapeshellarg(__DIR__ . '/eval-stdin.php');
             }
         } elseif ($file) {
             $command .= ' -f ' . escapeshellarg($file);


### PR DESCRIPTION
Fixes #2584: PHPDBG & process isolation - error due to wrong path to eval-stdin.php