### PR TITLE
Fix: Unpack arguments instead of using call_user_func_array()

### DIFF
--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -7,6 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\LogicalAnd;
@@ -38,6 +39,7 @@ use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
 use PHPUnit\Framework\Constraint\StringEndsWith;
 use PHPUnit\Framework\Constraint\StringContains;
 use PHPUnit\Framework\Constraint\RegularExpression;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Returns a matcher that matches when the method is executed
@@ -47,10 +49,7 @@ use PHPUnit\Framework\Constraint\RegularExpression;
  */
 function any()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::any',
-        func_get_args()
-    );
+    return TestCase::any(...func_get_args());
 }
 
 /**
@@ -60,10 +59,7 @@ function any()
  */
 function anything()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::anything',
-        func_get_args()
-    );
+    return Assert::anything(...func_get_args());
 }
 
 /**
@@ -75,10 +71,7 @@ function anything()
  */
 function arrayHasKey($key)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::arrayHasKey',
-        func_get_args()
-    );
+    Assert::arrayHasKey(...func_get_args());
 }
 
 /**
@@ -90,10 +83,7 @@ function arrayHasKey($key)
  */
 function assertArrayHasKey($key, $array, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertArrayHasKey',
-        func_get_args()
-    );
+    return Assert::assertArrayHasKey(...func_get_args());
 }
 
 /**
@@ -106,10 +96,7 @@ function assertArrayHasKey($key, $array, $message = '')
  */
 function assertArraySubset($subset, $array, $strict = false, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertArraySubset',
-        func_get_args()
-    );
+    return Assert::assertArraySubset(...func_get_args());
 }
 
 /**
@@ -121,10 +108,7 @@ function assertArraySubset($subset, $array, $strict = false, $message = '')
  */
 function assertArrayNotHasKey($key, $array, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertArrayNotHasKey',
-        func_get_args()
-    );
+    return Assert::assertArrayNotHasKey(...func_get_args());
 }
 
 /**
@@ -141,10 +125,7 @@ function assertArrayNotHasKey($key, $array, $message = '')
  */
 function assertAttributeContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeContains',
-        func_get_args()
-    );
+    return Assert::assertAttributeContains(...func_get_args());
 }
 
 /**
@@ -159,10 +140,7 @@ function assertAttributeContains($needle, $haystackAttributeName, $haystackClass
  */
 function assertAttributeContainsOnly($type, $haystackAttributeName, $haystackClassOrObject, $isNativeType = null, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeContainsOnly',
-        func_get_args()
-    );
+    return Assert::assertAttributeContainsOnly(...func_get_args());
 }
 
 /**
@@ -176,10 +154,7 @@ function assertAttributeContainsOnly($type, $haystackAttributeName, $haystackCla
  */
 function assertAttributeCount($expectedCount, $haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeCount',
-        func_get_args()
-    );
+    return Assert::assertAttributeCount(...func_get_args());
 }
 
 /**
@@ -192,10 +167,7 @@ function assertAttributeCount($expectedCount, $haystackAttributeName, $haystackC
  */
 function assertAttributeEmpty($haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeEmpty',
-        func_get_args()
-    );
+    return Assert::assertAttributeEmpty(...func_get_args());
 }
 
 /**
@@ -212,10 +184,7 @@ function assertAttributeEmpty($haystackAttributeName, $haystackClassOrObject, $m
  */
 function assertAttributeEquals($expected, $actualAttributeName, $actualClassOrObject, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeEquals',
-        func_get_args()
-    );
+    return Assert::assertAttributeEquals(...func_get_args());
 }
 
 /**
@@ -228,10 +197,7 @@ function assertAttributeEquals($expected, $actualAttributeName, $actualClassOrOb
  */
 function assertAttributeGreaterThan($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeGreaterThan',
-        func_get_args()
-    );
+    return Assert::assertAttributeGreaterThan(...func_get_args());
 }
 
 /**
@@ -244,10 +210,7 @@ function assertAttributeGreaterThan($expected, $actualAttributeName, $actualClas
  */
 function assertAttributeGreaterThanOrEqual($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeGreaterThanOrEqual',
-        func_get_args()
-    );
+    return Assert::assertAttributeGreaterThanOrEqual(...func_get_args());
 }
 
 /**
@@ -260,10 +223,7 @@ function assertAttributeGreaterThanOrEqual($expected, $actualAttributeName, $act
  */
 function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeInstanceOf',
-        func_get_args()
-    );
+    return Assert::assertAttributeInstanceOf(...func_get_args());
 }
 
 /**
@@ -276,10 +236,7 @@ function assertAttributeInstanceOf($expected, $attributeName, $classOrObject, $m
  */
 function assertAttributeInternalType($expected, $attributeName, $classOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeInternalType',
-        func_get_args()
-    );
+    return Assert::assertAttributeInternalType(...func_get_args());
 }
 
 /**
@@ -292,10 +249,7 @@ function assertAttributeInternalType($expected, $attributeName, $classOrObject, 
  */
 function assertAttributeLessThan($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeLessThan',
-        func_get_args()
-    );
+    return Assert::assertAttributeLessThan(...func_get_args());
 }
 
 /**
@@ -308,10 +262,7 @@ function assertAttributeLessThan($expected, $actualAttributeName, $actualClassOr
  */
 function assertAttributeLessThanOrEqual($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeLessThanOrEqual',
-        func_get_args()
-    );
+    return Assert::assertAttributeLessThanOrEqual(...func_get_args());
 }
 
 /**
@@ -328,10 +279,7 @@ function assertAttributeLessThanOrEqual($expected, $actualAttributeName, $actual
  */
 function assertAttributeNotContains($needle, $haystackAttributeName, $haystackClassOrObject, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotContains',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotContains(...func_get_args());
 }
 
 /**
@@ -347,10 +295,7 @@ function assertAttributeNotContains($needle, $haystackAttributeName, $haystackCl
  */
 function assertAttributeNotContainsOnly($type, $haystackAttributeName, $haystackClassOrObject, $isNativeType = null, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotContainsOnly',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotContainsOnly(...func_get_args());
 }
 
 /**
@@ -364,10 +309,7 @@ function assertAttributeNotContainsOnly($type, $haystackAttributeName, $haystack
  */
 function assertAttributeNotCount($expectedCount, $haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotCount',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotCount(...func_get_args());
 }
 
 /**
@@ -380,10 +322,7 @@ function assertAttributeNotCount($expectedCount, $haystackAttributeName, $haysta
  */
 function assertAttributeNotEmpty($haystackAttributeName, $haystackClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotEmpty',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotEmpty(...func_get_args());
 }
 
 /**
@@ -400,10 +339,7 @@ function assertAttributeNotEmpty($haystackAttributeName, $haystackClassOrObject,
  */
 function assertAttributeNotEquals($expected, $actualAttributeName, $actualClassOrObject, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotEquals',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotEquals(...func_get_args());
 }
 
 /**
@@ -416,10 +352,7 @@ function assertAttributeNotEquals($expected, $actualAttributeName, $actualClassO
  */
 function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotInstanceOf',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotInstanceOf(...func_get_args());
 }
 
 /**
@@ -432,10 +365,7 @@ function assertAttributeNotInstanceOf($expected, $attributeName, $classOrObject,
  */
 function assertAttributeNotInternalType($expected, $attributeName, $classOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotInternalType',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotInternalType(...func_get_args());
 }
 
 /**
@@ -449,10 +379,7 @@ function assertAttributeNotInternalType($expected, $attributeName, $classOrObjec
  */
 function assertAttributeNotSame($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeNotSame',
-        func_get_args()
-    );
+    return Assert::assertAttributeNotSame(...func_get_args());
 }
 
 /**
@@ -466,10 +393,7 @@ function assertAttributeNotSame($expected, $actualAttributeName, $actualClassOrO
  */
 function assertAttributeSame($expected, $actualAttributeName, $actualClassOrObject, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertAttributeSame',
-        func_get_args()
-    );
+    return Assert::assertAttributeSame(...func_get_args());
 }
 
 /**
@@ -481,10 +405,7 @@ function assertAttributeSame($expected, $actualAttributeName, $actualClassOrObje
  */
 function assertClassHasAttribute($attributeName, $className, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertClassHasAttribute',
-        func_get_args()
-    );
+    return Assert::assertClassHasAttribute(...func_get_args());
 }
 
 /**
@@ -496,10 +417,7 @@ function assertClassHasAttribute($attributeName, $className, $message = '')
  */
 function assertClassHasStaticAttribute($attributeName, $className, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertClassHasStaticAttribute',
-        func_get_args()
-    );
+    return Assert::assertClassHasStaticAttribute(...func_get_args());
 }
 
 /**
@@ -511,10 +429,7 @@ function assertClassHasStaticAttribute($attributeName, $className, $message = ''
  */
 function assertClassNotHasAttribute($attributeName, $className, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertClassNotHasAttribute',
-        func_get_args()
-    );
+    return Assert::assertClassNotHasAttribute(...func_get_args());
 }
 
 /**
@@ -526,10 +441,7 @@ function assertClassNotHasAttribute($attributeName, $className, $message = '')
  */
 function assertClassNotHasStaticAttribute($attributeName, $className, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertClassNotHasStaticAttribute',
-        func_get_args()
-    );
+    return Assert::assertClassNotHasStaticAttribute(...func_get_args());
 }
 
 /**
@@ -544,10 +456,7 @@ function assertClassNotHasStaticAttribute($attributeName, $className, $message =
  */
 function assertContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertContains',
-        func_get_args()
-    );
+    return Assert::assertContains(...func_get_args());
 }
 
 /**
@@ -560,10 +469,7 @@ function assertContains($needle, $haystack, $message = '', $ignoreCase = false, 
  */
 function assertContainsOnly($type, $haystack, $isNativeType = null, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertContainsOnly',
-        func_get_args()
-    );
+    return Assert::assertContainsOnly(...func_get_args());
 }
 
 /**
@@ -575,10 +481,7 @@ function assertContainsOnly($type, $haystack, $isNativeType = null, $message = '
  */
 function assertContainsOnlyInstancesOf($classname, $haystack, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertContainsOnlyInstancesOf',
-        func_get_args()
-    );
+    return Assert::assertContainsOnlyInstancesOf(...func_get_args());
 }
 
 /**
@@ -590,10 +493,7 @@ function assertContainsOnlyInstancesOf($classname, $haystack, $message = '')
  */
 function assertCount($expectedCount, $haystack, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertCount',
-        func_get_args()
-    );
+    return Assert::assertCount(...func_get_args());
 }
 
 /**
@@ -606,10 +506,7 @@ function assertCount($expectedCount, $haystack, $message = '')
  */
 function assertEmpty($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertEmpty',
-        func_get_args()
-    );
+    return Assert::assertEmpty(...func_get_args());
 }
 
 /**
@@ -622,10 +519,7 @@ function assertEmpty($actual, $message = '')
  */
 function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actualElement, $checkAttributes = false, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertEqualXMLStructure',
-        func_get_args()
-    );
+    return Assert::assertEqualXMLStructure(...func_get_args());
 }
 
 /**
@@ -641,10 +535,7 @@ function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actual
  */
 function assertEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertEquals',
-        func_get_args()
-    );
+    return Assert::assertEquals(...func_get_args());
 }
 
 /**
@@ -657,10 +548,7 @@ function assertEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth
  */
 function assertNotTrue($condition, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotTrue',
-        func_get_args()
-    );
+    return Assert::assertNotTrue(...func_get_args());
 }
 
 /**
@@ -673,10 +561,7 @@ function assertNotTrue($condition, $message = '')
  */
 function assertFalse($condition, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertFalse',
-        func_get_args()
-    );
+    return Assert::assertFalse(...func_get_args());
 }
 
 /**
@@ -691,10 +576,7 @@ function assertFalse($condition, $message = '')
  */
 function assertFileEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertFileEquals',
-        func_get_args()
-    );
+    return Assert::assertFileEquals(...func_get_args());
 }
 
 /**
@@ -705,10 +587,7 @@ function assertFileEquals($expected, $actual, $message = '', $canonicalize = fal
  */
 function assertFileExists($filename, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertFileExists',
-        func_get_args()
-    );
+    return Assert::assertFileExists(...func_get_args());
 }
 
 /**
@@ -723,10 +602,7 @@ function assertFileExists($filename, $message = '')
  */
 function assertFileNotEquals($expected, $actual, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertFileNotEquals',
-        func_get_args()
-    );
+    return Assert::assertFileNotEquals(...func_get_args());
 }
 
 /**
@@ -737,10 +613,7 @@ function assertFileNotEquals($expected, $actual, $message = '', $canonicalize = 
  */
 function assertFileNotExists($filename, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertFileNotExists',
-        func_get_args()
-    );
+    return Assert::assertFileNotExists(...func_get_args());
 }
 
 /**
@@ -752,10 +625,7 @@ function assertFileNotExists($filename, $message = '')
  */
 function assertGreaterThan($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertGreaterThan',
-        func_get_args()
-    );
+    return Assert::assertGreaterThan(...func_get_args());
 }
 
 /**
@@ -767,10 +637,7 @@ function assertGreaterThan($expected, $actual, $message = '')
  */
 function assertGreaterThanOrEqual($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertGreaterThanOrEqual',
-        func_get_args()
-    );
+    return Assert::assertGreaterThanOrEqual(...func_get_args());
 }
 
 /**
@@ -782,10 +649,7 @@ function assertGreaterThanOrEqual($expected, $actual, $message = '')
  */
 function assertInstanceOf($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertInstanceOf',
-        func_get_args()
-    );
+    return Assert::assertInstanceOf(...func_get_args());
 }
 
 /**
@@ -797,10 +661,7 @@ function assertInstanceOf($expected, $actual, $message = '')
  */
 function assertInternalType($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertInternalType',
-        func_get_args()
-    );
+    return Assert::assertInternalType(...func_get_args());
 }
 
 /**
@@ -811,10 +672,7 @@ function assertInternalType($expected, $actual, $message = '')
  */
 function assertJson($actualJson, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJson',
-        func_get_args()
-    );
+    return Assert::assertJson(...func_get_args());
 }
 
 /**
@@ -826,10 +684,7 @@ function assertJson($actualJson, $message = '')
  */
 function assertJsonFileEqualsJsonFile($expectedFile, $actualFile, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJsonFileEqualsJsonFile',
-        func_get_args()
-    );
+    return Assert::assertJsonFileEqualsJsonFile(...func_get_args());
 }
 
 /**
@@ -841,10 +696,7 @@ function assertJsonFileEqualsJsonFile($expectedFile, $actualFile, $message = '')
  */
 function assertJsonFileNotEqualsJsonFile($expectedFile, $actualFile, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJsonFileNotEqualsJsonFile',
-        func_get_args()
-    );
+    return Assert::assertJsonFileNotEqualsJsonFile(...func_get_args());
 }
 
 /**
@@ -856,10 +708,7 @@ function assertJsonFileNotEqualsJsonFile($expectedFile, $actualFile, $message = 
  */
 function assertJsonStringEqualsJsonFile($expectedFile, $actualJson, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJsonStringEqualsJsonFile',
-        func_get_args()
-    );
+    return Assert::assertJsonStringEqualsJsonFile(...func_get_args());
 }
 
 /**
@@ -871,10 +720,7 @@ function assertJsonStringEqualsJsonFile($expectedFile, $actualJson, $message = '
  */
 function assertJsonStringEqualsJsonString($expectedJson, $actualJson, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJsonStringEqualsJsonString',
-        func_get_args()
-    );
+    return Assert::assertJsonStringEqualsJsonString(...func_get_args());
 }
 
 /**
@@ -886,10 +732,7 @@ function assertJsonStringEqualsJsonString($expectedJson, $actualJson, $message =
  */
 function assertJsonStringNotEqualsJsonFile($expectedFile, $actualJson, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJsonStringNotEqualsJsonFile',
-        func_get_args()
-    );
+    return Assert::assertJsonStringNotEqualsJsonFile(...func_get_args());
 }
 
 /**
@@ -901,10 +744,7 @@ function assertJsonStringNotEqualsJsonFile($expectedFile, $actualJson, $message 
  */
 function assertJsonStringNotEqualsJsonString($expectedJson, $actualJson, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertJsonStringNotEqualsJsonString',
-        func_get_args()
-    );
+    return Assert::assertJsonStringNotEqualsJsonString(...func_get_args());
 }
 
 /**
@@ -916,10 +756,7 @@ function assertJsonStringNotEqualsJsonString($expectedJson, $actualJson, $messag
  */
 function assertLessThan($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertLessThan',
-        func_get_args()
-    );
+    return Assert::assertLessThan(...func_get_args());
 }
 
 /**
@@ -931,10 +768,7 @@ function assertLessThan($expected, $actual, $message = '')
  */
 function assertLessThanOrEqual($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertLessThanOrEqual',
-        func_get_args()
-    );
+    return Assert::assertLessThanOrEqual(...func_get_args());
 }
 
 /**
@@ -945,10 +779,7 @@ function assertLessThanOrEqual($expected, $actual, $message = '')
  */
 function assertFinite($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertFinite',
-        func_get_args()
-    );
+    return Assert::assertFinite(...func_get_args());
 }
 
 /**
@@ -959,10 +790,7 @@ function assertFinite($actual, $message = '')
  */
 function assertInfinite($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertInfinite',
-        func_get_args()
-    );
+    return Assert::assertInfinite(...func_get_args());
 }
 
 /**
@@ -973,10 +801,7 @@ function assertInfinite($actual, $message = '')
  */
 function assertNan($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNan',
-        func_get_args()
-    );
+    return Assert::assertNan(...func_get_args());
 }
 
 /**
@@ -991,10 +816,7 @@ function assertNan($actual, $message = '')
  */
 function assertNotContains($needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotContains',
-        func_get_args()
-    );
+    return Assert::assertNotContains(...func_get_args());
 }
 
 /**
@@ -1007,10 +829,7 @@ function assertNotContains($needle, $haystack, $message = '', $ignoreCase = fals
  */
 function assertNotContainsOnly($type, $haystack, $isNativeType = null, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotContainsOnly',
-        func_get_args()
-    );
+    return Assert::assertNotContainsOnly(...func_get_args());
 }
 
 /**
@@ -1022,10 +841,7 @@ function assertNotContainsOnly($type, $haystack, $isNativeType = null, $message 
  */
 function assertNotCount($expectedCount, $haystack, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotCount',
-        func_get_args()
-    );
+    return Assert::assertNotCount(...func_get_args());
 }
 
 /**
@@ -1038,10 +854,7 @@ function assertNotCount($expectedCount, $haystack, $message = '')
  */
 function assertNotEmpty($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotEmpty',
-        func_get_args()
-    );
+    return Assert::assertNotEmpty(...func_get_args());
 }
 
 /**
@@ -1057,10 +870,7 @@ function assertNotEmpty($actual, $message = '')
  */
 function assertNotEquals($expected, $actual, $message = '', $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotEquals',
-        func_get_args()
-    );
+    return Assert::assertNotEquals(...func_get_args());
 }
 
 /**
@@ -1072,10 +882,7 @@ function assertNotEquals($expected, $actual, $message = '', $delta = 0.0, $maxDe
  */
 function assertNotInstanceOf($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotInstanceOf',
-        func_get_args()
-    );
+    return Assert::assertNotInstanceOf(...func_get_args());
 }
 
 /**
@@ -1087,10 +894,7 @@ function assertNotInstanceOf($expected, $actual, $message = '')
  */
 function assertNotInternalType($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotInternalType',
-        func_get_args()
-    );
+    return Assert::assertNotInternalType(...func_get_args());
 }
 
 /**
@@ -1103,10 +907,7 @@ function assertNotInternalType($expected, $actual, $message = '')
  */
 function assertNotFalse($condition, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotFalse',
-        func_get_args()
-    );
+    return Assert::assertNotFalse(...func_get_args());
 }
 
 /**
@@ -1117,10 +918,7 @@ function assertNotFalse($condition, $message = '')
  */
 function assertNotNull($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotNull',
-        func_get_args()
-    );
+    return Assert::assertNotNull(...func_get_args());
 }
 
 /**
@@ -1132,10 +930,7 @@ function assertNotNull($actual, $message = '')
  */
 function assertNotRegExp($pattern, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotRegExp',
-        func_get_args()
-    );
+    return Assert::assertNotRegExp(...func_get_args());
 }
 
 /**
@@ -1149,10 +944,7 @@ function assertNotRegExp($pattern, $string, $message = '')
  */
 function assertNotSame($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotSame',
-        func_get_args()
-    );
+    return Assert::assertNotSame(...func_get_args());
 }
 
 /**
@@ -1165,10 +957,7 @@ function assertNotSame($expected, $actual, $message = '')
  */
 function assertNotSameSize($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNotSameSize',
-        func_get_args()
-    );
+    return Assert::assertNotSameSize(...func_get_args());
 }
 
 /**
@@ -1179,10 +968,7 @@ function assertNotSameSize($expected, $actual, $message = '')
  */
 function assertNull($actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertNull',
-        func_get_args()
-    );
+    return Assert::assertNull(...func_get_args());
 }
 
 /**
@@ -1194,10 +980,7 @@ function assertNull($actual, $message = '')
  */
 function assertObjectHasAttribute($attributeName, $object, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertObjectHasAttribute',
-        func_get_args()
-    );
+    return Assert::assertObjectHasAttribute(...func_get_args());
 }
 
 /**
@@ -1209,10 +992,7 @@ function assertObjectHasAttribute($attributeName, $object, $message = '')
  */
 function assertObjectNotHasAttribute($attributeName, $object, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertObjectNotHasAttribute',
-        func_get_args()
-    );
+    return Assert::assertObjectNotHasAttribute(...func_get_args());
 }
 
 /**
@@ -1224,10 +1004,7 @@ function assertObjectNotHasAttribute($attributeName, $object, $message = '')
  */
 function assertRegExp($pattern, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertRegExp',
-        func_get_args()
-    );
+    return Assert::assertRegExp(...func_get_args());
 }
 
 /**
@@ -1241,10 +1018,7 @@ function assertRegExp($pattern, $string, $message = '')
  */
 function assertSame($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertSame',
-        func_get_args()
-    );
+    return Assert::assertSame(...func_get_args());
 }
 
 /**
@@ -1257,10 +1031,7 @@ function assertSame($expected, $actual, $message = '')
  */
 function assertSameSize($expected, $actual, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertSameSize',
-        func_get_args()
-    );
+    return Assert::assertSameSize(...func_get_args());
 }
 
 /**
@@ -1272,10 +1043,7 @@ function assertSameSize($expected, $actual, $message = '')
  */
 function assertStringEndsNotWith($suffix, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringEndsNotWith',
-        func_get_args()
-    );
+    return Assert::assertStringEndsNotWith(...func_get_args());
 }
 
 /**
@@ -1287,10 +1055,7 @@ function assertStringEndsNotWith($suffix, $string, $message = '')
  */
 function assertStringEndsWith($suffix, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringEndsWith',
-        func_get_args()
-    );
+    return Assert::assertStringEndsWith(...func_get_args());
 }
 
 /**
@@ -1305,10 +1070,7 @@ function assertStringEndsWith($suffix, $string, $message = '')
  */
 function assertStringEqualsFile($expectedFile, $actualString, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringEqualsFile',
-        func_get_args()
-    );
+    return Assert::assertStringEqualsFile(...func_get_args());
 }
 
 /**
@@ -1320,10 +1082,7 @@ function assertStringEqualsFile($expectedFile, $actualString, $message = '', $ca
  */
 function assertStringMatchesFormat($format, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringMatchesFormat',
-        func_get_args()
-    );
+    return Assert::assertStringMatchesFormat(...func_get_args());
 }
 
 /**
@@ -1335,10 +1094,7 @@ function assertStringMatchesFormat($format, $string, $message = '')
  */
 function assertStringMatchesFormatFile($formatFile, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringMatchesFormatFile',
-        func_get_args()
-    );
+    return Assert::assertStringMatchesFormatFile(...func_get_args());
 }
 
 /**
@@ -1353,10 +1109,7 @@ function assertStringMatchesFormatFile($formatFile, $string, $message = '')
  */
 function assertStringNotEqualsFile($expectedFile, $actualString, $message = '', $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringNotEqualsFile',
-        func_get_args()
-    );
+    return Assert::assertStringNotEqualsFile(...func_get_args());
 }
 
 /**
@@ -1368,10 +1121,7 @@ function assertStringNotEqualsFile($expectedFile, $actualString, $message = '', 
  */
 function assertStringNotMatchesFormat($format, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringNotMatchesFormat',
-        func_get_args()
-    );
+    return Assert::assertStringNotMatchesFormat(...func_get_args());
 }
 
 /**
@@ -1383,10 +1133,7 @@ function assertStringNotMatchesFormat($format, $string, $message = '')
  */
 function assertStringNotMatchesFormatFile($formatFile, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringNotMatchesFormatFile',
-        func_get_args()
-    );
+    return Assert::assertStringNotMatchesFormatFile(...func_get_args());
 }
 
 /**
@@ -1398,10 +1145,7 @@ function assertStringNotMatchesFormatFile($formatFile, $string, $message = '')
  */
 function assertStringStartsNotWith($prefix, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringStartsNotWith',
-        func_get_args()
-    );
+    return Assert::assertStringStartsNotWith(...func_get_args());
 }
 
 /**
@@ -1413,10 +1157,7 @@ function assertStringStartsNotWith($prefix, $string, $message = '')
  */
 function assertStringStartsWith($prefix, $string, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertStringStartsWith',
-        func_get_args()
-    );
+    return Assert::assertStringStartsWith(...func_get_args());
 }
 
 /**
@@ -1428,10 +1169,7 @@ function assertStringStartsWith($prefix, $string, $message = '')
  */
 function assertThat($value, Constraint $constraint, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertThat',
-        func_get_args()
-    );
+    return Assert::assertThat(...func_get_args());
 }
 
 /**
@@ -1444,10 +1182,7 @@ function assertThat($value, Constraint $constraint, $message = '')
  */
 function assertTrue($condition, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertTrue',
-        func_get_args()
-    );
+    return Assert::assertTrue(...func_get_args());
 }
 
 /**
@@ -1459,10 +1194,7 @@ function assertTrue($condition, $message = '')
  */
 function assertXmlFileEqualsXmlFile($expectedFile, $actualFile, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertXmlFileEqualsXmlFile',
-        func_get_args()
-    );
+    return Assert::assertXmlFileEqualsXmlFile(...func_get_args());
 }
 
 /**
@@ -1474,10 +1206,7 @@ function assertXmlFileEqualsXmlFile($expectedFile, $actualFile, $message = '')
  */
 function assertXmlFileNotEqualsXmlFile($expectedFile, $actualFile, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertXmlFileNotEqualsXmlFile',
-        func_get_args()
-    );
+    return Assert::assertXmlFileNotEqualsXmlFile(...func_get_args());
 }
 
 /**
@@ -1489,10 +1218,7 @@ function assertXmlFileNotEqualsXmlFile($expectedFile, $actualFile, $message = ''
  */
 function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertXmlStringEqualsXmlFile',
-        func_get_args()
-    );
+    return Assert::assertXmlStringEqualsXmlFile(...func_get_args());
 }
 
 /**
@@ -1504,10 +1230,7 @@ function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
  */
 function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertXmlStringEqualsXmlString',
-        func_get_args()
-    );
+    return Assert::assertXmlStringEqualsXmlString(...func_get_args());
 }
 
 /**
@@ -1519,10 +1242,7 @@ function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
  */
 function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertXmlStringNotEqualsXmlFile',
-        func_get_args()
-    );
+    return Assert::assertXmlStringNotEqualsXmlFile(...func_get_args());
 }
 
 /**
@@ -1534,10 +1254,7 @@ function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '
  */
 function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = '')
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::assertXmlStringNotEqualsXmlString',
-        func_get_args()
-    );
+    return Assert::assertXmlStringNotEqualsXmlString(...func_get_args());
 }
 
 /**
@@ -1550,10 +1267,7 @@ function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = 
  */
 function at($index)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::at',
-        func_get_args()
-    );
+    return TestCase::at(...func_get_args());
 }
 
 /**
@@ -1563,10 +1277,7 @@ function at($index)
  */
 function atLeastOnce()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::atLeastOnce',
-        func_get_args()
-    );
+    return TestCase::atLeastOnce(...func_get_args());
 }
 
 /**
@@ -1579,10 +1290,7 @@ function atLeastOnce()
  */
 function attribute(Constraint $constraint, $attributeName)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::attribute',
-        func_get_args()
-    );
+    return Assert::attribute(...func_get_args());
 }
 
 /**
@@ -1601,10 +1309,7 @@ function attribute(Constraint $constraint, $attributeName)
  */
 function attributeEqualTo($attributeName, $value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::attributeEqualTo',
-        func_get_args()
-    );
+    return Assert::attributeEqualTo(...func_get_args());
 }
 
 /**
@@ -1616,10 +1321,7 @@ function attributeEqualTo($attributeName, $value, $delta = 0.0, $maxDepth = 10, 
  */
 function callback($callback)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::callback',
-        func_get_args()
-    );
+    return Assert::callback(...func_get_args());
 }
 
 /**
@@ -1631,10 +1333,7 @@ function callback($callback)
  */
 function classHasAttribute($attributeName)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::classHasAttribute',
-        func_get_args()
-    );
+    return Assert::classHasAttribute(...func_get_args());
 }
 
 /**
@@ -1647,10 +1346,7 @@ function classHasAttribute($attributeName)
  */
 function classHasStaticAttribute($attributeName)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::classHasStaticAttribute',
-        func_get_args()
-    );
+    return Assert::classHasStaticAttribute(...func_get_args());
 }
 
 /**
@@ -1665,10 +1361,7 @@ function classHasStaticAttribute($attributeName)
  */
 function contains($value, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::contains',
-        func_get_args()
-    );
+    return Assert::contains(...func_get_args());
 }
 
 /**
@@ -1681,10 +1374,7 @@ function contains($value, $checkForObjectIdentity = true, $checkForNonObjectIden
  */
 function containsOnly($type)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::containsOnly',
-        func_get_args()
-    );
+    return Assert::containsOnly(...func_get_args());
 }
 
 /**
@@ -1697,10 +1387,7 @@ function containsOnly($type)
  */
 function containsOnlyInstancesOf($classname)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::containsOnlyInstancesOf',
-        func_get_args()
-    );
+    return Assert::containsOnlyInstancesOf(...func_get_args());
 }
 
 /**
@@ -1712,10 +1399,7 @@ function containsOnlyInstancesOf($classname)
  */
 function countOf($count)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::countOf',
-        func_get_args()
-    );
+    return Assert::countOf(...func_get_args());
 }
 
 /**
@@ -1731,10 +1415,7 @@ function countOf($count)
  */
 function equalTo($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::equalTo',
-        func_get_args()
-    );
+    return Assert::equalTo(...func_get_args());
 }
 
 /**
@@ -1747,10 +1428,7 @@ function equalTo($value, $delta = 0.0, $maxDepth = 10, $canonicalize = false, $i
  */
 function exactly($count)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::exactly',
-        func_get_args()
-    );
+    return TestCase::exactly(...func_get_args());
 }
 
 /**
@@ -1760,10 +1438,7 @@ function exactly($count)
  */
 function fileExists()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::fileExists',
-        func_get_args()
-    );
+    return Assert::fileExists(...func_get_args());
 }
 
 /**
@@ -1775,10 +1450,7 @@ function fileExists()
  */
 function greaterThan($value)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::greaterThan',
-        func_get_args()
-    );
+    return Assert::greaterThan(...func_get_args());
 }
 
 /**
@@ -1792,10 +1464,7 @@ function greaterThan($value)
  */
 function greaterThanOrEqual($value)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::greaterThanOrEqual',
-        func_get_args()
-    );
+    return Assert::greaterThanOrEqual(...func_get_args());
 }
 
 /**
@@ -1807,10 +1476,7 @@ function greaterThanOrEqual($value)
  */
 function identicalTo($value)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::identicalTo',
-        func_get_args()
-    );
+    return Assert::identicalTo(...func_get_args());
 }
 
 /**
@@ -1820,10 +1486,7 @@ function identicalTo($value)
  */
 function isEmpty()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isEmpty',
-        func_get_args()
-    );
+    return Assert::isEmpty(...func_get_args());
 }
 
 /**
@@ -1833,10 +1496,7 @@ function isEmpty()
  */
 function isFalse()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isFalse',
-        func_get_args()
-    );
+    return Assert::isFalse(...func_get_args());
 }
 
 /**
@@ -1848,10 +1508,7 @@ function isFalse()
  */
 function isInstanceOf($className)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isInstanceOf',
-        func_get_args()
-    );
+    return Assert::isInstanceOf(...func_get_args());
 }
 
 /**
@@ -1861,10 +1518,7 @@ function isInstanceOf($className)
  */
 function isJson()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isJson',
-        func_get_args()
-    );
+    return Assert::isJson(...func_get_args());
 }
 
 /**
@@ -1874,10 +1528,7 @@ function isJson()
  */
 function isNull()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isNull',
-        func_get_args()
-    );
+    return Assert::isNull(...func_get_args());
 }
 
 /**
@@ -1887,10 +1538,7 @@ function isNull()
  */
 function isTrue()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isTrue',
-        func_get_args()
-    );
+    return Assert::isTrue(...func_get_args());
 }
 
 /**
@@ -1902,10 +1550,7 @@ function isTrue()
  */
 function isType($type)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::isType',
-        func_get_args()
-    );
+    return Assert::isType(...func_get_args());
 }
 
 /**
@@ -1917,10 +1562,7 @@ function isType($type)
  */
 function lessThan($value)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::lessThan',
-        func_get_args()
-    );
+    return Assert::lessThan(...func_get_args());
 }
 
 /**
@@ -1934,10 +1576,7 @@ function lessThan($value)
  */
 function lessThanOrEqual($value)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::lessThanOrEqual',
-        func_get_args()
-    );
+    return Assert::lessThanOrEqual(...func_get_args());
 }
 
 /**
@@ -1947,10 +1586,7 @@ function lessThanOrEqual($value)
  */
 function logicalAnd()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::logicalAnd',
-        func_get_args()
-    );
+    return Assert::logicalAnd(...func_get_args());
 }
 
 /**
@@ -1962,10 +1598,7 @@ function logicalAnd()
  */
 function logicalNot(Constraint $constraint)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::logicalNot',
-        func_get_args()
-    );
+    return Assert::logicalNot(...func_get_args());
 }
 
 /**
@@ -1975,10 +1608,7 @@ function logicalNot(Constraint $constraint)
  */
 function logicalOr()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::logicalOr',
-        func_get_args()
-    );
+    return Assert::logicalOr(...func_get_args());
 }
 
 /**
@@ -1988,10 +1618,7 @@ function logicalOr()
  */
 function logicalXor()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::logicalXor',
-        func_get_args()
-    );
+    return Assert::logicalXor(...func_get_args());
 }
 
 /**
@@ -2003,10 +1630,7 @@ function logicalXor()
  */
 function matches($string)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::matches',
-        func_get_args()
-    );
+    return Assert::matches(...func_get_args());
 }
 
 /**
@@ -2018,10 +1642,7 @@ function matches($string)
  */
 function matchesRegularExpression($pattern)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::matchesRegularExpression',
-        func_get_args()
-    );
+    return Assert::matchesRegularExpression(...func_get_args());
 }
 
 /**
@@ -2031,10 +1652,7 @@ function matchesRegularExpression($pattern)
  */
 function never()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::never',
-        func_get_args()
-    );
+    return TestCase::never(...func_get_args());
 }
 
 /**
@@ -2046,10 +1664,7 @@ function never()
  */
 function objectHasAttribute($attributeName)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::objectHasAttribute',
-        func_get_args()
-    );
+    return Assert::objectHasAttribute(...func_get_args());
 }
 
 /**
@@ -2059,10 +1674,7 @@ function objectHasAttribute($attributeName)
  */
 function onConsecutiveCalls()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::onConsecutiveCalls',
-        func_get_args()
-    );
+    return TestCase::onConsecutiveCalls(...func_get_args());
 }
 
 /**
@@ -2072,10 +1684,7 @@ function onConsecutiveCalls()
  */
 function once()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::once',
-        func_get_args()
-    );
+    return TestCase::once(...func_get_args());
 }
 
 /**
@@ -2085,10 +1694,7 @@ function once()
  */
 function returnArgument($argumentIndex)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::returnArgument',
-        func_get_args()
-    );
+    return TestCase::returnArgument(...func_get_args());
 }
 
 /**
@@ -2098,10 +1704,7 @@ function returnArgument($argumentIndex)
  */
 function returnCallback($callback)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::returnCallback',
-        func_get_args()
-    );
+    return TestCase::returnCallback(...func_get_args());
 }
 
 /**
@@ -2113,10 +1716,7 @@ function returnCallback($callback)
  */
 function returnSelf()
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::returnSelf',
-        func_get_args()
-    );
+    return TestCase::returnSelf(...func_get_args());
 }
 
 /**
@@ -2126,10 +1726,7 @@ function returnSelf()
  */
 function returnValue($value)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::returnValue',
-        func_get_args()
-    );
+    return TestCase::returnValue(...func_get_args());
 }
 
 /**
@@ -2139,10 +1736,7 @@ function returnValue($value)
  */
 function returnValueMap(array $valueMap)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::returnValueMap',
-        func_get_args()
-    );
+    return TestCase::returnValueMap(...func_get_args());
 }
 
 /**
@@ -2155,10 +1749,7 @@ function returnValueMap(array $valueMap)
  */
 function stringContains($string, $case = true)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::stringContains',
-        func_get_args()
-    );
+    return Assert::stringContains(...func_get_args());
 }
 
 /**
@@ -2170,10 +1761,7 @@ function stringContains($string, $case = true)
  */
 function stringEndsWith($suffix)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::stringEndsWith',
-        func_get_args()
-    );
+    return Assert::stringEndsWith(...func_get_args());
 }
 
 /**
@@ -2185,10 +1773,7 @@ function stringEndsWith($suffix)
  */
 function stringStartsWith($prefix)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\Assert::stringStartsWith',
-        func_get_args()
-    );
+    return Assert::stringStartsWith(...func_get_args());
 }
 
 /**
@@ -2198,8 +1783,5 @@ function stringStartsWith($prefix)
  */
 function throwException(Exception $exception)
 {
-    return call_user_func_array(
-        'PHPUnit\Framework\TestCase::throwException',
-        func_get_args()
-    );
+    return TestCase::throwException(...func_get_args());
 }


### PR DESCRIPTION
This PR

* [x] uses argument unpacking instead of using `call_user_func_array()`