### PR TITLE
TestCase - add getExpectedExceptionMessageRegExp method

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -549,6 +549,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     }
 
     /**
+     * @return string
+     */
+    public function getExpectedExceptionMessageRegExp()
+    {
+        return $this->expectedExceptionMessageRegExp;
+    }
+
+    /**
      * @param string $exception
      */
     public function expectException($exception)


### PR DESCRIPTION
We have setters for exception, it's code, msg and msg regex
We have getter for first one.
https://github.com/sebastianbergmann/phpunit/pull/2230/ introduced getters for middle two.
But the last one is not there. if there are getters for 3 of 4, there shall be all of them for usage consistency.