### PR TITLE
constraint\Composite: Pass ComparisonFailure from ExpectationFailedEx…

### DIFF
--- a/src/Framework/Constraint/Composite.php
+++ b/src/Framework/Constraint/Composite.php
@@ -54,7 +54,7 @@ abstract class Composite extends Constraint
                 $returnResult
             );
         } catch (ExpectationFailedException $e) {
-            $this->fail($other, $description);
+            $this->fail($other, $description, $e->getComparisonFailure());
         }
     }
 


### PR DESCRIPTION
When using the Composite constraint, the ComparisonFailure of the ExpectationFailedException caught while evaluating the child constraint was not passed to this->fail(), hiding potentially useful information.