### PR TITLE
re-enable assertEqualXMLStructure test on HHVM

### DIFF
--- a/tests/Regression/GitHub/1472.phpt
+++ b/tests/Regression/GitHub/1472.phpt
@@ -1,12 +1,5 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/1472
---SKIPIF--
-<?php
-// See: https://github.com/facebook/hhvm/issues/4669
-if (defined('HHVM_VERSION')) {
-    print 'skip: HHVM does not support cloning DOM nodes';
-}
-?>
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';


### PR DESCRIPTION
cloning DOM nodes was broken in HHVM at some point, but was fixed by
september last year.

refs facebook/hhvm#4669