### PR TITLE
add --no-bootstrap option

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -90,6 +90,7 @@ class Command
         'loader='                   => null,
         'log-junit='                => null,
         'log-teamcity='             => null,
+        'no-bootstrap'              => null,
         'no-configuration'          => null,
         'no-coverage'               => null,
         'no-extensions'             => null,
@@ -301,6 +302,10 @@ class Command
 
                 case '--bootstrap':
                     $this->arguments['bootstrap'] = $option[1];
+                    break;
+
+                case '--no-bootstrap':
+                    $this->arguments['bootstrap'] = "";
                     break;
 
                 case '--columns':
@@ -725,7 +730,9 @@ class Command
              * Issue #1216
              */
             if (isset($this->arguments['bootstrap'])) {
-                $this->handleBootstrap($this->arguments['bootstrap']);
+                if (!empty($this->arguments['bootstrap'])) {
+                    $this->handleBootstrap($this->arguments['bootstrap']);
+                }
             } elseif (isset($phpunitConfiguration['bootstrap'])) {
                 $this->handleBootstrap($phpunitConfiguration['bootstrap']);
             }
@@ -1014,6 +1021,7 @@ Test Execution Options:
 Configuration Options:
 
   --bootstrap <file>          A "bootstrap" PHP file that is run before the tests.
+  --no-bootstrap              Ignore default bootstrap from configuration file.
   -c|--configuration <file>   Read configuration from XML file.
   --no-configuration          Ignore default configuration file (phpunit.xml).
   --no-coverage               Ignore code coverage configuration.

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -84,6 +84,7 @@ Test Execution Options:
 Configuration Options:
 
   --bootstrap <file>          A "bootstrap" PHP file that is run before the tests.
+  --no-bootstrap              Ignore default bootstrap from configuration file.
   -c|--configuration <file>   Read configuration from XML file.
   --no-configuration          Ignore default configuration file (phpunit.xml).
   --no-coverage               Ignore code coverage configuration.

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -85,6 +85,7 @@ Test Execution Options:
 Configuration Options:
 
   --bootstrap <file>          A "bootstrap" PHP file that is run before the tests.
+  --no-bootstrap              Ignore default bootstrap from configuration file.
   -c|--configuration <file>   Read configuration from XML file.
   --no-configuration          Ignore default configuration file (phpunit.xml).
   --no-coverage               Ignore code coverage configuration.


### PR DESCRIPTION
Allow to ignore bootstrap option from configuration file:

```
--no-bootstrap
--bootstrap ""
```

Context, sometime, we may need to ensure some autoloader is load first, thus using:

`php  -d auto_prepend_file=bootstrap.php /usr/bin/phpunit --no-bootstrap`


Not sure if suitable for 6.1 or master.