### PR TITLE
50% of time spent in array_unique() in coverage validator 

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -1044,12 +1044,14 @@ class PHPUnit_Util_Test
                 $result[$filename] = [];
             }
 
-            $result[$filename] = array_unique(
-                array_merge(
-                    $result[$filename],
-                    range($reflector->getStartLine(), $reflector->getEndLine())
-                )
+            $result[$filename] = array_merge(
+                $result[$filename],
+                range($reflector->getStartLine(), $reflector->getEndLine())
             );
+        }
+
+        foreach ($result as $filename => $lineNumbers) {
+            $result[$filename] = array_keys(array_flip($lineNumbers));
         }
 
         return $result;


### PR DESCRIPTION
Same as #2699 but for the 5.7 branch. 