### PR TITLE
Enhancement: Enable native_function_invocation fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -32,6 +32,7 @@ return PhpCsFixer\Config::create()
             'lowercase_constants' => true,
             'lowercase_keywords' => true,
             'method_argument_space' => true,
+            'native_function_invocation' => true,
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,

--- a/build/phar-manifest.php
+++ b/build/phar-manifest.php
@@ -2,24 +2,24 @@
 <?php
 print 'phpunit/phpunit: ';
 
-$tag = @exec('git describe --tags 2>&1');
+$tag = @\exec('git describe --tags 2>&1');
 
-if (strpos($tag, '-') === false && strpos($tag, 'No names found') === false) {
+if (\strpos($tag, '-') === false && \strpos($tag, 'No names found') === false) {
     print $tag;
 } else {
-    $branch = @exec('git rev-parse --abbrev-ref HEAD');
-    $hash   = @exec('git log -1 --format="%H"');
+    $branch = @\exec('git rev-parse --abbrev-ref HEAD');
+    $hash   = @\exec('git log -1 --format="%H"');
     print $branch . '@' . $hash;
 }
 
 print "\n";
 
-$lock = json_decode(file_get_contents(__DIR__ . '/../composer.lock'));
+$lock = \json_decode(\file_get_contents(__DIR__ . '/../composer.lock'));
 
 foreach ($lock->packages as $package) {
     print $package->name . ': ' . $package->version;
 
-    if (!preg_match('/^[v= ]*(([0-9]+)(\\.([0-9]+)(\\.([0-9]+)(-([0-9]+))?(-?([a-zA-Z-+][a-zA-Z0-9\\.\\-:]*)?)?)?)?)$/', $package->version)) {
+    if (!\preg_match('/^[v= ]*(([0-9]+)(\\.([0-9]+)(\\.([0-9]+)(-([0-9]+))?(-?([a-zA-Z-+][a-zA-Z0-9\\.\\-:]*)?)?)?)?)$/', $package->version)) {
         print '@' . $package->source->reference;
     }
 

--- a/build/phar-version.php
+++ b/build/phar-version.php
@@ -4,12 +4,12 @@ if (!isset($argv[1]) || !isset($argv[2])) {
     exit(1);
 }
 
-file_put_contents(
+\file_put_contents(
     __DIR__ . '/phar/phpunit/Runner/Version.php',
-    str_replace(
+    \str_replace(
         'private static $pharVersion;',
         'private static $pharVersion = "' . $argv[1] . '";',
-        file_get_contents(__DIR__ . '/phar/phpunit/Runner/Version.php')
+        \file_get_contents(__DIR__ . '/phar/phpunit/Runner/Version.php')
     )
 );
 

--- a/build/version.php
+++ b/build/version.php
@@ -4,10 +4,10 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use SebastianBergmann\Version;
 
-$buffer  = file_get_contents(__DIR__ . '/../src/Runner/Version.php');
-$start   = strpos($buffer, 'new VersionId(\'') + strlen('new VersionId(\'');
-$end     = strpos($buffer, '\'', $start);
-$version = substr($buffer, $start, $end - $start);
+$buffer  = \file_get_contents(__DIR__ . '/../src/Runner/Version.php');
+$start   = \strpos($buffer, 'new VersionId(\'') + \strlen('new VersionId(\'');
+$end     = \strpos($buffer, '\'', $start);
+$version = \substr($buffer, $start, $end - $start);
 $version = new Version($version, __DIR__ . '/../');
 
 print $version->getVersion();

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -83,14 +83,14 @@ abstract class Assert
      */
     public static function assertArrayHasKey($key, $array, $message = '')
     {
-        if (!(is_int($key) || is_string($key))) {
+        if (!(\is_int($key) || \is_string($key))) {
             throw InvalidArgumentHelper::factory(
                 1,
                 'integer or string'
             );
         }
 
-        if (!(is_array($array) || $array instanceof ArrayAccess)) {
+        if (!(\is_array($array) || $array instanceof ArrayAccess)) {
             throw InvalidArgumentHelper::factory(
                 2,
                 'array or ArrayAccess'
@@ -112,14 +112,14 @@ abstract class Assert
      */
     public static function assertArraySubset($subset, $array, $strict = false, $message = '')
     {
-        if (!(is_array($subset) || $subset instanceof ArrayAccess)) {
+        if (!(\is_array($subset) || $subset instanceof ArrayAccess)) {
             throw InvalidArgumentHelper::factory(
                 1,
                 'array or ArrayAccess'
             );
         }
 
-        if (!(is_array($array) || $array instanceof ArrayAccess)) {
+        if (!(\is_array($array) || $array instanceof ArrayAccess)) {
             throw InvalidArgumentHelper::factory(
                 2,
                 'array or ArrayAccess'
@@ -140,14 +140,14 @@ abstract class Assert
      */
     public static function assertArrayNotHasKey($key, $array, $message = '')
     {
-        if (!(is_int($key) || is_string($key))) {
+        if (!(\is_int($key) || \is_string($key))) {
             throw InvalidArgumentHelper::factory(
                 1,
                 'integer or string'
             );
         }
 
-        if (!(is_array($array) || $array instanceof ArrayAccess)) {
+        if (!(\is_array($array) || $array instanceof ArrayAccess)) {
             throw InvalidArgumentHelper::factory(
                 2,
                 'array or ArrayAccess'
@@ -173,15 +173,15 @@ abstract class Assert
      */
     public static function assertContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
     {
-        if (is_array($haystack) ||
-            is_object($haystack) && $haystack instanceof Traversable) {
+        if (\is_array($haystack) ||
+            \is_object($haystack) && $haystack instanceof Traversable) {
             $constraint = new TraversableContains(
                 $needle,
                 $checkForObjectIdentity,
                 $checkForNonObjectIdentity
             );
-        } elseif (is_string($haystack)) {
-            if (!is_string($needle)) {
+        } elseif (\is_string($haystack)) {
+            if (!\is_string($needle)) {
                 throw InvalidArgumentHelper::factory(
                     1,
                     'string'
@@ -238,8 +238,8 @@ abstract class Assert
      */
     public static function assertNotContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
     {
-        if (is_array($haystack) ||
-            is_object($haystack) && $haystack instanceof Traversable) {
+        if (\is_array($haystack) ||
+            \is_object($haystack) && $haystack instanceof Traversable) {
             $constraint = new LogicalNot(
                 new TraversableContains(
                     $needle,
@@ -247,8 +247,8 @@ abstract class Assert
                     $checkForNonObjectIdentity
                 )
             );
-        } elseif (is_string($haystack)) {
-            if (!is_string($needle)) {
+        } elseif (\is_string($haystack)) {
+            if (!\is_string($needle)) {
                 throw InvalidArgumentHelper::factory(
                     1,
                     'string'
@@ -305,8 +305,8 @@ abstract class Assert
      */
     public static function assertContainsOnly($type, $haystack, $isNativeType = null, $message = '')
     {
-        if (!(is_array($haystack) ||
-            is_object($haystack) && $haystack instanceof Traversable)) {
+        if (!(\is_array($haystack) ||
+            \is_object($haystack) && $haystack instanceof Traversable)) {
             throw InvalidArgumentHelper::factory(
                 2,
                 'array or traversable'
@@ -336,8 +336,8 @@ abstract class Assert
      */
     public static function assertContainsOnlyInstancesOf($classname, $haystack, $message = '')
     {
-        if (!(is_array($haystack) ||
-            is_object($haystack) && $haystack instanceof Traversable)) {
+        if (!(\is_array($haystack) ||
+            \is_object($haystack) && $haystack instanceof Traversable)) {
             throw InvalidArgumentHelper::factory(
                 2,
                 'array or traversable'
@@ -384,8 +384,8 @@ abstract class Assert
      */
     public static function assertNotContainsOnly($type, $haystack, $isNativeType = null, $message = '')
     {
-        if (!(is_array($haystack) ||
-            is_object($haystack) && $haystack instanceof Traversable)) {
+        if (!(\is_array($haystack) ||
+            \is_object($haystack) && $haystack instanceof Traversable)) {
             throw InvalidArgumentHelper::factory(
                 2,
                 'array or traversable'
@@ -438,13 +438,13 @@ abstract class Assert
      */
     public static function assertCount($expectedCount, $haystack, $message = '')
     {
-        if (!is_int($expectedCount)) {
+        if (!\is_int($expectedCount)) {
             throw InvalidArgumentHelper::factory(1, 'integer');
         }
 
         if (!$haystack instanceof Countable &&
             !$haystack instanceof Traversable &&
-            !is_array($haystack)) {
+            !\is_array($haystack)) {
             throw InvalidArgumentHelper::factory(2, 'countable or traversable');
         }
 
@@ -482,13 +482,13 @@ abstract class Assert
      */
     public static function assertNotCount($expectedCount, $haystack, $message = '')
     {
-        if (!is_int($expectedCount)) {
+        if (!\is_int($expectedCount)) {
             throw InvalidArgumentHelper::factory(1, 'integer');
         }
 
         if (!$haystack instanceof Countable &&
             !$haystack instanceof Traversable &&
-            !is_array($haystack)) {
+            !\is_array($haystack)) {
             throw InvalidArgumentHelper::factory(2, 'countable or traversable');
         }
 
@@ -811,8 +811,8 @@ abstract class Assert
         static::assertFileExists($actual, $message);
 
         static::assertEquals(
-            file_get_contents($expected),
-            file_get_contents($actual),
+            \file_get_contents($expected),
+            \file_get_contents($actual),
             $message,
             0,
             10,
@@ -837,8 +837,8 @@ abstract class Assert
         static::assertFileExists($actual, $message);
 
         static::assertNotEquals(
-            file_get_contents($expected),
-            file_get_contents($actual),
+            \file_get_contents($expected),
+            \file_get_contents($actual),
             $message,
             0,
             10,
@@ -862,7 +862,7 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
 
         static::assertEquals(
-            file_get_contents($expectedFile),
+            \file_get_contents($expectedFile),
             $actualString,
             $message,
             0,
@@ -887,7 +887,7 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
 
         static::assertNotEquals(
-            file_get_contents($expectedFile),
+            \file_get_contents($expectedFile),
             $actualString,
             $message,
             0,
@@ -905,7 +905,7 @@ abstract class Assert
      */
     public static function assertIsReadable($filename, $message = '')
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -922,7 +922,7 @@ abstract class Assert
      */
     public static function assertNotIsReadable($filename, $message = '')
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -941,7 +941,7 @@ abstract class Assert
      */
     public static function assertIsWritable($filename, $message = '')
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -958,7 +958,7 @@ abstract class Assert
      */
     public static function assertNotIsWritable($filename, $message = '')
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -977,7 +977,7 @@ abstract class Assert
      */
     public static function assertDirectoryExists($directory, $message = '')
     {
-        if (!is_string($directory)) {
+        if (!\is_string($directory)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -994,7 +994,7 @@ abstract class Assert
      */
     public static function assertDirectoryNotExists($directory, $message = '')
     {
-        if (!is_string($directory)) {
+        if (!\is_string($directory)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -1061,7 +1061,7 @@ abstract class Assert
      */
     public static function assertFileExists($filename, $message = '')
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -1078,7 +1078,7 @@ abstract class Assert
      */
     public static function assertFileNotExists($filename, $message = '')
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -1253,15 +1253,15 @@ abstract class Assert
      */
     public static function assertClassHasAttribute($attributeName, $className, $message = '')
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
-        if (!is_string($className) || !class_exists($className)) {
+        if (!\is_string($className) || !\class_exists($className)) {
             throw InvalidArgumentHelper::factory(2, 'class name', $className);
         }
 
@@ -1281,15 +1281,15 @@ abstract class Assert
      */
     public static function assertClassNotHasAttribute($attributeName, $className, $message = '')
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
-        if (!is_string($className) || !class_exists($className)) {
+        if (!\is_string($className) || !\class_exists($className)) {
             throw InvalidArgumentHelper::factory(2, 'class name', $className);
         }
 
@@ -1309,15 +1309,15 @@ abstract class Assert
      */
     public static function assertClassHasStaticAttribute($attributeName, $className, $message = '')
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
-        if (!is_string($className) || !class_exists($className)) {
+        if (!\is_string($className) || !\class_exists($className)) {
             throw InvalidArgumentHelper::factory(2, 'class name', $className);
         }
 
@@ -1337,15 +1337,15 @@ abstract class Assert
      */
     public static function assertClassNotHasStaticAttribute($attributeName, $className, $message = '')
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
-        if (!is_string($className) || !class_exists($className)) {
+        if (!\is_string($className) || !\class_exists($className)) {
             throw InvalidArgumentHelper::factory(2, 'class name', $className);
         }
 
@@ -1367,15 +1367,15 @@ abstract class Assert
      */
     public static function assertObjectHasAttribute($attributeName, $object, $message = '')
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
-        if (!is_object($object)) {
+        if (!\is_object($object)) {
             throw InvalidArgumentHelper::factory(2, 'object');
         }
 
@@ -1395,15 +1395,15 @@ abstract class Assert
      */
     public static function assertObjectNotHasAttribute($attributeName, $object, $message = '')
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
-        if (!is_object($object)) {
+        if (!\is_object($object)) {
             throw InvalidArgumentHelper::factory(2, 'object');
         }
 
@@ -1425,7 +1425,7 @@ abstract class Assert
      */
     public static function assertSame($expected, $actual, $message = '')
     {
-        if (is_bool($expected) && is_bool($actual)) {
+        if (\is_bool($expected) && \is_bool($actual)) {
             static::assertEquals($expected, $actual, $message);
         } else {
             $constraint = new IsIdentical(
@@ -1465,7 +1465,7 @@ abstract class Assert
      */
     public static function assertNotSame($expected, $actual, $message = '')
     {
-        if (is_bool($expected) && is_bool($actual)) {
+        if (\is_bool($expected) && \is_bool($actual)) {
             static::assertNotEquals($expected, $actual, $message);
         } else {
             $constraint = new LogicalNot(
@@ -1503,7 +1503,7 @@ abstract class Assert
      */
     public static function assertInstanceOf($expected, $actual, $message = '')
     {
-        if (!(is_string($expected) && (class_exists($expected) || interface_exists($expected)))) {
+        if (!(\is_string($expected) && (\class_exists($expected) || \interface_exists($expected)))) {
             throw InvalidArgumentHelper::factory(1, 'class or interface name');
         }
 
@@ -1540,7 +1540,7 @@ abstract class Assert
      */
     public static function assertNotInstanceOf($expected, $actual, $message = '')
     {
-        if (!(is_string($expected) && (class_exists($expected) || interface_exists($expected)))) {
+        if (!(\is_string($expected) && (\class_exists($expected) || \interface_exists($expected)))) {
             throw InvalidArgumentHelper::factory(1, 'class or interface name');
         }
 
@@ -1577,7 +1577,7 @@ abstract class Assert
      */
     public static function assertInternalType($expected, $actual, $message = '')
     {
-        if (!is_string($expected)) {
+        if (!\is_string($expected)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -1614,7 +1614,7 @@ abstract class Assert
      */
     public static function assertNotInternalType($expected, $actual, $message = '')
     {
-        if (!is_string($expected)) {
+        if (!\is_string($expected)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -1651,11 +1651,11 @@ abstract class Assert
      */
     public static function assertRegExp($pattern, $string, $message = '')
     {
-        if (!is_string($pattern)) {
+        if (!\is_string($pattern)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1673,11 +1673,11 @@ abstract class Assert
      */
     public static function assertNotRegExp($pattern, $string, $message = '')
     {
-        if (!is_string($pattern)) {
+        if (!\is_string($pattern)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1700,13 +1700,13 @@ abstract class Assert
     {
         if (!$expected instanceof Countable &&
             !$expected instanceof Traversable &&
-            !is_array($expected)) {
+            !\is_array($expected)) {
             throw InvalidArgumentHelper::factory(1, 'countable or traversable');
         }
 
         if (!$actual instanceof Countable &&
             !$actual instanceof Traversable &&
-            !is_array($actual)) {
+            !\is_array($actual)) {
             throw InvalidArgumentHelper::factory(2, 'countable or traversable');
         }
 
@@ -1729,13 +1729,13 @@ abstract class Assert
     {
         if (!$expected instanceof Countable &&
             !$expected instanceof Traversable &&
-            !is_array($expected)) {
+            !\is_array($expected)) {
             throw InvalidArgumentHelper::factory(1, 'countable or traversable');
         }
 
         if (!$actual instanceof Countable &&
             !$actual instanceof Traversable &&
-            !is_array($actual)) {
+            !\is_array($actual)) {
             throw InvalidArgumentHelper::factory(2, 'countable or traversable');
         }
 
@@ -1755,11 +1755,11 @@ abstract class Assert
      */
     public static function assertStringMatchesFormat($format, $string, $message = '')
     {
-        if (!is_string($format)) {
+        if (!\is_string($format)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1777,11 +1777,11 @@ abstract class Assert
      */
     public static function assertStringNotMatchesFormat($format, $string, $message = '')
     {
-        if (!is_string($format)) {
+        if (!\is_string($format)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1803,12 +1803,12 @@ abstract class Assert
     {
         static::assertFileExists($formatFile, $message);
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
         $constraint = new StringMatchesFormatDescription(
-            file_get_contents($formatFile)
+            \file_get_contents($formatFile)
         );
 
         static::assertThat($string, $constraint, $message);
@@ -1825,13 +1825,13 @@ abstract class Assert
     {
         static::assertFileExists($formatFile, $message);
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
         $constraint = new LogicalNot(
             new StringMatchesFormatDescription(
-                file_get_contents($formatFile)
+                \file_get_contents($formatFile)
             )
         );
 
@@ -1847,11 +1847,11 @@ abstract class Assert
      */
     public static function assertStringStartsWith($prefix, $string, $message = '')
     {
-        if (!is_string($prefix)) {
+        if (!\is_string($prefix)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1871,11 +1871,11 @@ abstract class Assert
      */
     public static function assertStringStartsNotWith($prefix, $string, $message = '')
     {
-        if (!is_string($prefix)) {
+        if (!\is_string($prefix)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1895,11 +1895,11 @@ abstract class Assert
      */
     public static function assertStringEndsWith($suffix, $string, $message = '')
     {
-        if (!is_string($suffix)) {
+        if (!\is_string($suffix)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -1917,11 +1917,11 @@ abstract class Assert
      */
     public static function assertStringEndsNotWith($suffix, $string, $message = '')
     {
-        if (!is_string($suffix)) {
+        if (!\is_string($suffix)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_string($string)) {
+        if (!\is_string($string)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
@@ -2050,7 +2050,7 @@ abstract class Assert
             static::assertEquals(
                 $expectedElement->attributes->length,
                 $actualElement->attributes->length,
-                sprintf(
+                \sprintf(
                     '%s%sNumber of attributes on node "%s" does not match',
                     $message,
                     !empty($message) ? "\n" : '',
@@ -2066,7 +2066,7 @@ abstract class Assert
 
                 if (!$actualAttribute) {
                     static::fail(
-                        sprintf(
+                        \sprintf(
                             '%s%sCould not find attribute "%s" on node "%s"',
                             $message,
                             !empty($message) ? "\n" : '',
@@ -2084,7 +2084,7 @@ abstract class Assert
         static::assertEquals(
             $expectedElement->childNodes->length,
             $actualElement->childNodes->length,
-            sprintf(
+            \sprintf(
                 '%s%sNumber of child nodes of "%s" differs',
                 $message,
                 !empty($message) ? "\n" : '',
@@ -2111,7 +2111,7 @@ abstract class Assert
      */
     public static function assertThat($value, Constraint $constraint, $message = '')
     {
-        self::$count += count($constraint);
+        self::$count += \count($constraint);
 
         $constraint->evaluate($value, $message);
     }
@@ -2124,7 +2124,7 @@ abstract class Assert
      */
     public static function assertJson($actualJson, $message = '')
     {
-        if (!is_string($actualJson)) {
+        if (!\is_string($actualJson)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -2179,7 +2179,7 @@ abstract class Assert
     public static function assertJsonStringEqualsJsonFile($expectedFile, $actualJson, $message = '')
     {
         static::assertFileExists($expectedFile, $message);
-        $expectedJson = file_get_contents($expectedFile);
+        $expectedJson = \file_get_contents($expectedFile);
 
         static::assertJson($expectedJson, $message);
         static::assertJson($actualJson, $message);
@@ -2201,7 +2201,7 @@ abstract class Assert
     public static function assertJsonStringNotEqualsJsonFile($expectedFile, $actualJson, $message = '')
     {
         static::assertFileExists($expectedFile, $message);
-        $expectedJson = file_get_contents($expectedFile);
+        $expectedJson = \file_get_contents($expectedFile);
 
         static::assertJson($expectedJson, $message);
         static::assertJson($actualJson, $message);
@@ -2225,8 +2225,8 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
         static::assertFileExists($actualFile, $message);
 
-        $actualJson   = file_get_contents($actualFile);
-        $expectedJson = file_get_contents($expectedFile);
+        $actualJson   = \file_get_contents($actualFile);
+        $expectedJson = \file_get_contents($expectedFile);
 
         static::assertJson($expectedJson, $message);
         static::assertJson($actualJson, $message);
@@ -2253,8 +2253,8 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
         static::assertFileExists($actualFile, $message);
 
-        $actualJson   = file_get_contents($actualFile);
-        $expectedJson = file_get_contents($expectedFile);
+        $actualJson   = \file_get_contents($actualFile);
+        $expectedJson = \file_get_contents($expectedFile);
 
         static::assertJson($expectedJson, $message);
         static::assertJson($actualJson, $message);
@@ -2276,7 +2276,7 @@ abstract class Assert
      */
     public static function logicalAnd()
     {
-        $constraints = func_get_args();
+        $constraints = \func_get_args();
 
         $constraint = new LogicalAnd;
         $constraint->setConstraints($constraints);
@@ -2291,7 +2291,7 @@ abstract class Assert
      */
     public static function logicalOr()
     {
-        $constraints = func_get_args();
+        $constraints = \func_get_args();
 
         $constraint = new LogicalOr;
         $constraint->setConstraints($constraints);
@@ -2318,7 +2318,7 @@ abstract class Assert
      */
     public static function logicalXor()
     {
-        $constraints = func_get_args();
+        $constraints = \func_get_args();
 
         $constraint = new LogicalXor;
         $constraint->setConstraints($constraints);
@@ -2824,16 +2824,16 @@ abstract class Assert
      */
     public static function readAttribute($classOrObject, $attributeName)
     {
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
-        if (is_string($classOrObject)) {
-            if (!class_exists($classOrObject)) {
+        if (\is_string($classOrObject)) {
+            if (!\class_exists($classOrObject)) {
                 throw InvalidArgumentHelper::factory(
                     1,
                     'class name'
@@ -2846,7 +2846,7 @@ abstract class Assert
             );
         }
 
-        if (is_object($classOrObject)) {
+        if (\is_object($classOrObject)) {
             return static::getObjectAttribute(
                 $classOrObject,
                 $attributeName
@@ -2872,19 +2872,19 @@ abstract class Assert
      */
     public static function getStaticAttribute($className, $attributeName)
     {
-        if (!is_string($className)) {
+        if (!\is_string($className)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!class_exists($className)) {
+        if (!\class_exists($className)) {
             throw InvalidArgumentHelper::factory(1, 'class name');
         }
 
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
@@ -2893,7 +2893,7 @@ abstract class Assert
         while ($class) {
             $attributes = $class->getStaticProperties();
 
-            if (array_key_exists($attributeName, $attributes)) {
+            if (\array_key_exists($attributeName, $attributes)) {
                 return $attributes[$attributeName];
             }
 
@@ -2901,7 +2901,7 @@ abstract class Assert
         }
 
         throw new Exception(
-            sprintf(
+            \sprintf(
                 'Attribute "%s" not found in class.',
                 $attributeName
             )
@@ -2921,15 +2921,15 @@ abstract class Assert
      */
     public static function getObjectAttribute($object, $attributeName)
     {
-        if (!is_object($object)) {
+        if (!\is_object($object)) {
             throw InvalidArgumentHelper::factory(1, 'object');
         }
 
-        if (!is_string($attributeName)) {
+        if (!\is_string($attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'string');
         }
 
-        if (!preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
+        if (!\preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
@@ -2960,7 +2960,7 @@ abstract class Assert
         }
 
         throw new Exception(
-            sprintf(
+            \sprintf(
                 'Attribute "%s" not found in object.',
                 $attributeName
             )

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -50,7 +50,7 @@ use PHPUnit\Framework\TestCase;
  */
 function any()
 {
-    return TestCase::any(...func_get_args());
+    return TestCase::any(...\func_get_args());
 }
 
 /**
@@ -60,7 +60,7 @@ function any()
  */
 function anything()
 {
-    return Assert::anything(...func_get_args());
+    return Assert::anything(...\func_get_args());
 }
 
 /**
@@ -72,7 +72,7 @@ function anything()
  */
 function arrayHasKey($key)
 {
-    Assert::arrayHasKey(...func_get_args());
+    Assert::arrayHasKey(...\func_get_args());
 }
 
 /**
@@ -84,7 +84,7 @@ function arrayHasKey($key)
  */
 function assertArrayHasKey($key, $array, $message = '')
 {
-    return Assert::assertArrayHasKey(...func_get_args());
+    return Assert::assertArrayHasKey(...\func_get_args());
 }
 
 /**
@@ -97,7 +97,7 @@ function assertArrayHasKey($key, $array, $message = '')
  */
 function assertArraySubset($subset, $array, $strict = false, $message = '')
 {
-    return Assert::assertArraySubset(...func_get_args());
+    return Assert::assertArraySubset(...\func_get_args());
 }
 
 /**
@@ -109,7 +109,7 @@ function assertArraySubset($subset, $array, $strict = false, $message = '')
  */
 function assertArrayNotHasKey($key, $array, $message = '')
 {
-    return Assert::assertArrayNotHasKey(...func_get_args());
+    return Assert::assertArrayNotHasKey(...\func_get_args());
 }
 
 /**
@@ -126,7 +126,7 @@ function assertArrayNotHasKey($key, $array, $message = '')
  */
 function assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return Assert::assertAttributeContains(...func_get_args());
+    return Assert::assertAttributeContains(...\func_get_args());
 }
 
 /**
@@ -141,7 +141,7 @@ function assertAttributeContains($needle, $haystackAttributeName, $haystackClass
  */
 function assertAttributeContainsOnly($type, $haystackAttributeName, $haystackClassOrObject, $isNativeType = null, $message = '')
 {
-    return Assert::assertAttributeContainsOnly(...func_get_args());
+    return Assert::assertAttributeContainsOnly(...\func_get_args());
 }
 
 /**
@@ -155,7 +155,7 @@ function assertAttributeContainsOnly($type, $haystackAttributeName, $haystackCla
  */
 function assertAttributeCount($expectedCount, $haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return Assert::assertAttributeCount(...func_get_args());
+    return Assert::assertAttributeCount(...\func_get_args());
 }
 
 /**
@@ -168,7 +168,7 @@ function assertAttributeCount($expectedCount, $haystackAttributeName, $haystackC
  */
 function assertAttributeEmpty($haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return Assert::assertAttributeEmpty(...func_get_args());
+    return Assert::assertAttributeEmpty(...\func_get_args());
 }
 
 /**
@@ -185,7 +185,7 @@ function assertAttributeEmpty($haystackAttributeName, $haystackClassOrObject, $m
  */
 function assertAttributeEquals($expected, $actualAttributeName, $actualClassOrObject, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertAttributeEquals(...func_get_args());
+    return Assert::assertAttributeEquals(...\func_get_args());
 }
 
 /**
@@ -198,7 +198,7 @@ function assertAttributeEquals($expected, $actualAttributeName, $actualClassOrOb
  */
 function assertAttributeGreaterThan($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return Assert::assertAttributeGreaterThan(...func_get_args());
+    return Assert::assertAttributeGreaterThan(...\func_get_args());
 }
 
 /**
@@ -211,7 +211,7 @@ function assertAttributeGreaterThan($expected, $actualAttributeName, $actualClas
  */
 function assertAttributeGreaterThanOrEqual($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return Assert::assertAttributeGreaterThanOrEqual(...func_get_args());
+    return Assert::assertAttributeGreaterThanOrEqual(...\func_get_args());
 }
 
 /**
@@ -224,7 +224,7 @@ function assertAttributeGreaterThanOrEqual($expected, $actualAttributeName, $act
  */
 function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 {
-    return Assert::assertAttributeInstanceOf(...func_get_args());
+    return Assert::assertAttributeInstanceOf(...\func_get_args());
 }
 
 /**
@@ -237,7 +237,7 @@ function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $m
  */
 function assertAttributeInternalType($expected, $attributeName, $classOrObject, $message = '')
 {
-    return Assert::assertAttributeInternalType(...func_get_args());
+    return Assert::assertAttributeInternalType(...\func_get_args());
 }
 
 /**
@@ -250,7 +250,7 @@ function assertAttributeInternalType($expected, $attributeName, $classOrObject, 
  */
 function assertAttributeLessThan($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return Assert::assertAttributeLessThan(...func_get_args());
+    return Assert::assertAttributeLessThan(...\func_get_args());
 }
 
 /**
@@ -263,7 +263,7 @@ function assertAttributeLessThan($expected, $actualAttributeName, $actualClassOr
  */
 function assertAttributeLessThanOrEqual($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return Assert::assertAttributeLessThanOrEqual(...func_get_args());
+    return Assert::assertAttributeLessThanOrEqual(...\func_get_args());
 }
 
 /**
@@ -280,7 +280,7 @@ function assertAttributeLessThanOrEqual($expected, $actualAttributeName, $actual
  */
 function assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return Assert::assertAttributeNotContains(...func_get_args());
+    return Assert::assertAttributeNotContains(...\func_get_args());
 }
 
 /**
@@ -296,7 +296,7 @@ function assertAttributeNotContains($needle, $haystackAttributeName, $haystackCl
  */
 function assertAttributeNotContainsOnly($type, $haystackAttributeName, $haystackClassOrObject, $isNativeType = null, $message = '')
 {
-    return Assert::assertAttributeNotContainsOnly(...func_get_args());
+    return Assert::assertAttributeNotContainsOnly(...\func_get_args());
 }
 
 /**
@@ -310,7 +310,7 @@ function assertAttributeNotContainsOnly($type, $haystackAttributeName, $haystack
  */
 function assertAttributeNotCount($expectedCount, $haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return Assert::assertAttributeNotCount(...func_get_args());
+    return Assert::assertAttributeNotCount(...\func_get_args());
 }
 
 /**
@@ -323,7 +323,7 @@ function assertAttributeNotCount($expectedCount, $haystackAttributeName, $haysta
  */
 function assertAttributeNotEmpty($haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return Assert::assertAttributeNotEmpty(...func_get_args());
+    return Assert::assertAttributeNotEmpty(...\func_get_args());
 }
 
 /**
@@ -340,7 +340,7 @@ function assertAttributeNotEmpty($haystackAttributeName, $haystackClassOrObject,
  */
 function assertAttributeNotEquals($expected, $actualAttributeName, $actualClassOrObject, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertAttributeNotEquals(...func_get_args());
+    return Assert::assertAttributeNotEquals(...\func_get_args());
 }
 
 /**
@@ -353,7 +353,7 @@ function assertAttributeNotEquals($expected, $actualAttributeName, $actualClassO
  */
 function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 {
-    return Assert::assertAttributeNotInstanceOf(...func_get_args());
+    return Assert::assertAttributeNotInstanceOf(...\func_get_args());
 }
 
 /**
@@ -366,7 +366,7 @@ function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject,
  */
 function assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message = '')
 {
-    return Assert::assertAttributeNotInternalType(...func_get_args());
+    return Assert::assertAttributeNotInternalType(...\func_get_args());
 }
 
 /**
@@ -380,7 +380,7 @@ function assertAttributeNotInternalType($expected, $attributeName, $classOrObjec
  */
 function assertAttributeNotSame($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return Assert::assertAttributeNotSame(...func_get_args());
+    return Assert::assertAttributeNotSame(...\func_get_args());
 }
 
 /**
@@ -394,7 +394,7 @@ function assertAttributeNotSame($expected, $actualAttributeName, $actualClassOrO
  */
 function assertAttributeSame($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return Assert::assertAttributeSame(...func_get_args());
+    return Assert::assertAttributeSame(...\func_get_args());
 }
 
 /**
@@ -406,7 +406,7 @@ function assertAttributeSame($expected, $actualAttributeName, $actualClassOrObje
  */
 function assertClassHasAttribute($attributeName, $className, $message = '')
 {
-    return Assert::assertClassHasAttribute(...func_get_args());
+    return Assert::assertClassHasAttribute(...\func_get_args());
 }
 
 /**
@@ -418,7 +418,7 @@ function assertClassHasAttribute($attributeName, $className, $message = '')
  */
 function assertClassHasStaticAttribute($attributeName, $className, $message = '')
 {
-    return Assert::assertClassHasStaticAttribute(...func_get_args());
+    return Assert::assertClassHasStaticAttribute(...\func_get_args());
 }
 
 /**
@@ -430,7 +430,7 @@ function assertClassHasStaticAttribute($attributeName, $className, $message = ''
  */
 function assertClassNotHasAttribute($attributeName, $className, $message = '')
 {
-    return Assert::assertClassNotHasAttribute(...func_get_args());
+    return Assert::assertClassNotHasAttribute(...\func_get_args());
 }
 
 /**
@@ -442,7 +442,7 @@ function assertClassNotHasAttribute($attributeName, $className, $message = '')
  */
 function assertClassNotHasStaticAttribute($attributeName, $className, $message = '')
 {
-    return Assert::assertClassNotHasStaticAttribute(...func_get_args());
+    return Assert::assertClassNotHasStaticAttribute(...\func_get_args());
 }
 
 /**
@@ -457,7 +457,7 @@ function assertClassNotHasStaticAttribute($attributeName, $className, $message =
  */
 function assertContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return Assert::assertContains(...func_get_args());
+    return Assert::assertContains(...\func_get_args());
 }
 
 /**
@@ -470,7 +470,7 @@ function assertContains($needle, $haystack, $message = '', $ignoreCase = false, 
  */
 function assertContainsOnly($type, $haystack, $isNativeType = null, $message = '')
 {
-    return Assert::assertContainsOnly(...func_get_args());
+    return Assert::assertContainsOnly(...\func_get_args());
 }
 
 /**
@@ -482,7 +482,7 @@ function assertContainsOnly($type, $haystack, $isNativeType = null, $message = '
  */
 function assertContainsOnlyInstancesOf($classname, $haystack, $message = '')
 {
-    return Assert::assertContainsOnlyInstancesOf(...func_get_args());
+    return Assert::assertContainsOnlyInstancesOf(...\func_get_args());
 }
 
 /**
@@ -494,7 +494,7 @@ function assertContainsOnlyInstancesOf($classname, $haystack, $message = '')
  */
 function assertCount($expectedCount, $haystack, $message = '')
 {
-    return Assert::assertCount(...func_get_args());
+    return Assert::assertCount(...\func_get_args());
 }
 
 /**
@@ -507,7 +507,7 @@ function assertCount($expectedCount, $haystack, $message = '')
  */
 function assertEmpty($actual, $message = '')
 {
-    return Assert::assertEmpty(...func_get_args());
+    return Assert::assertEmpty(...\func_get_args());
 }
 
 /**
@@ -520,7 +520,7 @@ function assertEmpty($actual, $message = '')
  */
 function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actualElement, $checkAttributes = false, $message = '')
 {
-    return Assert::assertEqualXMLStructure(...func_get_args());
+    return Assert::assertEqualXMLStructure(...\func_get_args());
 }
 
 /**
@@ -536,7 +536,7 @@ function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actual
  */
 function assertEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertEquals(...func_get_args());
+    return Assert::assertEquals(...\func_get_args());
 }
 
 /**
@@ -549,7 +549,7 @@ function assertEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth
  */
 function assertNotTrue($condition, $message = '')
 {
-    return Assert::assertNotTrue(...func_get_args());
+    return Assert::assertNotTrue(...\func_get_args());
 }
 
 /**
@@ -562,7 +562,7 @@ function assertNotTrue($condition, $message = '')
  */
 function assertFalse($condition, $message = '')
 {
-    return Assert::assertFalse(...func_get_args());
+    return Assert::assertFalse(...\func_get_args());
 }
 
 /**
@@ -577,7 +577,7 @@ function assertFalse($condition, $message = '')
  */
 function assertFileEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertFileEquals(...func_get_args());
+    return Assert::assertFileEquals(...\func_get_args());
 }
 
 /**
@@ -588,7 +588,7 @@ function assertFileEquals($expected, $actual, $message = '', $canonicalize = fal
  */
 function assertFileExists($filename, $message = '')
 {
-    return Assert::assertFileExists(...func_get_args());
+    return Assert::assertFileExists(...\func_get_args());
 }
 
 /**
@@ -603,7 +603,7 @@ function assertFileExists($filename, $message = '')
  */
 function assertFileNotEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertFileNotEquals(...func_get_args());
+    return Assert::assertFileNotEquals(...\func_get_args());
 }
 
 /**
@@ -614,7 +614,7 @@ function assertFileNotEquals($expected, $actual, $message = '', $canonicalize = 
  */
 function assertFileNotExists($filename, $message = '')
 {
-    return Assert::assertFileNotExists(...func_get_args());
+    return Assert::assertFileNotExists(...\func_get_args());
 }
 
 /**
@@ -626,7 +626,7 @@ function assertFileNotExists($filename, $message = '')
  */
 function assertGreaterThan($expected, $actual, $message = '')
 {
-    return Assert::assertGreaterThan(...func_get_args());
+    return Assert::assertGreaterThan(...\func_get_args());
 }
 
 /**
@@ -638,7 +638,7 @@ function assertGreaterThan($expected, $actual, $message = '')
  */
 function assertGreaterThanOrEqual($expected, $actual, $message = '')
 {
-    return Assert::assertGreaterThanOrEqual(...func_get_args());
+    return Assert::assertGreaterThanOrEqual(...\func_get_args());
 }
 
 /**
@@ -650,7 +650,7 @@ function assertGreaterThanOrEqual($expected, $actual, $message = '')
  */
 function assertInstanceOf($expected, $actual, $message = '')
 {
-    return Assert::assertInstanceOf(...func_get_args());
+    return Assert::assertInstanceOf(...\func_get_args());
 }
 
 /**
@@ -662,7 +662,7 @@ function assertInstanceOf($expected, $actual, $message = '')
  */
 function assertInternalType($expected, $actual, $message = '')
 {
-    return Assert::assertInternalType(...func_get_args());
+    return Assert::assertInternalType(...\func_get_args());
 }
 
 /**
@@ -673,7 +673,7 @@ function assertInternalType($expected, $actual, $message = '')
  */
 function assertJson($actualJson, $message = '')
 {
-    return Assert::assertJson(...func_get_args());
+    return Assert::assertJson(...\func_get_args());
 }
 
 /**
@@ -685,7 +685,7 @@ function assertJson($actualJson, $message = '')
  */
 function assertJsonFileEqualsJsonFile($expectedFile, $actualFile, $message = '')
 {
-    return Assert::assertJsonFileEqualsJsonFile(...func_get_args());
+    return Assert::assertJsonFileEqualsJsonFile(...\func_get_args());
 }
 
 /**
@@ -697,7 +697,7 @@ function assertJsonFileEqualsJsonFile($expectedFile, $actualFile, $message = '')
  */
 function assertJsonFileNotEqualsJsonFile($expectedFile, $actualFile, $message = '')
 {
-    return Assert::assertJsonFileNotEqualsJsonFile(...func_get_args());
+    return Assert::assertJsonFileNotEqualsJsonFile(...\func_get_args());
 }
 
 /**
@@ -709,7 +709,7 @@ function assertJsonFileNotEqualsJsonFile($expectedFile, $actualFile, $message = 
  */
 function assertJsonStringEqualsJsonFile($expectedFile, $actualJson, $message = '')
 {
-    return Assert::assertJsonStringEqualsJsonFile(...func_get_args());
+    return Assert::assertJsonStringEqualsJsonFile(...\func_get_args());
 }
 
 /**
@@ -721,7 +721,7 @@ function assertJsonStringEqualsJsonFile($expectedFile, $actualJson, $message = '
  */
 function assertJsonStringEqualsJsonString($expectedJson, $actualJson, $message = '')
 {
-    return Assert::assertJsonStringEqualsJsonString(...func_get_args());
+    return Assert::assertJsonStringEqualsJsonString(...\func_get_args());
 }
 
 /**
@@ -733,7 +733,7 @@ function assertJsonStringEqualsJsonString($expectedJson, $actualJson, $message =
  */
 function assertJsonStringNotEqualsJsonFile($expectedFile, $actualJson, $message = '')
 {
-    return Assert::assertJsonStringNotEqualsJsonFile(...func_get_args());
+    return Assert::assertJsonStringNotEqualsJsonFile(...\func_get_args());
 }
 
 /**
@@ -745,7 +745,7 @@ function assertJsonStringNotEqualsJsonFile($expectedFile, $actualJson, $message 
  */
 function assertJsonStringNotEqualsJsonString($expectedJson, $actualJson, $message = '')
 {
-    return Assert::assertJsonStringNotEqualsJsonString(...func_get_args());
+    return Assert::assertJsonStringNotEqualsJsonString(...\func_get_args());
 }
 
 /**
@@ -757,7 +757,7 @@ function assertJsonStringNotEqualsJsonString($expectedJson, $actualJson, $messag
  */
 function assertLessThan($expected, $actual, $message = '')
 {
-    return Assert::assertLessThan(...func_get_args());
+    return Assert::assertLessThan(...\func_get_args());
 }
 
 /**
@@ -769,7 +769,7 @@ function assertLessThan($expected, $actual, $message = '')
  */
 function assertLessThanOrEqual($expected, $actual, $message = '')
 {
-    return Assert::assertLessThanOrEqual(...func_get_args());
+    return Assert::assertLessThanOrEqual(...\func_get_args());
 }
 
 /**
@@ -780,7 +780,7 @@ function assertLessThanOrEqual($expected, $actual, $message = '')
  */
 function assertFinite($actual, $message = '')
 {
-    return Assert::assertFinite(...func_get_args());
+    return Assert::assertFinite(...\func_get_args());
 }
 
 /**
@@ -791,7 +791,7 @@ function assertFinite($actual, $message = '')
  */
 function assertInfinite($actual, $message = '')
 {
-    return Assert::assertInfinite(...func_get_args());
+    return Assert::assertInfinite(...\func_get_args());
 }
 
 /**
@@ -802,7 +802,7 @@ function assertInfinite($actual, $message = '')
  */
 function assertNan($actual, $message = '')
 {
-    return Assert::assertNan(...func_get_args());
+    return Assert::assertNan(...\func_get_args());
 }
 
 /**
@@ -817,7 +817,7 @@ function assertNan($actual, $message = '')
  */
 function assertNotContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return Assert::assertNotContains(...func_get_args());
+    return Assert::assertNotContains(...\func_get_args());
 }
 
 /**
@@ -830,7 +830,7 @@ function assertNotContains($needle, $haystack, $message = '', $ignoreCase = fals
  */
 function assertNotContainsOnly($type, $haystack, $isNativeType = null, $message = '')
 {
-    return Assert::assertNotContainsOnly(...func_get_args());
+    return Assert::assertNotContainsOnly(...\func_get_args());
 }
 
 /**
@@ -842,7 +842,7 @@ function assertNotContainsOnly($type, $haystack, $isNativeType = null, $message 
  */
 function assertNotCount($expectedCount, $haystack, $message = '')
 {
-    return Assert::assertNotCount(...func_get_args());
+    return Assert::assertNotCount(...\func_get_args());
 }
 
 /**
@@ -855,7 +855,7 @@ function assertNotCount($expectedCount, $haystack, $message = '')
  */
 function assertNotEmpty($actual, $message = '')
 {
-    return Assert::assertNotEmpty(...func_get_args());
+    return Assert::assertNotEmpty(...\func_get_args());
 }
 
 /**
@@ -871,7 +871,7 @@ function assertNotEmpty($actual, $message = '')
  */
 function assertNotEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertNotEquals(...func_get_args());
+    return Assert::assertNotEquals(...\func_get_args());
 }
 
 /**
@@ -883,7 +883,7 @@ function assertNotEquals($expected, $actual, $message = '', $delta = 0.0, $maxDe
  */
 function assertNotInstanceOf($expected, $actual, $message = '')
 {
-    return Assert::assertNotInstanceOf(...func_get_args());
+    return Assert::assertNotInstanceOf(...\func_get_args());
 }
 
 /**
@@ -895,7 +895,7 @@ function assertNotInstanceOf($expected, $actual, $message = '')
  */
 function assertNotInternalType($expected, $actual, $message = '')
 {
-    return Assert::assertNotInternalType(...func_get_args());
+    return Assert::assertNotInternalType(...\func_get_args());
 }
 
 /**
@@ -908,7 +908,7 @@ function assertNotInternalType($expected, $actual, $message = '')
  */
 function assertNotFalse($condition, $message = '')
 {
-    return Assert::assertNotFalse(...func_get_args());
+    return Assert::assertNotFalse(...\func_get_args());
 }
 
 /**
@@ -919,7 +919,7 @@ function assertNotFalse($condition, $message = '')
  */
 function assertNotNull($actual, $message = '')
 {
-    return Assert::assertNotNull(...func_get_args());
+    return Assert::assertNotNull(...\func_get_args());
 }
 
 /**
@@ -931,7 +931,7 @@ function assertNotNull($actual, $message = '')
  */
 function assertNotRegExp($pattern, $string, $message = '')
 {
-    return Assert::assertNotRegExp(...func_get_args());
+    return Assert::assertNotRegExp(...\func_get_args());
 }
 
 /**
@@ -945,7 +945,7 @@ function assertNotRegExp($pattern, $string, $message = '')
  */
 function assertNotSame($expected, $actual, $message = '')
 {
-    return Assert::assertNotSame(...func_get_args());
+    return Assert::assertNotSame(...\func_get_args());
 }
 
 /**
@@ -958,7 +958,7 @@ function assertNotSame($expected, $actual, $message = '')
  */
 function assertNotSameSize($expected, $actual, $message = '')
 {
-    return Assert::assertNotSameSize(...func_get_args());
+    return Assert::assertNotSameSize(...\func_get_args());
 }
 
 /**
@@ -969,7 +969,7 @@ function assertNotSameSize($expected, $actual, $message = '')
  */
 function assertNull($actual, $message = '')
 {
-    return Assert::assertNull(...func_get_args());
+    return Assert::assertNull(...\func_get_args());
 }
 
 /**
@@ -981,7 +981,7 @@ function assertNull($actual, $message = '')
  */
 function assertObjectHasAttribute($attributeName, $object, $message = '')
 {
-    return Assert::assertObjectHasAttribute(...func_get_args());
+    return Assert::assertObjectHasAttribute(...\func_get_args());
 }
 
 /**
@@ -993,7 +993,7 @@ function assertObjectHasAttribute($attributeName, $object, $message = '')
  */
 function assertObjectNotHasAttribute($attributeName, $object, $message = '')
 {
-    return Assert::assertObjectNotHasAttribute(...func_get_args());
+    return Assert::assertObjectNotHasAttribute(...\func_get_args());
 }
 
 /**
@@ -1005,7 +1005,7 @@ function assertObjectNotHasAttribute($attributeName, $object, $message = '')
  */
 function assertRegExp($pattern, $string, $message = '')
 {
-    return Assert::assertRegExp(...func_get_args());
+    return Assert::assertRegExp(...\func_get_args());
 }
 
 /**
@@ -1019,7 +1019,7 @@ function assertRegExp($pattern, $string, $message = '')
  */
 function assertSame($expected, $actual, $message = '')
 {
-    return Assert::assertSame(...func_get_args());
+    return Assert::assertSame(...\func_get_args());
 }
 
 /**
@@ -1032,7 +1032,7 @@ function assertSame($expected, $actual, $message = '')
  */
 function assertSameSize($expected, $actual, $message = '')
 {
-    return Assert::assertSameSize(...func_get_args());
+    return Assert::assertSameSize(...\func_get_args());
 }
 
 /**
@@ -1044,7 +1044,7 @@ function assertSameSize($expected, $actual, $message = '')
  */
 function assertStringEndsNotWith($suffix, $string, $message = '')
 {
-    return Assert::assertStringEndsNotWith(...func_get_args());
+    return Assert::assertStringEndsNotWith(...\func_get_args());
 }
 
 /**
@@ -1056,7 +1056,7 @@ function assertStringEndsNotWith($suffix, $string, $message = '')
  */
 function assertStringEndsWith($suffix, $string, $message = '')
 {
-    return Assert::assertStringEndsWith(...func_get_args());
+    return Assert::assertStringEndsWith(...\func_get_args());
 }
 
 /**
@@ -1071,7 +1071,7 @@ function assertStringEndsWith($suffix, $string, $message = '')
  */
 function assertStringEqualsFile($expectedFile, $actualString, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertStringEqualsFile(...func_get_args());
+    return Assert::assertStringEqualsFile(...\func_get_args());
 }
 
 /**
@@ -1083,7 +1083,7 @@ function assertStringEqualsFile($expectedFile, $actualString, $message = '', $ca
  */
 function assertStringMatchesFormat($format, $string, $message = '')
 {
-    return Assert::assertStringMatchesFormat(...func_get_args());
+    return Assert::assertStringMatchesFormat(...\func_get_args());
 }
 
 /**
@@ -1095,7 +1095,7 @@ function assertStringMatchesFormat($format, $string, $message = '')
  */
 function assertStringMatchesFormatFile($formatFile, $string, $message = '')
 {
-    return Assert::assertStringMatchesFormatFile(...func_get_args());
+    return Assert::assertStringMatchesFormatFile(...\func_get_args());
 }
 
 /**
@@ -1110,7 +1110,7 @@ function assertStringMatchesFormatFile($formatFile, $string, $message = '')
  */
 function assertStringNotEqualsFile($expectedFile, $actualString, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::assertStringNotEqualsFile(...func_get_args());
+    return Assert::assertStringNotEqualsFile(...\func_get_args());
 }
 
 /**
@@ -1122,7 +1122,7 @@ function assertStringNotEqualsFile($expectedFile, $actualString, $message = '', 
  */
 function assertStringNotMatchesFormat($format, $string, $message = '')
 {
-    return Assert::assertStringNotMatchesFormat(...func_get_args());
+    return Assert::assertStringNotMatchesFormat(...\func_get_args());
 }
 
 /**
@@ -1134,7 +1134,7 @@ function assertStringNotMatchesFormat($format, $string, $message = '')
  */
 function assertStringNotMatchesFormatFile($formatFile, $string, $message = '')
 {
-    return Assert::assertStringNotMatchesFormatFile(...func_get_args());
+    return Assert::assertStringNotMatchesFormatFile(...\func_get_args());
 }
 
 /**
@@ -1146,7 +1146,7 @@ function assertStringNotMatchesFormatFile($formatFile, $string, $message = '')
  */
 function assertStringStartsNotWith($prefix, $string, $message = '')
 {
-    return Assert::assertStringStartsNotWith(...func_get_args());
+    return Assert::assertStringStartsNotWith(...\func_get_args());
 }
 
 /**
@@ -1158,7 +1158,7 @@ function assertStringStartsNotWith($prefix, $string, $message = '')
  */
 function assertStringStartsWith($prefix, $string, $message = '')
 {
-    return Assert::assertStringStartsWith(...func_get_args());
+    return Assert::assertStringStartsWith(...\func_get_args());
 }
 
 /**
@@ -1170,7 +1170,7 @@ function assertStringStartsWith($prefix, $string, $message = '')
  */
 function assertThat($value, Constraint $constraint, $message = '')
 {
-    return Assert::assertThat(...func_get_args());
+    return Assert::assertThat(...\func_get_args());
 }
 
 /**
@@ -1183,7 +1183,7 @@ function assertThat($value, Constraint $constraint, $message = '')
  */
 function assertTrue($condition, $message = '')
 {
-    return Assert::assertTrue(...func_get_args());
+    return Assert::assertTrue(...\func_get_args());
 }
 
 /**
@@ -1195,7 +1195,7 @@ function assertTrue($condition, $message = '')
  */
 function assertXmlFileEqualsXmlFile($expectedFile, $actualFile, $message = '')
 {
-    return Assert::assertXmlFileEqualsXmlFile(...func_get_args());
+    return Assert::assertXmlFileEqualsXmlFile(...\func_get_args());
 }
 
 /**
@@ -1207,7 +1207,7 @@ function assertXmlFileEqualsXmlFile($expectedFile, $actualFile, $message = '')
  */
 function assertXmlFileNotEqualsXmlFile($expectedFile, $actualFile, $message = '')
 {
-    return Assert::assertXmlFileNotEqualsXmlFile(...func_get_args());
+    return Assert::assertXmlFileNotEqualsXmlFile(...\func_get_args());
 }
 
 /**
@@ -1219,7 +1219,7 @@ function assertXmlFileNotEqualsXmlFile($expectedFile, $actualFile, $message = ''
  */
 function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
 {
-    return Assert::assertXmlStringEqualsXmlFile(...func_get_args());
+    return Assert::assertXmlStringEqualsXmlFile(...\func_get_args());
 }
 
 /**
@@ -1231,7 +1231,7 @@ function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
  */
 function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
 {
-    return Assert::assertXmlStringEqualsXmlString(...func_get_args());
+    return Assert::assertXmlStringEqualsXmlString(...\func_get_args());
 }
 
 /**
@@ -1243,7 +1243,7 @@ function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
  */
 function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '')
 {
-    return Assert::assertXmlStringNotEqualsXmlFile(...func_get_args());
+    return Assert::assertXmlStringNotEqualsXmlFile(...\func_get_args());
 }
 
 /**
@@ -1255,7 +1255,7 @@ function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '
  */
 function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = '')
 {
-    return Assert::assertXmlStringNotEqualsXmlString(...func_get_args());
+    return Assert::assertXmlStringNotEqualsXmlString(...\func_get_args());
 }
 
 /**
@@ -1268,7 +1268,7 @@ function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = 
  */
 function at($index)
 {
-    return TestCase::at(...func_get_args());
+    return TestCase::at(...\func_get_args());
 }
 
 /**
@@ -1278,7 +1278,7 @@ function at($index)
  */
 function atLeastOnce()
 {
-    return TestCase::atLeastOnce(...func_get_args());
+    return TestCase::atLeastOnce(...\func_get_args());
 }
 
 /**
@@ -1291,7 +1291,7 @@ function atLeastOnce()
  */
 function attribute(Constraint $constraint, $attributeName)
 {
-    return Assert::attribute(...func_get_args());
+    return Assert::attribute(...\func_get_args());
 }
 
 /**
@@ -1310,7 +1310,7 @@ function attribute(Constraint $constraint, $attributeName)
  */
 function attributeEqualTo($attributeName, $value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::attributeEqualTo(...func_get_args());
+    return Assert::attributeEqualTo(...\func_get_args());
 }
 
 /**
@@ -1322,7 +1322,7 @@ function attributeEqualTo($attributeName, $value, $delta = 0.0, $maxDepth = 10, 
  */
 function callback($callback)
 {
-    return Assert::callback(...func_get_args());
+    return Assert::callback(...\func_get_args());
 }
 
 /**
@@ -1334,7 +1334,7 @@ function callback($callback)
  */
 function classHasAttribute($attributeName)
 {
-    return Assert::classHasAttribute(...func_get_args());
+    return Assert::classHasAttribute(...\func_get_args());
 }
 
 /**
@@ -1347,7 +1347,7 @@ function classHasAttribute($attributeName)
  */
 function classHasStaticAttribute($attributeName)
 {
-    return Assert::classHasStaticAttribute(...func_get_args());
+    return Assert::classHasStaticAttribute(...\func_get_args());
 }
 
 /**
@@ -1362,7 +1362,7 @@ function classHasStaticAttribute($attributeName)
  */
 function contains($value, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return Assert::contains(...func_get_args());
+    return Assert::contains(...\func_get_args());
 }
 
 /**
@@ -1375,7 +1375,7 @@ function contains($value, $checkForObjectIdentity = true, $checkForNonObjectIden
  */
 function containsOnly($type)
 {
-    return Assert::containsOnly(...func_get_args());
+    return Assert::containsOnly(...\func_get_args());
 }
 
 /**
@@ -1388,7 +1388,7 @@ function containsOnly($type)
  */
 function containsOnlyInstancesOf($classname)
 {
-    return Assert::containsOnlyInstancesOf(...func_get_args());
+    return Assert::containsOnlyInstancesOf(...\func_get_args());
 }
 
 /**
@@ -1400,7 +1400,7 @@ function containsOnlyInstancesOf($classname)
  */
 function countOf($count)
 {
-    return Assert::countOf(...func_get_args());
+    return Assert::countOf(...\func_get_args());
 }
 
 /**
@@ -1416,7 +1416,7 @@ function countOf($count)
  */
 function equalTo($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return Assert::equalTo(...func_get_args());
+    return Assert::equalTo(...\func_get_args());
 }
 
 /**
@@ -1429,7 +1429,7 @@ function equalTo($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $i
  */
 function exactly($count)
 {
-    return TestCase::exactly(...func_get_args());
+    return TestCase::exactly(...\func_get_args());
 }
 
 /**
@@ -1439,7 +1439,7 @@ function exactly($count)
  */
 function fileExists()
 {
-    return Assert::fileExists(...func_get_args());
+    return Assert::fileExists(...\func_get_args());
 }
 
 /**
@@ -1451,7 +1451,7 @@ function fileExists()
  */
 function greaterThan($value)
 {
-    return Assert::greaterThan(...func_get_args());
+    return Assert::greaterThan(...\func_get_args());
 }
 
 /**
@@ -1465,7 +1465,7 @@ function greaterThan($value)
  */
 function greaterThanOrEqual($value)
 {
-    return Assert::greaterThanOrEqual(...func_get_args());
+    return Assert::greaterThanOrEqual(...\func_get_args());
 }
 
 /**
@@ -1477,7 +1477,7 @@ function greaterThanOrEqual($value)
  */
 function identicalTo($value)
 {
-    return Assert::identicalTo(...func_get_args());
+    return Assert::identicalTo(...\func_get_args());
 }
 
 /**
@@ -1487,7 +1487,7 @@ function identicalTo($value)
  */
 function isEmpty()
 {
-    return Assert::isEmpty(...func_get_args());
+    return Assert::isEmpty(...\func_get_args());
 }
 
 /**
@@ -1497,7 +1497,7 @@ function isEmpty()
  */
 function isFalse()
 {
-    return Assert::isFalse(...func_get_args());
+    return Assert::isFalse(...\func_get_args());
 }
 
 /**
@@ -1509,7 +1509,7 @@ function isFalse()
  */
 function isInstanceOf($className)
 {
-    return Assert::isInstanceOf(...func_get_args());
+    return Assert::isInstanceOf(...\func_get_args());
 }
 
 /**
@@ -1519,7 +1519,7 @@ function isInstanceOf($className)
  */
 function isJson()
 {
-    return Assert::isJson(...func_get_args());
+    return Assert::isJson(...\func_get_args());
 }
 
 /**
@@ -1529,7 +1529,7 @@ function isJson()
  */
 function isNull()
 {
-    return Assert::isNull(...func_get_args());
+    return Assert::isNull(...\func_get_args());
 }
 
 /**
@@ -1539,7 +1539,7 @@ function isNull()
  */
 function isTrue()
 {
-    return Assert::isTrue(...func_get_args());
+    return Assert::isTrue(...\func_get_args());
 }
 
 /**
@@ -1551,7 +1551,7 @@ function isTrue()
  */
 function isType($type)
 {
-    return Assert::isType(...func_get_args());
+    return Assert::isType(...\func_get_args());
 }
 
 /**
@@ -1563,7 +1563,7 @@ function isType($type)
  */
 function lessThan($value)
 {
-    return Assert::lessThan(...func_get_args());
+    return Assert::lessThan(...\func_get_args());
 }
 
 /**
@@ -1577,7 +1577,7 @@ function lessThan($value)
  */
 function lessThanOrEqual($value)
 {
-    return Assert::lessThanOrEqual(...func_get_args());
+    return Assert::lessThanOrEqual(...\func_get_args());
 }
 
 /**
@@ -1587,7 +1587,7 @@ function lessThanOrEqual($value)
  */
 function logicalAnd()
 {
-    return Assert::logicalAnd(...func_get_args());
+    return Assert::logicalAnd(...\func_get_args());
 }
 
 /**
@@ -1599,7 +1599,7 @@ function logicalAnd()
  */
 function logicalNot(Constraint $constraint)
 {
-    return Assert::logicalNot(...func_get_args());
+    return Assert::logicalNot(...\func_get_args());
 }
 
 /**
@@ -1609,7 +1609,7 @@ function logicalNot(Constraint $constraint)
  */
 function logicalOr()
 {
-    return Assert::logicalOr(...func_get_args());
+    return Assert::logicalOr(...\func_get_args());
 }
 
 /**
@@ -1619,7 +1619,7 @@ function logicalOr()
  */
 function logicalXor()
 {
-    return Assert::logicalXor(...func_get_args());
+    return Assert::logicalXor(...\func_get_args());
 }
 
 /**
@@ -1631,7 +1631,7 @@ function logicalXor()
  */
 function matches($string)
 {
-    return Assert::matches(...func_get_args());
+    return Assert::matches(...\func_get_args());
 }
 
 /**
@@ -1643,7 +1643,7 @@ function matches($string)
  */
 function matchesRegularExpression($pattern)
 {
-    return Assert::matchesRegularExpression(...func_get_args());
+    return Assert::matchesRegularExpression(...\func_get_args());
 }
 
 /**
@@ -1653,7 +1653,7 @@ function matchesRegularExpression($pattern)
  */
 function never()
 {
-    return TestCase::never(...func_get_args());
+    return TestCase::never(...\func_get_args());
 }
 
 /**
@@ -1665,7 +1665,7 @@ function never()
  */
 function objectHasAttribute($attributeName)
 {
-    return Assert::objectHasAttribute(...func_get_args());
+    return Assert::objectHasAttribute(...\func_get_args());
 }
 
 /**
@@ -1675,7 +1675,7 @@ function objectHasAttribute($attributeName)
  */
 function onConsecutiveCalls()
 {
-    return TestCase::onConsecutiveCalls(...func_get_args());
+    return TestCase::onConsecutiveCalls(...\func_get_args());
 }
 
 /**
@@ -1685,7 +1685,7 @@ function onConsecutiveCalls()
  */
 function once()
 {
-    return TestCase::once(...func_get_args());
+    return TestCase::once(...\func_get_args());
 }
 
 /**
@@ -1695,7 +1695,7 @@ function once()
  */
 function returnArgument($argumentIndex)
 {
-    return TestCase::returnArgument(...func_get_args());
+    return TestCase::returnArgument(...\func_get_args());
 }
 
 /**
@@ -1705,7 +1705,7 @@ function returnArgument($argumentIndex)
  */
 function returnCallback($callback)
 {
-    return TestCase::returnCallback(...func_get_args());
+    return TestCase::returnCallback(...\func_get_args());
 }
 
 /**
@@ -1717,7 +1717,7 @@ function returnCallback($callback)
  */
 function returnSelf()
 {
-    return TestCase::returnSelf(...func_get_args());
+    return TestCase::returnSelf(...\func_get_args());
 }
 
 /**
@@ -1727,7 +1727,7 @@ function returnSelf()
  */
 function returnValue($value)
 {
-    return TestCase::returnValue(...func_get_args());
+    return TestCase::returnValue(...\func_get_args());
 }
 
 /**
@@ -1737,7 +1737,7 @@ function returnValue($value)
  */
 function returnValueMap(array $valueMap)
 {
-    return TestCase::returnValueMap(...func_get_args());
+    return TestCase::returnValueMap(...\func_get_args());
 }
 
 /**
@@ -1750,7 +1750,7 @@ function returnValueMap(array $valueMap)
  */
 function stringContains($string, $case = true)
 {
-    return Assert::stringContains(...func_get_args());
+    return Assert::stringContains(...\func_get_args());
 }
 
 /**
@@ -1762,7 +1762,7 @@ function stringContains($string, $case = true)
  */
 function stringEndsWith($suffix)
 {
-    return Assert::stringEndsWith(...func_get_args());
+    return Assert::stringEndsWith(...\func_get_args());
 }
 
 /**
@@ -1774,7 +1774,7 @@ function stringEndsWith($suffix)
  */
 function stringStartsWith($prefix)
 {
-    return Assert::stringStartsWith(...func_get_args());
+    return Assert::stringStartsWith(...\func_get_args());
 }
 
 /**
@@ -1784,5 +1784,5 @@ function stringStartsWith($prefix)
  */
 function throwException(Exception $exception)
 {
-    return TestCase::throwException(...func_get_args());
+    return TestCase::throwException(...\func_get_args());
 }

--- a/src/Framework/Constraint/ArrayHasKey.php
+++ b/src/Framework/Constraint/ArrayHasKey.php
@@ -45,8 +45,8 @@ class ArrayHasKey extends Constraint
      */
     protected function matches($other)
     {
-        if (is_array($other)) {
-            return array_key_exists($this->key, $other);
+        if (\is_array($other)) {
+            return \array_key_exists($this->key, $other);
         }
 
         if ($other instanceof ArrayAccess) {

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -53,7 +53,7 @@ class ArraySubset extends Constraint
         $other        = $this->toArray($other);
         $this->subset = $this->toArray($this->subset);
 
-        $patched = array_replace_recursive($other, $this->subset);
+        $patched = \array_replace_recursive($other, $this->subset);
 
         if ($this->strict) {
             return $other === $patched;
@@ -94,7 +94,7 @@ class ArraySubset extends Constraint
      */
     private function toArray($other)
     {
-        if (is_array($other)) {
+        if (\is_array($other)) {
             return $other;
         }
 
@@ -103,7 +103,7 @@ class ArraySubset extends Constraint
         }
 
         if ($other instanceof \Traversable) {
-            return iterator_to_array($other);
+            return \iterator_to_array($other);
         }
 
         // Keep BC even if we know that array would not be the expected one

--- a/src/Framework/Constraint/Callback.php
+++ b/src/Framework/Constraint/Callback.php
@@ -25,7 +25,7 @@ class Callback extends Constraint
      */
     public function __construct($callback)
     {
-        if (!is_callable($callback)) {
+        if (!\is_callable($callback)) {
             throw InvalidArgumentHelper::factory(
                 1,
                 'callable'
@@ -47,7 +47,7 @@ class Callback extends Constraint
      */
     protected function matches($other)
     {
-        return call_user_func($this->callback, $other);
+        return \call_user_func($this->callback, $other);
     }
 
     /**

--- a/src/Framework/Constraint/ClassHasAttribute.php
+++ b/src/Framework/Constraint/ClassHasAttribute.php
@@ -55,7 +55,7 @@ class ClassHasAttribute extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'has attribute "%s"',
             $this->attributeName
         );
@@ -73,10 +73,10 @@ class ClassHasAttribute extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             '%sclass "%s" %s',
-            is_object($other) ? 'object of ' : '',
-            is_object($other) ? get_class($other) : $other,
+            \is_object($other) ? 'object of ' : '',
+            \is_object($other) ? \get_class($other) : $other,
             $this->toString()
         );
     }

--- a/src/Framework/Constraint/ClassHasStaticAttribute.php
+++ b/src/Framework/Constraint/ClassHasStaticAttribute.php
@@ -47,7 +47,7 @@ class ClassHasStaticAttribute extends ClassHasAttribute
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'has static attribute "%s"',
             $this->attributeName
         );

--- a/src/Framework/Constraint/Composite.php
+++ b/src/Framework/Constraint/Composite.php
@@ -65,6 +65,6 @@ abstract class Composite extends Constraint
      */
     public function count()
     {
-        return count($this->innerConstraint);
+        return \count($this->innerConstraint);
     }
 }

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -99,7 +99,7 @@ abstract class Constraint implements Countable, SelfDescribing
      */
     protected function fail($other, $description, ComparisonFailure $comparisonFailure = null)
     {
-        $failureDescription = sprintf(
+        $failureDescription = \sprintf(
             'Failed asserting that %s.',
             $this->failureDescription($other)
         );

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -50,8 +50,8 @@ class Count extends Constraint
      */
     protected function getCountOf($other)
     {
-        if ($other instanceof Countable || is_array($other)) {
-            return count($other);
+        if ($other instanceof Countable || \is_array($other)) {
+            return \count($other);
         }
 
         if ($other instanceof Traversable) {
@@ -66,7 +66,7 @@ class Count extends Constraint
             }
 
             $key   = $iterator->key();
-            $count = iterator_count($iterator);
+            $count = \iterator_count($iterator);
 
             // Manually rewind $iterator to previous key, since iterator_count
             // moves pointer.
@@ -110,7 +110,7 @@ class Count extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             'actual size %d matches expected size %d',
             $this->getCountOf($other),
             $this->expectedCount
@@ -122,7 +122,7 @@ class Count extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'count matches %d',
             $this->expectedCount
         );

--- a/src/Framework/Constraint/DirectoryExists.php
+++ b/src/Framework/Constraint/DirectoryExists.php
@@ -26,7 +26,7 @@ class DirectoryExists extends Constraint
      */
     protected function matches($other)
     {
-        return is_dir($other);
+        return \is_dir($other);
     }
 
     /**
@@ -41,7 +41,7 @@ class DirectoryExists extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             'directory "%s" exists',
             $other
         );

--- a/src/Framework/Constraint/Exception.php
+++ b/src/Framework/Constraint/Exception.php
@@ -60,15 +60,15 @@ class Exception extends Constraint
                     . "\n" . Filter::getFilteredStacktrace($other);
             }
 
-            return sprintf(
+            return \sprintf(
                 'exception of type "%s" matches expected exception "%s"%s',
-                get_class($other),
+                \get_class($other),
                 $this->className,
                 $message
             );
         }
 
-        return sprintf(
+        return \sprintf(
             'exception of type "%s" is thrown',
             $this->className
         );
@@ -81,7 +81,7 @@ class Exception extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'exception of type "%s"',
             $this->className
         );

--- a/src/Framework/Constraint/ExceptionCode.php
+++ b/src/Framework/Constraint/ExceptionCode.php
@@ -51,7 +51,7 @@ class ExceptionCode extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             '%s is equal to expected exception code %s',
             $this->exporter->export($other->getCode()),
             $this->exporter->export($this->expectedCode)

--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -36,7 +36,7 @@ class ExceptionMessage extends Constraint
      */
     protected function matches($other)
     {
-        return strpos($other->getMessage(), $this->expectedMessage) !== false;
+        return \strpos($other->getMessage(), $this->expectedMessage) !== false;
     }
 
     /**
@@ -51,7 +51,7 @@ class ExceptionMessage extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             "exception message '%s' contains '%s'",
             $other->getMessage(),
             $this->expectedMessage

--- a/src/Framework/Constraint/ExceptionMessageRegularExpression.php
+++ b/src/Framework/Constraint/ExceptionMessageRegularExpression.php
@@ -60,7 +60,7 @@ class ExceptionMessageRegularExpression extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             "exception message '%s' matches '%s'",
             $other->getMessage(),
             $this->expectedMessageRegExp

--- a/src/Framework/Constraint/FileExists.php
+++ b/src/Framework/Constraint/FileExists.php
@@ -26,7 +26,7 @@ class FileExists extends Constraint
      */
     protected function matches($other)
     {
-        return file_exists($other);
+        return \file_exists($other);
     }
 
     /**
@@ -41,7 +41,7 @@ class FileExists extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             'file "%s" exists',
             $other
         );

--- a/src/Framework/Constraint/IsEmpty.php
+++ b/src/Framework/Constraint/IsEmpty.php
@@ -27,7 +27,7 @@ class IsEmpty extends Constraint
     protected function matches($other)
     {
         if ($other instanceof Countable) {
-            return count($other) === 0;
+            return \count($other) === 0;
         }
 
         return empty($other);
@@ -55,9 +55,9 @@ class IsEmpty extends Constraint
      */
     protected function failureDescription($other)
     {
-        $type = gettype($other);
+        $type = \gettype($other);
 
-        return sprintf(
+        return \sprintf(
             '%s %s %s',
             $type[0] == 'a' || $type[0] == 'o' ? 'an' : 'a',
             $type,

--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -67,19 +67,19 @@ class IsEqual extends Constraint
     {
         parent::__construct();
 
-        if (!is_numeric($delta)) {
+        if (!\is_numeric($delta)) {
             throw InvalidArgumentHelper::factory(2, 'numeric');
         }
 
-        if (!is_int($maxDepth)) {
+        if (!\is_int($maxDepth)) {
             throw InvalidArgumentHelper::factory(3, 'integer');
         }
 
-        if (!is_bool($canonicalize)) {
+        if (!\is_bool($canonicalize)) {
             throw InvalidArgumentHelper::factory(4, 'boolean');
         }
 
-        if (!is_bool($ignoreCase)) {
+        if (!\is_bool($ignoreCase)) {
             throw InvalidArgumentHelper::factory(5, 'boolean');
         }
 
@@ -138,7 +138,7 @@ class IsEqual extends Constraint
             }
 
             throw new ExpectationFailedException(
-                trim($description . "\n" . $f->getMessage()),
+                \trim($description . "\n" . $f->getMessage()),
                 $f
             );
         }
@@ -155,25 +155,25 @@ class IsEqual extends Constraint
     {
         $delta = '';
 
-        if (is_string($this->value)) {
-            if (strpos($this->value, "\n") !== false) {
+        if (\is_string($this->value)) {
+            if (\strpos($this->value, "\n") !== false) {
                 return 'is equal to <text>';
             }
 
-            return sprintf(
+            return \sprintf(
                 'is equal to <string:%s>',
                 $this->value
             );
         }
 
         if ($this->delta != 0) {
-            $delta = sprintf(
+            $delta = \sprintf(
                 ' with delta <%F>',
                 $this->delta
             );
         }
 
-        return sprintf(
+        return \sprintf(
             'is equal to %s%s',
             $this->exporter->export($this->value),
             $delta

--- a/src/Framework/Constraint/IsFinite.php
+++ b/src/Framework/Constraint/IsFinite.php
@@ -24,7 +24,7 @@ class IsFinite extends Constraint
      */
     protected function matches($other)
     {
-        return is_finite($other);
+        return \is_finite($other);
     }
 
     /**

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -64,11 +64,11 @@ class IsIdentical extends Constraint
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
-        if (is_float($this->value) && is_float($other) &&
-            !is_infinite($this->value) && !is_infinite($other) &&
-            !is_nan($this->value) && !is_nan($other)
+        if (\is_float($this->value) && \is_float($other) &&
+            !\is_infinite($this->value) && !\is_infinite($other) &&
+            !\is_nan($this->value) && !\is_nan($other)
         ) {
-            $success = abs($this->value - $other) < self::EPSILON;
+            $success = \abs($this->value - $other) < self::EPSILON;
         } else {
             $success = $this->value === $other;
         }
@@ -81,12 +81,12 @@ class IsIdentical extends Constraint
             $f = null;
 
             // if both values are strings, make sure a diff is generated
-            if (is_string($this->value) && is_string($other)) {
+            if (\is_string($this->value) && \is_string($other)) {
                 $f = new SebastianBergmann\Comparator\ComparisonFailure(
                     $this->value,
                     $other,
-                    sprintf("'%s'", $this->value),
-                    sprintf("'%s'", $other)
+                    \sprintf("'%s'", $this->value),
+                    \sprintf("'%s'", $other)
                 );
             }
 
@@ -106,11 +106,11 @@ class IsIdentical extends Constraint
      */
     protected function failureDescription($other)
     {
-        if (is_object($this->value) && is_object($other)) {
+        if (\is_object($this->value) && \is_object($other)) {
             return 'two variables reference the same object';
         }
 
-        if (is_string($this->value) && is_string($other)) {
+        if (\is_string($this->value) && \is_string($other)) {
             return 'two strings are identical';
         }
 
@@ -124,9 +124,9 @@ class IsIdentical extends Constraint
      */
     public function toString()
     {
-        if (is_object($this->value)) {
+        if (\is_object($this->value)) {
             return 'is identical to an object of class "' .
-                get_class($this->value) . '"';
+                \get_class($this->value) . '"';
         }
 
         return 'is identical to ' . $this->exporter->export($this->value);

--- a/src/Framework/Constraint/IsInfinite.php
+++ b/src/Framework/Constraint/IsInfinite.php
@@ -24,7 +24,7 @@ class IsInfinite extends Constraint
      */
     protected function matches($other)
     {
-        return is_infinite($other);
+        return \is_infinite($other);
     }
 
     /**

--- a/src/Framework/Constraint/IsInstanceOf.php
+++ b/src/Framework/Constraint/IsInstanceOf.php
@@ -59,7 +59,7 @@ class IsInstanceOf extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             '%s is an instance of %s "%s"',
             $this->exporter->shortenedExport($other),
             $this->getType(),
@@ -74,7 +74,7 @@ class IsInstanceOf extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'is instance of %s "%s"',
             $this->getType(),
             $this->className

--- a/src/Framework/Constraint/IsJson.php
+++ b/src/Framework/Constraint/IsJson.php
@@ -28,8 +28,8 @@ class IsJson extends Constraint
             return false;
         }
 
-        json_decode($other);
-        if (json_last_error()) {
+        \json_decode($other);
+        if (\json_last_error()) {
             return false;
         }
 
@@ -52,12 +52,12 @@ class IsJson extends Constraint
             return 'an empty string is valid JSON';
         }
 
-        json_decode($other);
+        \json_decode($other);
         $error = JsonMatchesErrorMessageProvider::determineJsonError(
-            json_last_error()
+            \json_last_error()
         );
 
-        return sprintf(
+        return \sprintf(
             '%s is valid JSON (%s)',
             $this->exporter->shortenedExport($other),
             $error

--- a/src/Framework/Constraint/IsNan.php
+++ b/src/Framework/Constraint/IsNan.php
@@ -24,7 +24,7 @@ class IsNan extends Constraint
      */
     protected function matches($other)
     {
-        return is_nan($other);
+        return \is_nan($other);
     }
 
     /**

--- a/src/Framework/Constraint/IsReadable.php
+++ b/src/Framework/Constraint/IsReadable.php
@@ -26,7 +26,7 @@ class IsReadable extends Constraint
      */
     protected function matches($other)
     {
-        return is_readable($other);
+        return \is_readable($other);
     }
 
     /**
@@ -41,7 +41,7 @@ class IsReadable extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             '"%s" is readable',
             $other
         );

--- a/src/Framework/Constraint/IsType.php
+++ b/src/Framework/Constraint/IsType.php
@@ -66,7 +66,7 @@ class IsType extends Constraint
 
         if (!isset($this->types[$type])) {
             throw new \PHPUnit\Framework\Exception(
-                sprintf(
+                \sprintf(
                     'Type specified for PHPUnit\Framework\Constraint\IsType <%s> ' .
                     'is not a valid type.',
                     $type
@@ -89,41 +89,41 @@ class IsType extends Constraint
     {
         switch ($this->type) {
             case 'numeric':
-                return is_numeric($other);
+                return \is_numeric($other);
 
             case 'integer':
             case 'int':
-                return is_int($other);
+                return \is_int($other);
 
             case 'double':
             case 'float':
             case 'real':
-                return is_float($other);
+                return \is_float($other);
 
             case 'string':
-                return is_string($other);
+                return \is_string($other);
 
             case 'boolean':
             case 'bool':
-                return is_bool($other);
+                return \is_bool($other);
 
             case 'null':
-                return is_null($other);
+                return \is_null($other);
 
             case 'array':
-                return is_array($other);
+                return \is_array($other);
 
             case 'object':
-                return is_object($other);
+                return \is_object($other);
 
             case 'resource':
-                return is_resource($other) || is_string(@get_resource_type($other));
+                return \is_resource($other) || \is_string(@\get_resource_type($other));
 
             case 'scalar':
-                return is_scalar($other);
+                return \is_scalar($other);
 
             case 'callable':
-                return is_callable($other);
+                return \is_callable($other);
         }
     }
 
@@ -134,7 +134,7 @@ class IsType extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'is of type "%s"',
             $this->type
         );

--- a/src/Framework/Constraint/IsWritable.php
+++ b/src/Framework/Constraint/IsWritable.php
@@ -26,7 +26,7 @@ class IsWritable extends Constraint
      */
     protected function matches($other)
     {
-        return is_writable($other);
+        return \is_writable($other);
     }
 
     /**
@@ -41,7 +41,7 @@ class IsWritable extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             '"%s" is writable',
             $other
         );

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -64,12 +64,12 @@ class JsonMatches extends Constraint
      */
     private function canonicalizeJson($json)
     {
-        $decodedJson = json_decode($json, true);
-        if (json_last_error()) {
+        $decodedJson = \json_decode($json, true);
+        if (\json_last_error()) {
             return [true, null];
         }
         $this->recursiveSort($decodedJson);
-        $reencodedJson = json_encode($decodedJson);
+        $reencodedJson = \json_encode($decodedJson);
 
         return [false, $reencodedJson];
     }
@@ -81,8 +81,8 @@ class JsonMatches extends Constraint
      */
     private function recursiveSort(&$json)
     {
-        if (is_array($json)) {
-            ksort($json);
+        if (\is_array($json)) {
+            \ksort($json);
             foreach ($json as $key => &$value) {
                 $this->recursiveSort($value);
             }
@@ -96,7 +96,7 @@ class JsonMatches extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'matches JSON string "%s"',
             $this->value
         );

--- a/src/Framework/Constraint/JsonMatchesErrorMessageProvider.php
+++ b/src/Framework/Constraint/JsonMatchesErrorMessageProvider.php
@@ -52,7 +52,7 @@ class JsonMatchesErrorMessageProvider
      */
     public static function translateTypeToPrefix($type)
     {
-        switch (strtolower($type)) {
+        switch (\strtolower($type)) {
             case 'expected':
                 $prefix = 'Expected value JSON decode error - ';
                 break;

--- a/src/Framework/Constraint/LogicalAnd.php
+++ b/src/Framework/Constraint/LogicalAnd.php
@@ -116,7 +116,7 @@ class LogicalAnd extends Constraint
         $count = 0;
 
         foreach ($this->constraints as $constraint) {
-            $count += count($constraint);
+            $count += \count($constraint);
         }
 
         return $count;

--- a/src/Framework/Constraint/LogicalNot.php
+++ b/src/Framework/Constraint/LogicalNot.php
@@ -42,7 +42,7 @@ class LogicalNot extends Constraint
      */
     public static function negate($string)
     {
-        return str_replace(
+        return \str_replace(
             [
                 'contains ',
                 'exists',
@@ -114,7 +114,7 @@ class LogicalNot extends Constraint
      */
     protected function failureDescription($other)
     {
-        switch (get_class($this->constraint)) {
+        switch (\get_class($this->constraint)) {
             case LogicalAnd::class:
             case self::class:
             case LogicalOr::class:
@@ -134,7 +134,7 @@ class LogicalNot extends Constraint
      */
     public function toString()
     {
-        switch (get_class($this->constraint)) {
+        switch (\get_class($this->constraint)) {
             case LogicalAnd::class:
             case self::class:
             case LogicalOr::class:
@@ -154,6 +154,6 @@ class LogicalNot extends Constraint
      */
     public function count()
     {
-        return count($this->constraint);
+        return \count($this->constraint);
     }
 }

--- a/src/Framework/Constraint/LogicalOr.php
+++ b/src/Framework/Constraint/LogicalOr.php
@@ -108,7 +108,7 @@ class LogicalOr extends Constraint
         $count = 0;
 
         foreach ($this->constraints as $constraint) {
-            $count += count($constraint);
+            $count += \count($constraint);
         }
 
         return $count;

--- a/src/Framework/Constraint/LogicalXor.php
+++ b/src/Framework/Constraint/LogicalXor.php
@@ -113,7 +113,7 @@ class LogicalXor extends Constraint
         $count = 0;
 
         foreach ($this->constraints as $constraint) {
-            $count += count($constraint);
+            $count += \count($constraint);
         }
 
         return $count;

--- a/src/Framework/Constraint/RegularExpression.php
+++ b/src/Framework/Constraint/RegularExpression.php
@@ -44,7 +44,7 @@ class RegularExpression extends Constraint
      */
     protected function matches($other)
     {
-        return preg_match($this->pattern, $other) > 0;
+        return \preg_match($this->pattern, $other) > 0;
     }
 
     /**
@@ -54,7 +54,7 @@ class RegularExpression extends Constraint
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             'matches PCRE pattern "%s"',
             $this->pattern
         );

--- a/src/Framework/Constraint/StringContains.php
+++ b/src/Framework/Constraint/StringContains.php
@@ -53,10 +53,10 @@ class StringContains extends Constraint
     protected function matches($other)
     {
         if ($this->ignoreCase) {
-            return mb_stripos($other, $this->string) !== false;
+            return \mb_stripos($other, $this->string) !== false;
         }
 
-        return mb_strpos($other, $this->string) !== false;
+        return \mb_strpos($other, $this->string) !== false;
     }
 
     /**
@@ -67,12 +67,12 @@ class StringContains extends Constraint
     public function toString()
     {
         if ($this->ignoreCase) {
-            $string = mb_strtolower($this->string);
+            $string = \mb_strtolower($this->string);
         } else {
             $string = $this->string;
         }
 
-        return sprintf(
+        return \sprintf(
             'contains "%s"',
             $string
         );

--- a/src/Framework/Constraint/StringEndsWith.php
+++ b/src/Framework/Constraint/StringEndsWith.php
@@ -39,7 +39,7 @@ class StringEndsWith extends Constraint
      */
     protected function matches($other)
     {
-        return substr($other, 0 - strlen($this->suffix)) == $this->suffix;
+        return \substr($other, 0 - \strlen($this->suffix)) == $this->suffix;
     }
 
     /**

--- a/src/Framework/Constraint/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/StringMatchesFormatDescription.php
@@ -30,7 +30,7 @@ class StringMatchesFormatDescription extends RegularExpression
         parent::__construct($string);
 
         $this->pattern = $this->createPatternFromFormat(
-            preg_replace('/\r\n/', "\n", $string)
+            \preg_replace('/\r\n/', "\n", $string)
         );
 
         $this->string = $string;
@@ -43,21 +43,21 @@ class StringMatchesFormatDescription extends RegularExpression
 
     protected function additionalFailureDescription($other)
     {
-        $from = preg_split('(\r\n|\r|\n)', $this->string);
-        $to   = preg_split('(\r\n|\r|\n)', $other);
+        $from = \preg_split('(\r\n|\r|\n)', $this->string);
+        $to   = \preg_split('(\r\n|\r|\n)', $other);
 
         foreach ($from as $index => $line) {
             if (isset($to[$index]) && $line !== $to[$index]) {
                 $line = $this->createPatternFromFormat($line);
 
-                if (preg_match($line, $to[$index]) > 0) {
+                if (\preg_match($line, $to[$index]) > 0) {
                     $from[$index] = $to[$index];
                 }
             }
         }
 
-        $this->string = implode("\n", $from);
-        $other        = implode("\n", $to);
+        $this->string = \implode("\n", $from);
+        $other        = \implode("\n", $to);
 
         $differ = new Differ("--- Expected\n+++ Actual\n");
 
@@ -66,7 +66,7 @@ class StringMatchesFormatDescription extends RegularExpression
 
     protected function createPatternFromFormat($string)
     {
-        $string = str_replace(
+        $string = \str_replace(
             [
                 '%e',
                 '%s',
@@ -93,7 +93,7 @@ class StringMatchesFormatDescription extends RegularExpression
                 '[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?',
                 '.'
             ],
-            preg_quote($string, '/')
+            \preg_quote($string, '/')
         );
 
         return '/^' . $string . '$/s';

--- a/src/Framework/Constraint/StringStartsWith.php
+++ b/src/Framework/Constraint/StringStartsWith.php
@@ -39,7 +39,7 @@ class StringStartsWith extends Constraint
      */
     protected function matches($other)
     {
-        return strpos($other, $this->prefix) === 0;
+        return \strpos($other, $this->prefix) === 0;
     }
 
     /**

--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -44,11 +44,11 @@ class TraversableContains extends Constraint
     {
         parent::__construct();
 
-        if (!is_bool($checkForObjectIdentity)) {
+        if (!\is_bool($checkForObjectIdentity)) {
             throw InvalidArgumentHelper::factory(2, 'boolean');
         }
 
-        if (!is_bool($checkForNonObjectIdentity)) {
+        if (!\is_bool($checkForNonObjectIdentity)) {
             throw InvalidArgumentHelper::factory(3, 'boolean');
         }
 
@@ -71,7 +71,7 @@ class TraversableContains extends Constraint
             return $other->contains($this->value);
         }
 
-        if (is_object($this->value)) {
+        if (\is_object($this->value)) {
             foreach ($other as $element) {
                 if ($this->checkForObjectIdentity && $element === $this->value) {
                     return true;
@@ -103,7 +103,7 @@ class TraversableContains extends Constraint
      */
     public function toString()
     {
-        if (is_string($this->value) && strpos($this->value, "\n") !== false) {
+        if (\is_string($this->value) && \strpos($this->value, "\n") !== false) {
             return 'contains "' . $this->value . '"';
         }
 
@@ -122,9 +122,9 @@ class TraversableContains extends Constraint
      */
     protected function failureDescription($other)
     {
-        return sprintf(
+        return \sprintf(
             '%s %s',
-            is_array($other) ? 'an array' : 'a traversable',
+            \is_array($other) ? 'an array' : 'a traversable',
             $this->toString()
         );
     }

--- a/src/Framework/Exception.php
+++ b/src/Framework/Exception.php
@@ -75,6 +75,6 @@ class Exception extends \RuntimeException implements \PHPUnit\Exception
 
     public function __sleep()
     {
-        return array_keys(get_object_vars($this));
+        return \array_keys(\get_object_vars($this));
     }
 }

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -42,7 +42,7 @@ class ExceptionWrapper extends Exception
         // @see http://php.net/manual/en/class.pdoexception.php#95812
         parent::__construct($t->getMessage(), (int) $t->getCode());
 
-        $this->className = get_class($t);
+        $this->className = \get_class($t);
         $this->file      = $t->getFile();
         $this->line      = $t->getLine();
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -344,7 +344,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     {
         $class = new ReflectionClass($this);
 
-        $buffer = sprintf(
+        $buffer = \sprintf(
             '%s::%s',
             $class->name,
             $this->getName(false)
@@ -384,7 +384,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     public function getAnnotations()
     {
         return \PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
+            \get_class($this),
             $this->name
         );
     }
@@ -413,7 +413,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     public function getSize()
     {
         return \PHPUnit\Util\Test::getSize(
-            get_class($this),
+            \get_class($this),
             $this->getName(false)
         );
     }
@@ -459,7 +459,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             return $this->output;
         }
 
-        return ob_get_contents();
+        return \ob_get_contents();
     }
 
     /**
@@ -467,7 +467,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function hasOutput()
     {
-        if (strlen($this->output) === 0) {
+        if (\strlen($this->output) === 0) {
             return false;
         }
 
@@ -497,7 +497,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             throw new Exception;
         }
 
-        if (is_string($expectedRegex) || is_null($expectedRegex)) {
+        if (\is_string($expectedRegex) || \is_null($expectedRegex)) {
             $this->outputExpectedRegex = $expectedRegex;
         }
     }
@@ -511,7 +511,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             throw new Exception;
         }
 
-        if (is_string($expectedString) || is_null($expectedString)) {
+        if (\is_string($expectedString) || \is_null($expectedString)) {
             $this->outputExpectedString = $expectedString;
         }
     }
@@ -521,7 +521,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function hasExpectationOnOutput()
     {
-        return is_string($this->outputExpectedString) || is_string($this->outputExpectedRegex);
+        return \is_string($this->outputExpectedString) || \is_string($this->outputExpectedRegex);
     }
 
     /**
@@ -553,7 +553,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function expectException($exception)
     {
-        if (!is_string($exception)) {
+        if (!\is_string($exception)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -571,7 +571,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->expectedException = \Exception::class;
         }
 
-        if (!is_int($code) && !is_string($code)) {
+        if (!\is_int($code) && !\is_string($code)) {
             throw InvalidArgumentHelper::factory(1, 'integer or string');
         }
 
@@ -589,7 +589,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->expectedException = \Exception::class;
         }
 
-        if (!is_string($message)) {
+        if (!\is_string($message)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -603,7 +603,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function expectExceptionMessageRegExp($messageRegExp)
     {
-        if (!is_string($messageRegExp)) {
+        if (!\is_string($messageRegExp)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
@@ -615,7 +615,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setRegisterMockObjectsFromTestArgumentsRecursively($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -626,7 +626,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     {
         try {
             $expectedException = \PHPUnit\Util\Test::getExpectedException(
-                get_class($this),
+                \get_class($this),
                 $this->name
             );
 
@@ -659,7 +659,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     {
         try {
             $useErrorHandler = \PHPUnit\Util\Test::getErrorHandlerSettings(
-                get_class($this),
+                \get_class($this),
                 $this->name
             );
 
@@ -672,17 +672,17 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     protected function checkRequirements()
     {
-        if (!$this->name || !method_exists($this, $this->name)) {
+        if (!$this->name || !\method_exists($this, $this->name)) {
             return;
         }
 
         $missingRequirements = \PHPUnit\Util\Test::getMissingRequirements(
-            get_class($this),
+            \get_class($this),
             $this->name
         );
 
         if (!empty($missingRequirements)) {
-            $this->markTestSkipped(implode(PHP_EOL, $missingRequirements));
+            $this->markTestSkipped(\implode(PHP_EOL, $missingRequirements));
         }
     }
 
@@ -774,7 +774,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             } else {
                 $constants = '';
                 if (!empty($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
-                    $globals = '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = ' . var_export($GLOBALS['__PHPUNIT_BOOTSTRAP'], true) . ";\n";
+                    $globals = '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = ' . \var_export($GLOBALS['__PHPUNIT_BOOTSTRAP'], true) . ";\n";
                 } else {
                     $globals = '';
                 }
@@ -789,14 +789,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $isStrictAboutTodoAnnotatedTests            = $result->isStrictAboutTodoAnnotatedTests() ? 'true' : 'false';
             $isStrictAboutResourceUsageDuringSmallTests = $result->isStrictAboutResourceUsageDuringSmallTests() ? 'true' : 'false';
 
-            if (defined('PHPUNIT_COMPOSER_INSTALL')) {
-                $composerAutoload = var_export(PHPUNIT_COMPOSER_INSTALL, true);
+            if (\defined('PHPUNIT_COMPOSER_INSTALL')) {
+                $composerAutoload = \var_export(PHPUNIT_COMPOSER_INSTALL, true);
             } else {
                 $composerAutoload = '\'\'';
             }
 
-            if (defined('__PHPUNIT_PHAR__')) {
-                $phar = var_export(__PHPUNIT_PHAR__, true);
+            if (\defined('__PHPUNIT_PHAR__')) {
+                $phar = \var_export(__PHPUNIT_PHAR__, true);
             } else {
                 $phar = '\'\'';
             }
@@ -807,11 +807,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 $codeCoverageFilter = null;
             }
 
-            $data               = var_export(serialize($this->data), true);
-            $dataName           = var_export($this->dataName, true);
-            $dependencyInput    = var_export(serialize($this->dependencyInput), true);
-            $includePath        = var_export(get_include_path(), true);
-            $codeCoverageFilter = var_export(serialize($codeCoverageFilter), true);
+            $data               = \var_export(\serialize($this->data), true);
+            $dataName           = \var_export($this->dataName, true);
+            $dependencyInput    = \var_export(\serialize($this->dependencyInput), true);
+            $includePath        = \var_export(\get_include_path(), true);
+            $codeCoverageFilter = \var_export(\serialize($codeCoverageFilter), true);
             // must do these fixes because TestCaseMethod.tpl has unserialize('{data}') in it, and we can't break BC
             // the lines above used to use addcslashes() rather than var_export(), which breaks null byte escape sequences
             $data               = "'." . $data . ".'";
@@ -874,10 +874,10 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
         $this->snapshotGlobalState();
         $this->startOutputBuffering();
-        clearstatcache();
-        $currentWorkingDirectory = getcwd();
+        \clearstatcache();
+        $currentWorkingDirectory = \getcwd();
 
-        $hookMethods = \PHPUnit\Util\Test::getHookMethods(get_class($this));
+        $hookMethods = \PHPUnit\Util\Test::getHookMethods(\get_class($this));
 
         try {
             $hasMetRequirements = false;
@@ -904,9 +904,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
             if (!empty($this->warnings)) {
                 throw new Warning(
-                    implode(
+                    \implode(
                         "\n",
-                        array_unique($this->warnings)
+                        \array_unique($this->warnings)
                     )
                 );
             }
@@ -968,24 +968,24 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             }
         }
 
-        clearstatcache();
+        \clearstatcache();
 
-        if ($currentWorkingDirectory != getcwd()) {
-            chdir($currentWorkingDirectory);
+        if ($currentWorkingDirectory != \getcwd()) {
+            \chdir($currentWorkingDirectory);
         }
 
         $this->restoreGlobalState();
 
         // Clean up INI settings.
         foreach ($this->iniSettings as $varName => $oldValue) {
-            ini_set($varName, $oldValue);
+            \ini_set($varName, $oldValue);
         }
 
         $this->iniSettings = [];
 
         // Clean up locale settings.
         foreach ($this->locale as $category => $locale) {
-            setlocale($category, $locale);
+            \setlocale($category, $locale);
         }
 
         // Perform assertion on output.
@@ -1034,7 +1034,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->fail($e->getMessage());
         }
 
-        $testArguments = array_merge($this->data, $this->dependencyInput);
+        $testArguments = \array_merge($this->data, $this->dependencyInput);
 
         $this->registerMockObjectsFromTestArguments($testArguments);
 
@@ -1047,7 +1047,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         if (isset($e)) {
             $checkException = false;
 
-            if (!($e instanceof SkippedTestError) && is_string($this->expectedException)) {
+            if (!($e instanceof SkippedTestError) && \is_string($this->expectedException)) {
                 $checkException = true;
 
                 if ($e instanceof Exception) {
@@ -1072,7 +1072,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     )
                 );
 
-                if (is_string($this->expectedExceptionMessage) &&
+                if (\is_string($this->expectedExceptionMessage) &&
                     !empty($this->expectedExceptionMessage)
                 ) {
                     $this->assertThat(
@@ -1083,7 +1083,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     );
                 }
 
-                if (is_string($this->expectedExceptionMessageRegExp) &&
+                if (\is_string($this->expectedExceptionMessageRegExp) &&
                     !empty($this->expectedExceptionMessageRegExp)
                 ) {
                     $this->assertThat(
@@ -1146,7 +1146,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             foreach ($this->prophet->getProphecies() as $objectProphecy) {
                 foreach ($objectProphecy->getMethodProphecies() as $methodProphecies) {
                     foreach ($methodProphecies as $methodProphecy) {
-                        $this->numAssertions += count($methodProphecy->getCheckedPredictions());
+                        $this->numAssertions += \count($methodProphecy->getCheckedPredictions());
                     }
                 }
             }
@@ -1184,7 +1184,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function hasDependencies()
     {
-        return count($this->dependencies) > 0;
+        return \count($this->dependencies) > 0;
     }
 
     /**
@@ -1212,7 +1212,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setBackupGlobals($backupGlobals)
     {
-        if (is_null($this->backupGlobals) && is_bool($backupGlobals)) {
+        if (\is_null($this->backupGlobals) && \is_bool($backupGlobals)) {
             $this->backupGlobals = $backupGlobals;
         }
     }
@@ -1224,8 +1224,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setBackupStaticAttributes($backupStaticAttributes)
     {
-        if (is_null($this->backupStaticAttributes) &&
-            is_bool($backupStaticAttributes)
+        if (\is_null($this->backupStaticAttributes) &&
+            \is_bool($backupStaticAttributes)
         ) {
             $this->backupStaticAttributes = $backupStaticAttributes;
         }
@@ -1238,7 +1238,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setRunTestInSeparateProcess($runTestInSeparateProcess)
     {
-        if (is_bool($runTestInSeparateProcess)) {
+        if (\is_bool($runTestInSeparateProcess)) {
             if ($this->runTestInSeparateProcess === null) {
                 $this->runTestInSeparateProcess = $runTestInSeparateProcess;
             }
@@ -1254,7 +1254,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setPreserveGlobalState($preserveGlobalState)
     {
-        if (is_bool($preserveGlobalState)) {
+        if (\is_bool($preserveGlobalState)) {
             $this->preserveGlobalState = $preserveGlobalState;
         } else {
             throw InvalidArgumentHelper::factory(1, 'boolean');
@@ -1268,7 +1268,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setInIsolation($inIsolation)
     {
-        if (is_bool($inIsolation)) {
+        if (\is_bool($inIsolation)) {
             $this->inIsolation = $inIsolation;
         } else {
             throw InvalidArgumentHelper::factory(1, 'boolean');
@@ -1306,7 +1306,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function setOutputCallback($callback)
     {
-        if (!is_callable($callback)) {
+        if (!\is_callable($callback)) {
             throw InvalidArgumentHelper::factory(1, 'callback');
         }
 
@@ -1349,17 +1349,17 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     protected function iniSet($varName, $newValue)
     {
-        if (!is_string($varName)) {
+        if (!\is_string($varName)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        $currentValue = ini_set($varName, $newValue);
+        $currentValue = \ini_set($varName, $newValue);
 
         if ($currentValue !== false) {
             $this->iniSettings[$varName] = $currentValue;
         } else {
             throw new Exception(
-                sprintf(
+                \sprintf(
                     'INI setting "%s" could not be set to "%s".',
                     $varName,
                     $newValue
@@ -1379,9 +1379,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     protected function setLocale()
     {
-        $args = func_get_args();
+        $args = \func_get_args();
 
-        if (count($args) < 2) {
+        if (\count($args) < 2) {
             throw new Exception;
         }
 
@@ -1392,21 +1392,21 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME
         ];
 
-        if (defined('LC_MESSAGES')) {
+        if (\defined('LC_MESSAGES')) {
             $categories[] = LC_MESSAGES;
         }
 
-        if (!in_array($category, $categories)) {
+        if (!\in_array($category, $categories)) {
             throw new Exception;
         }
 
-        if (!is_array($locale) && !is_string($locale)) {
+        if (!\is_array($locale) && !\is_string($locale)) {
             throw new Exception;
         }
 
-        $this->locale[$category] = setlocale($category, 0);
+        $this->locale[$category] = \setlocale($category, 0);
 
-        $result = call_user_func_array('setlocale', $args);
+        $result = \call_user_func_array('setlocale', $args);
 
         if ($result === false) {
             throw new Exception(
@@ -1537,7 +1537,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $cloneArguments
         );
 
-        return get_class($mock);
+        return \get_class($mock);
     }
 
     /**
@@ -1591,10 +1591,10 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     protected function getMockFromWsdl($wsdlFile, $originalClassName = '', $mockClassName = '', array $methods = [], $callOriginalConstructor = true, array $options = [])
     {
         if ($originalClassName === '') {
-            $originalClassName = pathinfo(basename(parse_url($wsdlFile)['path']), PATHINFO_FILENAME);
+            $originalClassName = \pathinfo(\basename(\parse_url($wsdlFile)['path']), PATHINFO_FILENAME);
         }
 
-        if (!class_exists($originalClassName)) {
+        if (!\class_exists($originalClassName)) {
             eval(
                 $this->getMockObjectGenerator()->generateClassFromWsdl(
                     $wsdlFile,
@@ -1882,7 +1882,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public static function onConsecutiveCalls()
     {
-        $args = func_get_args();
+        $args = \func_get_args();
 
         return new PHPUnit_Framework_MockObject_Stub_ConsecutiveCalls($args);
     }
@@ -1900,7 +1900,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     public function dataDescription()
     {
-        return is_string($this->dataName) ? $this->dataName : '';
+        return \is_string($this->dataName) ? $this->dataName : '';
     }
 
     /**
@@ -1915,16 +1915,16 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $buffer = '';
 
         if (!empty($this->data)) {
-            if (is_int($this->dataName)) {
-                $buffer .= sprintf(' with data set #%d', $this->dataName);
+            if (\is_int($this->dataName)) {
+                $buffer .= \sprintf(' with data set #%d', $this->dataName);
             } else {
-                $buffer .= sprintf(' with data set "%s"', $this->dataName);
+                $buffer .= \sprintf(' with data set "%s"', $this->dataName);
             }
 
             $exporter = new Exporter;
 
             if ($includeData) {
-                $buffer .= sprintf(' (%s)', $exporter->shortenedRecursiveExport($this->data));
+                $buffer .= \sprintf(' (%s)', $exporter->shortenedRecursiveExport($this->data));
             }
         }
 
@@ -1954,33 +1954,33 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     protected function handleDependencies()
     {
         if (!empty($this->dependencies) && !$this->inIsolation) {
-            $className  = get_class($this);
+            $className  = \get_class($this);
             $passed     = $this->result->passed();
-            $passedKeys = array_keys($passed);
-            $numKeys    = count($passedKeys);
+            $passedKeys = \array_keys($passed);
+            $numKeys    = \count($passedKeys);
 
             for ($i = 0; $i < $numKeys; $i++) {
-                $pos = strpos($passedKeys[$i], ' with data set');
+                $pos = \strpos($passedKeys[$i], ' with data set');
 
                 if ($pos !== false) {
-                    $passedKeys[$i] = substr($passedKeys[$i], 0, $pos);
+                    $passedKeys[$i] = \substr($passedKeys[$i], 0, $pos);
                 }
             }
 
-            $passedKeys = array_flip(array_unique($passedKeys));
+            $passedKeys = \array_flip(\array_unique($passedKeys));
 
             foreach ($this->dependencies as $dependency) {
                 $clone = false;
 
-                if (strpos($dependency, 'clone ') === 0) {
+                if (\strpos($dependency, 'clone ') === 0) {
                     $clone      = true;
-                    $dependency = substr($dependency, strlen('clone '));
-                } elseif (strpos($dependency, '!clone ') === 0) {
+                    $dependency = \substr($dependency, \strlen('clone '));
+                } elseif (\strpos($dependency, '!clone ') === 0) {
                     $clone      = false;
-                    $dependency = substr($dependency, strlen('!clone '));
+                    $dependency = \substr($dependency, \strlen('!clone '));
                 }
 
-                if (strpos($dependency, '::') === false) {
+                if (\strpos($dependency, '::') === false) {
                     $dependency = $className . '::' . $dependency;
                 }
 
@@ -1989,7 +1989,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     $this->result->addError(
                         $this,
                         new SkippedTestError(
-                            sprintf(
+                            \sprintf(
                                 'This test depends on "%s" to pass.',
                                 $dependency
                             )
@@ -2121,17 +2121,17 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     private function startOutputBuffering()
     {
-        ob_start();
+        \ob_start();
 
         $this->outputBufferingActive = true;
-        $this->outputBufferingLevel  = ob_get_level();
+        $this->outputBufferingLevel  = \ob_get_level();
     }
 
     private function stopOutputBuffering()
     {
-        if (ob_get_level() != $this->outputBufferingLevel) {
-            while (ob_get_level() >= $this->outputBufferingLevel) {
-                ob_end_clean();
+        if (\ob_get_level() != $this->outputBufferingLevel) {
+            while (\ob_get_level() >= $this->outputBufferingLevel) {
+                \ob_end_clean();
             }
 
             throw new RiskyTestError(
@@ -2139,21 +2139,21 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             );
         }
 
-        $output = ob_get_contents();
+        $output = \ob_get_contents();
 
         if ($this->outputCallback === false) {
             $this->output = $output;
         } else {
-            $this->output = call_user_func_array(
+            $this->output = \call_user_func_array(
                 $this->outputCallback,
                 [$output]
             );
         }
 
-        ob_end_clean();
+        \ob_end_clean();
 
         $this->outputBufferingActive = false;
-        $this->outputBufferingLevel  = ob_get_level();
+        $this->outputBufferingLevel  = \ob_get_level();
     }
 
     private function snapshotGlobalState()
@@ -2214,7 +2214,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $blacklist->addGlobalVariable($globalVariable);
         }
 
-        if (!defined('PHPUNIT_TESTSUITE')) {
+        if (!\defined('PHPUNIT_TESTSUITE')) {
             $blacklist->addClassNamePrefix('PHPUnit');
             $blacklist->addClassNamePrefix('File_Iterator');
             $blacklist->addClassNamePrefix('SebastianBergmann\CodeCoverage');
@@ -2331,7 +2331,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             }
         }
 
-        if (!is_array($this->testResult) && !is_object($this->testResult)) {
+        if (!\is_array($this->testResult) && !\is_object($this->testResult)) {
             return true;
         }
 
@@ -2365,7 +2365,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     }
 
                     $this->registerMockObject($testArgument);
-                } elseif (is_array($testArgument)) {
+                } elseif (\is_array($testArgument)) {
                     $this->registerMockObjectsFromTestArguments($testArgument);
                 }
             }

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -43,7 +43,7 @@ class TestFailure
         if ($failedTest instanceof SelfDescribing) {
             $this->testName = $failedTest->toString();
         } else {
-            $this->testName = get_class($failedTest);
+            $this->testName = \get_class($failedTest);
         }
 
         if (!$failedTest instanceof TestCase || !$failedTest->isInIsolation()) {
@@ -60,7 +60,7 @@ class TestFailure
      */
     public function toString()
     {
-        return sprintf(
+        return \sprintf(
             '%s: %s',
             $this->testName,
             $this->thrownException->getMessage()
@@ -94,7 +94,7 @@ class TestFailure
             }
 
             if (!empty($buffer)) {
-                $buffer = trim($buffer) . "\n";
+                $buffer = \trim($buffer) . "\n";
             }
 
             return $buffer;
@@ -108,7 +108,7 @@ class TestFailure
             return $e->getClassName() . ': ' . $e->getMessage() . "\n";
         }
 
-        return get_class($e) . ': ' . $e->getMessage() . "\n";
+        return \get_class($e) . ': ' . $e->getMessage() . "\n";
     }
 
     /**

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -390,7 +390,7 @@ class TestResult implements Countable
     public function startTest(Test $test)
     {
         $this->lastTestFailed = false;
-        $this->runTests += count($test);
+        $this->runTests += \count($test);
 
         foreach ($this->listeners as $listener) {
             $listener->startTest($test);
@@ -410,7 +410,7 @@ class TestResult implements Countable
         }
 
         if (!$this->lastTestFailed && $test instanceof TestCase) {
-            $class = get_class($test);
+            $class = \get_class($test);
             $key   = $class . '::' . $test->getName();
 
             $this->passed[$key] = [
@@ -442,7 +442,7 @@ class TestResult implements Countable
      */
     public function riskyCount()
     {
-        return count($this->risky);
+        return \count($this->risky);
     }
 
     /**
@@ -462,7 +462,7 @@ class TestResult implements Countable
      */
     public function notImplementedCount()
     {
-        return count($this->notImplemented);
+        return \count($this->notImplemented);
     }
 
     /**
@@ -502,7 +502,7 @@ class TestResult implements Countable
      */
     public function skippedCount()
     {
-        return count($this->skipped);
+        return \count($this->skipped);
     }
 
     /**
@@ -522,7 +522,7 @@ class TestResult implements Countable
      */
     public function errorCount()
     {
-        return count($this->errors);
+        return \count($this->errors);
     }
 
     /**
@@ -542,7 +542,7 @@ class TestResult implements Countable
      */
     public function failureCount()
     {
-        return count($this->failures);
+        return \count($this->failures);
     }
 
     /**
@@ -562,7 +562,7 @@ class TestResult implements Countable
      */
     public function warningCount()
     {
-        return count($this->warnings);
+        return \count($this->warnings);
     }
 
     /**
@@ -640,7 +640,7 @@ class TestResult implements Countable
         $errorHandlerSet = false;
 
         if ($this->convertErrorsToExceptions) {
-            $oldErrorHandler = set_error_handler(
+            $oldErrorHandler = \set_error_handler(
                 [\PHPUnit\Util\ErrorHandler::class, 'handleError'],
                 E_ALL | E_STRICT
             );
@@ -648,7 +648,7 @@ class TestResult implements Countable
             if ($oldErrorHandler === null) {
                 $errorHandlerSet = true;
             } else {
-                restore_error_handler();
+                \restore_error_handler();
             }
         }
 
@@ -663,7 +663,7 @@ class TestResult implements Countable
         $monitorFunctions = $this->beStrictAboutResourceUsageDuringSmallTests &&
             !$test instanceof WarningTestCase &&
             $test->getSize() == \PHPUnit\Util\Test::SMALL &&
-            function_exists('xdebug_start_function_monitor');
+            \function_exists('xdebug_start_function_monitor');
 
         if ($monitorFunctions) {
             xdebug_start_function_monitor(ResourceOperations::getFunctions());
@@ -675,7 +675,7 @@ class TestResult implements Countable
             if (!$test instanceof WarningTestCase &&
                 $test->getSize() != \PHPUnit\Util\Test::UNKNOWN &&
                 $this->enforceTimeLimit &&
-                extension_loaded('pcntl') && class_exists('PHP_Invoker')
+                \extension_loaded('pcntl') && \class_exists('PHP_Invoker')
             ) {
                 switch ($test->getSize()) {
                     case \PHPUnit\Util\Test::SMALL:
@@ -729,7 +729,7 @@ class TestResult implements Countable
             $frame   = $e->getTrace()[0];
 
             $e = new AssertionFailedError(
-                sprintf(
+                \sprintf(
                     '%s in %s:%s',
                     $e->getMessage(),
                     $frame['file'],
@@ -758,7 +758,7 @@ class TestResult implements Countable
                     $this->addFailure(
                         $test,
                         new RiskyTestError(
-                            sprintf(
+                            \sprintf(
                                 '%s() used in %s:%s',
                                 $function['function'],
                                 $function['filename'],
@@ -785,12 +785,12 @@ class TestResult implements Countable
             if ($append && $test instanceof TestCase) {
                 try {
                     $linesToBeCovered = \PHPUnit\Util\Test::getLinesToBeCovered(
-                        get_class($test),
+                        \get_class($test),
                         $test->getName(false)
                     );
 
                     $linesToBeUsed = \PHPUnit\Util\Test::getLinesToBeUsed(
-                        get_class($test),
+                        \get_class($test),
                         $test->getName(false)
                     );
                 } catch (InvalidCoversTargetException $cce) {
@@ -848,7 +848,7 @@ class TestResult implements Countable
         }
 
         if ($errorHandlerSet === true) {
-            restore_error_handler();
+            \restore_error_handler();
         }
 
         if ($error === true) {
@@ -872,7 +872,7 @@ class TestResult implements Countable
             $this->addFailure(
                 $test,
                 new OutputError(
-                    sprintf(
+                    \sprintf(
                         'This test printed output: %s',
                         $test->getActualOutput()
                     )
@@ -953,7 +953,7 @@ class TestResult implements Countable
      */
     public function convertErrorsToExceptions($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -979,7 +979,7 @@ class TestResult implements Countable
      */
     public function stopOnError($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -995,7 +995,7 @@ class TestResult implements Countable
      */
     public function stopOnFailure($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1011,7 +1011,7 @@ class TestResult implements Countable
      */
     public function stopOnWarning($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1025,7 +1025,7 @@ class TestResult implements Countable
      */
     public function beStrictAboutTestsThatDoNotTestAnything($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1047,7 +1047,7 @@ class TestResult implements Countable
      */
     public function beStrictAboutOutputDuringTests($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1069,7 +1069,7 @@ class TestResult implements Countable
      */
     public function beStrictAboutResourceUsageDuringSmallTests($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1091,7 +1091,7 @@ class TestResult implements Countable
      */
     public function enforceTimeLimit($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1113,7 +1113,7 @@ class TestResult implements Countable
      */
     public function beStrictAboutTodoAnnotatedTests($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1137,7 +1137,7 @@ class TestResult implements Countable
      */
     public function stopOnRisky($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1153,7 +1153,7 @@ class TestResult implements Countable
      */
     public function stopOnIncomplete($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1169,7 +1169,7 @@ class TestResult implements Countable
      */
     public function stopOnSkipped($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1205,7 +1205,7 @@ class TestResult implements Countable
      */
     public function setTimeoutForSmallTests($timeout)
     {
-        if (!is_int($timeout)) {
+        if (!\is_int($timeout)) {
             throw InvalidArgumentHelper::factory(1, 'integer');
         }
 
@@ -1221,7 +1221,7 @@ class TestResult implements Countable
      */
     public function setTimeoutForMediumTests($timeout)
     {
-        if (!is_int($timeout)) {
+        if (!\is_int($timeout)) {
             throw InvalidArgumentHelper::factory(1, 'integer');
         }
 
@@ -1237,7 +1237,7 @@ class TestResult implements Countable
      */
     public function setTimeoutForLargeTests($timeout)
     {
-        if (!is_int($timeout)) {
+        if (!\is_int($timeout)) {
             throw InvalidArgumentHelper::factory(1, 'integer');
         }
 
@@ -1259,7 +1259,7 @@ class TestResult implements Countable
      */
     public function setRegisterMockObjectsFromTestArgumentsRecursively($flag)
     {
-        if (!is_bool($flag)) {
+        if (!\is_bool($flag)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -1287,10 +1287,10 @@ class TestResult implements Countable
         while (!$done) {
             if ($asReflectionObjects) {
                 $class = new ReflectionClass(
-                    $classes[count($classes) - 1]->getName()
+                    $classes[\count($classes) - 1]->getName()
                 );
             } else {
-                $class = new ReflectionClass($classes[count($classes) - 1]);
+                $class = new ReflectionClass($classes[\count($classes) - 1]);
             }
 
             $parent = $class->getParentClass();

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -126,13 +126,13 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
     {
         $argumentsValid = false;
 
-        if (is_object($theClass) &&
+        if (\is_object($theClass) &&
             $theClass instanceof ReflectionClass
         ) {
             $argumentsValid = true;
-        } elseif (is_string($theClass) &&
+        } elseif (\is_string($theClass) &&
             $theClass !== '' &&
-            class_exists($theClass, false)
+            \class_exists($theClass, false)
         ) {
             $argumentsValid = true;
 
@@ -141,7 +141,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             }
 
             $theClass = new ReflectionClass($theClass);
-        } elseif (is_string($theClass)) {
+        } elseif (\is_string($theClass)) {
             $this->setName($theClass);
 
             return;
@@ -170,7 +170,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         ) {
             $this->addTest(
                 self::warning(
-                    sprintf(
+                    \sprintf(
                         'Class "%s" has no public constructor.',
                         $theClass->getName()
                     )
@@ -187,7 +187,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         if (empty($this->tests)) {
             $this->addTest(
                 self::warning(
-                    sprintf(
+                    \sprintf(
                         'No tests found in class "%s".',
                         $theClass->getName()
                     )
@@ -255,11 +255,11 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function addTestSuite($testClass)
     {
-        if (is_string($testClass) && class_exists($testClass)) {
+        if (\is_string($testClass) && \class_exists($testClass)) {
             $testClass = new ReflectionClass($testClass);
         }
 
-        if (!is_object($testClass)) {
+        if (!\is_object($testClass)) {
             throw InvalidArgumentHelper::factory(
                 1,
                 'class name or object'
@@ -309,11 +309,11 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function addTestFile($filename)
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (file_exists($filename) && substr($filename, -5) == '.phpt') {
+        if (\file_exists($filename) && \substr($filename, -5) == '.phpt') {
             $this->addTest(
                 new PhptTestCase($filename)
             );
@@ -323,9 +323,9 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
 
         // The given file may contain further stub classes in addition to the
         // test class itself. Figure out the actual test class.
-        $classes    = get_declared_classes();
+        $classes    = \get_declared_classes();
         $filename   = Fileloader::checkAndLoad($filename);
-        $newClasses = array_diff(get_declared_classes(), $classes);
+        $newClasses = \array_diff(\get_declared_classes(), $classes);
 
         // The diff is empty in case a parent class (with test methods) is added
         // AFTER a child class that inherited from it. To account for that case,
@@ -335,18 +335,18 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             // On the assumption that test classes are defined first in files,
             // process discovered classes in approximate LIFO order, so as to
             // avoid unnecessary reflection.
-            $this->foundClasses = array_merge($newClasses, $this->foundClasses);
+            $this->foundClasses = \array_merge($newClasses, $this->foundClasses);
         }
 
         // The test class's name must match the filename, either in full, or as
         // a PEAR/PSR-0 prefixed shortname ('NameSpace_ShortName'), or as a
         // PSR-1 local shortname ('NameSpace\ShortName'). The comparison must be
         // anchored to prevent false-positive matches (e.g., 'OtherShortName').
-        $shortname      = basename($filename, '.php');
-        $shortnameRegEx = '/(?:^|_|\\\\)' . preg_quote($shortname, '/') . '$/';
+        $shortname      = \basename($filename, '.php');
+        $shortnameRegEx = '/(?:^|_|\\\\)' . \preg_quote($shortname, '/') . '$/';
 
         foreach ($this->foundClasses as $i => $className) {
-            if (preg_match($shortnameRegEx, $className)) {
+            if (\preg_match($shortnameRegEx, $className)) {
                 $class = new ReflectionClass($className);
 
                 if ($class->getFileName() == $filename) {
@@ -387,8 +387,8 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function addTestFiles($filenames)
     {
-        if (!(is_array($filenames) ||
-            (is_object($filenames) && $filenames instanceof Iterator))
+        if (!(\is_array($filenames) ||
+            (\is_object($filenames) && $filenames instanceof Iterator))
         ) {
             throw InvalidArgumentHelper::factory(
                 1,
@@ -417,7 +417,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         $numTests = 0;
 
         foreach ($this as $test) {
-            $numTests += count($test);
+            $numTests += \count($test);
         }
 
         $this->cachedNumTests = $numTests;
@@ -439,7 +439,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
 
         if (!$theClass->isInstantiable()) {
             return self::warning(
-                sprintf('Cannot instantiate class "%s".', $className)
+                \sprintf('Cannot instantiate class "%s".', $className)
             );
         }
 
@@ -464,7 +464,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             $parameters = $constructor->getParameters();
 
             // TestCase() or TestCase($name)
-            if (count($parameters) < 2) {
+            if (\count($parameters) < 2) {
                 $test = new $className;
             } // TestCase($name, $data)
             else {
@@ -474,7 +474,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                         $name
                     );
                 } catch (IncompleteTestError $e) {
-                    $message = sprintf(
+                    $message = \sprintf(
                         'Test for %s::%s marked incomplete by data provider',
                         $className,
                         $name
@@ -488,7 +488,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
 
                     $data = self::incompleteTest($className, $name, $message);
                 } catch (SkippedTestError $e) {
-                    $message = sprintf(
+                    $message = \sprintf(
                         'Test for %s::%s skipped by data provider',
                         $className,
                         $name
@@ -508,7 +508,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                 }
 
                 if (isset($t)) {
-                    $message = sprintf(
+                    $message = \sprintf(
                         'The data provider specified for %s::%s is invalid.',
                         $className,
                         $name
@@ -531,7 +531,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
 
                     if (empty($data)) {
                         $data = self::warning(
-                            sprintf(
+                            \sprintf(
                                 'No tests found in suite "%s".',
                                 $test->getName()
                             )
@@ -634,7 +634,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function getGroups()
     {
-        return array_keys($this->groups);
+        return \array_keys($this->groups);
     }
 
     public function getGroupDetails()
@@ -665,7 +665,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             $result = $this->createResult();
         }
 
-        if (count($this) == 0) {
+        if (\count($this) == 0) {
             return $result;
         }
 
@@ -678,18 +678,18 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
 
             foreach ($hookMethods['beforeClass'] as $beforeClassMethod) {
                 if ($this->testCase === true &&
-                    class_exists($this->name, false) &&
-                    method_exists($this->name, $beforeClassMethod)
+                    \class_exists($this->name, false) &&
+                    \method_exists($this->name, $beforeClassMethod)
                 ) {
                     if ($missingRequirements = \PHPUnit\Util\Test::getMissingRequirements($this->name, $beforeClassMethod)) {
-                        $this->markTestSuiteSkipped(implode(PHP_EOL, $missingRequirements));
+                        $this->markTestSuiteSkipped(\implode(PHP_EOL, $missingRequirements));
                     }
 
-                    call_user_func([$this->name, $beforeClassMethod]);
+                    \call_user_func([$this->name, $beforeClassMethod]);
                 }
             }
         } catch (SkippedTestSuiteError $e) {
-            $numTests = count($this);
+            $numTests = \count($this);
 
             for ($i = 0; $i < $numTests; $i++) {
                 $result->startTest($this);
@@ -708,7 +708,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         }
 
         if (isset($t)) {
-            $numTests = count($this);
+            $numTests = \count($this);
 
             for ($i = 0; $i < $numTests; $i++) {
                 if ($result->shouldStop()) {
@@ -743,8 +743,8 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         }
 
         foreach ($hookMethods['afterClass'] as $afterClassMethod) {
-            if ($this->testCase === true && class_exists($this->name, false) && method_exists($this->name, $afterClassMethod)) {
-                call_user_func([$this->name, $afterClassMethod]);
+            if ($this->testCase === true && \class_exists($this->name, false) && \method_exists($this->name, $afterClassMethod)) {
+                \call_user_func([$this->name, $afterClassMethod]);
             }
         }
 
@@ -762,7 +762,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function setRunTestInSeparateProcess($runTestInSeparateProcess)
     {
-        if (is_bool($runTestInSeparateProcess)) {
+        if (\is_bool($runTestInSeparateProcess)) {
             $this->runTestInSeparateProcess = $runTestInSeparateProcess;
         } else {
             throw InvalidArgumentHelper::factory(1, 'boolean');
@@ -855,7 +855,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         if (!$method->isPublic()) {
             $this->addTest(
                 self::warning(
-                    sprintf(
+                    \sprintf(
                         'Test method "%s" in test class "%s" is not public.',
                         $name,
                         $class->getName()
@@ -889,7 +889,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public static function isTestMethod(ReflectionMethod $method)
     {
-        if (strpos($method->name, 'test') === 0) {
+        if (\strpos($method->name, 'test') === 0) {
             return true;
         }
 
@@ -897,8 +897,8 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         // @test     on TestCase::testMethod()
         $docComment = $method->getDocComment();
 
-        return strpos($docComment, '@test') !== false ||
-            strpos($docComment, '@scenario') !== false;
+        return \strpos($docComment, '@test') !== false ||
+            \strpos($docComment, '@scenario') !== false;
     }
 
     /**
@@ -940,7 +940,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function setbeStrictAboutChangesToGlobalState($beStrictAboutChangesToGlobalState)
     {
-        if (is_null($this->beStrictAboutChangesToGlobalState) && is_bool($beStrictAboutChangesToGlobalState)) {
+        if (\is_null($this->beStrictAboutChangesToGlobalState) && \is_bool($beStrictAboutChangesToGlobalState)) {
             $this->beStrictAboutChangesToGlobalState = $beStrictAboutChangesToGlobalState;
         }
     }
@@ -950,7 +950,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function setBackupGlobals($backupGlobals)
     {
-        if (is_null($this->backupGlobals) && is_bool($backupGlobals)) {
+        if (\is_null($this->backupGlobals) && \is_bool($backupGlobals)) {
             $this->backupGlobals = $backupGlobals;
         }
     }
@@ -960,8 +960,8 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      */
     public function setBackupStaticAttributes($backupStaticAttributes)
     {
-        if (is_null($this->backupStaticAttributes) &&
-            is_bool($backupStaticAttributes)
+        if (\is_null($this->backupStaticAttributes) &&
+            \is_bool($backupStaticAttributes)
         ) {
             $this->backupStaticAttributes = $backupStaticAttributes;
         }

--- a/src/Framework/TestSuiteIterator.php
+++ b/src/Framework/TestSuiteIterator.php
@@ -49,7 +49,7 @@ class TestSuiteIterator implements RecursiveIterator
      */
     public function valid()
     {
-        return $this->position < count($this->tests);
+        return $this->position < \count($this->tests);
     }
 
     /**

--- a/src/Runner/BaseTestRunner.php
+++ b/src/Runner/BaseTestRunner.php
@@ -53,8 +53,8 @@ abstract class BaseTestRunner
      */
     public function getTest($suiteClassName, $suiteClassFile = '', $suffixes = '')
     {
-        if (is_dir($suiteClassName) &&
-            !is_file($suiteClassName . '.php') && empty($suiteClassFile)) {
+        if (\is_dir($suiteClassName) &&
+            !\is_file($suiteClassName . '.php') && empty($suiteClassFile)) {
             $facade = new File_Iterator_Facade;
             $files  = $facade->getFilesAsArray(
                 $suiteClassName,
@@ -93,7 +93,7 @@ abstract class BaseTestRunner
                 $test = $suiteMethod->invoke(null, $testClass->getName());
             } catch (ReflectionException $e) {
                 $this->runFailed(
-                    sprintf(
+                    \sprintf(
                         "Failed to invoke suite() method.\n%s",
                         $e->getMessage()
                     )

--- a/src/Runner/Filter/ExcludeGroupFilterIterator.php
+++ b/src/Runner/Filter/ExcludeGroupFilterIterator.php
@@ -18,6 +18,6 @@ class ExcludeGroupFilterIterator extends GroupFilterIterator
      */
     protected function doAccept($hash)
     {
-        return !in_array($hash, $this->groupTests);
+        return !\in_array($hash, $this->groupTests);
     }
 }

--- a/src/Runner/Filter/Factory.php
+++ b/src/Runner/Filter/Factory.php
@@ -30,7 +30,7 @@ class Factory
     {
         if (!$filter->isSubclassOf(\RecursiveFilterIterator::class)) {
             throw new InvalidArgumentException(
-                sprintf(
+                \sprintf(
                     'Class "%s" does not extend RecursiveFilterIterator',
                     $filter->name
                 )

--- a/src/Runner/Filter/GroupFilterIterator.php
+++ b/src/Runner/Filter/GroupFilterIterator.php
@@ -30,15 +30,15 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
         parent::__construct($iterator);
 
         foreach ($suite->getGroupDetails() as $group => $tests) {
-            if (in_array($group, $groups)) {
-                $testHashes = array_map(
+            if (\in_array($group, $groups)) {
+                $testHashes = \array_map(
                     function ($test) {
-                        return spl_object_hash($test);
+                        return \spl_object_hash($test);
                     },
                     $tests
                 );
 
-                $this->groupTests = array_merge($this->groupTests, $testHashes);
+                $this->groupTests = \array_merge($this->groupTests, $testHashes);
             }
         }
     }
@@ -54,7 +54,7 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
             return true;
         }
 
-        return $this->doAccept(spl_object_hash($test));
+        return $this->doAccept(\spl_object_hash($test));
     }
 
     abstract protected function doAccept($hash);

--- a/src/Runner/Filter/IncludeGroupFilterIterator.php
+++ b/src/Runner/Filter/IncludeGroupFilterIterator.php
@@ -18,6 +18,6 @@ class IncludeGroupFilterIterator extends GroupFilterIterator
      */
     protected function doAccept($hash)
     {
-        return in_array($hash, $this->groupTests);
+        return \in_array($hash, $this->groupTests);
     }
 }

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -50,9 +50,9 @@ class NameFilterIterator extends RecursiveFilterIterator
             // Handles:
             //  * testAssertEqualsSucceeds#4
             //  * testAssertEqualsSucceeds#4-8
-            if (preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
+            if (\preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
                 if (isset($matches[3]) && $matches[2] < $matches[3]) {
-                    $filter = sprintf(
+                    $filter = \sprintf(
                         '%s.*with data set #(\d+)$',
                         $matches[1]
                     );
@@ -60,7 +60,7 @@ class NameFilterIterator extends RecursiveFilterIterator
                     $this->filterMin = $matches[2];
                     $this->filterMax = $matches[3];
                 } else {
-                    $filter = sprintf(
+                    $filter = \sprintf(
                         '%s.*with data set #%s$',
                         $matches[1],
                         $matches[2]
@@ -69,8 +69,8 @@ class NameFilterIterator extends RecursiveFilterIterator
             } // Handles:
             //  * testDetermineJsonError@JSON_ERROR_NONE
             //  * testDetermineJsonError@JSON.*
-            elseif (preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
-                $filter = sprintf(
+            elseif (\preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
+                $filter = \sprintf(
                     '%s.*with data set "%s"$',
                     $matches[1],
                     $matches[2]
@@ -79,7 +79,7 @@ class NameFilterIterator extends RecursiveFilterIterator
 
             // Escape delimiters in regular expression. Do NOT use preg_quote,
             // to keep magic characters.
-            $filter = sprintf('/%s/', str_replace(
+            $filter = \sprintf('/%s/', \str_replace(
                 '/',
                 '\\/',
                 $filter
@@ -106,16 +106,16 @@ class NameFilterIterator extends RecursiveFilterIterator
             $name = $test->getMessage();
         } else {
             if ($tmp[0] != '') {
-                $name = implode('::', $tmp);
+                $name = \implode('::', $tmp);
             } else {
                 $name = $tmp[1];
             }
         }
 
-        $accepted = @preg_match($this->filter, $name, $matches);
+        $accepted = @\preg_match($this->filter, $name, $matches);
 
         if ($accepted && isset($this->filterMax)) {
-            $set      = end($matches);
+            $set      = \end($matches);
             $accepted = $set >= $this->filterMin && $set <= $this->filterMax;
         }
 

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -72,13 +72,13 @@ class PhptTestCase implements Test, SelfDescribing
      */
     public function __construct($filename, $phpUtil = null)
     {
-        if (!is_string($filename)) {
+        if (!\is_string($filename)) {
             throw InvalidArgumentHelper::factory(1, 'string');
         }
 
-        if (!is_file($filename)) {
+        if (!\is_file($filename)) {
             throw new Exception(
-                sprintf(
+                \sprintf(
                     'File "%s" does not exist.',
                     $filename
                 )
@@ -111,11 +111,11 @@ class PhptTestCase implements Test, SelfDescribing
             'EXPECTREGEX' => 'assertRegExp',
         ];
 
-        $actual = preg_replace('/\r\n/', "\n", trim($output));
+        $actual = \preg_replace('/\r\n/', "\n", \trim($output));
 
         foreach ($assertions as $sectionName => $sectionAssertion) {
             if (isset($sections[$sectionName])) {
-                $sectionContent = preg_replace('/\r\n/', "\n", trim($sections[$sectionName]));
+                $sectionContent = \preg_replace('/\r\n/', "\n", \trim($sections[$sectionName]));
                 $assertion      = $sectionAssertion;
                 $expected       = $sectionName == 'EXPECTREGEX' ? "/{$sectionContent}/" : $sectionContent;
 
@@ -150,7 +150,7 @@ class PhptTestCase implements Test, SelfDescribing
         $result->startTest($this);
 
         if (isset($sections['INI'])) {
-            $settings = array_merge($settings, $this->parseIniSection($sections['INI']));
+            $settings = \array_merge($settings, $this->parseIniSection($sections['INI']));
         }
 
         if (isset($sections['ENV'])) {
@@ -169,9 +169,9 @@ class PhptTestCase implements Test, SelfDescribing
             $skipif    = $this->render($sections['SKIPIF']);
             $jobResult = $this->phpUtil->runJob($skipif, $settings);
 
-            if (!strncasecmp('skip', ltrim($jobResult['stdout']), 4)) {
-                if (preg_match('/^\s*skip\s*(.+)\s*/i', $jobResult['stdout'], $message)) {
-                    $message = substr($message[1], 2);
+            if (!\strncasecmp('skip', \ltrim($jobResult['stdout']), 4)) {
+                if (\preg_match('/^\s*skip\s*(.+)\s*/i', $jobResult['stdout'], $message)) {
+                    $message = \substr($message[1], 2);
                 } else {
                     $message = '';
                 }
@@ -183,7 +183,7 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         if (isset($sections['XFAIL'])) {
-            $xfail = trim($sections['XFAIL']);
+            $xfail = \trim($sections['XFAIL']);
         }
 
         if (!$skip) {
@@ -308,8 +308,8 @@ class PhptTestCase implements Test, SelfDescribing
             'PHPDBG'
         ];
 
-        foreach (file($this->filename) as $line) {
-            if (preg_match('/^--([_A-Z]+)--/', $line, $result)) {
+        foreach (\file($this->filename) as $line) {
+            if (\preg_match('/^--([_A-Z]+)--/', $line, $result)) {
                 $section            = $result[1];
                 $sections[$section] = '';
 
@@ -322,19 +322,19 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         if (isset($sections['FILEEOF'])) {
-            $sections['FILE'] = rtrim($sections['FILEEOF'], "\r\n");
+            $sections['FILE'] = \rtrim($sections['FILEEOF'], "\r\n");
             unset($sections['FILEEOF']);
         }
 
-        $testDirectory = dirname($this->filename) . DIRECTORY_SEPARATOR;
+        $testDirectory = \dirname($this->filename) . DIRECTORY_SEPARATOR;
 
         foreach ($allowExternalSections as $section) {
             if (isset($sections[$section . '_EXTERNAL'])) {
-                $externalFilename = trim($sections[$section . '_EXTERNAL']);
+                $externalFilename = \trim($sections[$section . '_EXTERNAL']);
 
-                if (!is_file($testDirectory . $externalFilename) || !is_readable($testDirectory . $externalFilename)) {
+                if (!\is_file($testDirectory . $externalFilename) || !\is_readable($testDirectory . $externalFilename)) {
                     throw new Exception(
-                        sprintf(
+                        \sprintf(
                             'Could not load --%s-- %s for PHPT file',
                             $section . '_EXTERNAL',
                             $testDirectory . $externalFilename
@@ -342,7 +342,7 @@ class PhptTestCase implements Test, SelfDescribing
                     );
                 }
 
-                $sections[$section] = file_get_contents($testDirectory . $externalFilename);
+                $sections[$section] = \file_get_contents($testDirectory . $externalFilename);
 
                 unset($sections[$section . '_EXTERNAL']);
             }
@@ -351,7 +351,7 @@ class PhptTestCase implements Test, SelfDescribing
         $isValid = true;
 
         foreach ($requiredSections as $section) {
-            if (is_array($section)) {
+            if (\is_array($section)) {
                 $foundSection = false;
 
                 foreach ($section as $anySection) {
@@ -398,13 +398,13 @@ class PhptTestCase implements Test, SelfDescribing
      */
     private function render($code)
     {
-        return str_replace(
+        return \str_replace(
             [
                 '__DIR__',
                 '__FILE__'
             ],
             [
-                "'" . dirname($this->filename) . "'",
+                "'" . \dirname($this->filename) . "'",
                 "'" . $this->filename . "'"
             ],
             $code
@@ -420,15 +420,15 @@ class PhptTestCase implements Test, SelfDescribing
      */
     protected function parseIniSection($content)
     {
-        return preg_split('/\n|\r/', $content, -1, PREG_SPLIT_NO_EMPTY);
+        return \preg_split('/\n|\r/', $content, -1, PREG_SPLIT_NO_EMPTY);
     }
 
     protected function parseEnvSection($content)
     {
         $env = [];
 
-        foreach (explode("\n", trim($content)) as $e) {
-            $e = explode('=', trim($e), 2);
+        foreach (\explode("\n", \trim($content)) as $e) {
+            $e = \explode('=', \trim($e), 2);
 
             if (!empty($e[0]) && isset($e[1])) {
                 $env[$e[0]] = $e[1];

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -29,7 +29,7 @@ class StandardTestSuiteLoader implements TestSuiteLoader
      */
     public function load($suiteClassName, $suiteClassFile = '')
     {
-        $suiteClassName = str_replace('.php', '', $suiteClassName);
+        $suiteClassName = \str_replace('.php', '', $suiteClassName);
 
         if (empty($suiteClassFile)) {
             $suiteClassFile = Filesystem::classNameToFilename(
@@ -37,22 +37,22 @@ class StandardTestSuiteLoader implements TestSuiteLoader
             );
         }
 
-        if (!class_exists($suiteClassName, false)) {
-            $loadedClasses = get_declared_classes();
+        if (!\class_exists($suiteClassName, false)) {
+            $loadedClasses = \get_declared_classes();
 
             $filename = Fileloader::checkAndLoad($suiteClassFile);
 
-            $loadedClasses = array_values(
-                array_diff(get_declared_classes(), $loadedClasses)
+            $loadedClasses = \array_values(
+                \array_diff(\get_declared_classes(), $loadedClasses)
             );
         }
 
-        if (!class_exists($suiteClassName, false) && !empty($loadedClasses)) {
-            $offset = 0 - strlen($suiteClassName);
+        if (!\class_exists($suiteClassName, false) && !empty($loadedClasses)) {
+            $offset = 0 - \strlen($suiteClassName);
 
             foreach ($loadedClasses as $loadedClass) {
                 $class = new ReflectionClass($loadedClass);
-                if (substr($loadedClass, $offset) === $suiteClassName &&
+                if (\substr($loadedClass, $offset) === $suiteClassName &&
                     $class->getFileName() == $filename
                 ) {
                     $suiteClassName = $loadedClass;
@@ -61,7 +61,7 @@ class StandardTestSuiteLoader implements TestSuiteLoader
             }
         }
 
-        if (!class_exists($suiteClassName, false) && !empty($loadedClasses)) {
+        if (!\class_exists($suiteClassName, false) && !empty($loadedClasses)) {
             $testCaseClass = TestCase::class;
 
             foreach ($loadedClasses as $loadedClass) {
@@ -74,7 +74,7 @@ class StandardTestSuiteLoader implements TestSuiteLoader
                     $suiteClassName = $loadedClass;
                     $testCaseClass  = $loadedClass;
 
-                    if ($classFile == realpath($suiteClassFile)) {
+                    if ($classFile == \realpath($suiteClassFile)) {
                         break;
                     }
                 }
@@ -88,7 +88,7 @@ class StandardTestSuiteLoader implements TestSuiteLoader
                     ) {
                         $suiteClassName = $loadedClass;
 
-                        if ($classFile == realpath($suiteClassFile)) {
+                        if ($classFile == \realpath($suiteClassFile)) {
                             break;
                         }
                     }
@@ -96,16 +96,16 @@ class StandardTestSuiteLoader implements TestSuiteLoader
             }
         }
 
-        if (class_exists($suiteClassName, false)) {
+        if (\class_exists($suiteClassName, false)) {
             $class = new ReflectionClass($suiteClassName);
 
-            if ($class->getFileName() == realpath($suiteClassFile)) {
+            if ($class->getFileName() == \realpath($suiteClassFile)) {
                 return $class;
             }
         }
 
         throw new Exception(
-            sprintf(
+            \sprintf(
                 "Class '%s' could not be found in '%s'.",
                 $suiteClassName,
                 $suiteClassFile

--- a/src/Runner/Version.php
+++ b/src/Runner/Version.php
@@ -32,7 +32,7 @@ class Version
         }
 
         if (self::$version === null) {
-            $version       = new VersionId('6.1', dirname(dirname(__DIR__)));
+            $version       = new VersionId('6.1', \dirname(\dirname(__DIR__)));
             self::$version = $version->getVersion();
         }
 
@@ -44,13 +44,13 @@ class Version
      */
     public static function series()
     {
-        if (strpos(self::id(), '-')) {
-            $version = explode('-', self::id())[0];
+        if (\strpos(self::id(), '-')) {
+            $version = \explode('-', self::id())[0];
         } else {
             $version = self::id();
         }
 
-        return implode('.', array_slice(explode('.', $version), 0, 2));
+        return \implode('.', \array_slice(\explode('.', $version), 0, 2));
     }
 
     /**
@@ -66,7 +66,7 @@ class Version
      */
     public static function getReleaseChannel()
     {
-        if (strpos(self::$pharVersion, '-') !== false) {
+        if (\strpos(self::$pharVersion, '-') !== false) {
             return '-nightly';
         }
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -152,7 +152,7 @@ class Command
 
         $runner = $this->createRunner();
 
-        if (is_object($this->arguments['test']) &&
+        if (\is_object($this->arguments['test']) &&
             $this->arguments['test'] instanceof Test
         ) {
             $suite = $this->arguments['test'];
@@ -170,7 +170,7 @@ class Command
             print "Available test group(s):\n";
 
             $groups = $suite->getGroups();
-            sort($groups);
+            \sort($groups);
 
             foreach ($groups as $group) {
                 print " - $group\n";
@@ -289,7 +289,7 @@ class Command
             $this->options = Getopt::getopt(
                 $argv,
                 'd:c:hv',
-                array_keys($this->longOptions)
+                \array_keys($this->longOptions)
             );
         } catch (Exception $t) {
             $this->showError($t->getMessage());
@@ -306,7 +306,7 @@ class Command
                     break;
 
                 case '--columns':
-                    if (is_numeric($option[1])) {
+                    if (\is_numeric($option[1])) {
                         $this->arguments['columns'] = (int) $option[1];
                     } elseif ($option[1] == 'max') {
                         $this->arguments['columns'] = 'max';
@@ -349,13 +349,13 @@ class Command
                     break;
 
                 case 'd':
-                    $ini = explode('=', $option[1]);
+                    $ini = \explode('=', $option[1]);
 
                     if (isset($ini[0])) {
                         if (isset($ini[1])) {
-                            ini_set($ini[0], $ini[1]);
+                            \ini_set($ini[0], $ini[1]);
                         } else {
-                            ini_set($ini[0], true);
+                            \ini_set($ini[0], true);
                         }
                     }
                     break;
@@ -381,19 +381,19 @@ class Command
                 case '--generate-configuration':
                     $this->printVersionString();
 
-                    printf(
+                    \printf(
                         "Generating phpunit.xml in %s\n\n",
-                        getcwd()
+                        \getcwd()
                     );
 
                     print 'Bootstrap script (relative to path shown above; default: vendor/autoload.php): ';
-                    $bootstrapScript = trim(fgets(STDIN));
+                    $bootstrapScript = \trim(\fgets(STDIN));
 
                     print 'Tests directory (relative to path shown above; default: tests): ';
-                    $testsDirectory = trim(fgets(STDIN));
+                    $testsDirectory = \trim(\fgets(STDIN));
 
                     print 'Source directory (relative to path shown above; default: src): ';
-                    $src = trim(fgets(STDIN));
+                    $src = \trim(\fgets(STDIN));
 
                     if ($bootstrapScript == '') {
                         $bootstrapScript = 'vendor/autoload.php';
@@ -409,7 +409,7 @@ class Command
 
                     $generator = new ConfigurationGenerator;
 
-                    file_put_contents(
+                    \file_put_contents(
                         'phpunit.xml',
                         $generator->generateDefaultConfiguration(
                             Version::series(),
@@ -419,27 +419,27 @@ class Command
                         )
                     );
 
-                    printf(
+                    \printf(
                         "\nGenerated phpunit.xml in %s\n",
-                        getcwd()
+                        \getcwd()
                     );
 
                     exit(TestRunner::SUCCESS_EXIT);
                     break;
 
                 case '--group':
-                    $this->arguments['groups'] = explode(',', $option[1]);
+                    $this->arguments['groups'] = \explode(',', $option[1]);
                     break;
 
                 case '--exclude-group':
-                    $this->arguments['excludeGroups'] = explode(
+                    $this->arguments['excludeGroups'] = \explode(
                         ',',
                         $option[1]
                     );
                     break;
 
                 case '--test-suffix':
-                    $this->arguments['testSuffixes'] = explode(
+                    $this->arguments['testSuffixes'] = \explode(
                         ',',
                         $option[1]
                     );
@@ -526,14 +526,14 @@ class Command
                     break;
 
                 case '--testdox-group':
-                    $this->arguments['testdoxGroups'] = explode(
+                    $this->arguments['testdoxGroups'] = \explode(
                         ',',
                         $option[1]
                     );
                     break;
 
                 case '--testdox-exclude-group':
-                    $this->arguments['testdoxExcludeGroups'] = explode(
+                    $this->arguments['testdoxExcludeGroups'] = \explode(
                         ',',
                         $option[1]
                     );
@@ -577,7 +577,7 @@ class Command
                     break;
 
                 case '--atleast-version':
-                    if (version_compare(Version::id(), $option[1], '>=')) {
+                    if (\version_compare(Version::id(), $option[1], '>=')) {
                         exit(TestRunner::SUCCESS_EXIT);
                     }
 
@@ -634,7 +634,7 @@ class Command
                     break;
 
                 default:
-                    $optionName = str_replace('--', '', $option[0]);
+                    $optionName = \str_replace('--', '', $option[0]);
 
                     $handler = null;
                     if (isset($this->longOptions[$optionName])) {
@@ -643,7 +643,7 @@ class Command
                         $handler = $this->longOptions[$optionName . '='];
                     }
 
-                    if (isset($handler) && is_callable([$this, $handler])) {
+                    if (isset($handler) && \is_callable([$this, $handler])) {
                         $this->$handler($option[1]);
                     }
             }
@@ -657,17 +657,17 @@ class Command
             }
 
             if (isset($this->options[1][1])) {
-                $this->arguments['testFile'] = realpath($this->options[1][1]);
+                $this->arguments['testFile'] = \realpath($this->options[1][1]);
             } else {
                 $this->arguments['testFile'] = '';
             }
 
             if (isset($this->arguments['test']) &&
-                is_file($this->arguments['test']) &&
-                substr($this->arguments['test'], -5, 5) != '.phpt'
+                \is_file($this->arguments['test']) &&
+                \substr($this->arguments['test'], -5, 5) != '.phpt'
             ) {
-                $this->arguments['testFile'] = realpath($this->arguments['test']);
-                $this->arguments['test']     = substr($this->arguments['test'], 0, strrpos($this->arguments['test'], '.'));
+                $this->arguments['testFile'] = \realpath($this->arguments['test']);
+                $this->arguments['test']     = \substr($this->arguments['test'], 0, \strrpos($this->arguments['test'], '.'));
             }
         }
 
@@ -676,9 +676,9 @@ class Command
         }
 
         if (isset($includePath)) {
-            ini_set(
+            \ini_set(
                 'include_path',
-                $includePath . PATH_SEPARATOR . ini_get('include_path')
+                $includePath . PATH_SEPARATOR . \ini_get('include_path')
             );
         }
 
@@ -687,26 +687,26 @@ class Command
         }
 
         if (isset($this->arguments['configuration']) &&
-            is_dir($this->arguments['configuration'])
+            \is_dir($this->arguments['configuration'])
         ) {
             $configurationFile = $this->arguments['configuration'] . '/phpunit.xml';
 
-            if (file_exists($configurationFile)) {
-                $this->arguments['configuration'] = realpath(
+            if (\file_exists($configurationFile)) {
+                $this->arguments['configuration'] = \realpath(
                     $configurationFile
                 );
-            } elseif (file_exists($configurationFile . '.dist')) {
-                $this->arguments['configuration'] = realpath(
+            } elseif (\file_exists($configurationFile . '.dist')) {
+                $this->arguments['configuration'] = \realpath(
                     $configurationFile . '.dist'
                 );
             }
         } elseif (!isset($this->arguments['configuration']) &&
             $this->arguments['useDefaultConfiguration']
         ) {
-            if (file_exists('phpunit.xml')) {
-                $this->arguments['configuration'] = realpath('phpunit.xml');
-            } elseif (file_exists('phpunit.xml.dist')) {
-                $this->arguments['configuration'] = realpath(
+            if (\file_exists('phpunit.xml')) {
+                $this->arguments['configuration'] = \realpath('phpunit.xml');
+            } elseif (\file_exists('phpunit.xml.dist')) {
+                $this->arguments['configuration'] = \realpath(
                     'phpunit.xml.dist'
                 );
             }
@@ -742,7 +742,7 @@ class Command
                 $this->arguments['stderr'] = $phpunitConfiguration['stderr'];
             }
 
-            if (isset($phpunitConfiguration['extensionsDirectory']) && !isset($this->arguments['noExtensions']) && extension_loaded('phar')) {
+            if (isset($phpunitConfiguration['extensionsDirectory']) && !isset($this->arguments['noExtensions']) && \extension_loaded('phar')) {
                 $this->handleExtensions($phpunitConfiguration['extensionsDirectory']);
             }
 
@@ -792,12 +792,12 @@ class Command
         }
 
         if (isset($this->arguments['printer']) &&
-            is_string($this->arguments['printer'])
+            \is_string($this->arguments['printer'])
         ) {
             $this->arguments['printer'] = $this->handlePrinter($this->arguments['printer']);
         }
 
-        if (isset($this->arguments['test']) && is_string($this->arguments['test']) && substr($this->arguments['test'], -5, 5) == '.phpt') {
+        if (isset($this->arguments['test']) && \is_string($this->arguments['test']) && \substr($this->arguments['test'], -5, 5) == '.phpt') {
             $test = new PhptTestCase($this->arguments['test']);
 
             $this->arguments['test'] = new TestSuite;
@@ -822,21 +822,21 @@ class Command
      */
     protected function handleLoader($loaderClass, $loaderFile = '')
     {
-        if (!class_exists($loaderClass, false)) {
+        if (!\class_exists($loaderClass, false)) {
             if ($loaderFile == '') {
                 $loaderFile = Filesystem::classNameToFilename(
                     $loaderClass
                 );
             }
 
-            $loaderFile = stream_resolve_include_path($loaderFile);
+            $loaderFile = \stream_resolve_include_path($loaderFile);
 
             if ($loaderFile) {
                 require $loaderFile;
             }
         }
 
-        if (class_exists($loaderClass, false)) {
+        if (\class_exists($loaderClass, false)) {
             $class = new ReflectionClass($loaderClass);
 
             if ($class->implementsInterface(TestSuiteLoader::class) &&
@@ -851,7 +851,7 @@ class Command
         }
 
         $this->showError(
-            sprintf(
+            \sprintf(
                 'Could not use "%s" as loader.',
                 $loaderClass
             )
@@ -868,21 +868,21 @@ class Command
      */
     protected function handlePrinter($printerClass, $printerFile = '')
     {
-        if (!class_exists($printerClass, false)) {
+        if (!\class_exists($printerClass, false)) {
             if ($printerFile == '') {
                 $printerFile = Filesystem::classNameToFilename(
                     $printerClass
                 );
             }
 
-            $printerFile = stream_resolve_include_path($printerFile);
+            $printerFile = \stream_resolve_include_path($printerFile);
 
             if ($printerFile) {
                 require $printerFile;
             }
         }
 
-        if (class_exists($printerClass)) {
+        if (\class_exists($printerClass)) {
             $class = new ReflectionClass($printerClass);
 
             if ($class->implementsInterface(TestListener::class) &&
@@ -900,7 +900,7 @@ class Command
         }
 
         $this->showError(
-            sprintf(
+            \sprintf(
                 'Could not use "%s" as printer.',
                 $printerClass
             )
@@ -925,11 +925,11 @@ class Command
     {
         $this->printVersionString();
 
-        $latestVersion = file_get_contents('https://phar.phpunit.de/latest-version-of/phpunit');
-        $isOutdated    = version_compare($latestVersion, Version::id(), '>');
+        $latestVersion = \file_get_contents('https://phar.phpunit.de/latest-version-of/phpunit');
+        $isOutdated    = \version_compare($latestVersion, Version::id(), '>');
 
         if ($isOutdated) {
-            printf(
+            \printf(
                 "You are not using the latest version of PHPUnit.\n" .
                 "The latest version is PHPUnit %s.\n",
                 $latestVersion
@@ -1080,7 +1080,7 @@ EOT;
         $facade = new File_Iterator_Facade;
 
         foreach ($facade->getFilesAsArray($directory, '.phar') as $file) {
-            if (!file_exists('phar://' . $file . '/manifest.xml')) {
+            if (!\file_exists('phar://' . $file . '/manifest.xml')) {
                 $this->arguments['notLoadedExtensions'][] = $file . ' is not an extension for PHPUnit';
 
                 continue;

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -144,28 +144,28 @@ class ResultPrinter extends Printer implements TestListener
     {
         parent::__construct($out);
 
-        if (!is_bool($verbose)) {
+        if (!\is_bool($verbose)) {
             throw InvalidArgumentHelper::factory(2, 'boolean');
         }
 
         $availableColors = [self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS];
 
-        if (!in_array($colors, $availableColors)) {
+        if (!\in_array($colors, $availableColors)) {
             throw InvalidArgumentHelper::factory(
                 3,
-                vsprintf('value from "%s", "%s" or "%s"', $availableColors)
+                \vsprintf('value from "%s", "%s" or "%s"', $availableColors)
             );
         }
 
-        if (!is_bool($debug)) {
+        if (!\is_bool($debug)) {
             throw InvalidArgumentHelper::factory(4, 'boolean');
         }
 
-        if (!is_int($numberOfColumns) && $numberOfColumns != 'max') {
+        if (!\is_int($numberOfColumns) && $numberOfColumns != 'max') {
             throw InvalidArgumentHelper::factory(5, 'integer or "max"');
         }
 
-        if (!is_bool($reverse)) {
+        if (!\is_bool($reverse)) {
             throw InvalidArgumentHelper::factory(6, 'boolean');
         }
 
@@ -213,7 +213,7 @@ class ResultPrinter extends Printer implements TestListener
      */
     protected function printDefects(array $defects, $type)
     {
-        $count = count($defects);
+        $count = \count($defects);
 
         if ($count == 0) {
             return;
@@ -224,7 +224,7 @@ class ResultPrinter extends Printer implements TestListener
         }
 
         $this->write(
-            sprintf(
+            \sprintf(
                 "There %s %d %s%s:\n",
                 ($count == 1) ? 'was' : 'were',
                 $count,
@@ -236,7 +236,7 @@ class ResultPrinter extends Printer implements TestListener
         $i = 1;
 
         if ($this->reverse) {
-            $defects = array_reverse($defects);
+            $defects = \array_reverse($defects);
         }
 
         foreach ($defects as $defect) {
@@ -263,7 +263,7 @@ class ResultPrinter extends Printer implements TestListener
     protected function printDefectHeader(TestFailure $defect, $count)
     {
         $this->write(
-            sprintf(
+            \sprintf(
                 "\n%d) %s\n",
                 $count,
                 $defect->getTestName()
@@ -342,7 +342,7 @@ class ResultPrinter extends Printer implements TestListener
      */
     protected function printFooter(TestResult $result)
     {
-        if (count($result) === 0) {
+        if (\count($result) === 0) {
             $this->writeWithColor(
                 'fg-black, bg-yellow',
                 'No tests executed!'
@@ -358,10 +358,10 @@ class ResultPrinter extends Printer implements TestListener
         ) {
             $this->writeWithColor(
                 'fg-black, bg-green',
-                sprintf(
+                \sprintf(
                     'OK (%d test%s, %d assertion%s)',
-                    count($result),
-                    (count($result) == 1) ? '' : 's',
+                    \count($result),
+                    (\count($result) == 1) ? '' : 's',
                     $this->numAssertions,
                     ($this->numAssertions == 1) ? '' : 's'
                 )
@@ -405,7 +405,7 @@ class ResultPrinter extends Printer implements TestListener
                 }
             }
 
-            $this->writeCountString(count($result), 'Tests', $color, true);
+            $this->writeCountString(\count($result), 'Tests', $color, true);
             $this->writeCountString($this->numAssertions, 'Assertions', $color, true);
             $this->writeCountString($result->errorCount(), 'Errors', $color);
             $this->writeCountString($result->failureCount(), 'Failures', $color);
@@ -508,9 +508,9 @@ class ResultPrinter extends Printer implements TestListener
     public function startTestSuite(TestSuite $suite)
     {
         if ($this->numTests == -1) {
-            $this->numTests      = count($suite);
-            $this->numTestsWidth = strlen((string) $this->numTests);
-            $this->maxColumn     = $this->numberOfColumns - strlen('  /  (XXX%)') - (2 * $this->numTestsWidth);
+            $this->numTests      = \count($suite);
+            $this->numTestsWidth = \strlen((string) $this->numTests);
+            $this->maxColumn     = $this->numberOfColumns - \strlen('  /  (XXX%)') - (2 * $this->numTestsWidth);
         }
     }
 
@@ -532,7 +532,7 @@ class ResultPrinter extends Printer implements TestListener
     {
         if ($this->debug) {
             $this->write(
-                sprintf(
+                \sprintf(
                     "\nStarting test '%s'.\n",
                     \PHPUnit\Util\Test::describe($test)
                 )
@@ -580,16 +580,16 @@ class ResultPrinter extends Printer implements TestListener
             || $this->numTestsRun == $this->numTests
         ) {
             if ($this->numTestsRun == $this->numTests) {
-                $this->write(str_repeat(' ', $this->maxColumn - $this->column));
+                $this->write(\str_repeat(' ', $this->maxColumn - $this->column));
             }
 
             $this->write(
-                sprintf(
+                \sprintf(
                     ' %' . $this->numTestsWidth . 'd / %' .
                     $this->numTestsWidth . 'd (%3s%%)',
                     $this->numTestsRun,
                     $this->numTests,
-                    floor(($this->numTestsRun / $this->numTests) * 100)
+                    \floor(($this->numTestsRun / $this->numTests) * 100)
                 )
             );
 
@@ -620,24 +620,24 @@ class ResultPrinter extends Printer implements TestListener
             return $buffer;
         }
 
-        $codes   = array_map('trim', explode(',', $color));
-        $lines   = explode("\n", $buffer);
-        $padding = max(array_map('strlen', $lines));
+        $codes   = \array_map('trim', \explode(',', $color));
+        $lines   = \explode("\n", $buffer);
+        $padding = \max(\array_map('strlen', $lines));
         $styles  = [];
 
         foreach ($codes as $code) {
             $styles[] = self::$ansiCodes[$code];
         }
 
-        $style = sprintf("\x1b[%sm", implode(';', $styles));
+        $style = \sprintf("\x1b[%sm", \implode(';', $styles));
 
         $styledLines = [];
 
         foreach ($lines as $line) {
-            $styledLines[] = $style . str_pad($line, $padding) . "\x1b[0m";
+            $styledLines[] = $style . \str_pad($line, $padding) . "\x1b[0m";
         }
 
-        return implode("\n", $styledLines);
+        return \implode("\n", $styledLines);
     }
 
     /**
@@ -681,7 +681,7 @@ class ResultPrinter extends Printer implements TestListener
         if ($always || $count > 0) {
             $this->writeWithColor(
                 $color,
-                sprintf(
+                \sprintf(
                     '%s%s: %d',
                     !$first ? ', ' : '',
                     $name,

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -205,10 +205,10 @@ class TestRunner extends BaseTestRunner
             $suite->setbeStrictAboutChangesToGlobalState(true);
         }
 
-        if (is_int($arguments['repeat']) && $arguments['repeat'] > 0) {
+        if (\is_int($arguments['repeat']) && $arguments['repeat'] > 0) {
             $_suite = new TestSuite;
 
-            foreach (range(1, $arguments['repeat']) as $step) {
+            foreach (\range(1, $arguments['repeat']) as $step) {
                 $_suite->addTest($suite);
             }
 
@@ -265,7 +265,7 @@ class TestRunner extends BaseTestRunner
             } else {
                 $printerClass = ResultPrinter::class;
 
-                if (isset($arguments['printer']) && is_string($arguments['printer']) && class_exists($arguments['printer'], false)) {
+                if (isset($arguments['printer']) && \is_string($arguments['printer']) && \class_exists($arguments['printer'], false)) {
                     $class = new ReflectionClass($arguments['printer']);
 
                     if ($class->isSubclassOf(ResultPrinter::class)) {
@@ -294,9 +294,9 @@ class TestRunner extends BaseTestRunner
             $runtime = $this->runtime->getNameWithVersion();
 
             if ($this->runtime->hasXdebug()) {
-                $runtime .= sprintf(
+                $runtime .= \sprintf(
                     ' with Xdebug %s',
-                    phpversion('xdebug')
+                    \phpversion('xdebug')
                 );
             }
 
@@ -570,7 +570,7 @@ class TestRunner extends BaseTestRunner
                     $writer = new HtmlReport(
                         $arguments['reportLowUpperBound'],
                         $arguments['reportHighLowerBound'],
-                        sprintf(
+                        \sprintf(
                             ' and <a href="https://phpunit.de/">PHPUnit %s</a>',
                             Version::id()
                         )
@@ -696,7 +696,7 @@ class TestRunner extends BaseTestRunner
     protected function write($buffer)
     {
         if (PHP_SAPI != 'cli' && PHP_SAPI != 'phpdbg') {
-            $buffer = htmlspecialchars($buffer);
+            $buffer = \htmlspecialchars($buffer);
         }
 
         if ($this->printer !== null) {
@@ -733,8 +733,8 @@ class TestRunner extends BaseTestRunner
             );
         }
 
-        $arguments['debug']     = isset($arguments['debug'])     ? $arguments['debug']     : false;
-        $arguments['filter']    = isset($arguments['filter'])    ? $arguments['filter']    : false;
+        $arguments['debug']     = isset($arguments['debug']) ? $arguments['debug'] : false;
+        $arguments['filter']    = isset($arguments['filter']) ? $arguments['filter'] : false;
         $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : [];
 
         if (isset($arguments['configuration'])) {
@@ -887,18 +887,18 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!empty($groupConfiguration['exclude']) && !isset($arguments['excludeGroups'])) {
-                $arguments['excludeGroups'] = array_diff($groupConfiguration['exclude'], $groupCliArgs);
+                $arguments['excludeGroups'] = \array_diff($groupConfiguration['exclude'], $groupCliArgs);
             }
 
             foreach ($arguments['configuration']->getListenerConfiguration() as $listener) {
-                if (!class_exists($listener['class'], false) &&
+                if (!\class_exists($listener['class'], false) &&
                     $listener['file'] !== '') {
                     require_once $listener['file'];
                 }
 
-                if (!class_exists($listener['class'])) {
+                if (!\class_exists($listener['class'])) {
                     throw new Exception(
-                        sprintf(
+                        \sprintf(
                             'Class "%s" does not exist',
                             $listener['class']
                         )
@@ -909,14 +909,14 @@ class TestRunner extends BaseTestRunner
 
                 if (!$listenerClass->implementsInterface(TestListener::class)) {
                     throw new Exception(
-                        sprintf(
+                        \sprintf(
                             'Class "%s" does not implement the PHPUnit\Framework\TestListener interface',
                             $listener['class']
                         )
                     );
                 }
 
-                if (count($listener['arguments']) == 0) {
+                if (\count($listener['arguments']) == 0) {
                     $listener = new $listener['class'];
                 } else {
                     $listener = $listenerClass->newInstanceArgs(
@@ -1017,46 +1017,46 @@ class TestRunner extends BaseTestRunner
             }
         }
 
-        $arguments['addUncoveredFilesFromWhitelist']                  = isset($arguments['addUncoveredFilesFromWhitelist'])                  ? $arguments['addUncoveredFilesFromWhitelist']                  : true;
-        $arguments['backupGlobals']                                   = isset($arguments['backupGlobals'])                                   ? $arguments['backupGlobals']                                   : null;
-        $arguments['backupStaticAttributes']                          = isset($arguments['backupStaticAttributes'])                          ? $arguments['backupStaticAttributes']                          : null;
-        $arguments['beStrictAboutChangesToGlobalState']               = isset($arguments['beStrictAboutChangesToGlobalState'])               ? $arguments['beStrictAboutChangesToGlobalState']               : null;
-        $arguments['beStrictAboutResourceUsageDuringSmallTests']      = isset($arguments['beStrictAboutResourceUsageDuringSmallTests'])      ? $arguments['beStrictAboutResourceUsageDuringSmallTests']      : false;
-        $arguments['cacheTokens']                                     = isset($arguments['cacheTokens'])                                     ? $arguments['cacheTokens']                                     : false;
-        $arguments['colors']                                          = isset($arguments['colors'])                                          ? $arguments['colors']                                          : ResultPrinter::COLOR_DEFAULT;
-        $arguments['columns']                                         = isset($arguments['columns'])                                         ? $arguments['columns']                                         : 80;
-        $arguments['convertErrorsToExceptions']                       = isset($arguments['convertErrorsToExceptions'])                       ? $arguments['convertErrorsToExceptions']                       : true;
-        $arguments['convertNoticesToExceptions']                      = isset($arguments['convertNoticesToExceptions'])                      ? $arguments['convertNoticesToExceptions']                      : true;
-        $arguments['convertWarningsToExceptions']                     = isset($arguments['convertWarningsToExceptions'])                     ? $arguments['convertWarningsToExceptions']                     : true;
-        $arguments['crap4jThreshold']                                 = isset($arguments['crap4jThreshold'])                                 ? $arguments['crap4jThreshold']                                 : 30;
-        $arguments['disallowTestOutput']                              = isset($arguments['disallowTestOutput'])                              ? $arguments['disallowTestOutput']                              : false;
-        $arguments['disallowTodoAnnotatedTests']                      = isset($arguments['disallowTodoAnnotatedTests'])                      ? $arguments['disallowTodoAnnotatedTests']                      : false;
-        $arguments['enforceTimeLimit']                                = isset($arguments['enforceTimeLimit'])                                ? $arguments['enforceTimeLimit']                                : false;
-        $arguments['excludeGroups']                                   = isset($arguments['excludeGroups'])                                   ? $arguments['excludeGroups']                                   : [];
-        $arguments['failOnRisky']                                     = isset($arguments['failOnRisky'])                                     ? $arguments['failOnRisky']                                     : false;
-        $arguments['failOnWarning']                                   = isset($arguments['failOnWarning'])                                   ? $arguments['failOnWarning']                                   : false;
-        $arguments['groups']                                          = isset($arguments['groups'])                                          ? $arguments['groups']                                          : [];
-        $arguments['processIsolation']                                = isset($arguments['processIsolation'])                                ? $arguments['processIsolation']                                : false;
-        $arguments['processUncoveredFilesFromWhitelist']              = isset($arguments['processUncoveredFilesFromWhitelist'])              ? $arguments['processUncoveredFilesFromWhitelist']              : false;
+        $arguments['addUncoveredFilesFromWhitelist']                  = isset($arguments['addUncoveredFilesFromWhitelist']) ? $arguments['addUncoveredFilesFromWhitelist'] : true;
+        $arguments['backupGlobals']                                   = isset($arguments['backupGlobals']) ? $arguments['backupGlobals'] : null;
+        $arguments['backupStaticAttributes']                          = isset($arguments['backupStaticAttributes']) ? $arguments['backupStaticAttributes'] : null;
+        $arguments['beStrictAboutChangesToGlobalState']               = isset($arguments['beStrictAboutChangesToGlobalState']) ? $arguments['beStrictAboutChangesToGlobalState'] : null;
+        $arguments['beStrictAboutResourceUsageDuringSmallTests']      = isset($arguments['beStrictAboutResourceUsageDuringSmallTests']) ? $arguments['beStrictAboutResourceUsageDuringSmallTests'] : false;
+        $arguments['cacheTokens']                                     = isset($arguments['cacheTokens']) ? $arguments['cacheTokens'] : false;
+        $arguments['colors']                                          = isset($arguments['colors']) ? $arguments['colors'] : ResultPrinter::COLOR_DEFAULT;
+        $arguments['columns']                                         = isset($arguments['columns']) ? $arguments['columns'] : 80;
+        $arguments['convertErrorsToExceptions']                       = isset($arguments['convertErrorsToExceptions']) ? $arguments['convertErrorsToExceptions'] : true;
+        $arguments['convertNoticesToExceptions']                      = isset($arguments['convertNoticesToExceptions']) ? $arguments['convertNoticesToExceptions'] : true;
+        $arguments['convertWarningsToExceptions']                     = isset($arguments['convertWarningsToExceptions']) ? $arguments['convertWarningsToExceptions'] : true;
+        $arguments['crap4jThreshold']                                 = isset($arguments['crap4jThreshold']) ? $arguments['crap4jThreshold'] : 30;
+        $arguments['disallowTestOutput']                              = isset($arguments['disallowTestOutput']) ? $arguments['disallowTestOutput'] : false;
+        $arguments['disallowTodoAnnotatedTests']                      = isset($arguments['disallowTodoAnnotatedTests']) ? $arguments['disallowTodoAnnotatedTests'] : false;
+        $arguments['enforceTimeLimit']                                = isset($arguments['enforceTimeLimit']) ? $arguments['enforceTimeLimit'] : false;
+        $arguments['excludeGroups']                                   = isset($arguments['excludeGroups']) ? $arguments['excludeGroups'] : [];
+        $arguments['failOnRisky']                                     = isset($arguments['failOnRisky']) ? $arguments['failOnRisky'] : false;
+        $arguments['failOnWarning']                                   = isset($arguments['failOnWarning']) ? $arguments['failOnWarning'] : false;
+        $arguments['groups']                                          = isset($arguments['groups']) ? $arguments['groups'] : [];
+        $arguments['processIsolation']                                = isset($arguments['processIsolation']) ? $arguments['processIsolation'] : false;
+        $arguments['processUncoveredFilesFromWhitelist']              = isset($arguments['processUncoveredFilesFromWhitelist']) ? $arguments['processUncoveredFilesFromWhitelist'] : false;
         $arguments['registerMockObjectsFromTestArgumentsRecursively'] = isset($arguments['registerMockObjectsFromTestArgumentsRecursively']) ? $arguments['registerMockObjectsFromTestArgumentsRecursively'] : false;
-        $arguments['repeat']                                          = isset($arguments['repeat'])                                          ? $arguments['repeat']                                          : false;
-        $arguments['reportHighLowerBound']                            = isset($arguments['reportHighLowerBound'])                            ? $arguments['reportHighLowerBound']                            : 90;
-        $arguments['reportLowUpperBound']                             = isset($arguments['reportLowUpperBound'])                             ? $arguments['reportLowUpperBound']                             : 50;
-        $arguments['reportUselessTests']                              = isset($arguments['reportUselessTests'])                              ? $arguments['reportUselessTests']                              : true;
-        $arguments['reverseList']                                     = isset($arguments['reverseList'])                                     ? $arguments['reverseList']                                     : false;
-        $arguments['stopOnError']                                     = isset($arguments['stopOnError'])                                     ? $arguments['stopOnError']                                     : false;
-        $arguments['stopOnFailure']                                   = isset($arguments['stopOnFailure'])                                   ? $arguments['stopOnFailure']                                   : false;
-        $arguments['stopOnIncomplete']                                = isset($arguments['stopOnIncomplete'])                                ? $arguments['stopOnIncomplete']                                : false;
-        $arguments['stopOnRisky']                                     = isset($arguments['stopOnRisky'])                                     ? $arguments['stopOnRisky']                                     : false;
-        $arguments['stopOnSkipped']                                   = isset($arguments['stopOnSkipped'])                                   ? $arguments['stopOnSkipped']                                   : false;
-        $arguments['stopOnWarning']                                   = isset($arguments['stopOnWarning'])                                   ? $arguments['stopOnWarning']                                   : false;
-        $arguments['strictCoverage']                                  = isset($arguments['strictCoverage'])                                  ? $arguments['strictCoverage']                                  : false;
-        $arguments['testdoxExcludeGroups']                            = isset($arguments['testdoxExcludeGroups'])                            ? $arguments['testdoxExcludeGroups']                            : [];
-        $arguments['testdoxGroups']                                   = isset($arguments['testdoxGroups'])                                   ? $arguments['testdoxGroups']                                   : [];
-        $arguments['timeoutForLargeTests']                            = isset($arguments['timeoutForLargeTests'])                            ? $arguments['timeoutForLargeTests']                            : 60;
-        $arguments['timeoutForMediumTests']                           = isset($arguments['timeoutForMediumTests'])                           ? $arguments['timeoutForMediumTests']                           : 10;
-        $arguments['timeoutForSmallTests']                            = isset($arguments['timeoutForSmallTests'])                            ? $arguments['timeoutForSmallTests']                            : 1;
-        $arguments['verbose']                                         = isset($arguments['verbose'])                                         ? $arguments['verbose']                                         : false;
+        $arguments['repeat']                                          = isset($arguments['repeat']) ? $arguments['repeat'] : false;
+        $arguments['reportHighLowerBound']                            = isset($arguments['reportHighLowerBound']) ? $arguments['reportHighLowerBound'] : 90;
+        $arguments['reportLowUpperBound']                             = isset($arguments['reportLowUpperBound']) ? $arguments['reportLowUpperBound'] : 50;
+        $arguments['reportUselessTests']                              = isset($arguments['reportUselessTests']) ? $arguments['reportUselessTests'] : true;
+        $arguments['reverseList']                                     = isset($arguments['reverseList']) ? $arguments['reverseList'] : false;
+        $arguments['stopOnError']                                     = isset($arguments['stopOnError']) ? $arguments['stopOnError'] : false;
+        $arguments['stopOnFailure']                                   = isset($arguments['stopOnFailure']) ? $arguments['stopOnFailure'] : false;
+        $arguments['stopOnIncomplete']                                = isset($arguments['stopOnIncomplete']) ? $arguments['stopOnIncomplete'] : false;
+        $arguments['stopOnRisky']                                     = isset($arguments['stopOnRisky']) ? $arguments['stopOnRisky'] : false;
+        $arguments['stopOnSkipped']                                   = isset($arguments['stopOnSkipped']) ? $arguments['stopOnSkipped'] : false;
+        $arguments['stopOnWarning']                                   = isset($arguments['stopOnWarning']) ? $arguments['stopOnWarning'] : false;
+        $arguments['strictCoverage']                                  = isset($arguments['strictCoverage']) ? $arguments['strictCoverage'] : false;
+        $arguments['testdoxExcludeGroups']                            = isset($arguments['testdoxExcludeGroups']) ? $arguments['testdoxExcludeGroups'] : [];
+        $arguments['testdoxGroups']                                   = isset($arguments['testdoxGroups']) ? $arguments['testdoxGroups'] : [];
+        $arguments['timeoutForLargeTests']                            = isset($arguments['timeoutForLargeTests']) ? $arguments['timeoutForLargeTests'] : 60;
+        $arguments['timeoutForMediumTests']                           = isset($arguments['timeoutForMediumTests']) ? $arguments['timeoutForMediumTests'] : 10;
+        $arguments['timeoutForSmallTests']                            = isset($arguments['timeoutForSmallTests']) ? $arguments['timeoutForSmallTests'] : 1;
+        $arguments['verbose']                                         = isset($arguments['verbose']) ? $arguments['verbose'] : false;
     }
 
     /**
@@ -1070,7 +1070,7 @@ class TestRunner extends BaseTestRunner
         }
 
         $this->write(
-            sprintf(
+            \sprintf(
                 "%-15s%s\n",
                 $type . ':',
                 $message

--- a/src/Util/Blacklist.php
+++ b/src/Util/Blacklist.php
@@ -67,14 +67,14 @@ class Blacklist
      */
     public function isBlacklisted($file)
     {
-        if (defined('PHPUNIT_TESTSUITE')) {
+        if (\defined('PHPUNIT_TESTSUITE')) {
             return false;
         }
 
         $this->initialize();
 
         foreach (self::$directories as $directory) {
-            if (strpos($file, $directory) === 0) {
+            if (\strpos($file, $directory) === 0) {
                 return true;
             }
         }
@@ -88,7 +88,7 @@ class Blacklist
             self::$directories = [];
 
             foreach (self::$blacklistedClassNames as $className => $parent) {
-                if (!class_exists($className)) {
+                if (!\class_exists($className)) {
                     continue;
                 }
 
@@ -96,7 +96,7 @@ class Blacklist
                 $directory = $reflector->getFileName();
 
                 for ($i = 0; $i < $parent; $i++) {
-                    $directory = dirname($directory);
+                    $directory = \dirname($directory);
                 }
 
                 self::$directories[] = $directory;
@@ -108,7 +108,7 @@ class Blacklist
             if (DIRECTORY_SEPARATOR === '\\') {
                 // tempnam() prefix is limited to first 3 chars.
                 // @see http://php.net/manual/en/function.tempnam.php
-                self::$directories[] = sys_get_temp_dir() . '\\PHP';
+                self::$directories[] = \sys_get_temp_dir() . '\\PHP';
             }
         }
     }

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -182,11 +182,11 @@ class Configuration
      */
     public static function getInstance($filename)
     {
-        $realpath = realpath($filename);
+        $realpath = \realpath($filename);
 
         if ($realpath === false) {
             throw new Exception(
-                sprintf(
+                \sprintf(
                     'Could not read "%s".',
                     $filename
                 )
@@ -489,25 +489,25 @@ class Configuration
         $configuration = $this->getPHPConfiguration();
 
         if (!empty($configuration['include_path'])) {
-            ini_set(
+            \ini_set(
                 'include_path',
-                implode(PATH_SEPARATOR, $configuration['include_path']) .
+                \implode(PATH_SEPARATOR, $configuration['include_path']) .
                 PATH_SEPARATOR .
-                ini_get('include_path')
+                \ini_get('include_path')
             );
         }
 
         foreach ($configuration['ini'] as $name => $value) {
-            if (defined($value)) {
-                $value = constant($value);
+            if (\defined($value)) {
+                $value = \constant($value);
             }
 
-            ini_set($name, $value);
+            \ini_set($name, $value);
         }
 
         foreach ($configuration['const'] as $name => $value) {
-            if (!defined($name)) {
-                define($name, $value);
+            if (!\defined($name)) {
+                \define($name, $value);
             }
         }
 
@@ -523,7 +523,7 @@ class Configuration
                     break;
 
                 default:
-                    $target = &$GLOBALS['_' . strtoupper($array)];
+                    $target = &$GLOBALS['_' . \strtoupper($array)];
                     break;
             }
 
@@ -533,8 +533,8 @@ class Configuration
         }
 
         foreach ($configuration['env'] as $name => $value) {
-            if (false === getenv($name)) {
-                putenv("{$name}={$value}");
+            if (false === \getenv($name)) {
+                \putenv("{$name}={$value}");
             }
             if (!isset($_ENV[$name])) {
                 $_ENV[$name] = $value;
@@ -917,10 +917,10 @@ class Configuration
         }
 
         $fileIteratorFacade = new File_Iterator_Facade;
-        $testSuiteFilter    = $testSuiteFilter ? explode(self::TEST_SUITE_FILTER_SEPARATOR, $testSuiteFilter) : [];
+        $testSuiteFilter    = $testSuiteFilter ? \explode(self::TEST_SUITE_FILTER_SEPARATOR, $testSuiteFilter) : [];
 
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
-            if (!empty($testSuiteFilter) && !in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
+            if (!empty($testSuiteFilter) && !\in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
                 continue;
             }
 
@@ -942,7 +942,7 @@ class Configuration
                 $phpVersionOperator = '>=';
             }
 
-            if (!version_compare(PHP_VERSION, $phpVersion, $phpVersionOperator)) {
+            if (!\version_compare(PHP_VERSION, $phpVersion, $phpVersionOperator)) {
                 continue;
             }
 
@@ -968,7 +968,7 @@ class Configuration
         }
 
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
-            if (!empty($testSuiteFilter) && !in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
+            if (!empty($testSuiteFilter) && !\in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
                 continue;
             }
 
@@ -1001,7 +1001,7 @@ class Configuration
                 $phpVersionOperator = '>=';
             }
 
-            if (!version_compare(PHP_VERSION, $phpVersion, $phpVersionOperator)) {
+            if (!\version_compare(PHP_VERSION, $phpVersion, $phpVersionOperator)) {
                 continue;
             }
 
@@ -1019,11 +1019,11 @@ class Configuration
      */
     protected function getBoolean($value, $default)
     {
-        if (strtolower($value) == 'false') {
+        if (\strtolower($value) == 'false') {
             return false;
         }
 
-        if (strtolower($value) == 'true') {
+        if (\strtolower($value) == 'true') {
             return true;
         }
 
@@ -1038,7 +1038,7 @@ class Configuration
      */
     protected function getInteger($value, $default)
     {
-        if (is_numeric($value)) {
+        if (\is_numeric($value)) {
             return (int) $value;
         }
 
@@ -1118,7 +1118,7 @@ class Configuration
      */
     protected function toAbsolutePath($path, $useIncludePath = false)
     {
-        $path = trim($path);
+        $path = \trim($path);
 
         if ($path[0] === '/') {
             return $path;
@@ -1132,22 +1132,22 @@ class Configuration
         //  - C:\windows
         //  - C:/windows
         //  - c:/windows
-        if (defined('PHP_WINDOWS_VERSION_BUILD') &&
+        if (\defined('PHP_WINDOWS_VERSION_BUILD') &&
             ($path[0] === '\\' ||
-                (strlen($path) >= 3 && preg_match('#^[A-Z]\:[/\\\]#i', substr($path, 0, 3))))
+                (\strlen($path) >= 3 && \preg_match('#^[A-Z]\:[/\\\]#i', \substr($path, 0, 3))))
         ) {
             return $path;
         }
 
         // Stream
-        if (strpos($path, '://') !== false) {
+        if (\strpos($path, '://') !== false) {
             return $path;
         }
 
-        $file = dirname($this->filename) . DIRECTORY_SEPARATOR . $path;
+        $file = \dirname($this->filename) . DIRECTORY_SEPARATOR . $path;
 
-        if ($useIncludePath && !file_exists($file)) {
-            $includePathFile = stream_resolve_include_path($path);
+        if ($useIncludePath && !\file_exists($file)) {
+            $includePathFile = \stream_resolve_include_path($path);
 
             if ($includePathFile) {
                 $file = $includePathFile;

--- a/src/Util/ConfigurationGenerator.php
+++ b/src/Util/ConfigurationGenerator.php
@@ -48,7 +48,7 @@ EOT;
      */
     public function generateDefaultConfiguration($phpunitVersion, $bootstrapScript, $testsDirectory, $srcDirectory)
     {
-        return str_replace(
+        return \str_replace(
             [
                 '{phpunit_version}',
                 '{bootstrap_script}',

--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -42,14 +42,14 @@ class ErrorHandler
      */
     public static function handleError($errno, $errstr, $errfile, $errline)
     {
-        if (!($errno & error_reporting())) {
+        if (!($errno & \error_reporting())) {
             return false;
         }
 
         self::$errorStack[] = [$errno, $errstr, $errfile, $errline];
 
-        $trace = debug_backtrace(false);
-        array_shift($trace);
+        $trace = \debug_backtrace(false);
+        \array_shift($trace);
 
         foreach ($trace as $frame) {
             if ($frame['function'] == '__toString') {
@@ -97,11 +97,11 @@ class ErrorHandler
             if (!$expired) {
                 $expired = true;
                 // cleans temporary error handler
-                return restore_error_handler();
+                return \restore_error_handler();
             }
         };
 
-        set_error_handler(function ($errno, $errstr) use ($severity) {
+        \set_error_handler(function ($errno, $errstr) use ($severity) {
             if ($errno === $severity) {
                 return;
             }

--- a/src/Util/Fileloader.php
+++ b/src/Util/Fileloader.php
@@ -28,11 +28,11 @@ class Fileloader
      */
     public static function checkAndLoad($filename)
     {
-        $includePathFilename = stream_resolve_include_path($filename);
+        $includePathFilename = \stream_resolve_include_path($filename);
 
-        if (!$includePathFilename || !is_readable($includePathFilename)) {
+        if (!$includePathFilename || !\is_readable($includePathFilename)) {
             throw new Exception(
-                sprintf('Cannot open file "%s".' . "\n", $filename)
+                \sprintf('Cannot open file "%s".' . "\n", $filename)
             );
         }
 
@@ -50,13 +50,13 @@ class Fileloader
      */
     public static function load($filename)
     {
-        $oldVariableNames = array_keys(get_defined_vars());
+        $oldVariableNames = \array_keys(\get_defined_vars());
 
         include_once $filename;
 
-        $newVariables     = get_defined_vars();
-        $newVariableNames = array_diff(
-            array_keys($newVariables),
+        $newVariables     = \get_defined_vars();
+        $newVariableNames = \array_diff(
+            \array_keys($newVariables),
             $oldVariableNames
         );
 

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -31,7 +31,7 @@ class Filesystem
      */
     public static function classNameToFilename($className)
     {
-        return str_replace(
+        return \str_replace(
             ['_', '\\'],
             DIRECTORY_SEPARATOR,
             $className

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -28,9 +28,9 @@ class Filter
     public static function getFilteredStacktrace($e, $asString = true)
     {
         $prefix = false;
-        $script = realpath($GLOBALS['_SERVER']['SCRIPT_NAME']);
+        $script = \realpath($GLOBALS['_SERVER']['SCRIPT_NAME']);
 
-        if (defined('__PHPUNIT_PHAR_ROOT__')) {
+        if (\defined('__PHPUNIT_PHAR_ROOT__')) {
             $prefix = __PHPUNIT_PHAR_ROOT__;
         }
 
@@ -58,7 +58,7 @@ class Filter
         }
 
         if (!self::frameExists($eTrace, $eFile, $eLine)) {
-            array_unshift(
+            \array_unshift(
                 $eTrace,
                 ['file' => $eFile, 'line' => $eLine]
             );
@@ -67,13 +67,13 @@ class Filter
         $blacklist = new Blacklist;
 
         foreach ($eTrace as $frame) {
-            if (isset($frame['file']) && is_file($frame['file']) &&
+            if (isset($frame['file']) && \is_file($frame['file']) &&
                 !$blacklist->isBlacklisted($frame['file']) &&
-                ($prefix === false || strpos($frame['file'], $prefix) !== 0) &&
+                ($prefix === false || \strpos($frame['file'], $prefix) !== 0) &&
                 $frame['file'] !== $script
             ) {
                 if ($asString === true) {
-                    $filteredStacktrace .= sprintf(
+                    $filteredStacktrace .= \sprintf(
                         "%s:%s\n",
                         $frame['file'],
                         isset($frame['line']) ? $frame['line'] : '?'

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -26,43 +26,43 @@ class Getopt
         $non_opts = [];
 
         if ($long_options) {
-            sort($long_options);
+            \sort($long_options);
         }
 
         if (isset($args[0][0]) && $args[0][0] != '-') {
-            array_shift($args);
+            \array_shift($args);
         }
 
-        reset($args);
-        array_map('trim', $args);
+        \reset($args);
+        \array_map('trim', $args);
 
-        while (false !== $arg = current($args)) {
-            $i = key($args);
-            next($args);
+        while (false !== $arg = \current($args)) {
+            $i = \key($args);
+            \next($args);
             if ($arg == '') {
                 continue;
             }
 
             if ($arg == '--') {
-                $non_opts = array_merge($non_opts, array_slice($args, $i + 1));
+                $non_opts = \array_merge($non_opts, \array_slice($args, $i + 1));
                 break;
             }
 
             if ($arg[0] != '-' ||
-                (strlen($arg) > 1 && $arg[1] == '-' && !$long_options)
+                (\strlen($arg) > 1 && $arg[1] == '-' && !$long_options)
             ) {
                 $non_opts[] = $args[$i];
                 continue;
-            } elseif (strlen($arg) > 1 && $arg[1] == '-') {
+            } elseif (\strlen($arg) > 1 && $arg[1] == '-') {
                 self::parseLongOption(
-                    substr($arg, 2),
+                    \substr($arg, 2),
                     $long_options,
                     $opts,
                     $args
                 );
             } else {
                 self::parseShortOption(
-                    substr($arg, 1),
+                    \substr($arg, 1),
                     $short_options,
                     $opts,
                     $args
@@ -75,13 +75,13 @@ class Getopt
 
     protected static function parseShortOption($arg, $short_options, &$opts, &$args)
     {
-        $argLen = strlen($arg);
+        $argLen = \strlen($arg);
 
         for ($i = 0; $i < $argLen; $i++) {
             $opt     = $arg[$i];
             $opt_arg = null;
 
-            if (($spec = strstr($short_options, $opt)) === false ||
+            if (($spec = \strstr($short_options, $opt)) === false ||
                 $arg[$i] == ':'
             ) {
                 throw new Exception(
@@ -89,18 +89,18 @@ class Getopt
                 );
             }
 
-            if (strlen($spec) > 1 && $spec[1] == ':') {
+            if (\strlen($spec) > 1 && $spec[1] == ':') {
                 if ($i + 1 < $argLen) {
-                    $opts[] = [$opt, substr($arg, $i + 1)];
+                    $opts[] = [$opt, \substr($arg, $i + 1)];
                     break;
                 }
-                if (!(strlen($spec) > 2 && $spec[2] == ':')) {
-                    if (false === $opt_arg = current($args)) {
+                if (!(\strlen($spec) > 2 && $spec[2] == ':')) {
+                    if (false === $opt_arg = \current($args)) {
                         throw new Exception(
                             "option requires an argument -- $opt"
                         );
                     }
-                    next($args);
+                    \next($args);
                 }
             }
 
@@ -110,44 +110,44 @@ class Getopt
 
     protected static function parseLongOption($arg, $long_options, &$opts, &$args)
     {
-        $count   = count($long_options);
-        $list    = explode('=', $arg);
+        $count   = \count($long_options);
+        $list    = \explode('=', $arg);
         $opt     = $list[0];
         $opt_arg = null;
 
-        if (count($list) > 1) {
+        if (\count($list) > 1) {
             $opt_arg = $list[1];
         }
 
-        $opt_len = strlen($opt);
+        $opt_len = \strlen($opt);
 
         for ($i = 0; $i < $count; $i++) {
             $long_opt  = $long_options[$i];
-            $opt_start = substr($long_opt, 0, $opt_len);
+            $opt_start = \substr($long_opt, 0, $opt_len);
 
             if ($opt_start != $opt) {
                 continue;
             }
 
-            $opt_rest = substr($long_opt, $opt_len);
+            $opt_rest = \substr($long_opt, $opt_len);
 
             if ($opt_rest != '' && $opt[0] != '=' && $i + 1 < $count &&
-                $opt == substr($long_options[$i + 1], 0, $opt_len)
+                $opt == \substr($long_options[$i + 1], 0, $opt_len)
             ) {
                 throw new Exception(
                     "option --$opt is ambiguous"
                 );
             }
 
-            if (substr($long_opt, -1) == '=') {
-                if (substr($long_opt, -2) != '==') {
-                    if (!strlen($opt_arg)) {
-                        if (false === $opt_arg = current($args)) {
+            if (\substr($long_opt, -1) == '=') {
+                if (\substr($long_opt, -2) != '==') {
+                    if (!\strlen($opt_arg)) {
+                        if (false === $opt_arg = \current($args)) {
                             throw new Exception(
                                 "option --$opt requires an argument"
                             );
                         }
-                        next($args);
+                        \next($args);
                     }
                 }
             } elseif ($opt_arg) {
@@ -156,7 +156,7 @@ class Getopt
                 );
             }
 
-            $full_option = '--' . preg_replace('/={1,2}$/', '', $long_opt);
+            $full_option = '--' . \preg_replace('/={1,2}$/', '', $long_opt);
             $opts[]      = [$full_option, $opt_arg];
 
             return;

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -31,7 +31,7 @@ class GlobalState
      */
     public static function getIncludedFilesAsString()
     {
-        return static::processIncludedFilesAsString(get_included_files());
+        return static::processIncludedFilesAsString(\get_included_files());
     }
 
     /**
@@ -45,23 +45,23 @@ class GlobalState
         $prefix    = false;
         $result    = '';
 
-        if (defined('__PHPUNIT_PHAR__')) {
+        if (\defined('__PHPUNIT_PHAR__')) {
             $prefix = 'phar://' . __PHPUNIT_PHAR__ . '/';
         }
 
-        for ($i = count($files) - 1; $i > 0; $i--) {
+        for ($i = \count($files) - 1; $i > 0; $i--) {
             $file = $files[$i];
 
-            if ($prefix !== false && strpos($file, $prefix) === 0) {
+            if ($prefix !== false && \strpos($file, $prefix) === 0) {
                 continue;
             }
 
             // Skip virtual file system protocols
-            if (preg_match('/^(vfs|phpvfs[a-z0-9]+):/', $file)) {
+            if (\preg_match('/^(vfs|phpvfs[a-z0-9]+):/', $file)) {
                 continue;
             }
 
-            if (!$blacklist->isBlacklisted($file) && is_file($file)) {
+            if (!$blacklist->isBlacklisted($file) && \is_file($file)) {
                 $result = 'require_once \'' . $file . "';\n" . $result;
             }
         }
@@ -75,10 +75,10 @@ class GlobalState
     public static function getIniSettingsAsString()
     {
         $result      = '';
-        $iniSettings = ini_get_all(null, false);
+        $iniSettings = \ini_get_all(null, false);
 
         foreach ($iniSettings as $key => $value) {
-            $result .= sprintf(
+            $result .= \sprintf(
                 '@ini_set(%s, %s);' . "\n",
                 self::exportVariable($key),
                 self::exportVariable($value)
@@ -93,12 +93,12 @@ class GlobalState
      */
     public static function getConstantsAsString()
     {
-        $constants = get_defined_constants(true);
+        $constants = \get_defined_constants(true);
         $result    = '';
 
         if (isset($constants['user'])) {
             foreach ($constants['user'] as $name => $value) {
-                $result .= sprintf(
+                $result .= \sprintf(
                     'if (!defined(\'%s\')) define(\'%s\', %s);' . "\n",
                     $name,
                     $name,
@@ -120,14 +120,14 @@ class GlobalState
 
         foreach ($superGlobalArrays as $superGlobalArray) {
             if (isset($GLOBALS[$superGlobalArray]) &&
-                is_array($GLOBALS[$superGlobalArray])
+                \is_array($GLOBALS[$superGlobalArray])
             ) {
-                foreach (array_keys($GLOBALS[$superGlobalArray]) as $key) {
+                foreach (\array_keys($GLOBALS[$superGlobalArray]) as $key) {
                     if ($GLOBALS[$superGlobalArray][$key] instanceof Closure) {
                         continue;
                     }
 
-                    $result .= sprintf(
+                    $result .= \sprintf(
                         '$GLOBALS[\'%s\'][\'%s\'] = %s;' . "\n",
                         $superGlobalArray,
                         $key,
@@ -140,9 +140,9 @@ class GlobalState
         $blacklist   = $superGlobalArrays;
         $blacklist[] = 'GLOBALS';
 
-        foreach (array_keys($GLOBALS) as $key) {
-            if (!in_array($key, $blacklist) && !$GLOBALS[$key] instanceof Closure) {
-                $result .= sprintf(
+        foreach (\array_keys($GLOBALS) as $key) {
+            if (!\in_array($key, $blacklist) && !$GLOBALS[$key] instanceof Closure) {
+                $result .= \sprintf(
                     '$GLOBALS[\'%s\'] = %s;' . "\n",
                     $key,
                     self::exportVariable($GLOBALS[$key])
@@ -163,14 +163,14 @@ class GlobalState
 
     protected static function exportVariable($variable)
     {
-        if (is_scalar($variable) || is_null($variable) ||
-            (is_array($variable) && self::arrayOnlyContainsScalars($variable))
+        if (\is_scalar($variable) || \is_null($variable) ||
+            (\is_array($variable) && self::arrayOnlyContainsScalars($variable))
         ) {
-            return var_export($variable, true);
+            return \var_export($variable, true);
         }
 
         return 'unserialize(' .
-            var_export(serialize($variable), true) .
+            \var_export(\serialize($variable), true) .
             ')';
     }
 
@@ -184,9 +184,9 @@ class GlobalState
         $result = true;
 
         foreach ($array as $element) {
-            if (is_array($element)) {
+            if (\is_array($element)) {
                 $result = self::arrayOnlyContainsScalars($element);
-            } elseif (!is_scalar($element) && !is_null($element)) {
+            } elseif (!\is_scalar($element) && !\is_null($element)) {
                 $result = false;
             }
 

--- a/src/Util/InvalidArgumentHelper.php
+++ b/src/Util/InvalidArgumentHelper.php
@@ -26,13 +26,13 @@ class InvalidArgumentHelper
      */
     public static function factory($argument, $type, $value = null)
     {
-        $stack = debug_backtrace(false);
+        $stack = \debug_backtrace(false);
 
         return new Exception(
-            sprintf(
+            \sprintf(
                 'Argument #%d%sof %s::%s() must be a %s',
                 $argument,
-                $value !== null ? ' (' . gettype($value) . '#' . $value . ')' : ' (No Value) ',
+                $value !== null ? ' (' . \gettype($value) . '#' . $value . ')' : ' (No Value) ',
                 $stack[1]['class'],
                 $stack[1]['function'],
                 $type

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -201,7 +201,7 @@ class JUnit extends Printer implements TestListener
             )
         );
 
-        $error->setAttribute('type', get_class($e));
+        $error->setAttribute('type', \get_class($e));
 
         $this->currentTestCase->appendChild($error);
 
@@ -230,7 +230,7 @@ class JUnit extends Printer implements TestListener
         $testSuite = $this->document->createElement('testsuite');
         $testSuite->setAttribute('name', $suite->getName());
 
-        if (class_exists($suite->getName(), false)) {
+        if (\class_exists($suite->getName(), false)) {
             try {
                 $class = new ReflectionClass($suite->getName());
 
@@ -289,16 +289,16 @@ class JUnit extends Printer implements TestListener
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'time',
-            sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
+            \sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
         );
 
         if ($this->testSuiteLevel > 1) {
-            $this->testSuiteTests[$this->testSuiteLevel - 1]      += $this->testSuiteTests[$this->testSuiteLevel];
+            $this->testSuiteTests[$this->testSuiteLevel - 1] += $this->testSuiteTests[$this->testSuiteLevel];
             $this->testSuiteAssertions[$this->testSuiteLevel - 1] += $this->testSuiteAssertions[$this->testSuiteLevel];
-            $this->testSuiteErrors[$this->testSuiteLevel - 1]     += $this->testSuiteErrors[$this->testSuiteLevel];
-            $this->testSuiteFailures[$this->testSuiteLevel - 1]   += $this->testSuiteFailures[$this->testSuiteLevel];
-            $this->testSuiteSkipped[$this->testSuiteLevel - 1]    += $this->testSuiteSkipped[$this->testSuiteLevel];
-            $this->testSuiteTimes[$this->testSuiteLevel - 1]      += $this->testSuiteTimes[$this->testSuiteLevel];
+            $this->testSuiteErrors[$this->testSuiteLevel - 1] += $this->testSuiteErrors[$this->testSuiteLevel];
+            $this->testSuiteFailures[$this->testSuiteLevel - 1] += $this->testSuiteFailures[$this->testSuiteLevel];
+            $this->testSuiteSkipped[$this->testSuiteLevel - 1] += $this->testSuiteSkipped[$this->testSuiteLevel];
+            $this->testSuiteTimes[$this->testSuiteLevel - 1] += $this->testSuiteTimes[$this->testSuiteLevel];
         }
 
         $this->testSuiteLevel--;
@@ -322,7 +322,7 @@ class JUnit extends Printer implements TestListener
                 $method = $class->getMethod($test->getName());
 
                 $testCase->setAttribute('class', $class->getName());
-                $testCase->setAttribute('classname', str_replace('\\', '.', $class->getName()));
+                $testCase->setAttribute('classname', \str_replace('\\', '.', $class->getName()));
                 $testCase->setAttribute('file', $class->getFileName());
                 $testCase->setAttribute('line', $method->getStartLine());
             }
@@ -351,7 +351,7 @@ class JUnit extends Printer implements TestListener
 
         $this->currentTestCase->setAttribute(
             'time',
-            sprintf('%F', $time)
+            \sprintf('%F', $time)
         );
 
         $this->testSuites[$this->testSuiteLevel]->appendChild(
@@ -361,7 +361,7 @@ class JUnit extends Printer implements TestListener
         $this->testSuiteTests[$this->testSuiteLevel]++;
         $this->testSuiteTimes[$this->testSuiteLevel] += $time;
 
-        if (method_exists($test, 'hasOutput') && $test->hasOutput()) {
+        if (\method_exists($test, 'hasOutput') && $test->hasOutput()) {
             $systemOut = $this->document->createElement('system-out');
 
             $systemOut->appendChild(
@@ -395,7 +395,7 @@ class JUnit extends Printer implements TestListener
      */
     public function setWriteDocument($flag)
     {
-        if (is_bool($flag)) {
+        if (\is_bool($flag)) {
             $this->writeDocument = $flag;
         }
     }
@@ -431,7 +431,7 @@ class JUnit extends Printer implements TestListener
         if ($e instanceof ExceptionWrapper) {
             $fault->setAttribute('type', $e->getClassName());
         } else {
-            $fault->setAttribute('type', get_class($e));
+            $fault->setAttribute('type', \get_class($e));
         }
 
         $this->currentTestCase->appendChild($fault);

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -121,17 +121,17 @@ class TeamCity extends ResultPrinter
             if ($comparisonFailure instanceof ComparisonFailure) {
                 $expectedString = $comparisonFailure->getExpectedAsString();
 
-                if (is_null($expectedString) || empty($expectedString)) {
+                if (\is_null($expectedString) || empty($expectedString)) {
                     $expectedString = self::getPrimitiveValueAsString($comparisonFailure->getExpected());
                 }
 
                 $actualString = $comparisonFailure->getActualAsString();
 
-                if (is_null($actualString) || empty($actualString)) {
+                if (\is_null($actualString) || empty($actualString)) {
                     $actualString = self::getPrimitiveValueAsString($comparisonFailure->getActual());
                 }
 
-                if (!is_null($actualString) && !is_null($expectedString)) {
+                if (!\is_null($actualString) && !\is_null($expectedString)) {
                     $parameters['type']     = 'comparisonFailure';
                     $parameters['actual']   = $actualString;
                     $parameters['expected'] = $expectedString;
@@ -204,8 +204,8 @@ class TeamCity extends ResultPrinter
      */
     public function startTestSuite(TestSuite $suite)
     {
-        if (stripos(ini_get('disable_functions'), 'getmypid') === false) {
-            $this->flowId = getmypid();
+        if (\stripos(\ini_get('disable_functions'), 'getmypid') === false) {
+            $this->flowId = \getmypid();
         } else {
             $this->flowId = false;
         }
@@ -215,7 +215,7 @@ class TeamCity extends ResultPrinter
 
             $this->printEvent(
                 'testCount',
-                ['count' => count($suite)]
+                ['count' => \count($suite)]
             );
         }
 
@@ -227,13 +227,13 @@ class TeamCity extends ResultPrinter
 
         $parameters = ['name' => $suiteName];
 
-        if (class_exists($suiteName, false)) {
+        if (\class_exists($suiteName, false)) {
             $fileName                   = self::getFileName($suiteName);
             $parameters['locationHint'] = "php_qn://$fileName::\\$suiteName";
         } else {
-            $split = preg_split('/::/', $suiteName);
+            $split = \preg_split('/::/', $suiteName);
 
-            if (count($split) == 2 && method_exists($split[0], $split[1])) {
+            if (\count($split) == 2 && \method_exists($split[0], $split[1])) {
                 $fileName                   = self::getFileName($split[0]);
                 $parameters['locationHint'] = "php_qn://$fileName::\\$suiteName";
                 $parameters['name']         = $split[1];
@@ -258,10 +258,10 @@ class TeamCity extends ResultPrinter
 
         $parameters = ['name' => $suiteName];
 
-        if (!class_exists($suiteName, false)) {
-            $split = preg_split('/::/', $suiteName);
+        if (!\class_exists($suiteName, false)) {
+            $split = \preg_split('/::/', $suiteName);
 
-            if (count($split) == 2 && method_exists($split[0], $split[1])) {
+            if (\count($split) == 2 && \method_exists($split[0], $split[1])) {
                 $parameters['name'] = $split[1];
             }
         }
@@ -281,7 +281,7 @@ class TeamCity extends ResultPrinter
         $params                = ['name' => $testName];
 
         if ($test instanceof TestCase) {
-            $className              = get_class($test);
+            $className              = \get_class($test);
             $fileName               = self::getFileName($className);
             $params['locationHint'] = "php_qn://$fileName::\\$className::$testName";
         }
@@ -303,7 +303,7 @@ class TeamCity extends ResultPrinter
             'testFinished',
             [
                 'name'     => $test->getName(),
-                'duration' => (int) (round($time, 2) * 1000)
+                'duration' => (int) (\round($time, 2) * 1000)
             ]
         );
     }
@@ -338,11 +338,11 @@ class TeamCity extends ResultPrinter
         $message = '';
 
         if (!$e instanceof Exception) {
-            if (strlen(get_class($e)) != 0) {
-                $message .= get_class($e);
+            if (\strlen(\get_class($e)) != 0) {
+                $message .= \get_class($e);
             }
 
-            if (strlen($message) != 0 && strlen($e->getMessage()) != 0) {
+            if (\strlen($message) != 0 && \strlen($e->getMessage()) != 0) {
                 $message .= ' : ';
             }
         }
@@ -370,7 +370,7 @@ class TeamCity extends ResultPrinter
                 $previous->getPreviousWrapped() : $previous->getPrevious();
         }
 
-        return ' ' . str_replace("\n", "\n ", $stackTrace);
+        return ' ' . \str_replace("\n", "\n ", $stackTrace);
     }
 
     /**
@@ -380,16 +380,16 @@ class TeamCity extends ResultPrinter
      */
     private static function getPrimitiveValueAsString($value)
     {
-        if (is_null($value)) {
+        if (\is_null($value)) {
             return 'null';
         }
 
-        if (is_bool($value)) {
+        if (\is_bool($value)) {
             return $value == true ? 'true' : 'false';
         }
 
-        if (is_scalar($value)) {
-            return print_r($value, true);
+        if (\is_scalar($value)) {
+            return \print_r($value, true);
         }
     }
 
@@ -400,12 +400,12 @@ class TeamCity extends ResultPrinter
      */
     private static function escapeValue($text)
     {
-        $text = str_replace('|', '||', $text);
-        $text = str_replace("'", "|'", $text);
-        $text = str_replace("\n", '|n', $text);
-        $text = str_replace("\r", '|r', $text);
-        $text = str_replace(']', '|]', $text);
-        $text = str_replace('[', '|[', $text);
+        $text = \str_replace('|', '||', $text);
+        $text = \str_replace("'", "|'", $text);
+        $text = \str_replace("\n", '|n', $text);
+        $text = \str_replace("\r", '|r', $text);
+        $text = \str_replace(']', '|]', $text);
+        $text = \str_replace('[', '|[', $text);
 
         return $text;
     }

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -74,7 +74,7 @@ abstract class AbstractPhpProcess
      */
     public function setUseStderrRedirection($stderrRedirection)
     {
-        if (!is_bool($stderrRedirection)) {
+        if (!\is_bool($stderrRedirection)) {
             throw InvalidArgumentHelper::factory(1, 'boolean');
         }
 
@@ -223,12 +223,12 @@ abstract class AbstractPhpProcess
             $command .= ' -qrr ';
 
             if ($file) {
-                $command .= '-e ' . escapeshellarg($file);
+                $command .= '-e ' . \escapeshellarg($file);
             } else {
-                $command .= escapeshellarg(__DIR__ . '/eval-stdin.php');
+                $command .= \escapeshellarg(__DIR__ . '/eval-stdin.php');
             }
         } elseif ($file) {
-            $command .= ' -f ' . escapeshellarg($file);
+            $command .= ' -f ' . \escapeshellarg($file);
         }
 
         if ($this->args) {
@@ -285,27 +285,27 @@ abstract class AbstractPhpProcess
         if (!empty($stderr)) {
             $result->addError(
                 $test,
-                new Exception(trim($stderr)),
+                new Exception(\trim($stderr)),
                 $time
             );
         } else {
-            set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            \set_error_handler(function ($errno, $errstr, $errfile, $errline) {
                 throw new ErrorException($errstr, $errno, $errno, $errfile, $errline);
             });
             try {
-                if (strpos($stdout, "#!/usr/bin/env php\n") === 0) {
-                    $stdout = substr($stdout, 19);
+                if (\strpos($stdout, "#!/usr/bin/env php\n") === 0) {
+                    $stdout = \substr($stdout, 19);
                 }
 
-                $childResult = unserialize(str_replace("#!/usr/bin/env php\n", '', $stdout));
-                restore_error_handler();
+                $childResult = \unserialize(\str_replace("#!/usr/bin/env php\n", '', $stdout));
+                \restore_error_handler();
             } catch (ErrorException $e) {
-                restore_error_handler();
+                \restore_error_handler();
                 $childResult = false;
 
                 $result->addError(
                     $test,
-                    new Exception(trim($stdout), 0, $e),
+                    new Exception(\trim($stdout), 0, $e),
                     $time
                 );
             }
@@ -398,12 +398,12 @@ abstract class AbstractPhpProcess
         if ($exception instanceof __PHP_Incomplete_Class) {
             $exceptionArray = [];
             foreach ((array) $exception as $key => $value) {
-                $key                  = substr($key, strrpos($key, "\0") + 1);
+                $key                  = \substr($key, \strrpos($key, "\0") + 1);
                 $exceptionArray[$key] = $value;
             }
 
             $exception = new SyntheticError(
-                sprintf(
+                \sprintf(
                     '%s: %s',
                     $exceptionArray['_PHP_Incomplete_Class_Name'],
                     $exceptionArray['message']

--- a/src/Util/PHP/DefaultPhpProcess.php
+++ b/src/Util/PHP/DefaultPhpProcess.php
@@ -39,8 +39,8 @@ class DefaultPhpProcess extends AbstractPhpProcess
     public function runJob($job, array $settings = [])
     {
         if ($this->useTempFile || $this->stdin) {
-            if (!($this->tempFile = tempnam(sys_get_temp_dir(), 'PHPUnit')) ||
-                file_put_contents($this->tempFile, $job) === false
+            if (!($this->tempFile = \tempnam(\sys_get_temp_dir(), 'PHPUnit')) ||
+                \file_put_contents($this->tempFile, $job) === false
             ) {
                 throw new Exception(
                     'Unable to write temporary file'
@@ -81,10 +81,10 @@ class DefaultPhpProcess extends AbstractPhpProcess
         if ($this->env) {
             $env = isset($_SERVER) ? $_SERVER : [];
             unset($env['argv'], $env['argc']);
-            $env = array_merge($env, $this->env);
+            $env = \array_merge($env, $this->env);
 
             foreach ($env as $envKey => $envVar) {
-                if (is_array($envVar)) {
+                if (\is_array($envVar)) {
                     unset($env[$envKey]);
                 }
             }
@@ -95,7 +95,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
             1 => isset($handles[1]) ? $handles[1] : ['pipe', 'w'],
             2 => isset($handles[2]) ? $handles[2] : ['pipe', 'w'],
         ];
-        $process = proc_open(
+        $process = \proc_open(
             $this->getCommand($settings, $this->tempFile),
             $pipeSpec,
             $pipes,
@@ -103,7 +103,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
             $env
         );
 
-        if (!is_resource($process)) {
+        if (!\is_resource($process)) {
             throw new Exception(
                 'Unable to spawn worker process'
             );
@@ -112,7 +112,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
         if ($job) {
             $this->process($pipes[0], $job);
         }
-        fclose($pipes[0]);
+        \fclose($pipes[0]);
 
         if ($this->timeout) {
             $stderr = $stdout = '';
@@ -123,13 +123,13 @@ class DefaultPhpProcess extends AbstractPhpProcess
                 $w = null;
                 $e = null;
 
-                $n = @stream_select($r, $w, $e, $this->timeout);
+                $n = @\stream_select($r, $w, $e, $this->timeout);
 
                 if ($n === false) {
                     break;
                 } elseif ($n === 0) {
-                    proc_terminate($process, 9);
-                    throw new Exception(sprintf('Job execution aborted after %d seconds', $this->timeout));
+                    \proc_terminate($process, 9);
+                    throw new Exception(\sprintf('Job execution aborted after %d seconds', $this->timeout));
                 } elseif ($n > 0) {
                     foreach ($r as $pipe) {
                         $pipeOffset = 0;
@@ -144,9 +144,9 @@ class DefaultPhpProcess extends AbstractPhpProcess
                             break;
                         }
 
-                        $line = fread($pipe, 8192);
-                        if (strlen($line) == 0) {
-                            fclose($pipes[$pipeOffset]);
+                        $line = \fread($pipe, 8192);
+                        if (\strlen($line) == 0) {
+                            \fclose($pipes[$pipeOffset]);
                             unset($pipes[$pipeOffset]);
                         } else {
                             if ($pipeOffset == 1) {
@@ -164,29 +164,29 @@ class DefaultPhpProcess extends AbstractPhpProcess
             }
         } else {
             if (isset($pipes[1])) {
-                $stdout = stream_get_contents($pipes[1]);
-                fclose($pipes[1]);
+                $stdout = \stream_get_contents($pipes[1]);
+                \fclose($pipes[1]);
             }
 
             if (isset($pipes[2])) {
-                $stderr = stream_get_contents($pipes[2]);
-                fclose($pipes[2]);
+                $stderr = \stream_get_contents($pipes[2]);
+                \fclose($pipes[2]);
             }
         }
 
         if (isset($handles[1])) {
-            rewind($handles[1]);
-            $stdout = stream_get_contents($handles[1]);
-            fclose($handles[1]);
+            \rewind($handles[1]);
+            $stdout = \stream_get_contents($handles[1]);
+            \fclose($handles[1]);
         }
 
         if (isset($handles[2])) {
-            rewind($handles[2]);
-            $stderr = stream_get_contents($handles[2]);
-            fclose($handles[2]);
+            \rewind($handles[2]);
+            $stderr = \stream_get_contents($handles[2]);
+            \fclose($handles[2]);
         }
 
-        proc_close($process);
+        \proc_close($process);
         $this->cleanup();
 
         return ['stdout' => $stdout, 'stderr' => $stderr];
@@ -200,13 +200,13 @@ class DefaultPhpProcess extends AbstractPhpProcess
      */
     protected function process($pipe, $job)
     {
-        fwrite($pipe, $job);
+        \fwrite($pipe, $job);
     }
 
     protected function cleanup()
     {
         if ($this->tempFile) {
-            unlink($this->tempFile);
+            \unlink($this->tempFile);
         }
     }
 }

--- a/src/Util/PHP/WindowsPhpProcess.php
+++ b/src/Util/PHP/WindowsPhpProcess.php
@@ -25,7 +25,7 @@ class WindowsPhpProcess extends DefaultPhpProcess
 
     protected function getHandles()
     {
-        if (false === $stdout_handle = tmpfile()) {
+        if (false === $stdout_handle = \tmpfile()) {
             throw new Exception(
                 'A temporary file could not be created; verify that your TEMP environment variable is writable'
             );

--- a/src/Util/PHP/eval-stdin.php
+++ b/src/Util/PHP/eval-stdin.php
@@ -7,4 +7,4 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-eval('?>' . file_get_contents('php://stdin'));
+eval('?>' . \file_get_contents('php://stdin'));

--- a/src/Util/Printer.php
+++ b/src/Util/Printer.php
@@ -43,23 +43,23 @@ class Printer
     public function __construct($out = null)
     {
         if ($out !== null) {
-            if (is_string($out)) {
-                if (strpos($out, 'socket://') === 0) {
-                    $out = explode(':', str_replace('socket://', '', $out));
+            if (\is_string($out)) {
+                if (\strpos($out, 'socket://') === 0) {
+                    $out = \explode(':', \str_replace('socket://', '', $out));
 
-                    if (count($out) != 2) {
+                    if (\count($out) != 2) {
                         throw new Exception;
                     }
 
-                    $this->out = fsockopen($out[0], $out[1]);
+                    $this->out = \fsockopen($out[0], $out[1]);
                 } else {
-                    if (strpos($out, 'php://') === false &&
-                        !is_dir(dirname($out))
+                    if (\strpos($out, 'php://') === false &&
+                        !\is_dir(\dirname($out))
                     ) {
-                        mkdir(dirname($out), 0777, true);
+                        \mkdir(\dirname($out), 0777, true);
                     }
 
-                    $this->out = fopen($out, 'wt');
+                    $this->out = \fopen($out, 'wt');
                 }
 
                 $this->outTarget = $out;
@@ -74,8 +74,8 @@ class Printer
      */
     public function flush()
     {
-        if ($this->out && strncmp($this->outTarget, 'php://', 6) !== 0) {
-            fclose($this->out);
+        if ($this->out && \strncmp($this->outTarget, 'php://', 6) !== 0) {
+            \fclose($this->out);
         }
     }
 
@@ -89,9 +89,9 @@ class Printer
     public function incrementalFlush()
     {
         if ($this->out) {
-            fflush($this->out);
+            \fflush($this->out);
         } else {
-            flush();
+            \flush();
         }
     }
 
@@ -101,14 +101,14 @@ class Printer
     public function write($buffer)
     {
         if ($this->out) {
-            fwrite($this->out, $buffer);
+            \fwrite($this->out, $buffer);
 
             if ($this->autoFlush) {
                 $this->incrementalFlush();
             }
         } else {
             if (PHP_SAPI != 'cli' && PHP_SAPI != 'phpdbg') {
-                $buffer = htmlspecialchars($buffer, ENT_SUBSTITUTE);
+                $buffer = \htmlspecialchars($buffer, ENT_SUBSTITUTE);
             }
 
             print $buffer;
@@ -139,7 +139,7 @@ class Printer
      */
     public function setAutoFlush($autoFlush)
     {
-        if (is_bool($autoFlush)) {
+        if (\is_bool($autoFlush)) {
             $this->autoFlush = $autoFlush;
         } else {
             throw InvalidArgumentHelper::factory(1, 'boolean');

--- a/src/Util/RegularExpression.php
+++ b/src/Util/RegularExpression.php
@@ -26,7 +26,7 @@ class RegularExpression
     public static function safeMatch($pattern, $subject, $matches = null, $flags = 0, $offset = 0)
     {
         $handler_terminator = ErrorHandler::handleErrorOnce(E_WARNING);
-        $match              = preg_match($pattern, $subject, $matches, $flags, $offset);
+        $match              = \preg_match($pattern, $subject, $matches, $flags, $offset);
         $handler_terminator(); // cleaning
 
         return $match;

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -56,12 +56,12 @@ class Test
                 return $test->toString();
             }
 
-            return get_class($test);
+            return \get_class($test);
         }
 
         if ($test instanceof TestCase) {
             return [
-                get_class($test), $test->getName()
+                \get_class($test), $test->getName()
             ];
         }
 
@@ -69,7 +69,7 @@ class Test
             return ['', $test->toString()];
         }
 
-        return ['', get_class($test)];
+        return ['', \get_class($test)];
     }
 
     /**
@@ -126,9 +126,9 @@ class Test
         $classShortcut = null;
 
         if (!empty($annotations['class'][$mode . 'DefaultClass'])) {
-            if (count($annotations['class'][$mode . 'DefaultClass']) > 1) {
+            if (\count($annotations['class'][$mode . 'DefaultClass']) > 1) {
                 throw new CodeCoverageException(
-                    sprintf(
+                    \sprintf(
                         'More than one @%sClass annotation in class or interface "%s".',
                         $mode,
                         $className
@@ -146,21 +146,21 @@ class Test
         }
 
         if (isset($annotations['method'][$mode])) {
-            $list = array_merge($list, $annotations['method'][$mode]);
+            $list = \array_merge($list, $annotations['method'][$mode]);
         }
 
         $codeList = [];
 
-        foreach (array_unique($list) as $element) {
-            if ($classShortcut && strncmp($element, '::', 2) === 0) {
+        foreach (\array_unique($list) as $element) {
+            if ($classShortcut && \strncmp($element, '::', 2) === 0) {
                 $element = $classShortcut . $element;
             }
 
-            $element = preg_replace('/[\s()]+$/', '', $element);
-            $element = explode(' ', $element);
+            $element = \preg_replace('/[\s()]+$/', '', $element);
+            $element = \explode(' ', $element);
             $element = $element[0];
 
-            $codeList = array_merge(
+            $codeList = \array_merge(
                 $codeList,
                 self::resolveElementToReflectionObjects($element)
             );
@@ -185,14 +185,14 @@ class Test
         $docComment .= "\n" . $reflector->getDocComment();
         $requires = [];
 
-        if ($count = preg_match_all(self::REGEX_REQUIRES_OS, $docComment, $matches)) {
-            $requires['OS'] = sprintf(
+        if ($count = \preg_match_all(self::REGEX_REQUIRES_OS, $docComment, $matches)) {
+            $requires['OS'] = \sprintf(
                 '/%s/i',
-                addcslashes($matches['value'][$count - 1], '/')
+                \addcslashes($matches['value'][$count - 1], '/')
             );
         }
 
-        if ($count = preg_match_all(self::REGEX_REQUIRES_VERSION, $docComment, $matches)) {
+        if ($count = \preg_match_all(self::REGEX_REQUIRES_VERSION, $docComment, $matches)) {
             for ($i = 0; $i < $count; $i++) {
                 $requires[$matches['name'][$i]] = [
                     'version'  => $matches['version'][$i],
@@ -201,7 +201,7 @@ class Test
             }
         }
 
-        if ($count = preg_match_all(self::REGEX_REQUIRES, $docComment, $matches)) {
+        if ($count = \preg_match_all(self::REGEX_REQUIRES, $docComment, $matches)) {
             for ($i = 0; $i < $count; $i++) {
                 $name = $matches['name'][$i] . 's';
 
@@ -240,8 +240,8 @@ class Test
 
         $operator = empty($required['PHP']['operator']) ? '>=' : $required['PHP']['operator'];
 
-        if (!empty($required['PHP']) && !version_compare(PHP_VERSION, $required['PHP']['version'], $operator)) {
-            $missing[] = sprintf('PHP %s %s is required.', $operator, $required['PHP']['version']);
+        if (!empty($required['PHP']) && !\version_compare(PHP_VERSION, $required['PHP']['version'], $operator)) {
+            $missing[] = \sprintf('PHP %s %s is required.', $operator, $required['PHP']['version']);
         }
 
         if (!empty($required['PHPUnit'])) {
@@ -249,28 +249,28 @@ class Test
 
             $operator = empty($required['PHPUnit']['operator']) ? '>=' : $required['PHPUnit']['operator'];
 
-            if (!version_compare($phpunitVersion, $required['PHPUnit']['version'], $operator)) {
-                $missing[] = sprintf('PHPUnit %s %s is required.', $operator, $required['PHPUnit']['version']);
+            if (!\version_compare($phpunitVersion, $required['PHPUnit']['version'], $operator)) {
+                $missing[] = \sprintf('PHPUnit %s %s is required.', $operator, $required['PHPUnit']['version']);
             }
         }
 
-        if (!empty($required['OS']) && !preg_match($required['OS'], PHP_OS)) {
-            $missing[] = sprintf('Operating system matching %s is required.', $required['OS']);
+        if (!empty($required['OS']) && !\preg_match($required['OS'], PHP_OS)) {
+            $missing[] = \sprintf('Operating system matching %s is required.', $required['OS']);
         }
 
         if (!empty($required['functions'])) {
             foreach ($required['functions'] as $function) {
-                $pieces = explode('::', $function);
+                $pieces = \explode('::', $function);
 
-                if (2 === count($pieces) && method_exists($pieces[0], $pieces[1])) {
+                if (2 === \count($pieces) && \method_exists($pieces[0], $pieces[1])) {
                     continue;
                 }
 
-                if (function_exists($function)) {
+                if (\function_exists($function)) {
                     continue;
                 }
 
-                $missing[] = sprintf('Function %s is required.', $function);
+                $missing[] = \sprintf('Function %s is required.', $function);
             }
         }
 
@@ -280,20 +280,20 @@ class Test
                     continue;
                 }
 
-                if (!extension_loaded($extension)) {
-                    $missing[] = sprintf('Extension %s is required.', $extension);
+                if (!\extension_loaded($extension)) {
+                    $missing[] = \sprintf('Extension %s is required.', $extension);
                 }
             }
         }
 
         if (!empty($required['extension_versions'])) {
             foreach ($required['extension_versions'] as $extension => $required) {
-                $actualVersion = phpversion($extension);
+                $actualVersion = \phpversion($extension);
 
                 $operator = empty($required['operator']) ? '>=' : $required['operator'];
 
-                if (false === $actualVersion || !version_compare($actualVersion, $required['version'], $operator)) {
-                    $missing[] = sprintf('Extension %s %s %s is required.', $extension, $operator, $required['version']);
+                if (false === $actualVersion || !\version_compare($actualVersion, $required['version'], $operator)) {
+                    $missing[] = \sprintf('Extension %s %s %s is required.', $extension, $operator, $required['version']);
                 }
             }
         }
@@ -313,9 +313,9 @@ class Test
     {
         $reflector  = new ReflectionMethod($className, $methodName);
         $docComment = $reflector->getDocComment();
-        $docComment = substr($docComment, 3, -2);
+        $docComment = \substr($docComment, 3, -2);
 
-        if (preg_match(self::REGEX_EXPECTED_EXCEPTION, $docComment, $matches)) {
+        if (\preg_match(self::REGEX_EXPECTED_EXCEPTION, $docComment, $matches)) {
             $annotations = self::parseTestMethodAnnotations(
                 $className,
                 $methodName
@@ -327,7 +327,7 @@ class Test
             $messageRegExp = '';
 
             if (isset($matches[2])) {
-                $message = trim($matches[2]);
+                $message = \trim($matches[2]);
             } elseif (isset($annotations['method']['expectedExceptionMessage'])) {
                 $message = self::parseAnnotationContent(
                     $annotations['method']['expectedExceptionMessage'][0]
@@ -348,10 +348,10 @@ class Test
                 );
             }
 
-            if (is_numeric($code)) {
+            if (\is_numeric($code)) {
                 $code = (int) $code;
-            } elseif (is_string($code) && defined($code)) {
-                $code = (int) constant($code);
+            } elseif (\is_string($code) && \defined($code)) {
+                $code = (int) \constant($code);
             }
 
             return [
@@ -375,9 +375,9 @@ class Test
      */
     private static function parseAnnotationContent($message)
     {
-        if (strpos($message, '::') !== false && count(explode('::', $message)) == 2) {
-            if (defined($message)) {
-                $message = constant($message);
+        if (\strpos($message, '::') !== false && \count(\explode('::', $message)) == 2) {
+            if (\defined($message)) {
+                $message = \constant($message);
             }
         }
 
@@ -391,7 +391,7 @@ class Test
      * @param string $methodName
      *
      * @return array When a data provider is specified and exists
-     *         null  When no data provider is specified
+     *               null  When no data provider is specified
      *
      * @throws Exception
      */
@@ -406,17 +406,17 @@ class Test
             $data = self::getDataFromTestWithAnnotation($docComment);
         }
 
-        if (is_array($data) && empty($data)) {
+        if (\is_array($data) && empty($data)) {
             throw new SkippedTestError;
         }
 
         if ($data !== null) {
             foreach ($data as $key => $value) {
-                if (!is_array($value)) {
+                if (!\is_array($value)) {
                     throw new Exception(
-                        sprintf(
+                        \sprintf(
                             'Data set %s is invalid.',
-                            is_int($key) ? '#' . $key : '"' . $key . '"'
+                            \is_int($key) ? '#' . $key : '"' . $key . '"'
                         )
                     );
                 }
@@ -440,22 +440,22 @@ class Test
      */
     private static function getDataFromDataProviderAnnotation($docComment, $className, $methodName)
     {
-        if (preg_match_all(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
+        if (\preg_match_all(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
             $result = [];
 
             foreach ($matches[1] as $match) {
-                $dataProviderMethodNameNamespace = explode('\\', $match);
-                $leaf                            = explode('::', array_pop($dataProviderMethodNameNamespace));
-                $dataProviderMethodName          = array_pop($leaf);
+                $dataProviderMethodNameNamespace = \explode('\\', $match);
+                $leaf                            = \explode('::', \array_pop($dataProviderMethodNameNamespace));
+                $dataProviderMethodName          = \array_pop($leaf);
 
                 if (!empty($dataProviderMethodNameNamespace)) {
-                    $dataProviderMethodNameNamespace = implode('\\', $dataProviderMethodNameNamespace) . '\\';
+                    $dataProviderMethodNameNamespace = \implode('\\', $dataProviderMethodNameNamespace) . '\\';
                 } else {
                     $dataProviderMethodNameNamespace = '';
                 }
 
                 if (!empty($leaf)) {
-                    $dataProviderClassName = $dataProviderMethodNameNamespace . array_pop($leaf);
+                    $dataProviderClassName = $dataProviderMethodNameNamespace . \array_pop($leaf);
                 } else {
                     $dataProviderClassName = $className;
                 }
@@ -478,11 +478,11 @@ class Test
                 }
 
                 if ($data instanceof Iterator) {
-                    $data = iterator_to_array($data);
+                    $data = \iterator_to_array($data);
                 }
 
-                if (is_array($data)) {
-                    $result = array_merge($result, $data);
+                if (\is_array($data)) {
+                    $result = \array_merge($result, $data);
                 }
             }
 
@@ -502,23 +502,23 @@ class Test
     {
         $docComment = self::cleanUpMultiLineAnnotation($docComment);
 
-        if (preg_match(self::REGEX_TEST_WITH, $docComment, $matches, PREG_OFFSET_CAPTURE)) {
-            $offset            = strlen($matches[0][0]) + $matches[0][1];
-            $annotationContent = substr($docComment, $offset);
+        if (\preg_match(self::REGEX_TEST_WITH, $docComment, $matches, PREG_OFFSET_CAPTURE)) {
+            $offset            = \strlen($matches[0][0]) + $matches[0][1];
+            $annotationContent = \substr($docComment, $offset);
             $data              = [];
 
-            foreach (explode("\n", $annotationContent) as $candidateRow) {
-                $candidateRow = trim($candidateRow);
+            foreach (\explode("\n", $annotationContent) as $candidateRow) {
+                $candidateRow = \trim($candidateRow);
 
                 if ($candidateRow[0] !== '[') {
                     break;
                 }
 
-                $dataSet = json_decode($candidateRow, true);
+                $dataSet = \json_decode($candidateRow, true);
 
-                if (json_last_error() != JSON_ERROR_NONE) {
+                if (\json_last_error() != JSON_ERROR_NONE) {
                     throw new Exception(
-                        'The dataset for the @testWith annotation cannot be parsed: ' . json_last_error_msg()
+                        'The dataset for the @testWith annotation cannot be parsed: ' . \json_last_error_msg()
                     );
                 }
 
@@ -536,10 +536,10 @@ class Test
     private static function cleanUpMultiLineAnnotation($docComment)
     {
         //removing initial '   * ' for docComment
-        $docComment = str_replace("\r\n", "\n", $docComment);
-        $docComment = preg_replace('/' . '\n' . '\s*' . '\*' . '\s?' . '/', "\n", $docComment);
-        $docComment = substr($docComment, 0, -1);
-        $docComment = rtrim($docComment, "\n");
+        $docComment = \str_replace("\r\n", "\n", $docComment);
+        $docComment = \preg_replace('/' . '\n' . '\s*' . '\*' . '\s?' . '/', "\n", $docComment);
+        $docComment = \substr($docComment, 0, -1);
+        $docComment = \rtrim($docComment, "\n");
 
         return $docComment;
     }
@@ -560,13 +560,13 @@ class Test
             $annotations = [];
 
             foreach ($traits as $trait) {
-                $annotations = array_merge(
+                $annotations = \array_merge(
                     $annotations,
                     self::parseAnnotations($trait->getDocComment())
                 );
             }
 
-            self::$annotationCache[$className] = array_merge(
+            self::$annotationCache[$className] = \array_merge(
                 $annotations,
                 self::parseAnnotations($class->getDocComment())
             );
@@ -598,16 +598,16 @@ class Test
     public static function getInlineAnnotations($className, $methodName)
     {
         $method      = new ReflectionMethod($className, $methodName);
-        $code        = file($method->getFileName());
+        $code        = \file($method->getFileName());
         $lineNumber  = $method->getStartLine();
         $startLine   = $method->getStartLine() - 1;
         $endLine     = $method->getEndLine() - 1;
-        $methodLines = array_slice($code, $startLine, $endLine - $startLine + 1);
+        $methodLines = \array_slice($code, $startLine, $endLine - $startLine + 1);
         $annotations = [];
 
         foreach ($methodLines as $line) {
-            if (preg_match('#/\*\*?\s*@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?\*/$#m', $line, $matches)) {
-                $annotations[strtolower($matches['name'])] = [
+            if (\preg_match('#/\*\*?\s*@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?\*/$#m', $line, $matches)) {
+                $annotations[\strtolower($matches['name'])] = [
                     'line'  => $lineNumber,
                     'value' => $matches['value']
                 ];
@@ -628,10 +628,10 @@ class Test
     {
         $annotations = [];
         // Strip away the docblock header and footer to ease parsing of one line annotations
-        $docblock = substr($docblock, 3, -2);
+        $docblock = \substr($docblock, 3, -2);
 
-        if (preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docblock, $matches)) {
-            $numMatches = count($matches[0]);
+        if (\preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docblock, $matches)) {
+            $numMatches = \count($matches[0]);
 
             for ($i = 0; $i < $numMatches; ++$i) {
                 $annotations[$matches['name'][$i]][] = (string) $matches['value'][$i];
@@ -687,13 +687,13 @@ class Test
         }
 
         if (isset($annotations['method']['depends'])) {
-            $dependencies = array_merge(
+            $dependencies = \array_merge(
                 $dependencies,
                 $annotations['method']['depends']
             );
         }
 
-        return array_unique($dependencies);
+        return \array_unique($dependencies);
     }
 
     /**
@@ -737,19 +737,19 @@ class Test
         }
 
         if (isset($annotations['class']['group'])) {
-            $groups = array_merge($groups, $annotations['class']['group']);
+            $groups = \array_merge($groups, $annotations['class']['group']);
         }
 
         if (isset($annotations['method']['group'])) {
-            $groups = array_merge($groups, $annotations['method']['group']);
+            $groups = \array_merge($groups, $annotations['method']['group']);
         }
 
         if (isset($annotations['class']['ticket'])) {
-            $groups = array_merge($groups, $annotations['class']['ticket']);
+            $groups = \array_merge($groups, $annotations['class']['ticket']);
         }
 
         if (isset($annotations['method']['ticket'])) {
-            $groups = array_merge($groups, $annotations['method']['ticket']);
+            $groups = \array_merge($groups, $annotations['method']['ticket']);
         }
 
         foreach (['method', 'class'] as $element) {
@@ -761,7 +761,7 @@ class Test
             }
         }
 
-        return array_unique($groups);
+        return \array_unique($groups);
     }
 
     /**
@@ -774,11 +774,11 @@ class Test
      */
     public static function getSize($className, $methodName)
     {
-        $groups = array_flip(self::getGroups($className, $methodName));
+        $groups = \array_flip(self::getGroups($className, $methodName));
         $class  = new ReflectionClass($className);
 
         if (isset($groups['large']) ||
-            (class_exists('PHPUnit\DbUnit\TestCase', false) &&
+            (\class_exists('PHPUnit\DbUnit\TestCase', false) &&
                 $class->isSubclassOf('PHPUnit\DbUnit\TestCase'))
         ) {
             return self::LARGE;
@@ -843,7 +843,7 @@ class Test
      */
     public static function getHookMethods($className)
     {
-        if (!class_exists($className, false)) {
+        if (!\class_exists($className, false)) {
             return self::emptyHookMethodsArray();
         }
 
@@ -855,14 +855,14 @@ class Test
 
                 foreach ($class->getMethods() as $method) {
                     if (self::isBeforeClassMethod($method)) {
-                        array_unshift(
+                        \array_unshift(
                             self::$hookMethods[$className]['beforeClass'],
                             $method->getName()
                         );
                     }
 
                     if (self::isBeforeMethod($method)) {
-                        array_unshift(
+                        \array_unshift(
                             self::$hookMethods[$className]['before'],
                             $method->getName()
                         );
@@ -944,21 +944,21 @@ class Test
     {
         $codeToCoverList = [];
 
-        if (strpos($element, '\\') !== false && function_exists($element)) {
+        if (\strpos($element, '\\') !== false && \function_exists($element)) {
             $codeToCoverList[] = new ReflectionFunction($element);
-        } elseif (strpos($element, '::') !== false) {
-            list($className, $methodName) = explode('::', $element);
+        } elseif (\strpos($element, '::') !== false) {
+            list($className, $methodName) = \explode('::', $element);
 
             if (isset($methodName[0]) && $methodName[0] == '<') {
                 $classes = [$className];
 
                 foreach ($classes as $className) {
-                    if (!class_exists($className) &&
-                        !interface_exists($className) &&
-                        !trait_exists($className)
+                    if (!\class_exists($className) &&
+                        !\interface_exists($className) &&
+                        !\trait_exists($className)
                     ) {
                         throw new InvalidCoversTargetException(
-                            sprintf(
+                            \sprintf(
                                 'Trying to @cover or @use not existing class or ' .
                                 'interface "%s".',
                                 $className
@@ -970,11 +970,11 @@ class Test
                     $methods = $class->getMethods();
                     $inverse = isset($methodName[1]) && $methodName[1] == '!';
 
-                    if (strpos($methodName, 'protected')) {
+                    if (\strpos($methodName, 'protected')) {
                         $visibility = 'isProtected';
-                    } elseif (strpos($methodName, 'private')) {
+                    } elseif (\strpos($methodName, 'private')) {
                         $visibility = 'isPrivate';
-                    } elseif (strpos($methodName, 'public')) {
+                    } elseif (\strpos($methodName, 'public')) {
                         $visibility = 'isPublic';
                     }
 
@@ -990,18 +990,18 @@ class Test
                 $classes = [$className];
 
                 foreach ($classes as $className) {
-                    if ($className == '' && function_exists($methodName)) {
+                    if ($className == '' && \function_exists($methodName)) {
                         $codeToCoverList[] = new ReflectionFunction(
                             $methodName
                         );
                     } else {
-                        if (!((class_exists($className) ||
-                                interface_exists($className) ||
-                                trait_exists($className)) &&
-                            method_exists($className, $methodName))
+                        if (!((\class_exists($className) ||
+                                \interface_exists($className) ||
+                                \trait_exists($className)) &&
+                            \method_exists($className, $methodName))
                         ) {
                             throw new InvalidCoversTargetException(
-                                sprintf(
+                                \sprintf(
                                     'Trying to @cover or @use not existing method "%s::%s".',
                                     $className,
                                     $methodName
@@ -1019,28 +1019,28 @@ class Test
         } else {
             $extended = false;
 
-            if (strpos($element, '<extended>') !== false) {
-                $element  = str_replace('<extended>', '', $element);
+            if (\strpos($element, '<extended>') !== false) {
+                $element  = \str_replace('<extended>', '', $element);
                 $extended = true;
             }
 
             $classes = [$element];
 
             if ($extended) {
-                $classes = array_merge(
+                $classes = \array_merge(
                     $classes,
-                    class_implements($element),
-                    class_parents($element)
+                    \class_implements($element),
+                    \class_parents($element)
                 );
             }
 
             foreach ($classes as $className) {
-                if (!class_exists($className) &&
-                    !interface_exists($className) &&
-                    !trait_exists($className)
+                if (!\class_exists($className) &&
+                    !\interface_exists($className) &&
+                    !\trait_exists($className)
                 ) {
                     throw new InvalidCoversTargetException(
-                        sprintf(
+                        \sprintf(
                             'Trying to @cover or @use not existing class or ' .
                             'interface "%s".',
                             $className
@@ -1071,10 +1071,10 @@ class Test
                 $result[$filename] = [];
             }
 
-            $result[$filename] = array_unique(
-                array_merge(
+            $result[$filename] = \array_unique(
+                \array_merge(
                     $result[$filename],
-                    range($reflector->getStartLine(), $reflector->getEndLine())
+                    \range($reflector->getStartLine(), $reflector->getEndLine())
                 )
             );
         }
@@ -1089,7 +1089,7 @@ class Test
      */
     private static function isBeforeClassMethod(ReflectionMethod $method)
     {
-        return $method->isStatic() && strpos($method->getDocComment(), '@beforeClass') !== false;
+        return $method->isStatic() && \strpos($method->getDocComment(), '@beforeClass') !== false;
     }
 
     /**
@@ -1099,7 +1099,7 @@ class Test
      */
     private static function isBeforeMethod(ReflectionMethod $method)
     {
-        return preg_match('/@before\b/', $method->getDocComment());
+        return \preg_match('/@before\b/', $method->getDocComment());
     }
 
     /**
@@ -1109,7 +1109,7 @@ class Test
      */
     private static function isAfterClassMethod(ReflectionMethod $method)
     {
-        return $method->isStatic() && strpos($method->getDocComment(), '@afterClass') !== false;
+        return $method->isStatic() && \strpos($method->getDocComment(), '@afterClass') !== false;
     }
 
     /**
@@ -1119,6 +1119,6 @@ class Test
      */
     private static function isAfterMethod(ReflectionMethod $method)
     {
-        return preg_match('/@after\b/', $method->getDocComment());
+        return \preg_match('/@after\b/', $method->getDocComment());
     }
 }

--- a/src/Util/TestDox/HtmlResultPrinter.php
+++ b/src/Util/TestDox/HtmlResultPrinter.php
@@ -92,7 +92,7 @@ EOT;
     protected function startClass($name)
     {
         $this->write(
-            sprintf(
+            \sprintf(
                 $this->classHeader,
                 $name,
                 $this->currentTestClassPrettified
@@ -109,7 +109,7 @@ EOT;
     protected function onTest($name, $success = true)
     {
         $this->write(
-            sprintf(
+            \sprintf(
                 "            <li style=\"color: %s;\">%s %s</li>\n",
                 $success ? '#555753' : '#ef2929',
                 $success ? '✓' : '❌',

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -42,19 +42,19 @@ class NamePrettifier
         $title = $name;
 
         if ($this->suffix !== null &&
-            $this->suffix == substr($name, -1 * strlen($this->suffix))
+            $this->suffix == \substr($name, -1 * \strlen($this->suffix))
         ) {
-            $title = substr($title, 0, strripos($title, $this->suffix));
+            $title = \substr($title, 0, \strripos($title, $this->suffix));
         }
 
         if ($this->prefix !== null &&
-            $this->prefix == substr($name, 0, strlen($this->prefix))
+            $this->prefix == \substr($name, 0, \strlen($this->prefix))
         ) {
-            $title = substr($title, strlen($this->prefix));
+            $title = \substr($title, \strlen($this->prefix));
         }
 
-        if (substr($title, 0, 1) == '\\') {
-            $title = substr($title, 1);
+        if (\substr($title, 0, 1) == '\\') {
+            $title = \substr($title, 1);
         }
 
         return $title;
@@ -71,43 +71,43 @@ class NamePrettifier
     {
         $buffer = '';
 
-        if (!is_string($name) || strlen($name) == 0) {
+        if (!\is_string($name) || \strlen($name) == 0) {
             return $buffer;
         }
 
-        $string = preg_replace('#\d+$#', '', $name, -1, $count);
+        $string = \preg_replace('#\d+$#', '', $name, -1, $count);
 
-        if (in_array($string, $this->strings)) {
+        if (\in_array($string, $this->strings)) {
             $name = $string;
         } elseif ($count == 0) {
             $this->strings[] = $string;
         }
 
-        if (substr($name, 0, 4) == 'test') {
-            $name = substr($name, 4);
+        if (\substr($name, 0, 4) == 'test') {
+            $name = \substr($name, 4);
         }
 
-        if (strlen($name) == 0) {
+        if (\strlen($name) == 0) {
             return $buffer;
         }
 
-        $name[0] = strtoupper($name[0]);
+        $name[0] = \strtoupper($name[0]);
 
-        if (strpos($name, '_') !== false) {
-            return trim(str_replace('_', ' ', $name));
+        if (\strpos($name, '_') !== false) {
+            return \trim(\str_replace('_', ' ', $name));
         }
 
-        $max        = strlen($name);
+        $max        = \strlen($name);
         $wasNumeric = false;
 
         for ($i = 0; $i < $max; $i++) {
             if ($i > 0 &&
-                ord($name[$i]) >= 65 &&
-                ord($name[$i]) <= 90
+                \ord($name[$i]) >= 65 &&
+                \ord($name[$i]) <= 90
             ) {
-                $buffer .= ' ' . strtolower($name[$i]);
+                $buffer .= ' ' . \strtolower($name[$i]);
             } else {
-                $isNumeric = is_numeric($name[$i]);
+                $isNumeric = \is_numeric($name[$i]);
 
                 if (!$wasNumeric && $isNumeric) {
                     $buffer .= ' ';

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -252,7 +252,7 @@ abstract class ResultPrinter extends Printer implements TestListener
             return;
         }
 
-        $class = get_class($test);
+        $class = \get_class($test);
 
         if ($this->testClass != $class) {
             if ($this->testClass != '') {
@@ -387,7 +387,7 @@ abstract class ResultPrinter extends Printer implements TestListener
 
         if (!empty($this->groups)) {
             foreach ($test->getGroups() as $group) {
-                if (in_array($group, $this->groups)) {
+                if (\in_array($group, $this->groups)) {
                     return true;
                 }
             }
@@ -397,7 +397,7 @@ abstract class ResultPrinter extends Printer implements TestListener
 
         if (!empty($this->excludeGroups)) {
             foreach ($test->getGroups() as $group) {
-                if (in_array($group, $this->excludeGroups)) {
+                if (\in_array($group, $this->excludeGroups)) {
                     return false;
                 }
             }

--- a/src/Util/TestDox/XmlResultPrinter.php
+++ b/src/Util/TestDox/XmlResultPrinter.php
@@ -179,7 +179,7 @@ class XmlResultPrinter extends Printer implements TestListener
 
         /* @var TestCase $test */
 
-        $groups = array_filter(
+        $groups = \array_filter(
             $test->getGroups(),
             function ($group) {
                 if ($group == 'small' || $group == 'medium' || $group == 'large') {
@@ -192,16 +192,16 @@ class XmlResultPrinter extends Printer implements TestListener
 
         $node = $this->document->createElement('test');
 
-        $node->setAttribute('className', get_class($test));
+        $node->setAttribute('className', \get_class($test));
         $node->setAttribute('methodName', $test->getName());
-        $node->setAttribute('prettifiedClassName', $this->prettifier->prettifyTestClass(get_class($test)));
+        $node->setAttribute('prettifiedClassName', $this->prettifier->prettifyTestClass(\get_class($test)));
         $node->setAttribute('prettifiedMethodName', $this->prettifier->prettifyTestMethod($test->getName()));
         $node->setAttribute('status', $test->getStatus());
         $node->setAttribute('time', $time);
         $node->setAttribute('size', $test->getSize());
-        $node->setAttribute('groups', implode(',', $groups));
+        $node->setAttribute('groups', \implode(',', $groups));
 
-        $inlineAnnotations = \PHPUnit\Util\Test::getInlineAnnotations(get_class($test), $test->getName());
+        $inlineAnnotations = \PHPUnit\Util\Test::getInlineAnnotations(\get_class($test), $test->getName());
 
         if (isset($inlineAnnotations['given']) && isset($inlineAnnotations['when']) && isset($inlineAnnotations['then'])) {
             $node->setAttribute('given', $inlineAnnotations['given']['value']);

--- a/src/Util/Type.php
+++ b/src/Util/Type.php
@@ -22,7 +22,7 @@ class Type
      */
     public static function isType($type)
     {
-        return in_array(
+        return \in_array(
             $type,
             [
                 'numeric',

--- a/src/Util/Xml.php
+++ b/src/Util/Xml.php
@@ -50,8 +50,8 @@ class Xml
             return $actual;
         }
 
-        if (!is_string($actual)) {
-            throw new Exception('Could not load XML from ' . gettype($actual));
+        if (!\is_string($actual)) {
+            throw new Exception('Could not load XML from ' . \gettype($actual));
         }
 
         if ($actual === '') {
@@ -60,16 +60,16 @@ class Xml
 
         // Required for XInclude on Windows.
         if ($xinclude) {
-            $cwd = getcwd();
-            @chdir(dirname($filename));
+            $cwd = \getcwd();
+            @\chdir(\dirname($filename));
         }
 
         $document                     = new DOMDocument;
         $document->preserveWhiteSpace = false;
 
-        $internal  = libxml_use_internal_errors(true);
+        $internal  = \libxml_use_internal_errors(true);
         $message   = '';
-        $reporting = error_reporting(0);
+        $reporting = \error_reporting(0);
 
         if ('' !== $filename) {
             // Necessary for xinclude
@@ -86,21 +86,21 @@ class Xml
             $document->xinclude();
         }
 
-        foreach (libxml_get_errors() as $error) {
+        foreach (\libxml_get_errors() as $error) {
             $message .= "\n" . $error->message;
         }
 
-        libxml_use_internal_errors($internal);
-        error_reporting($reporting);
+        \libxml_use_internal_errors($internal);
+        \error_reporting($reporting);
 
         if ($xinclude) {
-            @chdir($cwd);
+            @\chdir($cwd);
         }
 
         if ($loaded === false || ($strict && $message !== '')) {
             if ($filename !== '') {
                 throw new Exception(
-                    sprintf(
+                    \sprintf(
                         'Could not load "%s".%s',
                         $filename,
                         $message != '' ? "\n" . $message : ''
@@ -130,13 +130,13 @@ class Xml
      */
     public static function loadFile($filename, $isHtml = false, $xinclude = false, $strict = false)
     {
-        $reporting = error_reporting(0);
-        $contents  = file_get_contents($filename);
-        error_reporting($reporting);
+        $reporting = \error_reporting(0);
+        $contents  = \file_get_contents($filename);
+        \error_reporting($reporting);
 
         if ($contents === false) {
             throw new Exception(
-                sprintf(
+                \sprintf(
                     'Could not read "%s".',
                     $filename
                 )
@@ -172,10 +172,10 @@ class Xml
      */
     public static function prepareString($string)
     {
-        return preg_replace(
+        return \preg_replace(
             '/[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]/',
             '',
-            htmlspecialchars(
+            \htmlspecialchars(
                 self::convertToUtf8($string),
                 ENT_QUOTES,
                 'UTF-8'
@@ -247,7 +247,7 @@ class Xml
             case 'string':
                 $variable = $element->textContent;
 
-                settype($variable, $element->tagName);
+                \settype($variable, $element->tagName);
                 break;
         }
 
@@ -264,11 +264,11 @@ class Xml
     private static function convertToUtf8($string)
     {
         if (!self::isUtf8($string)) {
-            if (function_exists('mb_convert_encoding')) {
-                return mb_convert_encoding($string, 'UTF-8');
+            if (\function_exists('mb_convert_encoding')) {
+                return \mb_convert_encoding($string, 'UTF-8');
             }
 
-            return utf8_encode($string);
+            return \utf8_encode($string);
         }
 
         return $string;
@@ -283,23 +283,23 @@ class Xml
      */
     private static function isUtf8($string)
     {
-        $length = strlen($string);
+        $length = \strlen($string);
 
         for ($i = 0; $i < $length; $i++) {
-            if (ord($string[$i]) < 0x80) {
+            if (\ord($string[$i]) < 0x80) {
                 $n = 0;
-            } elseif ((ord($string[$i]) & 0xE0) == 0xC0) {
+            } elseif ((\ord($string[$i]) & 0xE0) == 0xC0) {
                 $n = 1;
-            } elseif ((ord($string[$i]) & 0xF0) == 0xE0) {
+            } elseif ((\ord($string[$i]) & 0xF0) == 0xE0) {
                 $n = 2;
-            } elseif ((ord($string[$i]) & 0xF0) == 0xF0) {
+            } elseif ((\ord($string[$i]) & 0xF0) == 0xF0) {
                 $n = 3;
             } else {
                 return false;
             }
 
             for ($j = 0; $j < $n; $j++) {
-                if ((++$i == $length) || ((ord($string[$i]) & 0xC0) != 0x80)) {
+                if ((++$i == $length) || ((\ord($string[$i]) & 0xC0) != 0x80)) {
                     return false;
                 }
             }

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -21,7 +21,7 @@ class AssertTest extends TestCase
 
     protected function setUp()
     {
-        $this->filesDirectory = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR;
+        $this->filesDirectory = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR;
     }
 
     public function testFail()
@@ -501,8 +501,8 @@ class AssertTest extends TestCase
         $object = new \SampleClass(4, 8, 15);
         // cannot use $filesDirectory, because neither setUp() nor
         // setUpBeforeClass() are executed before the data providers
-        $file     = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'foo.xml';
-        $resource = fopen($file, 'r');
+        $file     = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'foo.xml';
+        $resource = \fopen($file, 'r');
 
         return [
             // null
@@ -514,7 +514,7 @@ class AssertTest extends TestCase
             // floats
             [2.3, 2.3],
             [1 / 3, 1 - 2 / 3],
-            [log(0), log(0)],
+            [\log(0), \log(0)],
             // arrays
             [[], []],
             [[0 => 1], [0 => 1]],
@@ -552,7 +552,7 @@ class AssertTest extends TestCase
 
         // cannot use $filesDirectory, because neither setUp() nor
         // setUpBeforeClass() are executed before the data providers
-        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'foo.xml';
+        $file = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'foo.xml';
 
         return [
             // strings
@@ -584,7 +584,7 @@ class AssertTest extends TestCase
             [$book1, $book2],
             [$book3, $book4], // same content, different class
             // resources
-            [fopen($file, 'r'), fopen($file, 'r')],
+            [\fopen($file, 'r'), \fopen($file, 'r')],
             // SplObjectStorage
             [$storage1, $storage2],
             // DOMDocument
@@ -665,8 +665,8 @@ class AssertTest extends TestCase
             // We want these values to differ
             [0, 'Foobar'],
             ['Foobar', 0],
-            [3, acos(8)],
-            [acos(8), 3]
+            [3, \acos(8)],
+            [\acos(8), 3]
         ];
     }
 
@@ -785,7 +785,7 @@ class AssertTest extends TestCase
     public function equalProvider()
     {
         // same |= equal
-        return array_merge($this->equalValues(), $this->sameValues());
+        return \array_merge($this->equalValues(), $this->sameValues());
     }
 
     public function notEqualProvider()
@@ -802,7 +802,7 @@ class AssertTest extends TestCase
     {
         // not equal |= not same
         // equal, ¬same |= not same
-        return array_merge($this->notEqualValues(), $this->equalValues());
+        return \array_merge($this->notEqualValues(), $this->equalValues());
     }
 
     /**
@@ -911,14 +911,14 @@ class AssertTest extends TestCase
     {
         $this->assertXmlStringEqualsXmlFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'foo.xml')
+            \file_get_contents($this->filesDirectory . 'foo.xml')
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertXmlStringEqualsXmlFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'bar.xml')
+            \file_get_contents($this->filesDirectory . 'bar.xml')
         );
     }
 
@@ -926,14 +926,14 @@ class AssertTest extends TestCase
     {
         $this->assertXmlStringNotEqualsXmlFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'bar.xml')
+            \file_get_contents($this->filesDirectory . 'bar.xml')
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertXmlStringNotEqualsXmlFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'foo.xml')
+            \file_get_contents($this->filesDirectory . 'foo.xml')
         );
     }
 
@@ -2510,14 +2510,14 @@ XML;
     {
         $this->assertStringEqualsFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'foo.xml')
+            \file_get_contents($this->filesDirectory . 'foo.xml')
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertStringEqualsFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'bar.xml')
+            \file_get_contents($this->filesDirectory . 'bar.xml')
         );
     }
 
@@ -2525,14 +2525,14 @@ XML;
     {
         $this->assertStringNotEqualsFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'bar.xml')
+            \file_get_contents($this->filesDirectory . 'bar.xml')
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertStringNotEqualsFile(
             $this->filesDirectory . 'foo.xml',
-            file_get_contents($this->filesDirectory . 'foo.xml')
+            \file_get_contents($this->filesDirectory . 'foo.xml')
         );
     }
 
@@ -2943,7 +2943,7 @@ XML;
     public function testAssertJsonStringEqualsJsonFile()
     {
         $file    = __DIR__ . '/../_files/JsonData/simpleObject.json';
-        $actual  = json_encode(['Mascott' => 'Tux']);
+        $actual  = \json_encode(['Mascott' => 'Tux']);
         $message = '';
 
         $this->assertJsonStringEqualsJsonFile($file, $actual, $message);
@@ -2952,7 +2952,7 @@ XML;
     public function testAssertJsonStringEqualsJsonFileExpectingExpectationFailedException()
     {
         $file    = __DIR__ . '/../_files/JsonData/simpleObject.json';
-        $actual  = json_encode(['Mascott' => 'Beastie']);
+        $actual  = \json_encode(['Mascott' => 'Beastie']);
         $message = '';
 
         try {
@@ -2985,7 +2985,7 @@ XML;
     public function testAssertJsonStringNotEqualsJsonFile()
     {
         $file    = __DIR__ . '/../_files/JsonData/simpleObject.json';
-        $actual  = json_encode(['Mascott' => 'Beastie']);
+        $actual  = \json_encode(['Mascott' => 'Beastie']);
         $message = '';
 
         $this->assertJsonStringNotEqualsJsonFile($file, $actual, $message);

--- a/tests/Framework/Constraint/ExceptionMessageRegExpTest.php
+++ b/tests/Framework/Constraint/ExceptionMessageRegExpTest.php
@@ -40,7 +40,7 @@ class ExceptionMessageRegExpTest extends TestCase
      */
     public function testMessageXdebugScreamCompatibility()
     {
-        ini_set('xdebug.scream', '1');
+        \ini_set('xdebug.scream', '1');
 
         throw new \Exception('Screaming preg_match');
     }

--- a/tests/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/Framework/Constraint/JsonMatchesTest.php
@@ -26,7 +26,7 @@ class JsonMatchesTest extends TestCase
 
     public function testToString()
     {
-        $jsonValue  = json_encode(['Mascott' => 'Tux']);
+        $jsonValue  = \json_encode(['Mascott' => 'Tux']);
         $constraint = new JsonMatches($jsonValue);
 
         $this->assertEquals('matches JSON string "' . $jsonValue . '"', $constraint->toString());
@@ -35,10 +35,10 @@ class JsonMatchesTest extends TestCase
     public static function evaluateDataprovider()
     {
         return [
-            'valid JSON'                              => [true, json_encode(['Mascott'                           => 'Tux']), json_encode(['Mascott'                           => 'Tux'])],
-            'error syntax'                            => [false, '{"Mascott"::}', json_encode(['Mascott'         => 'Tux'])],
-            'error UTF-8'                             => [false, json_encode('\xB1\x31'), json_encode(['Mascott' => 'Tux'])],
-            'invalid JSON in class instantiation'     => [false, json_encode(['Mascott'                          => 'Tux']), '{"Mascott"::}'],
+            'valid JSON'                              => [true, \json_encode(['Mascott'                           => 'Tux']), \json_encode(['Mascott'                           => 'Tux'])],
+            'error syntax'                            => [false, '{"Mascott"::}', \json_encode(['Mascott'         => 'Tux'])],
+            'error UTF-8'                             => [false, \json_encode('\xB1\x31'), \json_encode(['Mascott' => 'Tux'])],
+            'invalid JSON in class instantiation'     => [false, \json_encode(['Mascott'                          => 'Tux']), '{"Mascott"::}'],
             'string type not equals number'           => [false, '{"age": "5"}', '{"age": 5}'],
             'string type not equals boolean'          => [false, '{"age": "true"}', '{"age": true}'],
             'string type not equals null'             => [false, '{"age": "null"}', '{"age": null}'],

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -248,7 +248,7 @@ EOF
 
     public function testConstraintFileNotExists()
     {
-        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ClassWithNonPublicAttributes.php';
+        $file = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ClassWithNonPublicAttributes.php';
 
         $constraint = Assert::logicalNot(
             Assert::fileExists()
@@ -278,7 +278,7 @@ EOF
 
     public function testConstraintFileNotExists2()
     {
-        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ClassWithNonPublicAttributes.php';
+        $file = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'ClassWithNonPublicAttributes.php';
 
         $constraint = Assert::logicalNot(
             Assert::fileExists()
@@ -579,8 +579,8 @@ EOF
         $a      = new \stdClass;
         $a->foo = 'bar';
         $b      = new \stdClass;
-        $ahash  = spl_object_hash($a);
-        $bhash  = spl_object_hash($b);
+        $ahash  = \spl_object_hash($a);
+        $bhash  = \spl_object_hash($b);
 
         $c               = new \stdClass;
         $c->foo          = 'bar';
@@ -604,8 +604,8 @@ EOF
         $storage1->attach($b);
         $storage2 = new \SplObjectStorage;
         $storage2->attach($b);
-        $storage1hash = spl_object_hash($storage1);
-        $storage2hash = spl_object_hash($storage2);
+        $storage1hash = \spl_object_hash($storage1);
+        $storage2hash = \spl_object_hash($storage2);
 
         $dom1                     = new \DOMDocument;
         $dom1->preserveWhiteSpace = false;
@@ -1239,11 +1239,11 @@ EOF
 
     public function resources()
     {
-        $fh = fopen(__FILE__, 'r');
-        fclose($fh);
+        $fh = \fopen(__FILE__, 'r');
+        \fclose($fh);
 
         return [
-            'open resource'     => [fopen(__FILE__, 'r')],
+            'open resource'     => [\fopen(__FILE__, 'r')],
             'closed resource'   => [$fh],
         ];
     }
@@ -1257,7 +1257,7 @@ EOF
 
         $this->assertTrue($constraint->evaluate($resource, '', true));
 
-        @fclose($resource);
+        @\fclose($resource);
     }
 
     public function testConstraintIsNotType()
@@ -2284,7 +2284,7 @@ EOF
         $this->assertTrue($constraint->evaluate('ORYGINAŁ', '', true));
         $this->assertTrue($constraint->evaluate('oryginał', '', true));
         $this->assertEquals('contains "oryginał"', $constraint->toString());
-        $this->assertEquals(1, count($constraint));
+        $this->assertEquals(1, \count($constraint));
 
         $this->expectException(ExpectationFailedException::class);
 
@@ -2299,7 +2299,7 @@ EOF
         $this->assertFalse($constraint->evaluate('ORYGINAŁ', '', true));
         $this->assertTrue($constraint->evaluate('oryginał', '', true));
         $this->assertEquals('contains "oryginał"', $constraint->toString());
-        $this->assertEquals(1, count($constraint));
+        $this->assertEquals(1, \count($constraint));
 
         $this->expectException(ExpectationFailedException::class);
 
@@ -2368,7 +2368,7 @@ EOF
         $this->assertFalse($constraint->evaluate('ORYGINAŁ', '', true));
         $this->assertFalse($constraint->evaluate('oryginał', '', true));
         $this->assertEquals('does not contain "oryginał"', $constraint->toString());
-        $this->assertEquals(1, count($constraint));
+        $this->assertEquals(1, \count($constraint));
 
         $this->expectException(ExpectationFailedException::class);
 
@@ -2385,7 +2385,7 @@ EOF
         $this->assertTrue($constraint->evaluate('ORYGINAŁ', '', true));
         $this->assertFalse($constraint->evaluate('oryginał', '', true));
         $this->assertEquals('does not contain "oryginał"', $constraint->toString());
-        $this->assertEquals(1, count($constraint));
+        $this->assertEquals(1, \count($constraint));
 
         $this->expectException(ExpectationFailedException::class);
 
@@ -3033,6 +3033,6 @@ EOF
      */
     private function trimnl($string)
     {
-        return preg_replace('/[ ]*\n/', "\n", $string);
+        return \preg_replace('/[ ]*\n/', "\n", $string);
     }
 }

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -192,7 +192,7 @@ class SuiteTest extends TestCase
         $suite->run($this->result);
 
         $skipped           = $this->result->skipped();
-        $lastSkippedResult = array_pop($skipped);
+        $lastSkippedResult = \array_pop($skipped);
         $message           = $lastSkippedResult->thrownException()->getMessage();
 
         $this->assertContains('Test for DataProviderDependencyTest::testDependency skipped by data provider', $message);
@@ -224,7 +224,7 @@ class SuiteTest extends TestCase
             'DontSkipInheritedClass'
         );
 
-        $dir = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Inheritance' . DIRECTORY_SEPARATOR;
+        $dir = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'Inheritance' . DIRECTORY_SEPARATOR;
 
         $suite->addTestFile($dir . 'InheritanceA.php');
         $suite->addTestFile($dir . 'InheritanceB.php');

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -393,7 +393,7 @@ class TestCaseTest extends TestCase
     public function testStaticAttributesBackupPre()
     {
         $GLOBALS['singleton'] = \Singleton::getInstance();
-        self::$testStatic    = 123;
+        self::$testStatic     = 123;
     }
 
     /**
@@ -578,12 +578,12 @@ class TestCaseTest extends TestCase
 
     public function testCurrentWorkingDirectoryIsRestored()
     {
-        $expectedCwd = getcwd();
+        $expectedCwd = \getcwd();
 
         $test = new \ChangeCurrentWorkingDirectoryTest('testSomethingThatChangesTheCwd');
         $test->run();
 
-        $this->assertSame($expectedCwd, getcwd());
+        $this->assertSame($expectedCwd, \getcwd());
     }
 
     /**

--- a/tests/Framework/TestImplementorTest.php
+++ b/tests/Framework/TestImplementorTest.php
@@ -19,7 +19,7 @@ class TestImplementorTest extends TestCase
         $test = new \DoubleTestCase(new \Success);
         $test->run($result);
 
-        $this->assertCount(count($test), $result);
+        $this->assertCount(\count($test), $result);
         $this->assertEquals(0, $result->errorCount());
         $this->assertEquals(0, $result->failureCount());
     }

--- a/tests/Runner/PhptTestCaseTest.php
+++ b/tests/Runner/PhptTestCaseTest.php
@@ -69,9 +69,9 @@ EOF;
 
     protected function setUp()
     {
-        $this->dirname  = sys_get_temp_dir();
+        $this->dirname  = \sys_get_temp_dir();
         $this->filename = $this->dirname . '/phpunit.phpt';
-        touch($this->filename);
+        \touch($this->filename);
 
         $this->phpProcess = $this->getMockForAbstractClass(AbstractPhpProcess::class, [], '', false);
         $this->testCase   = new PhptTestCase($this->filename, $this->phpProcess);
@@ -79,7 +79,7 @@ EOF;
 
     protected function tearDown()
     {
-        @unlink($this->filename);
+        @\unlink($this->filename);
 
         $this->filename = null;
         $this->testCase = null;
@@ -92,7 +92,7 @@ EOF;
      */
     private function setPhpContent($content)
     {
-        file_put_contents($this->filename, $content);
+        \file_put_contents($this->filename, $content);
     }
 
     public function testShouldRunFileSectionAsTest()

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -24,7 +24,7 @@ class ConfigurationTest extends TestCase
     protected function setUp()
     {
         $this->configuration = Configuration::getInstance(
-            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.xml'
+            \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.xml'
         );
     }
 
@@ -37,7 +37,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenTrueInConfigurationFile()
     {
-        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.true.xml';
+        $configurationFilename =  \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.true.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -46,7 +46,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenFalseInConfigurationFile()
     {
-        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.false.xml';
+        $configurationFilename =  \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.false.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -55,7 +55,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenEmptyInConfigurationFile()
     {
-        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.empty.xml';
+        $configurationFilename =  \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.empty.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -64,7 +64,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenInvalidInConfigurationFile()
     {
-        $configurationFilename =  dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
+        $configurationFilename =  \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -157,9 +157,9 @@ class ConfigurationTest extends TestCase
     public function testListenerConfigurationIsReadCorrectly()
     {
         $dir         = __DIR__;
-        $includePath = ini_get('include_path');
+        $includePath = \ini_get('include_path');
 
-        ini_set('include_path', $dir . PATH_SEPARATOR . $includePath);
+        \ini_set('include_path', $dir . PATH_SEPARATOR . $includePath);
 
         $this->assertEquals(
             [
@@ -178,8 +178,8 @@ class ConfigurationTest extends TestCase
                 3 => 19.78,
                 4 => null,
                 5 => new \stdClass,
-                6 => dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'MyTestFile.php',
-                7 => dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'MyRelativePath',
+                6 => \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'MyTestFile.php',
+                7 => \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'MyRelativePath',
               ],
             ],
             [
@@ -199,7 +199,7 @@ class ConfigurationTest extends TestCase
             $this->configuration->getListenerConfiguration()
         );
 
-        ini_set('include_path', $includePath);
+        \ini_set('include_path', $includePath);
     }
 
     public function testLoggingConfigurationIsReadCorrectly()
@@ -228,7 +228,7 @@ class ConfigurationTest extends TestCase
             [
             'include_path' =>
             [
-              dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.',
+              \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.',
               '/path/to/lib'
             ],
             'ini'    => ['foo' => 'bar'],
@@ -253,13 +253,13 @@ class ConfigurationTest extends TestCase
     {
         $this->configuration->handlePHPConfiguration();
 
-        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.' . PATH_SEPARATOR . '/path/to/lib';
-        $this->assertStringStartsWith($path, ini_get('include_path'));
+        $path = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.' . PATH_SEPARATOR . '/path/to/lib';
+        $this->assertStringStartsWith($path, \ini_get('include_path'));
         $this->assertEquals(false, \FOO);
         $this->assertEquals(true, \BAR);
         $this->assertEquals(false, $GLOBALS['foo']);
         $this->assertEquals(true, $_ENV['foo']);
-        $this->assertEquals(true, getenv('foo'));
+        $this->assertEquals(true, \getenv('foo'));
         $this->assertEquals('bar', $_POST['foo']);
         $this->assertEquals('bar', $_GET['foo']);
         $this->assertEquals('bar', $_COOKIE['foo']);
@@ -279,7 +279,7 @@ class ConfigurationTest extends TestCase
         $this->configuration->handlePHPConfiguration();
 
         $this->assertEquals(false, $_ENV['foo']);
-        $this->assertEquals(true, getenv('foo'));
+        $this->assertEquals(true, \getenv('foo'));
     }
 
     /**
@@ -289,11 +289,11 @@ class ConfigurationTest extends TestCase
      */
     public function testHandlePHPConfigurationDoesNotOverriteVariablesFromPutEnv()
     {
-        putenv('foo=putenv');
+        \putenv('foo=putenv');
         $this->configuration->handlePHPConfiguration();
 
         $this->assertEquals(true, $_ENV['foo']);
-        $this->assertEquals('putenv', getenv('foo'));
+        $this->assertEquals('putenv', \getenv('foo'));
     }
 
     public function testPHPUnitConfigurationIsReadCorrectly()
@@ -339,7 +339,7 @@ class ConfigurationTest extends TestCase
     public function testXincludeInConfiguration()
     {
         $configurationWithXinclude = Configuration::getInstance(
-            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration_xinclude.xml'
+            \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration_xinclude.xml'
         );
 
         $this->assertConfigurationEquals(
@@ -354,7 +354,7 @@ class ConfigurationTest extends TestCase
     public function testWithEmptyConfigurations()
     {
         $emptyConfiguration = Configuration::getInstance(
-            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration_empty.xml'
+            \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration_empty.xml'
         );
 
         $logging = $emptyConfiguration->getLoggingConfiguration();
@@ -425,7 +425,7 @@ class ConfigurationTest extends TestCase
     public function testGetTestSuiteNamesReturnsTheNamesIfDefined()
     {
         $configuration = Configuration::getInstance(
-            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.suites.xml'
+            \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.suites.xml'
         );
 
         $names = $configuration->getTestSuiteNames();
@@ -436,12 +436,12 @@ class ConfigurationTest extends TestCase
     public function testTestSuiteConfigurationForASingleFileInASuite()
     {
         $configuration = Configuration::getInstance(
-            dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.one-file-suite.xml'
+            \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'configuration.one-file-suite.xml'
         );
 
         $config = $configuration->getTestSuiteConfiguration();
         $tests  = $config->tests();
 
-        $this->assertEquals(1, count($tests));
+        $this->assertEquals(1, \count($tests));
     }
 }

--- a/tests/Util/GetoptTest.php
+++ b/tests/Util/GetoptTest.php
@@ -170,7 +170,7 @@ class GetoptTest extends TestCase
     public function testItHandlesLongParametesWithValues()
     {
         $command = 'command parameter-0 --exec parameter-1 --conf config.xml --optn parameter-2 --optn=content-of-o parameter-n';
-        $args    = explode(' ', $command);
+        $args    = \explode(' ', $command);
         unset($args[0]);
         $expected = [
             [
@@ -193,7 +193,7 @@ class GetoptTest extends TestCase
     public function testItHandlesShortParametesWithValues()
     {
         $command = 'command parameter-0 -x parameter-1 -c config.xml -o parameter-2 -ocontent-of-o parameter-n';
-        $args    = explode(' ', $command);
+        $args    = \explode(' ', $command);
         unset($args[0]);
         $expected = [
             [

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -389,23 +389,23 @@ class TestTest extends TestCase
      */
     public function testGetProvidedDataRegEx()
     {
-        $result = preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider method', $matches);
+        $result = \preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider method', $matches);
         $this->assertEquals(1, $result);
         $this->assertEquals('method', $matches[1]);
 
-        $result = preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider class::method', $matches);
+        $result = \preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider class::method', $matches);
         $this->assertEquals(1, $result);
         $this->assertEquals('class::method', $matches[1]);
 
-        $result = preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider namespace\class::method', $matches);
+        $result = \preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider namespace\class::method', $matches);
         $this->assertEquals(1, $result);
         $this->assertEquals('namespace\class::method', $matches[1]);
 
-        $result = preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider namespace\namespace\class::method', $matches);
+        $result = \preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider namespace\namespace\class::method', $matches);
         $this->assertEquals(1, $result);
         $this->assertEquals('namespace\namespace\class::method', $matches[1]);
 
-        $result = preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider メソッド', $matches);
+        $result = \preg_match(Test::REGEX_DATA_PROVIDER, '@dataProvider メソッド', $matches);
         $this->assertEquals(1, $result);
         $this->assertEquals('メソッド', $matches[1]);
     }
@@ -438,7 +438,7 @@ class TestTest extends TestCase
     {
         $dataSets = Test::getProvidedData(\MultipleDataProviderTest::class, 'testTwo');
 
-        $this->assertEquals(9, count($dataSets));
+        $this->assertEquals(9, \count($dataSets));
 
         $aCount = 0;
         $bCount = 0;
@@ -544,7 +544,7 @@ class TestTest extends TestCase
     {
         $this->assertEquals(
             ['Foo', 'ほげ'],
-            Test::getDependencies(get_class($this), 'methodForTestParseAnnotation')
+            Test::getDependencies(\get_class($this), 'methodForTestParseAnnotation')
         );
     }
 
@@ -562,7 +562,7 @@ class TestTest extends TestCase
     {
         $this->assertEquals(
             ['Bar'],
-            Test::getDependencies(get_class($this), 'methodForTestParseAnnotationThatIsOnlyOneLine')
+            Test::getDependencies(\get_class($this), 'methodForTestParseAnnotationThatIsOnlyOneLine')
         );
     }
 
@@ -577,7 +577,7 @@ class TestTest extends TestCase
      */
     public function testGetLinesToBeCovered($test, $lines)
     {
-        if (strpos($test, 'Namespace') === 0) {
+        if (\strpos($test, 'Namespace') === 0) {
             $expected = [
               TEST_FILES_PATH . 'NamespaceCoveredClass.php' => $lines
             ];
@@ -656,7 +656,7 @@ class TestTest extends TestCase
     public function testFunctionParenthesesAreAllowed()
     {
         $this->assertSame(
-            [TEST_FILES_PATH . 'CoveredFunction.php' => range(2, 4)],
+            [TEST_FILES_PATH . 'CoveredFunction.php' => \range(2, 4)],
             Test::getLinesToBeCovered(
                 'CoverageFunctionParenthesesTest',
                 'testSomething'
@@ -667,7 +667,7 @@ class TestTest extends TestCase
     public function testFunctionParenthesesAreAllowedWithWhitespace()
     {
         $this->assertSame(
-            [TEST_FILES_PATH . 'CoveredFunction.php' => range(2, 4)],
+            [TEST_FILES_PATH . 'CoveredFunction.php' => \range(2, 4)],
             Test::getLinesToBeCovered(
                 'CoverageFunctionParenthesesWhitespaceTest',
                 'testSomething'
@@ -678,7 +678,7 @@ class TestTest extends TestCase
     public function testMethodParenthesesAreAllowed()
     {
         $this->assertSame(
-            [TEST_FILES_PATH . 'CoveredClass.php' => range(31, 35)],
+            [TEST_FILES_PATH . 'CoveredClass.php' => \range(31, 35)],
             Test::getLinesToBeCovered(
                 'CoverageMethodParenthesesTest',
                 'testSomething'
@@ -689,7 +689,7 @@ class TestTest extends TestCase
     public function testMethodParenthesesAreAllowedWithWhitespace()
     {
         $this->assertSame(
-            [TEST_FILES_PATH . 'CoveredClass.php' => range(31, 35)],
+            [TEST_FILES_PATH . 'CoveredClass.php' => \range(31, 35)],
             Test::getLinesToBeCovered(
                 'CoverageMethodParenthesesWhitespaceTest',
                 'testSomething'
@@ -701,7 +701,7 @@ class TestTest extends TestCase
     {
         $this->assertEquals(
             [
-                TEST_FILES_PATH . 'NamespaceCoveredFunction.php' => range(4, 7)
+                TEST_FILES_PATH . 'NamespaceCoveredFunction.php' => \range(4, 7)
             ],
             Test::getLinesToBeCovered(
                 \CoverageNamespacedFunctionTest::class,
@@ -719,91 +719,91 @@ class TestTest extends TestCase
           ],
           [
             'CoverageClassExtendedTest',
-            array_merge(range(19, 36), range(2, 17))
+            \array_merge(\range(19, 36), \range(2, 17))
           ],
           [
             'CoverageClassTest',
-            range(19, 36)
+            \range(19, 36)
           ],
           [
             'CoverageMethodTest',
-            range(31, 35)
+            \range(31, 35)
           ],
           [
             'CoverageMethodOneLineAnnotationTest',
-            range(31, 35)
+            \range(31, 35)
           ],
           [
             'CoverageNotPrivateTest',
-            array_merge(range(25, 29), range(31, 35))
+            \array_merge(\range(25, 29), \range(31, 35))
           ],
           [
             'CoverageNotProtectedTest',
-            array_merge(range(21, 23), range(31, 35))
+            \array_merge(\range(21, 23), \range(31, 35))
           ],
           [
             'CoverageNotPublicTest',
-            array_merge(range(21, 23), range(25, 29))
+            \array_merge(\range(21, 23), \range(25, 29))
           ],
           [
             'CoveragePrivateTest',
-            range(21, 23)
+            \range(21, 23)
           ],
           [
             'CoverageProtectedTest',
-            range(25, 29)
+            \range(25, 29)
           ],
           [
             'CoveragePublicTest',
-            range(31, 35)
+            \range(31, 35)
           ],
           [
             'CoverageFunctionTest',
-            range(2, 4)
+            \range(2, 4)
           ],
           [
             'NamespaceCoverageClassExtendedTest',
-            array_merge(range(21, 38), range(4, 19))
+            \array_merge(\range(21, 38), \range(4, 19))
           ],
           [
             'NamespaceCoverageClassTest',
-            range(21, 38)
+            \range(21, 38)
           ],
           [
             'NamespaceCoverageMethodTest',
-            range(33, 37)
+            \range(33, 37)
           ],
           [
             'NamespaceCoverageNotPrivateTest',
-            array_merge(range(27, 31), range(33, 37))
+            \array_merge(\range(27, 31), \range(33, 37))
           ],
           [
             'NamespaceCoverageNotProtectedTest',
-            array_merge(range(23, 25), range(33, 37))
+            \array_merge(\range(23, 25), \range(33, 37))
           ],
           [
             'NamespaceCoverageNotPublicTest',
-            array_merge(range(23, 25), range(27, 31))
+            \array_merge(\range(23, 25), \range(27, 31))
           ],
           [
             'NamespaceCoveragePrivateTest',
-            range(23, 25)
+            \range(23, 25)
           ],
           [
             'NamespaceCoverageProtectedTest',
-            range(27, 31)
+            \range(27, 31)
           ],
           [
             'NamespaceCoveragePublicTest',
-            range(33, 37)
+            \range(33, 37)
           ],
           [
             'NamespaceCoverageCoversClassTest',
-            array_merge(range(23, 25), range(27, 31), range(33, 37), range(6, 8), range(10, 13), range(15, 18))
+            \array_merge(\range(23, 25), \range(27, 31), \range(33, 37), \range(6, 8), \range(10, 13), \range(15, 18))
           ],
           [
             'NamespaceCoverageCoversClassPublicTest',
-            range(33, 37)
+            \range(33, 37)
           ],
           [
             'CoverageNothingTest',

--- a/tests/Util/XmlTest.php
+++ b/tests/Util/XmlTest.php
@@ -31,9 +31,9 @@ class XmlTest extends TestCase
         } catch (Exception $e) {
         }
 
-        $this->assertNull($e, sprintf(
+        $this->assertNull($e, \sprintf(
             'PHPUnit_Util_XML::prepareString("\x%02x") should not crash DomDocument',
-            ord($char)
+            \ord($char)
         ));
     }
 
@@ -42,7 +42,7 @@ class XmlTest extends TestCase
         $data = [];
 
         for ($i = 0; $i < 256; $i++) {
-            $data[] = [chr($i)];
+            $data[] = [\chr($i)];
         }
 
         return $data;


### PR DESCRIPTION
This PR

* [x] enables the `native_function_invocation` fixer
* [x] runs `php-cs-fixer`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.1.2#usage:

> **native_function_invocation**
Add leading `\` before function invocation of internal function to speed
up resolving.
*Rule is: configurable, risky.*

Also see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2462.