### PR TITLE
Use directory separator in test expectations

### DIFF
--- a/tests/Regression/GitHub/1471.phpt
+++ b/tests/Regression/GitHub/1471.phpt
@@ -20,7 +20,7 @@ There was 1 failure:
 1) Issue1471Test::testFailure
 Failed asserting that false is true.
 
-%s/Issue1471Test.php:%d
+%s%eIssue1471Test.php:%d
 
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/Regression/GitHub/2145.phpt
+++ b/tests/Regression/GitHub/2145.phpt
@@ -21,7 +21,7 @@ Time: %s, Memory: %s
 There was 1 error:
 
 1) Issue2145Test
-Exception in %s/Issue2145Test.php:%d
+Exception in %s%eIssue2145Test.php:%d
 %A
 ERRORS!
 Tests: 2, Assertions: 0, Errors: 1.

--- a/tests/TextUI/log-junit.phpt
+++ b/tests/TextUI/log-junit.phpt
@@ -16,36 +16,36 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 .FEISRW                                                             7 / 7 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="vendor\project\StatusTest" file="%s/StatusTest.php" tests="7" assertions="2" errors="2" failures="2" skipped="2" time="%s">
-    <testcase name="testSuccess" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="1" time="%s"/>
-    <testcase name="testFailure" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="1" time="%s">
+  <testsuite name="vendor\project\StatusTest" file="%s%eStatusTest.php" tests="7" assertions="2" errors="2" failures="2" skipped="2" time="%s">
+    <testcase name="testSuccess" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="1" time="%s"/>
+    <testcase name="testFailure" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="1" time="%s">
       <failure type="PHPUnit\Framework\ExpectationFailedException">vendor\project\StatusTest::testFailure
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 </failure>
     </testcase>
-    <testcase name="testError" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="0" time="%s">
+    <testcase name="testError" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="0" time="%s">
       <error type="RuntimeException">vendor\project\StatusTest::testError
 RuntimeException:%w
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 </error>
     </testcase>
-    <testcase name="testIncomplete" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="0" time="%s">
+    <testcase name="testIncomplete" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="0" time="%s">
       <skipped/>
     </testcase>
-    <testcase name="testSkipped" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="0" time="%s">
+    <testcase name="testSkipped" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="0" time="%s">
       <skipped/>
     </testcase>
-    <testcase name="testRisky" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="0" time="%s">
+    <testcase name="testRisky" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="0" time="%s">
       <error type="PHPUnit\Framework\RiskyTestError">Risky Test
 </error>
     </testcase>
-    <testcase name="testWarning" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s/StatusTest.php" line="%d" assertions="0" time="%s">
+    <testcase name="testWarning" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="0" time="%s">
       <warning type="PHPUnit\Framework\Warning">vendor\project\StatusTest::testWarning
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 </warning>
     </testcase>
   </testsuite>
@@ -59,7 +59,7 @@ There was 1 error:
 1) vendor\project\StatusTest::testError
 RuntimeException:%w
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -67,7 +67,7 @@ There was 1 warning:
 
 1) vendor\project\StatusTest::testWarning
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -76,7 +76,7 @@ There was 1 failure:
 1) vendor\project\StatusTest::testFailure
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 

--- a/tests/TextUI/log-teamcity.phpt
+++ b/tests/TextUI/log-teamcity.phpt
@@ -16,17 +16,17 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testCount count='3' flowId='%d']
 
-##teamcity[testSuiteStarted name='BankAccountTest' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest' flowId='%d']
+##teamcity[testSuiteStarted name='BankAccountTest' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest' flowId='%d']
 
-##teamcity[testStarted name='testBalanceIsInitiallyZero' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest::testBalanceIsInitiallyZero' flowId='%d']
+##teamcity[testStarted name='testBalanceIsInitiallyZero' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest::testBalanceIsInitiallyZero' flowId='%d']
 .
 ##teamcity[testFinished name='testBalanceIsInitiallyZero' duration='%s' flowId='%d']
 
-##teamcity[testStarted name='testBalanceCannotBecomeNegative' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative' flowId='%d']
+##teamcity[testStarted name='testBalanceCannotBecomeNegative' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative' flowId='%d']
 .
 ##teamcity[testFinished name='testBalanceCannotBecomeNegative' duration='%s' flowId='%d']
 
-##teamcity[testStarted name='testBalanceCannotBecomeNegative2' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative2' flowId='%d']
+##teamcity[testStarted name='testBalanceCannotBecomeNegative2' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative2' flowId='%d']
 .                                                                 3 / 3 (100%)
 ##teamcity[testFinished name='testBalanceCannotBecomeNegative2' duration='%s' flowId='%d']
 

--- a/tests/TextUI/phar-extension.phpt
+++ b/tests/TextUI/phar-extension.phpt
@@ -11,7 +11,7 @@ PHPUnit\TextUI\Command::main();
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime:       %s
-Configuration: %s/phpunit-example-extension/phpunit.xml
+Configuration: %s%ephpunit-example-extension%ephpunit.xml
 Extension:     phpunit/phpunit-example-extension 1.0.1
 
 .                                                                   1 / 1 (100%)

--- a/tests/TextUI/teamcity-inner-exceptions.phpt
+++ b/tests/TextUI/teamcity-inner-exceptions.phpt
@@ -15,17 +15,17 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testCount count='2' flowId='%d']
 
-##teamcity[testSuiteStarted name='ExceptionStackTest' locationHint='php_qn://%s/tests/_files/ExceptionStackTest.php::\ExceptionStackTest' flowId='%d']
+##teamcity[testSuiteStarted name='ExceptionStackTest' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest' flowId='%d']
 
-##teamcity[testStarted name='testPrintingChildException' locationHint='php_qn://%s/tests/_files/ExceptionStackTest.php::\ExceptionStackTest::testPrintingChildException' flowId='%d']
+##teamcity[testStarted name='testPrintingChildException' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest::testPrintingChildException' flowId='%d']
 
-##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n )|n' details=' %s/tests/_files/ExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n  )|n |n %s/tests/_files/ExceptionStackTest.php:10|n ' flowId='%d']
+##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n )|n' details=' %s%etests%e_files%eExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n  )|n |n %s%etests%e_files%eExceptionStackTest.php:10|n ' flowId='%d']
 
 ##teamcity[testFinished name='testPrintingChildException' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testNestedExceptions' locationHint='php_qn://%s/tests/_files/ExceptionStackTest.php::\ExceptionStackTest::testNestedExceptions' flowId='%d']
+##teamcity[testStarted name='testNestedExceptions' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest::testNestedExceptions' flowId='%d']
 
-##teamcity[testFailed name='testNestedExceptions' message='One' details=' %s/tests/_files/ExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s/tests/_files/ExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s/tests/_files/ExceptionStackTest.php:20|n ' flowId='%d']
+##teamcity[testFailed name='testNestedExceptions' message='One' details=' %s%etests%e_files%eExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s%etests%e_files%eExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s%etests%e_files%eExceptionStackTest.php:20|n ' flowId='%d']
 
 ##teamcity[testFinished name='testNestedExceptions' duration='%d' flowId='%d']
 

--- a/tests/TextUI/teamcity.phpt
+++ b/tests/TextUI/teamcity.phpt
@@ -15,17 +15,17 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testCount count='3' flowId='%d']
 
-##teamcity[testSuiteStarted name='BankAccountTest' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest' flowId='%d']
+##teamcity[testSuiteStarted name='BankAccountTest' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest' flowId='%d']
 
-##teamcity[testStarted name='testBalanceIsInitiallyZero' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest::testBalanceIsInitiallyZero' flowId='%d']
+##teamcity[testStarted name='testBalanceIsInitiallyZero' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest::testBalanceIsInitiallyZero' flowId='%d']
 
 ##teamcity[testFinished name='testBalanceIsInitiallyZero' duration='%s' flowId='%d']
 
-##teamcity[testStarted name='testBalanceCannotBecomeNegative' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative' flowId='%d']
+##teamcity[testStarted name='testBalanceCannotBecomeNegative' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative' flowId='%d']
 
 ##teamcity[testFinished name='testBalanceCannotBecomeNegative' duration='%s' flowId='%d']
 
-##teamcity[testStarted name='testBalanceCannotBecomeNegative2' locationHint='php_qn://%s/tests/_files/BankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative2' flowId='%d']
+##teamcity[testStarted name='testBalanceCannotBecomeNegative2' locationHint='php_qn://%s%etests%e_files%eBankAccountTest.php::\BankAccountTest::testBalanceCannotBecomeNegative2' flowId='%d']
 
 ##teamcity[testFinished name='testBalanceCannotBecomeNegative2' duration='%s' flowId='%d']
 

--- a/tests/TextUI/testdox-xml.phpt
+++ b/tests/TextUI/testdox-xml.phpt
@@ -32,7 +32,7 @@ There was 1 error:
 1) vendor\project\StatusTest::testError
 RuntimeException:%s
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -40,7 +40,7 @@ There was 1 warning:
 
 1) vendor\project\StatusTest::testWarning
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -49,7 +49,7 @@ There was 1 failure:
 1) vendor\project\StatusTest::testFailure
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 


### PR DESCRIPTION
Test expectations have to use the placeholder "%e" for the directory
separator to support executing tests on Windows systems.