### PR TITLE
Fix: Append strings instead of reassigning

### DIFF
--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -90,7 +90,7 @@ class TestFailure
             $buffer = $e->toString();
 
             if ($e instanceof ExpectationFailedException && $e->getComparisonFailure()) {
-                $buffer = $buffer . $e->getComparisonFailure()->getDiff();
+                $buffer .= $e->getComparisonFailure()->getDiff();
             }
 
             if (!empty($buffer)) {

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -339,11 +339,11 @@ class TeamCity extends ResultPrinter
 
         if (!$e instanceof Exception) {
             if (strlen(get_class($e)) != 0) {
-                $message = $message . get_class($e);
+                $message .= get_class($e);
             }
 
             if (strlen($message) != 0 && strlen($e->getMessage()) != 0) {
-                $message = $message . ' : ';
+                $message .= ' : ';
             }
         }
 


### PR DESCRIPTION
This PR

* [x] appends strings to existing variables instead of reassigning values