### PR TITLE
Fix regression with self-referencing arrays handling

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2441,7 +2441,7 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     }
 
                     $this->registerMockObject($testArgument);
-                } elseif (is_array($testArgument) && !in_array($testArgument, $visited)) {
+                } elseif (is_array($testArgument) && !in_array($testArgument, $visited, true)) {
                     $visited[] = $testArgument;
 
                     $this->registerMockObjectsFromTestArguments(

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -647,7 +647,7 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
         $this->assertNull($mock->bar());
     }
 
-    public function testProvidingOfAuoreferencedArray()
+    public function testProvidingOfAutoreferencedArray()
     {
         $test = new \TestAutoreferenced('testJsonEncodeException', $this->getAutoreferencedArray());
         $test->runBare();
@@ -670,5 +670,20 @@ class Framework_TestCaseTest extends PHPUnit_Framework_TestCase
                 'data' => $recursionData
             ]
         ];
+    }
+
+    public function testProvidingArrayThatMixesObjectsAndScalars()
+    {
+        $data = [
+            [123],
+            ['foo'],
+            [$this->createMock(Mockable::class)],
+        ];
+
+        $test = new \TestAutoreferenced('testJsonEncodeException', [$data]);
+        $test->runBare();
+
+        $this->assertInternalType('array', $test->myTestData);
+        $this->assertSame($data, $test->myTestData);
     }
 }


### PR DESCRIPTION
Fixes a regression introduced with #2620: when arrays mix objects with scalars, it produces errors such as:
```
Object of class Foo could not be converted to int
```