### PR TITLE
Fix weird character in failure output on Windows systems

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -420,7 +420,7 @@ class JUnit extends Printer implements TestListener
             $buffer = '';
         }
 
-        $buffer .= TestFailure::exceptionToString($e) . PHP_EOL .
+        $buffer .= TestFailure::exceptionToString($e) . "\n" .
                    Filter::getFilteredStacktrace($e);
 
         $fault = $this->document->createElement(


### PR DESCRIPTION
The output should not use PHP_EOL as this my result in some weird
encoded characters on Windows systems.