### PR TITLE
Fix: No need to assign default values

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -151,12 +151,12 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @var array
      */
-    private $data = [];
+    private $data;
 
     /**
      * @var string
      */
-    private $dataName = '';
+    private $dataName;
 
     /**
      * @var bool

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -121,7 +121,7 @@ class ResultPrinter extends Printer implements TestListener
     /**
      * @var bool
      */
-    private $reverse = false;
+    private $reverse;
 
     /**
      * @var bool


### PR DESCRIPTION
This PR

* [x] removes default value assignments which are immediately overwritten in corresponding constructors