### PR TITLE
Use DIRECTORY_SEPARATOR for path comparission

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('TEST_FILES_PATH')) {
-    define('TEST_FILES_PATH', __DIR__ . '/_files/');
+    define('TEST_FILES_PATH', __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR);
 }
 
 ini_set('precision', 14);


### PR DESCRIPTION
Using the DIRECTORY_SEPARATOR instead of hard coded forward slashes
solves a lot of failing tests on Windows systems.