### PR TITLE
Fix undeclared class: `RiskyTestError` is namespaced in phpunit 6.0

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -17,7 +17,6 @@ use PHP_Invoker;
 use PHP_Invoker_TimeoutException;
 use PHP_Timer;
 use PHPUnit_Framework_MockObject_Exception;
-use PHPUnit_Framework_RiskyTestError;
 use PHPUnit\Util\Blacklist;
 use PHPUnit\Util\InvalidArgumentHelper;
 use PHPUnit\Util\Printer;
@@ -698,7 +697,7 @@ class TestResult implements Countable
         } catch (PHP_Invoker_TimeoutException $e) {
             $this->addFailure(
                 $test,
-                new PHPUnit_Framework_RiskyTestError(
+                new RiskyTestError(
                     $e->getMessage()
                 ),
                 $_timeout


### PR DESCRIPTION
7d5e09690c1585c20e6fb3a35194234227c97aac fixed a bug in phpunit 5.7.
That fix was then merged into phpunit 6.0, but the class name wasn't
updated for 6.0.

(Noticed by phan static analyzer - I don't think there's code covering that case)

The namespaced version is found in src/Framework/RiskyTestError.php of this project