### PR TITLE
2049 Whitelist error messages

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -433,52 +433,54 @@ class TestRunner extends BaseTestRunner
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
             }
-            else {
-                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
 
-                $codeCoverageReports = 0;
-
-                unset($codeCoverage);
-            }
-
-            if (isset($codeCoverage) && isset($arguments['configuration'])) {
+            if (isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
 
-                $codeCoverage->setAddUncoveredFilesFromWhitelist(
-                    $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist']
-                );
+                if (empty($filterConfiguration['whitelist'])) {
+                    $this->writeMessage('Error', 'No whitelist is configured, no code coverage will be generated.');
 
-                $codeCoverage->setProcessUncoveredFilesFromWhitelist(
-                    $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist']
-                );
+                    $codeCoverageReports = 0;
 
-                foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
-                    $this->codeCoverageFilter->addDirectoryToWhitelist(
-                        $dir['path'],
-                        $dir['suffix'],
-                        $dir['prefix']
+                    unset($codeCoverage);
+
+                } else {
+                    $codeCoverage->setAddUncoveredFilesFromWhitelist(
+                        $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist']
                     );
-                }
 
-                foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
-                    $this->codeCoverageFilter->addFileToWhitelist($file);
-                }
-
-                foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
-                    $this->codeCoverageFilter->removeDirectoryFromWhitelist(
-                        $dir['path'],
-                        $dir['suffix'],
-                        $dir['prefix']
+                    $codeCoverage->setProcessUncoveredFilesFromWhitelist(
+                        $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist']
                     );
-                }
 
-                foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
-                    $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
+                        $this->codeCoverageFilter->addDirectoryToWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
+                        $this->codeCoverageFilter->addFileToWhitelist($file);
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
+                        $this->codeCoverageFilter->removeDirectoryFromWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
+                        $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    }
                 }
             }
 
-            if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed for testing.');
+            if (isset($codeCoverage) && !$this->codeCoverageFilter->hasWhitelist()) {
+                $this->writeMessage('Error', 'Incorrect whitelist configuration. No code coverage will be generated.');
 
                 $codeCoverageReports = 0;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -478,7 +478,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed fort testing.');
+                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed for testing.');
 
                 $codeCoverageReports = 0;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -441,7 +441,7 @@ class TestRunner extends BaseTestRunner
                 unset($codeCoverage);
             }
 
-            if (isset($arguments['configuration'])) {
+            if (isset($codeCoverage) && isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
 
                 $codeCoverage->setAddUncoveredFilesFromWhitelist(

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -433,6 +433,13 @@ class TestRunner extends BaseTestRunner
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
             }
+            else {
+                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
+
+                $codeCoverageReports = 0;
+
+                unset($codeCoverage);
+            }
 
             if (isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
@@ -471,7 +478,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
+                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed fort testing.');
 
                 $codeCoverageReports = 0;
 

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -222,6 +222,12 @@ class Configuration
 
         $tmp = $this->xpath->query('filter/whitelist');
 
+        if ($tmp->length == 0) {
+            return [
+                'whitelist' => []
+            ];
+        }
+
         if ($tmp->length == 1) {
             if ($tmp->item(0)->hasAttribute('addUncoveredFilesFromWhitelist')) {
                 $addUncoveredFilesFromWhitelist = $this->getBoolean(


### PR DESCRIPTION
Configuaration's method getFilterConfiguration is now returning an empty array if the whitelist node is not set in the xml configuration. This allows for short circuiting with an appropriate error message in TestRunner's doRun method. 