### PR TITLE
Unpack nested IteratorAggregate objects for Count

### DIFF
--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -56,11 +56,11 @@ class Count extends Constraint
         }
 
         if ($other instanceof Traversable) {
-            if ($other instanceof IteratorAggregate) {
-                $iterator = $other->getIterator();
-            } else {
-                $iterator = $other;
+            while ($other instanceof IteratorAggregate) {
+                $other = $other->getIterator();
             }
+
+            $iterator = $other;
 
             if ($iterator instanceof Generator) {
                 return $this->getCountOfGenerator($iterator);

--- a/tests/Framework/Constraint/CountTest.php
+++ b/tests/Framework/Constraint/CountTest.php
@@ -24,8 +24,10 @@ class CountTest extends TestCase
 
         $countConstraint = new Count(2);
         $it              = new \TestIterator([1, 2]);
+        $ia              = new \TestIteratorAggregate($it);
 
         $this->assertTrue($countConstraint->evaluate($it, '', true));
+        $this->assertTrue($countConstraint->evaluate($ia, '', true));
     }
 
     public function testCountDoesNotChangeIteratorKey()
@@ -59,6 +61,22 @@ class CountTest extends TestCase
 
         $it->next();
         $countConstraint->evaluate($it, '', true);
+        $this->assertFalse($it->valid());
+
+        // test with IteratorAggregate
+        $it = new \TestIterator([1, 2]);
+        $ia = new \TestIteratorAggregate($it);
+
+        $countConstraint = new Count(2);
+        $countConstraint->evaluate($ia, '', true);
+        $this->assertEquals(1, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($ia, '', true);
+        $this->assertEquals(2, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($ia, '', true);
         $this->assertFalse($it->valid());
     }
 

--- a/tests/Framework/Constraint/CountTest.php
+++ b/tests/Framework/Constraint/CountTest.php
@@ -25,9 +25,11 @@ class CountTest extends TestCase
         $countConstraint = new Count(2);
         $it              = new \TestIterator([1, 2]);
         $ia              = new \TestIteratorAggregate($it);
+        $ia2             = new \TestIteratorAggregate2($ia);
 
         $this->assertTrue($countConstraint->evaluate($it, '', true));
         $this->assertTrue($countConstraint->evaluate($ia, '', true));
+        $this->assertTrue($countConstraint->evaluate($ia2, '', true));
     }
 
     public function testCountDoesNotChangeIteratorKey()
@@ -77,6 +79,23 @@ class CountTest extends TestCase
 
         $it->next();
         $countConstraint->evaluate($ia, '', true);
+        $this->assertFalse($it->valid());
+
+        // test with nested IteratorAggregate
+        $it = new \TestIterator([1, 2]);
+        $ia = new \TestIteratorAggregate($it);
+        $ia2 = new \TestIteratorAggregate2($ia);
+
+        $countConstraint = new Count(2);
+        $countConstraint->evaluate($ia2, '', true);
+        $this->assertEquals(1, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($ia2, '', true);
+        $this->assertEquals(2, $it->current());
+
+        $it->next();
+        $countConstraint->evaluate($ia2, '', true);
         $this->assertFalse($it->valid());
     }
 

--- a/tests/_files/TestIteratorAggregate.php
+++ b/tests/_files/TestIteratorAggregate.php
@@ -1,0 +1,16 @@
+<?php
+
+class TestIteratorAggregate implements IteratorAggregate
+{
+    private $traversable;
+
+    public function __construct(\Traversable $traversable)
+    {
+        $this->traversable = $traversable;
+    }
+
+    public function getIterator()
+    {
+        return $this->traversable;
+    }
+}

--- a/tests/_files/TestIteratorAggregate2.php
+++ b/tests/_files/TestIteratorAggregate2.php
@@ -1,0 +1,19 @@
+<?php
+
+/* This class is used for testing a chain of IteratorAggregate objects, since
+ * PHP does allow IteratorAggregate::getIterator() to return an instance of the
+ * same class. */
+class TestIteratorAggregate2 implements IteratorAggregate
+{
+    private $traversable;
+
+    public function __construct(\Traversable $traversable)
+    {
+        $this->traversable = $traversable;
+    }
+
+    public function getIterator()
+    {
+        return $this->traversable;
+    }
+}


### PR DESCRIPTION
From my previous comment in https://github.com/sebastianbergmann/phpunit/pull/2642#discussion_r117659301:

> Within the Traversable case, the function checks for an IteratorAggregate and attempts to unwrap it *once* by calling [`IteratorAggregate::getIterator()`](http://php.net/manual/en/iteratoraggregate.getiterator.php). The function then checks for a Generator instance and handles that separately. After that point, the existing implementation makes two assumptions, which I believe are premature:
>
> 1. It assumes that the object is an Iterator instance when it invokes the `key()` method. This fails to acknowledge that `IteratorAggregate::getIterator()` can return any Traversable instance.

This PR adds logic to unwrap nested IteratorAggregate objects until we encounter a Traversable that is not an IteratorAggregate instance. This ensures that generator detection (#2149) and internal Traversables (#2642) are properly detected before we attempt to restore the Iterator's position after counting (#1125).

In a separate commit, the PR also adds missing regression tests for Count's handling of non-nested IteratorAggregate objects.