### PR TITLE
#2267 Addressing the issue of of passing integers as exception codes/messages

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1073,7 +1073,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 );
 
                 if (is_string($this->expectedExceptionMessage) &&
-                    !empty($this->expectedExceptionMessage)
+                    $this->expectedExceptionMessage != ''
                 ) {
                     $this->assertThat(
                         $e,
@@ -1084,7 +1084,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 }
 
                 if (is_string($this->expectedExceptionMessageRegExp) &&
-                    !empty($this->expectedExceptionMessageRegExp)
+                    $this->expectedExceptionMessageRegExp != ''
                 ) {
                     $this->assertThat(
                         $e,

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -433,52 +433,54 @@ class TestRunner extends BaseTestRunner
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
             }
-            else {
-                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
 
-                $codeCoverageReports = 0;
-
-                unset($codeCoverage);
-            }
-
-            if (isset($codeCoverage) && isset($arguments['configuration'])) {
+            if (isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
 
-                $codeCoverage->setAddUncoveredFilesFromWhitelist(
-                    $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist']
-                );
+                if (empty($filterConfiguration['whitelist'])) {
+                    $this->writeMessage('Error', 'No whitelist is configured, no code coverage will be generated.');
 
-                $codeCoverage->setProcessUncoveredFilesFromWhitelist(
-                    $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist']
-                );
+                    $codeCoverageReports = 0;
 
-                foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
-                    $this->codeCoverageFilter->addDirectoryToWhitelist(
-                        $dir['path'],
-                        $dir['suffix'],
-                        $dir['prefix']
+                    unset($codeCoverage);
+
+                } else {
+                    $codeCoverage->setAddUncoveredFilesFromWhitelist(
+                        $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist']
                     );
-                }
 
-                foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
-                    $this->codeCoverageFilter->addFileToWhitelist($file);
-                }
-
-                foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
-                    $this->codeCoverageFilter->removeDirectoryFromWhitelist(
-                        $dir['path'],
-                        $dir['suffix'],
-                        $dir['prefix']
+                    $codeCoverage->setProcessUncoveredFilesFromWhitelist(
+                        $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist']
                     );
-                }
 
-                foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
-                    $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
+                        $this->codeCoverageFilter->addDirectoryToWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
+                        $this->codeCoverageFilter->addFileToWhitelist($file);
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
+                        $this->codeCoverageFilter->removeDirectoryFromWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
+                        $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    }
                 }
             }
 
-            if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed for testing.');
+            if (isset($codeCoverage) && !$this->codeCoverageFilter->hasWhitelist()) {
+                $this->writeMessage('Error', 'Incorrect whitelist configuration. No code coverage will be generated.');
 
                 $codeCoverageReports = 0;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -478,7 +478,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed fort testing.');
+                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed for testing.');
 
                 $codeCoverageReports = 0;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -441,7 +441,7 @@ class TestRunner extends BaseTestRunner
                 unset($codeCoverage);
             }
 
-            if (isset($arguments['configuration'])) {
+            if (isset($codeCoverage) && isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
 
                 $codeCoverage->setAddUncoveredFilesFromWhitelist(

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -433,6 +433,13 @@ class TestRunner extends BaseTestRunner
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
             }
+            else {
+                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
+
+                $codeCoverageReports = 0;
+
+                unset($codeCoverage);
+            }
 
             if (isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
@@ -471,7 +478,7 @@ class TestRunner extends BaseTestRunner
             }
 
             if (!$this->codeCoverageFilter->hasWhitelist()) {
-                $this->writeMessage('Error', 'No whitelist configured, no code coverage will be generated');
+                $this->writeMessage('Error', 'Whitelist is improperly configured, no files listed fort testing.');
 
                 $codeCoverageReports = 0;
 

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -222,6 +222,12 @@ class Configuration
 
         $tmp = $this->xpath->query('filter/whitelist');
 
+        if ($tmp->length == 0) {
+            return [
+                'whitelist' => []
+            ];
+        }
+
         if ($tmp->length == 1) {
             if ($tmp->item(0)->hasAttribute('addUncoveredFilesFromWhitelist')) {
                 $addUncoveredFilesFromWhitelist = $this->getBoolean(


### PR DESCRIPTION
Officially, #2267 is referencing the now depricated setExpectedException. But it was necessary to check that the problem did not also exist in expectExceptionCode. Though expectExceptionCode seems to be working as expected, in researching it was discovered that expectExceptionMessage and expectExceptionRegex would skip the test if '0' was set. It turns out that the empty() method was being used to check if the variable was set. Of empty returns true for '0', so the checks were updated to check for empty strings instead. 