### PR TITLE
Ensure minimal count of 80 characters by default in ResultPrinter output

### DIFF
--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -172,7 +172,7 @@ class ResultPrinter extends Printer implements TestListener
         $console            = new Console;
         $maxNumberOfColumns = $console->getNumberOfColumns();
 
-        if ($numberOfColumns == 'max' || $numberOfColumns > $maxNumberOfColumns) {
+        if ($numberOfColumns == 'max' || ($numberOfColumns !== 80 && $numberOfColumns > $maxNumberOfColumns)) {
             $numberOfColumns = $maxNumberOfColumns;
         }
 


### PR DESCRIPTION
Windows systems support only 79 characters by default. The 80th character
is preserved for a new line. However using the 80th character position
doesn't break anything but having an empty line between result output.
As even the standard CMD on a Windows system supports more than 80
columns per default this is an acceptable output which ensures test
expectations.