### PR TITLE
Added more descriptive error messages for whitelist issues

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -478,7 +478,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed fort testing.');
+                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed for testing.');
 
                 $codeCoverageReports = 0;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -441,7 +441,7 @@ class TestRunner extends BaseTestRunner
                 unset($codeCoverage);
             }
 
-            if (isset($arguments['configuration'])) {
+            if (isset($codeCoverage) && isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
 
                 $codeCoverage->setAddUncoveredFilesFromWhitelist(

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -433,6 +433,13 @@ class TestRunner extends BaseTestRunner
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
             }
+            else {
+                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
+
+                $codeCoverageReports = 0;
+
+                unset($codeCoverage);
+            }
 
             if (isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
@@ -471,7 +478,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
+                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed fort testing.');
 
                 $codeCoverageReports = 0;
 


### PR DESCRIPTION
ref: issue #2049 
The "No white list configured" was misleading when you had a whitelist element configured in `phpunit.xml`, but using invalid directories so that no test files were returned. Added a check for the existence of the white list element, and moved the original error to there. Then updated the "empty" error message to more accurately note the problem.