### PR TITLE
Bugfix #2705: if 'stderr=false' is set in phpunit.xml, it is ignored and considered true

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -279,7 +279,7 @@ class TestRunner extends BaseTestRunner
                 }
 
                 $this->printer = new $printerClass(
-                    isset($arguments['stderr']) ? 'php://stderr' : null,
+                    (isset($arguments['stderr']) && $arguments['stderr'] === true) ? 'php://stderr' : null,
                     $arguments['verbose'],
                     $arguments['colors'],
                     $arguments['debug'],


### PR DESCRIPTION
see bug #2705 

This bug was tested on phpunit 6.2.1, I do not know if it needs to be applied to other branches.