### PR TITLE
Fix order of the sequences tests when the child test depends on the parent test

### DIFF
--- a/src/Framework/DependentTestInterface.php
+++ b/src/Framework/DependentTestInterface.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Framework;
+
+interface DependentTestInterface extends Test
+{
+    /**
+     * Get list of tests name that this test depends from
+     *
+     * @return string
+     */
+    public function getDependencies();
+
+    /**
+     * @return string
+     */
+    public function getName();
+}

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -96,7 +96,7 @@ use Throwable;
  * ?>
  * </code>
  */
-abstract class TestCase extends Assert implements Test, SelfDescribing
+abstract class TestCase extends Assert implements DependentTestInterface, SelfDescribing
 {
     /**
      * Enable or disable the backup and restoration of the $GLOBALS array.
@@ -1171,6 +1171,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     public function setDependencies(array $dependencies)
     {
         $this->dependencies = $dependencies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies()
+    {
+        return $this->dependencies;
     }
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -25,6 +25,7 @@ use PHPUnit\Runner\Version;
 use PHPUnit\Runner\TestSuiteLoader;
 use PHPUnit\Util\Configuration;
 use PHPUnit\Util\ConfigurationGenerator;
+use PHPUnit\Util\DependencyResolver\Solver;
 use PHPUnit\Util\Fileloader;
 use PHPUnit\Util\Filesystem;
 use PHPUnit\Util\Getopt;
@@ -204,6 +205,7 @@ class Command
 
         unset($this->arguments['test']);
         unset($this->arguments['testFile']);
+        $this->resolveTestSuite($suite);
 
         try {
             $result = $runner->doRun($suite, $this->arguments, $exit);
@@ -803,6 +805,16 @@ class Command
             exit(TestRunner::EXCEPTION_EXIT);
         }
     }
+
+    /**
+     * @param TestSuite $testSuite
+     */
+    protected function resolveTestSuite(TestSuite $testSuite)
+    {
+        $solver = new Solver();
+        $solver->resolve($testSuite);
+    }
+
 
     /**
      * Handles the loading of the PHPUnit_Runner_TestSuiteLoader implementation.

--- a/src/Util/DependencyResolver/Problem.php
+++ b/src/Util/DependencyResolver/Problem.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\DependencyResolver;
+
+class Problem extends \SplDoublyLinkedList
+{
+    /** @var object */
+    protected $object;
+
+    /** @var string */
+    protected $name;
+
+    /**
+     * @param string $name
+     * @param null $object
+     * @param array $dependencies
+     */
+    public function __construct($name, $object, array $dependencies = [])
+    {
+        $this->name = $name;
+        $this->object = $object;
+
+        foreach ($dependencies as $dependency) {
+            $this->push($dependency);
+        }
+    }
+
+    /**
+     * @return object
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Util/DependencyResolver/Solver.php
+++ b/src/Util/DependencyResolver/Solver.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\DependencyResolver;
+
+use PHPUnit\Framework\DependentTestInterface;
+use PHPUnit\Framework\TestSuite;
+
+class Solver
+{
+    /**
+     * @param TestSuite $testSuite
+     */
+    public function resolve(TestSuite $testSuite)
+    {
+        $this->resolveDependency($testSuite);
+    }
+
+    /**
+     * @param TestSuite $testSuite
+     * @return Problem
+     */
+    protected function resolveDependency(TestSuite $testSuite)
+    {
+        $problems = [];
+
+        foreach ($testSuite->tests() as $test) {
+            if ($test instanceof TestSuite) {
+                $problems[] = $this->resolveDependency($test);
+                continue;
+            }
+
+            if ($test instanceof DependentTestInterface) {
+                $problems[] = new Problem($test->getName(), $test, $test->getDependencies());
+            } else {
+                $testName = is_callable([$test, 'getName']) ? $test->getName() : spl_object_hash($test);
+                $problems[] = new Problem($testName, $test);
+            }
+        }
+
+        return $this->mergeProblems($testSuite, $problems);
+    }
+
+    /**
+     * @param TestSuite $testSuite
+     * @param Problem[] $problems
+     * @return Problem
+     */
+    protected function mergeProblems(TestSuite $testSuite, array $problems)
+    {
+        list ($tests, $poolProblems, $inPool, $dependencies) = [[], [], [], []];
+        foreach ($problems as $problem) {
+            $poolProblems[$problem->getName()][] = $problem;
+        }
+
+        $resolver = function (
+            Problem $problem,
+            array $tests = []
+        ) use (
+            &$resolver,
+            &$inPool,
+            &$dependencies,
+            $poolProblems
+        ) {
+            $inPool[$problem->getName()] = true;
+
+            while (!$problem->isEmpty()) {
+                $dependency = $problem->pop();
+                $dependencies[] = $dependency;
+                if (!array_key_exists($dependency, $inPool) && array_key_exists($dependency, $poolProblems)) {
+                    /** @var Problem $element */
+                    foreach ($poolProblems[$dependency] as $nextProblem) {
+                        $tests = $resolver($nextProblem, $tests);
+                    }
+                }
+            }
+
+            if (!in_array($problem->getObject(), $tests, true)) {
+                $tests[] = $problem->getObject();
+            }
+
+            return $tests;
+        };
+
+        foreach ($problems as $problem) {
+            $tests = $resolver($problem, $tests);
+        }
+        $testSuite->setTests($tests);
+
+        return new Problem($testSuite->getName(), $testSuite, array_unique($dependencies));
+    }
+}

--- a/tests/TextUI/dependencies4.phpt
+++ b/tests/TextUI/dependencies4.phpt
@@ -1,0 +1,18 @@
+--TEST--
+phpunit DependencyExtendTest ../_files/DependencyExtendTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'DependencyExtendTest';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/DependencyExtendTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/tests/Util/DependencyResolver/ProblemTest.php
+++ b/tests/Util/DependencyResolver/ProblemTest.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\DependencyResolver;
+
+use PHPUnit\Framework\TestCase;
+
+class ProblemTest extends TestCase
+{
+    public function testGetName()
+    {
+        $problem = new Problem('testName', new \stdClass());
+        $this->assertSame('testName', $problem->getName());
+    }
+
+    public function testGetObject()
+    {
+        $object = new \stdClass();
+        $problem = new Problem('testName', $object);
+        $this->assertSame($object, $problem->getObject());
+    }
+}

--- a/tests/Util/DependencyResolver/SolverTest.php
+++ b/tests/Util/DependencyResolver/SolverTest.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\DependencyResolver;
+
+use PHPUnit\Framework\DependentTestInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Util\DependencyResolver\Stub\StubTestCase;
+
+class SolverTest extends TestCase
+{
+    /** @var Solver */
+    protected $solver;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->solver = new Solver();
+    }
+
+    /**
+     * @dataProvider dependsTestProvider
+     *
+     * @param TestSuite $testSuite
+     * @param array $expectedOrderTests
+     */
+    public function testResolve(TestSuite $testSuite, array $expectedOrderTests)
+    {
+        $this->solver->resolve($testSuite);
+
+        $getTestList = function (TestSuite $testSuite) use (&$getTestList) {
+            $testList = [];
+            foreach ($testSuite->tests() as $test) {
+                if ($test instanceof TestSuite) {
+                    $testList = array_merge($testList, $getTestList($test));
+                } elseif ($test instanceof DependentTestInterface) {
+                    $testList[] = $test->getName();
+                }
+            }
+
+            return $testList;
+        };
+
+        $testList = $getTestList($testSuite);
+
+        foreach ($expectedOrderTests as $test) {
+            $first = array_search($test[0], $testList);
+            $second = array_search($test[1], $testList);
+            $this->assertTrue($first < $second);
+        }
+    }
+
+    public function dependsTestProvider()
+    {
+        yield 'not depend tests' => [
+            'testSuite' => $this->createTestSuite(
+                'test1',
+                ['testA' => [], 'testB' => [], 'testC' => []]
+            ),
+            'expectedOrderTests' => [
+                ['testA', 'testB'],
+                ['testB', 'testC']
+            ]
+        ];
+
+        yield 'depend tests one' => [
+            'testSuite' => $this->createTestSuite(
+                'test1',
+                ['testA' => ['testC'], 'testB' => ['testA'], 'testC' => []]
+            ),
+            'expectedOrderTests' => [
+                ['testA', 'testB'],
+                ['testC', 'testA']
+            ]
+        ];
+
+        yield 'depend tests two' => [
+            'testSuite' => $this->createTestSuite(
+                'test1',
+                [
+                    'testA' => ['testC', 'testB', 'testD'],
+                    'testB' => [],
+                    'testC' => ['testD'],
+                    'testD' => ['testB']
+                ]
+            ),
+            'expectedOrderTests' => [
+                ['testB', 'testD'],
+                ['testB', 'testA'],
+                ['testB', 'testC'],
+                ['testC', 'testA']
+            ]
+        ];
+
+        yield 'depend test suite' => [
+            'testSuite' => $this->createTestSuite(
+                'test1',
+                [
+                    'testA' => ['testC'],
+                    'testB' => $this->createTestSuite('testB', [
+                        'testB1' => ['testA'],
+                        'testB2' => ['testA']
+                    ]),
+                    'testC' => []
+                ]
+            ),
+            'expectedOrderTests' => [
+                ['testA', 'testB1'],
+                ['testA', 'testB2'],
+                ['testC', 'testA']
+            ]
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @param array $tests
+     * @return TestSuite
+     */
+    protected function createTestSuite($name, array $tests)
+    {
+        $testSuite = new TestSuite('', $name);
+        foreach ($tests as $name => $dependencies) {
+            if ($dependencies instanceof TestSuite) {
+                $testSuite->addTest($dependencies);
+            } else {
+                $testSuite->addTest(new StubTestCase($name, $dependencies));
+            }
+        }
+
+        return $testSuite;
+    }
+}

--- a/tests/Util/DependencyResolver/Stub/StubTestCase.php
+++ b/tests/Util/DependencyResolver/Stub/StubTestCase.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\DependencyResolver\Stub;
+
+use PHPUnit\Framework\DependentTestInterface;
+use PHPUnit\Framework\TestResult;
+
+class StubTestCase implements DependentTestInterface
+{
+    protected $name;
+
+    protected $dependencies;
+
+    public function __construct($name, array $dependencies)
+    {
+        $this->name = $name;
+        $this->dependencies = $dependencies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies()
+    {
+        return $this->dependencies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run(TestResult $result = null)
+    {
+    }
+}

--- a/tests/Util/DependencyResolver/Stub/StubTestSuite.php
+++ b/tests/Util/DependencyResolver/Stub/StubTestSuite.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\DependencyResolver\Stub;
+
+use PHPUnit\Framework\TestSuite;
+
+class StubTestSuite extends TestSuite
+{
+    /**
+     * @param string $theClass
+     * @param string $name
+     */
+    public function __construct($theClass = '', $name = '')
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/_files/DependencyExtendTest.php
+++ b/tests/_files/DependencyExtendTest.php
@@ -1,0 +1,18 @@
+<?php
+
+class DependencyExtendTest extends DependencyTestCase
+{
+    /**
+     * @depends testB
+     */
+    public function testC($value)
+    {
+        $this->assertSame(2, $value);
+    }
+
+    public function testA()
+    {
+        $this->assertTrue(true);
+        return 1;
+    }
+}

--- a/tests/_files/DependencyTestCase.php
+++ b/tests/_files/DependencyTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+abstract class DependencyTestCase extends TestCase
+{
+    /**
+     * @depends testA
+     */
+    public function testB($value)
+    {
+        $this->assertSame(1, $value);
+        return 2;
+    }
+}


### PR DESCRIPTION
Hi,
I wanted to inherit two tests, but when a child test depends on the parent test, this test will skiped, see example:
```php
namespace Acme\Bundle\TestBundle\Tests\Unit\Depends;

abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
{
    public function testA()
    {
        $this->assertTrue(true);
        return 1;
    }

    abstract public function testB($value);
}

```
```php
namespace Acme\Bundle\TestBundle\Tests\Unit\Depends;

class ExtendTest extends AbstractTestCase
{
    /**
     * @depends testA
     */
    public function testB($value)
    {
        $this->assertSame(1, $value);
    }
}

```
Output: 
```
PHPUnit 5.7.5 by Sebastian Bergmann and contributors.

S

Time: 114 ms, Memory: 4.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 1, Assertions: 1, Skipped: 1.
```