### PR TITLE
Added ability to test empty strings for exception messages

### DIFF
--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -36,6 +36,10 @@ class ExceptionMessage extends Constraint
      */
     protected function matches($other)
     {
+        if ($this->expectedMessage == '') {
+            return ($other->getMessage() == '');
+        }
+
         return \strpos($other->getMessage(), $this->expectedMessage) !== false;
     }
 

--- a/src/Framework/Constraint/ExceptionMessageRegularExpression.php
+++ b/src/Framework/Constraint/ExceptionMessageRegularExpression.php
@@ -37,6 +37,10 @@ class ExceptionMessageRegularExpression extends Constraint
      */
     protected function matches($other)
     {
+        if ($this->expectedMessageRegExp == '') {
+            return ($other->getMessage() == '');
+        }
+
         $match = RegularExpressionUtil::safeMatch($this->expectedMessageRegExp, $other->getMessage());
 
         if (false === $match) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -175,14 +175,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      *
      * @var string
      */
-    private $expectedExceptionMessage = '';
+    private $expectedExceptionMessage = null;
 
     /**
      * The regex pattern to validate the expected Exception message.
      *
      * @var string
      */
-    private $expectedExceptionMessageRegExp = '';
+    private $expectedExceptionMessageRegExp = null;
 
     /**
      * The code of the expected Exception.
@@ -1070,8 +1070,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     )
                 );
 
-                if (\is_string($this->expectedExceptionMessage) &&
-                    !empty($this->expectedExceptionMessage)) {
+                if (\is_string($this->expectedExceptionMessage)) {
                     $this->assertThat(
                         $e,
                         new ExceptionMessage(
@@ -1080,8 +1079,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     );
                 }
 
-                if (\is_string($this->expectedExceptionMessageRegExp) &&
-                    !empty($this->expectedExceptionMessageRegExp)) {
+                if (\is_string($this->expectedExceptionMessageRegExp)) {
                     $this->assertThat(
                         $e,
                         new ExceptionMessageRegularExpression(


### PR DESCRIPTION
Setting the initial values to null, checking only if they are strings in order to test, and then adding additional empty string tests in the matches() methods for ExceptionMessage and ExceptionMessageRegularExpression works for allowing even empty strings to be tests as expected messages.