### PR TITLE
Support counting non-Iterator Traversable objects

### DIFF
--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Framework\Constraint;
 
 use Countable;
+use Iterator;
 use IteratorAggregate;
 use Traversable;
 use Generator;
@@ -63,6 +64,10 @@ class Count extends Constraint
 
             if ($iterator instanceof Generator) {
                 return $this->getCountOfGenerator($iterator);
+            }
+
+            if (!$iterator instanceof Iterator) {
+                return \iterator_count($iterator);
             }
 
             $key   = $iterator->key();

--- a/tests/Framework/Constraint/CountTest.php
+++ b/tests/Framework/Constraint/CountTest.php
@@ -93,4 +93,19 @@ class CountTest extends TestCase
         $countConstraint->evaluate($generator, '', true);
         $this->assertEquals(null, $generator->current());
     }
+
+    public function testCountTraversable()
+    {
+        $countConstraint = new Count(5);
+
+        // DatePeriod is used as an object that is Traversable but does not
+        // implement Iterator or IteratorAggregate. The following ISO 8601
+        // recurring time interval will yield five total DateTime objects.
+        $datePeriod = new \DatePeriod('R4/2017-05-01T00:00:00Z/P1D');
+
+        $this->assertInstanceOf(\Traversable::class, $datePeriod);
+        $this->assertNotInstanceOf(\Iterator::class, $datePeriod);
+        $this->assertNotInstanceOf(\IteratorAggregate::class, $datePeriod);
+        $this->assertTrue($countConstraint->evaluate($datePeriod, '', true));
+    }
 }


### PR DESCRIPTION
Per the commit message:

> Extension classes may implement Traversable without also implementing Iterator or IteratorAggregate.

I discovered this with [`MongoDB\Driver\Cursor`](http://php.net/manual/en/class.mongodb-driver-cursor.php), which is only Traversable (it implements PHP's internal iteration handlers).

While this does remove the assumption of an Iterator API, it also defeats the purpose of the [original patch](https://github.com/sebastianbergmann/phpunit/commit/36cc20f7f7efa52947a48cd0d11de1742a28231e) from #1125 to undoing the side-effect of `iterator_count()` advancing the object. I have two observations on that:

 * Some Traversables or Iterators may not support rewinding. While [`NoRewindIterator::rewind()`](http://php.net/manual/en/norewinditerator.rewind.php) is implemented as a NOOP, I can imagine some other advance-only iterators throwing exceptions when calling `rewind()`. This is the case with `MongoDB\Driver\Cursor`, as we cannot rewind the result set coming from the database.
 * Traversable objects that are neither an Iterator or IteratorAggregate interface may still support rewinding. In that case, we may want to compose them in an [IteratorIterator](http://php.net/iteratoriterator) to allow the original fix from #1125 to apply.

I'm open to feedback on the above points and can revise the PR as needed.