### PR TITLE
change the check for exception message from empty() to check for empt…

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1071,7 +1071,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 );
 
                 if (\is_string($this->expectedExceptionMessage) &&
-                    !empty($this->expectedExceptionMessage)) {
+                    $this->expectedExceptionMessage == '') {
                     $this->assertThat(
                         $e,
                         new ExceptionMessage(
@@ -1081,7 +1081,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 }
 
                 if (\is_string($this->expectedExceptionMessageRegExp) &&
-                    !empty($this->expectedExceptionMessageRegExp)) {
+                    $this->expectedExceptionMessageRegExp == '') {
                     $this->assertThat(
                         $e,
                         new ExceptionMessageRegularExpression(


### PR DESCRIPTION
Isse #2267 - Originally this issue was opened based on a bug with setExpectedException, which has been depricated. Checking to see if the same issue existed for expectExceptionCode led to realizing that although expectException code was working as expected, expectedExceptionMessage and expectExceptionMessageRegex we showing a passed test if '0' was set as the message. They were using the empty() method, so it was necessary to change them to check for an empty string instead. 