### PR TITLE
add @requires support for Composer packages (and versions).

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -32,7 +32,7 @@ class Test
     const REGEX_EXPECTED_EXCEPTION = '(@expectedException\s+([:.\w\\\\x7f-\xff]+)(?:[\t ]+(\S*))?(?:[\t ]+(\S*))?\s*$)m';
     const REGEX_REQUIRES_VERSION   = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m';
     const REGEX_REQUIRES_OS        = '/@requires\s+OS\s+(?P<value>.+?)[ \t]*\r?$/m';
-    const REGEX_REQUIRES           = '/@requires\s+(?P<name>function|extension)\s+(?P<value>([^ ]+?))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
+    const REGEX_REQUIRES           = '/@requires\s+(?P<name>function|extension|package)\s+(?P<value>([^ ]+?))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
 
     const UNKNOWN = -1;
     const SMALL   = 0;
@@ -42,6 +42,8 @@ class Test
     private static $annotationCache = [];
 
     private static $hookMethods = [];
+    
+    private static $installedPackages;
 
     /**
      * @param \PHPUnit\Framework\Test $test
@@ -201,6 +203,7 @@ class Test
 
         if ($count = preg_match_all(self::REGEX_REQUIRES, $docComment, $matches)) {
             for ($i = 0; $i < $count; $i++) {
+                $versionsKey = $matches['name'][$i] . '_versions';
                 $name = $matches['name'][$i] . 's';
 
                 if (!isset($requires[$name])) {
@@ -209,11 +212,11 @@ class Test
 
                 $requires[$name][] = $matches['value'][$i];
 
-                if (empty($matches['version'][$i]) || $name != 'extensions') {
+                if (empty($matches['version'][$i]) || !in_array($name, ['extensions', 'packages'], true)) {
                     continue;
                 }
 
-                $requires['extension_versions'][$matches['value'][$i]] = [
+                $requires[$versionsKey][$matches['value'][$i]] = [
                     'version'  => $matches['version'][$i],
                     'operator' => $matches['operator'][$i]
                 ];
@@ -295,8 +298,122 @@ class Test
                 }
             }
         }
+        
+        $packages = self::getInstalledPackages();
+
+        if (!empty($required['packages'])) {
+            foreach ($required['packages'] as $package) {
+                if (isset($required['package_versions'][$package])) {
+                    continue;
+                }
+
+                if (!array_key_exists($package, $packages)) {
+                    $missing[] = sprintf('Package %s is required.', $package);
+                }
+            }
+        }
+
+        if (!empty($required['package_versions'])) {
+            foreach ($required['package_versions'] as $package => $required) {
+                $actualVersion = $packages[$package];
+
+                $operator = empty($required['operator']) ? '>=' : $required['operator'];
+
+                if (false === $actualVersion || !version_compare($actualVersion, $required['version'], $operator)) {
+                    $missing[] = sprintf('Package %s %s %s is required.', $package, $operator, $required['version']);
+                }
+            }
+        }
 
         return $missing;
+    }
+    
+    /**
+     * @return mixed[]
+     */
+    private static function getInstalledPackages()
+    {
+        if (self::$installedPackages === null) {
+            try {
+                self::$installedPackages = self::parseInstalledPackages();
+            } catch (\Exception $e) {
+                // TODO Log it?
+                
+                self::$installedPackages = [];
+            }
+        }
+        
+        return self::$installedPackages;
+    }
+    
+    /**
+     * @return \mixed[]
+     */
+    private static function parseInstalledPackages()
+    {
+        $file = self::getComposerLockFile();
+    
+        $json = self::parseComposerLockFile($file);
+        
+        if (!is_array($json)) {
+            throw new \RuntimeException('Parsed composer.lock must be an array.');
+        }
+        
+        if (!array_key_exists('packages', $json)) {
+            throw new \RuntimeException('Key `packages` in composer.lock is required.');
+        }
+        
+        $jsonPackages = $json['packages'];
+        if (!is_array($jsonPackages)) {
+            throw new \RuntimeException('Key `packages` in composer.lock must be an array.');
+        }
+        
+        $packages = [];
+        
+        /** @var mixed[] $jsonPackages */
+        foreach ($jsonPackages as $package) {
+            $package = (array) $package;
+            if (array_key_exists('name', $package) && array_key_exists('version', $package)) {
+                $packages[$package['name']] = $package['version'];
+            }
+        }
+        
+        return $packages;
+    }
+    
+    /**
+     * TODO Find a better way to get the Composer lock file handle.
+     *
+     * @return \SplFileInfo
+     */
+    private static function getComposerLockFile()
+    {
+        if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+            throw new \RuntimeException('PHPUNIT_COMPOSER_INSTALL must be defined.');
+        }
+    
+        $autoloadFile = constant('PHPUNIT_COMPOSER_INSTALL');
+    
+        return new \SplFileInfo(dirname($autoloadFile, 2) . '/composer.lock');
+    }
+    
+    /**
+     * TODO Find a better way to get the Composer lock file handle.
+     *
+     * @param \SplFileInfo $file
+     * @return \mixed[]
+     */
+    private static function parseComposerLockFile(\SplFileInfo $file)
+    {
+        if (!$file->isFile()) {
+            throw new \RuntimeException(sprintf('%s must be a readable file.', $file->getFilename()));
+        }
+        
+        if (!$file->isReadable()) {
+            throw new \RuntimeException(sprintf('%s must be a readable file.', $file->getFilename()));
+        }
+        
+        return json_decode(file_get_contents($file->getFilename()), 1);
     }
 
     /**

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -381,6 +381,9 @@ class TestTest extends TestCase
             ['testExtensionVersionOperatorEquals', ['Extension testExtOne = 1.0 is required.']],
             ['testExtensionVersionOperatorDoubleEquals', ['Extension testExtOne == 1.0 is required.']],
             ['testExtensionVersionOperatorNoSpace', ['Extension testExtOne >= 99 is required.']],
+            ['testPackageNoVersion', ['Package test/non-existing-package is required.']],
+            ['testPackageVersionOperatorNoSpace', ['Package sebastian/comparator < 2.0 is required.']],
+            ['testPackageVersionOperatorSpace', ['Package sebastian/comparator < 2.0 is required.']],
         ];
     }
 

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -344,4 +344,25 @@ class RequirementsTest extends TestCase
     public function testExtensionVersionOperatorNoSpace()
     {
     }
+
+    /**
+     * @requires package test/non-existing-package
+     */
+    public function testPackageNoVersion()
+    {
+    }
+
+    /**
+     * @requires package sebastian/comparator <2.0
+     */
+    public function testPackageVersionOperatorNoSpace()
+    {
+    }
+
+    /**
+     * @requires package sebastian/comparator < 2.0
+     */
+    public function testPackageVersionOperatorSpace()
+    {
+    }
 }


### PR DESCRIPTION
i thought something like this might help in testing branches that support multiple versions of dependencies, and maybe suggested/dev dependencies.

i'm not a fan of the way i've implemented discovery and parsing of composer.lock, nor the exception handling. if there is any interest in this, please guide me : )

i branched from `6.0.11`.