### PR TITLE
Consistent JUnit testcase output of test results when using data providers

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -316,10 +316,10 @@ class JUnit extends Printer implements TestListener
 
         if ($test instanceof TestCase) {
             $class      = new ReflectionClass($test);
-            $methodName = $test->getName();
+            $methodName = $test->getName(!$test->usesDataProvider());
 
             if ($class->hasMethod($methodName)) {
-                $method = $class->getMethod($test->getName());
+                $method = $class->getMethod($methodName);
 
                 $testCase->setAttribute('class', $class->getName());
                 $testCase->setAttribute('classname', \str_replace('\\', '.', $class->getName()));

--- a/tests/TextUI/dataprovider-log-xml-isolation.phpt
+++ b/tests/TextUI/dataprovider-log-xml-isolation.phpt
@@ -18,16 +18,16 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 <testsuites>
   <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
     <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
-      <testcase name="testAdd with data set #0" assertions="1" time="%f"/>
-      <testcase name="testAdd with data set #1" assertions="1" time="%f"/>
-      <testcase name="testAdd with data set #2" assertions="1" time="%f">
+      <testcase name="testAdd with data set #0" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
+      <testcase name="testAdd with data set #1" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
+      <testcase name="testAdd with data set #2" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f">
         <failure type="PHPUnit\Framework\ExpectationFailedException">DataProviderTest::testAdd with data set #2 (1, 1, 3)
 Failed asserting that 2 matches expected 3.
 
 %s:%i
 </failure>
       </testcase>
-      <testcase name="testAdd with data set #3" assertions="1" time="%f"/>
+      <testcase name="testAdd with data set #3" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
     </testsuite>
   </testsuite>
 </testsuites>

--- a/tests/TextUI/dataprovider-log-xml.phpt
+++ b/tests/TextUI/dataprovider-log-xml.phpt
@@ -17,16 +17,16 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 <testsuites>
   <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
     <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
-      <testcase name="testAdd with data set #0" assertions="1" time="%f"/>
-      <testcase name="testAdd with data set #1" assertions="1" time="%f"/>
-      <testcase name="testAdd with data set #2" assertions="1" time="%f">
+      <testcase name="testAdd with data set #0" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
+      <testcase name="testAdd with data set #1" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
+      <testcase name="testAdd with data set #2" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f">
         <failure type="PHPUnit\Framework\ExpectationFailedException">DataProviderTest::testAdd with data set #2 (1, 1, 3)
 Failed asserting that 2 matches expected 3.
 
 %s:%i
 </failure>
       </testcase>
-      <testcase name="testAdd with data set #3" assertions="1" time="%f"/>
+      <testcase name="testAdd with data set #3" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
     </testsuite>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
For simple tests, the attributes "class", "classname", "file" and "line" are set in the XML node "testcase"  (--log-junit) for every executed test. 

But if you use the "@dataProvider" annotation, then no information about the class or the file will be added to the XML node.

Apart from the fact that this is not consistent, this also means that the tests generated by data providers are not recognized by SonarQube, for example.

With my change, I have matched the output in both cases.