### PR TITLE
Bugfix: #2572 

### DIFF
--- a/ChangeLog-5.7.md
+++ b/ChangeLog-5.7.md
@@ -2,6 +2,12 @@
 
 All notable changes of the PHPUnit 5.7 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [5.7.18] - 2017-XX-XX
+
+### Fixed
+
+* Fixed [#2572](https://github.com/sebastianbergmann/phpunit/issues/2572): Self referencing array breaks with PHPUnit 5.7 but worked with PHPUnit 4.8
+
 ## [5.7.17] - 2017-03-19
 
 ### Fixed

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2421,9 +2421,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
     /**
      * @param array $testArguments
+     * @param array $originalTestArguments
      */
-    private function registerMockObjectsFromTestArguments(array $testArguments)
-    {
+    private function registerMockObjectsFromTestArguments(
+        array $testArguments,
+        array &$visited = []
+    ) {
         if ($this->registerMockObjectsFromTestArgumentsRecursively) {
             $enumerator = new Enumerator;
 
@@ -2440,8 +2443,12 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     }
 
                     $this->registerMockObject($testArgument);
-                } elseif (is_array($testArgument)) {
-                    $this->registerMockObjectsFromTestArguments($testArgument);
+                } elseif (is_array($testArgument) && !in_array($testArgument, $visited)) {
+                    $visited[] = $testArgument;
+                    $this->registerMockObjectsFromTestArguments(
+                        $testArgument,
+                        $visited
+                    );
                 }
             }
         }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2421,12 +2421,10 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
 
     /**
      * @param array $testArguments
-     * @param array $originalTestArguments
+     * @param array &$visited
      */
-    private function registerMockObjectsFromTestArguments(
-        array $testArguments,
-        array &$visited = []
-    ) {
+    private function registerMockObjectsFromTestArguments(array $testArguments, array &$visited = [])
+    {
         if ($this->registerMockObjectsFromTestArgumentsRecursively) {
             $enumerator = new Enumerator;
 
@@ -2445,10 +2443,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     $this->registerMockObject($testArgument);
                 } elseif (is_array($testArgument) && !in_array($testArgument, $visited)) {
                     $visited[] = $testArgument;
-                    $this->registerMockObjectsFromTestArguments(
-                        $testArgument,
-                        $visited
-                    );
+                    $this->registerMockObjectsFromTestArguments($testArgument, $visited);
                 }
             }
         }

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -646,4 +646,29 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($mock->foo());
         $this->assertNull($mock->bar());
     }
+
+    public function testProvidingOfAuoreferencedArray()
+    {
+        $test = new \TestAutoreferenced('testJsonEncodeException', $this->getAutoreferencedArray());
+        $test->runBare();
+
+        $this->assertInternalType('array', $test->myTestData);
+        $this->assertArrayHasKey('data', $test->myTestData);
+        $this->assertEquals($test->myTestData['data'][0], $test->myTestData['data']);
+    }
+
+    /**
+     * @return array
+     */
+    private function getAutoreferencedArray()
+    {
+        $recursionData   = [];
+        $recursionData[] = &$recursionData;
+
+        return [
+            'RECURSION' => [
+                'data' => $recursionData
+            ]
+        ];
+    }
 }

--- a/tests/_files/TestAutoreferenced.php
+++ b/tests/_files/TestAutoreferenced.php
@@ -1,0 +1,12 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class TestAutoreferenced extends TestCase
+{
+    public $myTestData = null;
+
+    public function testJsonEncodeException($data)
+    {
+        $this->myTestData = $data;
+    }
+}


### PR DESCRIPTION
Support autoreferenced array as arguments in 5.7: Added a check to avoid infinite recursion on self-referenced arrays. This fixes #2572