### PR TITLE
Stop requiring Printer subclassing for test listeners

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -876,9 +876,7 @@ class Command
         if (\class_exists($printerClass)) {
             $class = new ReflectionClass($printerClass);
 
-            if ($class->implementsInterface(TestListener::class) &&
-                $class->isSubclassOf(Printer::class) &&
-                $class->isInstantiable()) {
+            if ($class->implementsInterface(TestListener::class) && $class->isInstantiable()) {
                 if ($class->isSubclassOf(ResultPrinter::class)) {
                     return $printerClass;
                 }


### PR DESCRIPTION
This PR is porting #2685 to 6.1. Original text:

> This PR stops checking if test listeners are subclasses of `PHPUnit\Util\Printer`. It should not be needed, since the check about the `TestListener` interface should be enough.
> 
> The rationale behind this is also that the interface has a FC implementation in 5.x, and the `Printer` doesn't.
> 
> This PR targets 5.x; if a different PR is needed to port this to 6, I will gladly write that too.