### PR TITLE
Truncate STDOUT in isolated process for file resource

### DIFF
--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -61,6 +61,11 @@ function __phpunit_run_isolated_test()
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
     if ($stdout = stream_get_contents(STDOUT)) {
         $output = $stdout . $output;
+        $streamMetaData = stream_get_meta_data(STDOUT);
+        if (!empty($streamMetaData['stream_type']) && 'STDIO' === $streamMetaData['stream_type']) {
+            @ftruncate(STDOUT, 0);
+            @rewind(STDOUT);
+        }
     }
 
     print serialize(


### PR DESCRIPTION
If STDOUT in an isolated process is a file resource (default on Windows
system), the current content has to be truncated before new content can
be written. Otherwise wrong and unexpected content stays in the file
and further result processing throws errors.