### PR TITLE
Enhancement: Enable native_function_invocation fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -32,6 +32,7 @@ return PhpCsFixer\Config::create()
             'lowercase_constants' => true,
             'lowercase_keywords' => true,
             'method_argument_space' => true,
+            'native_function_invocation' => true,
             'no_alias_functions' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,


### PR DESCRIPTION
This PR

* [x] enables the `native_function_invocation` fixer

Replaces #2594.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.1.2#usage:

> **native_function_invocation**
Add leading `\` before function invocation of internal function to speed
up resolving.
*Rule is: configurable, risky.*

Also see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2462.