### PR TITLE
Fix: Allow to mock protected methods with createConfiguredMock()

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1460,7 +1460,16 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     protected function createConfiguredMock($originalClassName, array $configuration)
     {
-        $o = $this->createMock($originalClassName);
+        $methods = array_keys($configuration);
+
+        $o = $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->setMethods(empty($methods) ? null : $methods)
+            ->getMock();
+
 
         foreach ($configuration as $method => $return) {
             $o->method($method)->willReturn($return);

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -664,7 +664,7 @@ class TestCaseTest extends TestCase
 
     public function testConfiguredMockCanBeCreatedWithProtectedMethod()
     {
-        /** @var \Mockable $mock */
+        /** @var \MockableWithProtectedMethod $mock */
         $mock = $this->createConfiguredMock(
             \MockableWithProtectedMethod::class,
             [

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -661,4 +661,17 @@ class TestCaseTest extends TestCase
         $this->assertFalse($mock->foo());
         $this->assertNull($mock->bar());
     }
+
+    public function testConfiguredMockCanBeCreatedWithProtectedMethod()
+    {
+        /** @var \Mockable $mock */
+        $mock = $this->createConfiguredMock(
+            \MockableWithProtectedMethod::class,
+            [
+                'bar' => true,
+            ]
+        );
+
+        $this->assertTrue($mock->foo());
+    }
 }

--- a/tests/_files/MockableWithProtectedMethod.php
+++ b/tests/_files/MockableWithProtectedMethod.php
@@ -1,0 +1,13 @@
+<?php
+class MockableWithProtectedMethod
+{
+    public function foo()
+    {
+        return $this->bar();
+    }
+
+    protected function bar()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that `protected` methods can be mocked using `createConfiguredMock()`
* [ ] adjusts `createConfiguedMock()` to set the methods intended to be mocked

Fixes #2556.