### PR TITLE
50% of time spent in array_unique() in coverage validator

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -1118,12 +1118,14 @@ class Test
                 $result[$filename] = [];
             }
 
-            $result[$filename] = \array_unique(
-                \array_merge(
-                    $result[$filename],
-                    \range($reflector->getStartLine(), $reflector->getEndLine())
-                )
+            $result[$filename] = \array_merge(
+                $result[$filename],
+                \range($reflector->getStartLine(), $reflector->getEndLine())
             );
+        }
+
+        foreach ($result as $filename => $lineNumbers) {
+            $result[$filename] = \array_keys(\array_flip($lineNumbers));
         }
 
         return $result;


### PR DESCRIPTION
We are using [ockcyp/covers-validator](https://github.com/oradwell/covers-validator) to validate our `@covers` annotations before running the test suite. 

Recently we've noticed 50% of the run time of this package is spent in `array_unique()` in `PHPUnit_Util_Test::resolveReflectionObjectsToLines`. 

This method contains calls to `array_unique` which has an n^2 time complexity. Almost 50% of time spend is in this method.

![screen shot 2017-06-01 at 14 35 12](https://cloud.githubusercontent.com/assets/701299/26680024/ed1723e4-46d7-11e7-8dc0-8d6ec054b0c4.png)

I've changed this method to be faster:

* Only remove duplicate line numbers once per file instead for every reflector; 
* Do a linear time complexity clean up by using `\array_flip()` and then using `\array_keys()`.