### PR TITLE
Fix: Remove default assignments when value is null

### DIFF
--- a/src/Framework/Constraint/LogicalAnd.php
+++ b/src/Framework/Constraint/LogicalAnd.php
@@ -24,7 +24,7 @@ class LogicalAnd extends Constraint
     /**
      * @var Constraint
      */
-    protected $lastConstraint = null;
+    protected $lastConstraint;
 
     /**
      * @param Constraint[] $constraints

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -105,7 +105,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      *
      * @var bool
      */
-    protected $backupGlobals = null;
+    protected $backupGlobals;
 
     /**
      * @var array
@@ -119,7 +119,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      *
      * @var bool
      */
-    protected $backupStaticAttributes = null;
+    protected $backupStaticAttributes;
 
     /**
      * @var array
@@ -131,7 +131,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      *
      * @var bool
      */
-    protected $runTestInSeparateProcess = null;
+    protected $runTestInSeparateProcess;
 
     /**
      * Whether or not this test should preserve the global state when
@@ -161,14 +161,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @var bool
      */
-    private $useErrorHandler = null;
+    private $useErrorHandler;
 
     /**
      * The name of the expected Exception.
      *
      * @var string
      */
-    private $expectedException = null;
+    private $expectedException;
 
     /**
      * The message of the expected Exception.
@@ -196,7 +196,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      *
      * @var string
      */
-    private $name = null;
+    private $name;
 
     /**
      * @var array
@@ -226,7 +226,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @var array
      */
-    private $mockObjectGenerator = null;
+    private $mockObjectGenerator;
 
     /**
      * @var int
@@ -261,12 +261,12 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @var string
      */
-    private $outputExpectedRegex = null;
+    private $outputExpectedRegex;
 
     /**
      * @var string
      */
-    private $outputExpectedString = null;
+    private $outputExpectedString;
 
     /**
      * @var mixed

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -86,7 +86,7 @@ class TestResult implements Countable
     /**
      * @var TestSuite
      */
-    protected $topTestSuite = null;
+    protected $topTestSuite;
 
     /**
      * Code Coverage information.

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -38,19 +38,19 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      *
      * @var bool
      */
-    protected $backupGlobals = null;
+    protected $backupGlobals;
 
     /**
      * Enable or disable the backup and restoration of static attributes.
      *
      * @var bool
      */
-    protected $backupStaticAttributes = null;
+    protected $backupStaticAttributes;
 
     /**
      * @var bool
      */
-    private $beStrictAboutChangesToGlobalState = null;
+    private $beStrictAboutChangesToGlobalState;
 
     /**
      * @var bool
@@ -98,7 +98,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
     /**
      * @var Factory
      */
-    private $iteratorFilter = null;
+    private $iteratorFilter;
 
     /**
      * Constructs a new TestSuite:

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -20,7 +20,7 @@ class NameFilterIterator extends RecursiveFilterIterator
     /**
      * @var string
      */
-    protected $filter = null;
+    protected $filter;
 
     /**
      * @var int

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -63,12 +63,12 @@ class TestRunner extends BaseTestRunner
     /**
      * @var TestSuiteLoader
      */
-    protected $loader = null;
+    protected $loader;
 
     /**
      * @var ResultPrinter
      */
-    protected $printer = null;
+    protected $printer;
 
     /**
      * @var bool

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -96,7 +96,7 @@ class JUnit extends Printer implements TestListener
     /**
      * @var DOMElement
      */
-    protected $currentTestCase = null;
+    protected $currentTestCase;
 
     /**
      * Constructor.


### PR DESCRIPTION
This PR

* [x] removes default assignments when the value is `null`