### PR TITLE
Add package attribute for junit

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -229,6 +229,7 @@ class JUnit extends Printer implements TestListener
     {
         $testSuite = $this->document->createElement('testsuite');
         $testSuite->setAttribute('name', $suite->getName());
+        $testSuite->setAttribute('package', $suite->getName());
 
         if (\class_exists($suite->getName(), false)) {
             try {

--- a/tests/TextUI/dataprovider-log-xml-isolation.phpt
+++ b/tests/TextUI/dataprovider-log-xml-isolation.phpt
@@ -16,8 +16,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ..F.                                                                4 / 4 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
-    <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
+  <testsuite name="DataProviderTest" package="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
+    <testsuite name="DataProviderTest::testAdd" package="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
       <testcase name="testAdd with data set #0" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #1" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #2" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f">

--- a/tests/TextUI/dataprovider-log-xml.phpt
+++ b/tests/TextUI/dataprovider-log-xml.phpt
@@ -15,8 +15,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ..F.                                                                4 / 4 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
-    <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
+  <testsuite name="DataProviderTest" package="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
+    <testsuite name="DataProviderTest::testAdd" package="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
       <testcase name="testAdd with data set #0" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #1" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #2" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f">

--- a/tests/TextUI/log-junit.phpt
+++ b/tests/TextUI/log-junit.phpt
@@ -16,7 +16,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 .FEISRW                                                             7 / 7 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="vendor\project\StatusTest" file="%s%eStatusTest.php" tests="7" assertions="2" errors="2" failures="2" skipped="2" time="%s">
+  <testsuite name="vendor\project\StatusTest" package="vendor\project\StatusTest" file="%s%eStatusTest.php" tests="7" assertions="2" errors="2" failures="2" skipped="2" time="%s">
     <testcase name="testSuccess" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="1" time="%s"/>
     <testcase name="testFailure" class="vendor\project\StatusTest" classname="vendor.project.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="1" time="%s">
       <failure type="PHPUnit\Framework\ExpectationFailedException">vendor\project\StatusTest::testFailure


### PR DESCRIPTION
When using xUnit plugin within Jenkins context to parse PHPUnit junit.xml report, the test result lists PHPUnit tests under package "(root)". This patch will enable testsuite name to be displayed here instead.