### PR TITLE
Fix test for AbstractPhpProcessTest on Windows systems

### DIFF
--- a/tests/Util/PHP/AbstractPhpProcessTest.php
+++ b/tests/Util/PHP/AbstractPhpProcessTest.php
@@ -87,7 +87,8 @@ class AbstractPhpProcessTest extends TestCase
 
     public function testShouldHaveFileToCreateCommand()
     {
-        $expectedCommandFormat  = '%s -%c \'file.php\'';
+        $argumentEscapingCharacter = DIRECTORY_SEPARATOR === '\\' ? '"' : '\'';
+        $expectedCommandFormat  = sprintf('%%s -%%c %1$sfile.php%1$s', $argumentEscapingCharacter);
         $actualCommand          = $this->phpProcess->getCommand([], 'file.php');
 
         $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);


### PR DESCRIPTION
On Windows systems the escaping character for shell arguments is a
double quote instead of a single quote. The unit test has to use proper
escaping character for its assertion.