### PR TITLE
Make agument types consistent with implementation and underlying function argument types

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1965,9 +1965,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are equal.
      *
-     * @param string $expectedFile
-     * @param string $actualXml
-     * @param string $message
+     * @param string             $expectedFile
+     * @param string|DOMDocument $actualXml
+     * @param string             $message
      */
     public static function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
     {
@@ -1980,9 +1980,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are not equal.
      *
-     * @param string $expectedFile
-     * @param string $actualXml
-     * @param string $message
+     * @param string             $expectedFile
+     * @param string|DOMDocument $actualXml
+     * @param string             $message
      */
     public static function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '')
     {
@@ -1995,9 +1995,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are equal.
      *
-     * @param string $expectedXml
-     * @param string $actualXml
-     * @param string $message
+     * @param string|DOMDocument $expectedXml
+     * @param string|DOMDocument $actualXml
+     * @param string             $message
      */
     public static function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
     {
@@ -2010,9 +2010,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are not equal.
      *
-     * @param string $expectedXml
-     * @param string $actualXml
-     * @param string $message
+     * @param string|DOMDocument $expectedXml
+     * @param string|DOMDocument $actualXml
+     * @param string             $message
      */
     public static function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = '')
     {

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1213,9 +1213,9 @@ function assertXmlFileNotEqualsXmlFile($expectedFile, $actualFile, $message = ''
 /**
  * Asserts that two XML documents are equal.
  *
- * @param string $expectedFile
- * @param string $actualXml
- * @param string $message
+ * @param string             $expectedFile
+ * @param string|DOMDocument $actualXml
+ * @param string             $message
  */
 function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
 {
@@ -1225,9 +1225,9 @@ function assertXmlStringEqualsXmlFile($expectedFile, $actualXml, $message = '')
 /**
  * Asserts that two XML documents are equal.
  *
- * @param string $expectedXml
- * @param string $actualXml
- * @param string $message
+ * @param string|DOMDocument $expectedXml
+ * @param string|DOMDocument $actualXml
+ * @param string             $message
  */
 function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
 {
@@ -1237,9 +1237,9 @@ function assertXmlStringEqualsXmlString($expectedXml, $actualXml, $message = '')
 /**
  * Asserts that two XML documents are not equal.
  *
- * @param string $expectedFile
- * @param string $actualXml
- * @param string $message
+ * @param string             $expectedFile
+ * @param string|DOMDocument $actualXml
+ * @param string             $message
  */
 function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '')
 {
@@ -1249,9 +1249,9 @@ function assertXmlStringNotEqualsXmlFile($expectedFile, $actualXml, $message = '
 /**
  * Asserts that two XML documents are not equal.
  *
- * @param string $expectedXml
- * @param string $actualXml
- * @param string $message
+ * @param string|DOMDocument $expectedXml
+ * @param string|DOMDocument $actualXml
+ * @param string             $message
  */
 function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message = '')
 {


### PR DESCRIPTION
The types of `$(expected|actual)Xml` aguments in `assertXml*()` methods and corresponding function aliases are declared as `string` however the underlying method `Xml::load()` allows them to be `string|DOMDocument`.

Static code analysis of the tests using these assertions with [phpstan](https://github.com/phpstan/phpstan) produces false positives like:
```
Parameter #2 $actualXml of method PHPUnit\Framework\Assert::assertXmlStringEqualsXmlFile() expects string, DOMDocument given.
```