### PR TITLE
Update TeamCity.php

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -185,7 +185,7 @@ class TeamCity extends ResultPrinter
         }
     }
 
-    public function printIgnoredTest($testName, Exception $e)
+    public function printIgnoredTest($testName, \Exception $e)
     {
         $this->printEvent(
             'testIgnored',
@@ -329,11 +329,11 @@ class TeamCity extends ResultPrinter
     }
 
     /**
-     * @param Exception $e
+     * @param \Exception $e
      *
      * @return string
      */
-    private static function getMessage(Exception $e)
+    private static function getMessage(\Exception $e)
     {
         $message = '';
 
@@ -351,11 +351,11 @@ class TeamCity extends ResultPrinter
     }
 
     /**
-     * @param Exception $e
+     * @param \Exception $e
      *
      * @return string
      */
-    private static function getDetails(Exception $e)
+    private static function getDetails(\Exception $e)
     {
         $stackTrace = Filter::getFilteredStacktrace($e);
         $previous   = $e instanceof ExceptionWrapper ?


### PR DESCRIPTION
The method \Util\Log\TeamCity::addError has a type hint for \Exception but the called getMessage and getDetails only allows \PHPUnit\Framework\Exception\Exception, fixed this by changing the type hint of getMessage and getDetails