### PR TITLE
Allow using a \Traversable as data provider, not only \Iterater

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -23,6 +23,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;
 use ReflectionMethod;
+use Traversable;
 
 /**
  * Test helpers.
@@ -517,7 +518,7 @@ class Test
                     $data = $dataProviderMethod->invoke($object, $methodName);
                 }
 
-                if ($data instanceof Iterator) {
+                if ($data instanceof Traversable) {
                     $data = \iterator_to_array($data);
                 }
 

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -613,6 +613,23 @@ class TestTest extends TestCase
         $this->assertEquals(3, $cCount);
     }
 
+    public function testWithVariousIterableDataProviders()
+    {
+        $dataSets = Test::getProvidedData(\VariousIterableDataProviderTest::class, 'test');
+
+        $this->assertEquals([
+            ['A'],
+            ['B'],
+            ['C'],
+            ['D'],
+            ['E'],
+            ['F'],
+            ['G'],
+            ['H'],
+            ['I'],
+        ], $dataSets);
+    }
+
     public function testTestWithEmptyAnnotation()
     {
         $result = Test::getDataFromTestWithAnnotation("/**\n * @anotherAnnotation\n */");

--- a/tests/_files/MultipleDataProviderTest.php
+++ b/tests/_files/MultipleDataProviderTest.php
@@ -57,11 +57,9 @@ class MultipleDataProviderTest extends TestCase
 
     public static function providerE()
     {
-        return new WrapperIteratorAggregate([
-            [null, 'ok', null],
-            [null, 'ok', null],
-            [null, 'ok', null],
-        ]);
+        yield [null, 'ok', null];
+        yield [null, 'ok', null];
+        yield [null, 'ok', null];
     }
 
     public static function providerF()

--- a/tests/_files/MultipleDataProviderTest.php
+++ b/tests/_files/MultipleDataProviderTest.php
@@ -57,9 +57,11 @@ class MultipleDataProviderTest extends TestCase
 
     public static function providerE()
     {
-        yield [null, 'ok', null];
-        yield [null, 'ok', null];
-        yield [null, 'ok', null];
+        return new WrapperIteratorAggregate([
+            [null, 'ok', null],
+            [null, 'ok', null],
+            [null, 'ok', null],
+        ]);
     }
 
     public static function providerF()

--- a/tests/_files/VariousIterableDataProviderTest.php
+++ b/tests/_files/VariousIterableDataProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+class VariousIterableDataProviderTest
+{
+    /**
+     * @dataProvider asArrayProvider
+     * @dataProvider asIteratorProvider
+     * @dataProvider asTraversableProvider
+     */
+    public function test()
+    {
+    }
+
+    public static function asArrayProvider()
+    {
+        return [
+            ['A'],
+            ['B'],
+            ['C'],
+        ];
+    }
+
+    public static function asIteratorProvider()
+    {
+        yield ['D'];
+        yield ['E'];
+        yield ['F'];
+    }
+
+    public static function asTraversableProvider()
+    {
+        return new WrapperIteratorAggregate([
+            ['G'],
+            ['H'],
+            ['I'],
+        ]);
+    }
+}

--- a/tests/_files/WrapperIteratorAggregate.php
+++ b/tests/_files/WrapperIteratorAggregate.php
@@ -1,0 +1,22 @@
+<?php
+
+class WrapperIteratorAggregate implements IteratorAggregate
+{
+    /**
+     * @var array|\Traversable
+     */
+    private $baseCollection;
+
+    public function __construct($baseCollection)
+    {
+        assert(is_array($baseCollection) || $baseCollection instanceof Traversable);
+        $this->baseCollection = $baseCollection;
+    }
+
+    public function getIterator()
+    {
+        foreach ($this->baseCollection as $k => $v) {
+            yield $k => $v;
+        }
+    }
+}


### PR DESCRIPTION
I'm not sure whether it's a bug or not, so I'm targeting `6.1` the current stable branch.