### PR TITLE
Add forward compatible Test interface

### DIFF
--- a/src/ForwardCompatibility/Test.php
+++ b/src/ForwardCompatibility/Test.php
@@ -1,0 +1,13 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Framework;
+
+class_alias('\PHPUnit_Framework_Test', '\PHPUnit\Framework\Test');


### PR DESCRIPTION
5.7 is still alive and it misses much of forward compatibility.