### PR TITLE
Issue 2271/allow custom cli options

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -378,7 +378,6 @@ class Command
                     break;
 
                 case 'g':
-                    echo "DEBUG: \$option[1] = '$option[1]'\n";
                     $this->arguments['globals'][] = $option[1];
                     break;
 
@@ -731,7 +730,7 @@ class Command
 
             $configuration->handlePHPConfiguration();
 
-            // command line globals (-g option) override PHP config (in phpunit.xml) (Issue #2271)
+            // command line globals (-g option) override PHP config <var>s (in phpunit.xml) (Issue #2271)
             if (isset($this->arguments['globals'])) {
                 $this->handleGlobals($this->arguments['globals']);
             }
@@ -1069,43 +1068,39 @@ EOT;
 
 
     /**
-     * Handles the command line global assignments.
+     * Handles the command line global assignments (-g options).
+     *
+     * This method iterates through each user (-g) option, performs a simple syntax check (must contain "="),
+     * then assigns the global variable named on the left-hand side to the value on the right-hand side.
+     * Certain values are determined to have special data types (numeric, boolean, null, or array), otherwise text.
      *
      * @param array $globalAssignments
      */
     protected function handleGlobals($globalAssignments)
     {
         foreach ($globalAssignments as $assignment) {
-            echo "DEBUG: \$assignment = '$assignment'\n";
             if (strpos($assignment, '=') === false) {
                 continue;
             }
             list($name, $value) = explode('=', $assignment, 2);
-            echo "DEBUG: \$name = '$name'\n";
-            echo "DEBUG: \$value = '$value'\n";
 
             switch (true) {
                 case strcmp($value, "true") === 0:
-                    echo "DEBUG: assigning as boolean true\n";
                     $GLOBALS[$name] = true;
                     break;
                 case strcmp($value, "false") === 0:
-                    echo "DEBUG: assigning as boolean false\n";
                     $GLOBALS[$name] = false;
                     break;
                 case strcmp($value, "null") === 0:
-                    echo "DEBUG: assigning as null\n";
                     $GLOBALS[$name] = null;
                     break;
                 case preg_match('/^\[.*\]$/', $value) :
                     // if $value begins and ends with brackets then eval()
                     $tmpValue = "";
-                    echo "DEBUG: assigning as an array using eval\n";
                     eval("\$tmpValue = " . $value . ";");
                     $GLOBALS[$name] = $tmpValue;
                     break;
                 case is_numeric($value):
-                    echo "DEBUG: assigning as a float\n";
                     $GLOBALS[$name] = (float)$value;
                     break;
                 default:

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1096,7 +1096,7 @@ EOT;
                 case strcmp($value, "null") === 0:
                     $GLOBALS[$name] = null;
                     break;
-                case preg_match('/^\[.*\]$/', $value) :
+                case preg_match('/^\[.*\]$/', $value):
                     // if $value begins and ends with brackets then eval()
                     $tmpValue = "";
                     eval("\$tmpValue = " . $value . ";");

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1069,34 +1069,36 @@ EOT;
 
 
     /**
-     * Handles the command line global definitions.
+     * Handles the command line global assignments.
      *
-     * @param array $globalDefinitionsArray
+     * @param array $globalAssignments
      */
-    protected function handleGlobals($globalDefinitionsArray)
+    protected function handleGlobals($globalAssignments)
     {
-        foreach ($globalDefinitionsArray as $definition) {
-            echo "DEBUG: \$definition = '$definition'\n";
-            if (strpos($definition, '=') === false) {
+        foreach ($globalAssignments as $assignment) {
+            echo "DEBUG: \$assignment = '$assignment'\n";
+            if (strpos($assignment, '=') === false) {
                 continue;
             }
-            list($name, $value) = explode('=', $definition, 2);
+            list($name, $value) = explode('=', $assignment, 2);
             echo "DEBUG: \$name = '$name'\n";
             echo "DEBUG: \$value = '$value'\n";
-            if (is_null($value)) {
-                continue;
-            }
 
             switch (true) {
-                case strcmp($value,"true") === 0:
+                case strcmp($value, "true") === 0:
                     echo "DEBUG: assigning as boolean true\n";
                     $GLOBALS[$name] = true;
                     break;
-                case strcmp($value,"false") === 0:
+                case strcmp($value, "false") === 0:
                     echo "DEBUG: assigning as boolean false\n";
                     $GLOBALS[$name] = false;
                     break;
+                case strcmp($value, "null") === 0:
+                    echo "DEBUG: assigning as null\n";
+                    $GLOBALS[$name] = null;
+                    break;
                 case preg_match('/^\[.*\]$/', $value) :
+                    // if $value begins and ends with brackets then eval()
                     $tmpValue = "";
                     echo "DEBUG: assigning as an array using eval\n";
                     eval("\$tmpValue = " . $value . ";");
@@ -1107,10 +1109,10 @@ EOT;
                     $GLOBALS[$name] = (float)$value;
                     break;
                 default:
+                    // all other globals are assigned as strings
                     $GLOBALS[$name] = $value;
                     break;
             }
-
         }
     }
 

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -92,6 +92,7 @@ Configuration Options:
   --include-path <path(s)>    Prepend PHP's include_path with given path(s).
   -d key[=value]              Sets a php.ini value.
   --generate-configuration    Generate configuration file with suggested settings.
+  -g <assignment>             Define a global variable.
 
 Miscellaneous Options:
 

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -93,6 +93,7 @@ Configuration Options:
   --include-path <path(s)>    Prepend PHP's include_path with given path(s).
   -d key[=value]              Sets a php.ini value.
   --generate-configuration    Generate configuration file with suggested settings.
+  -g <assignment>             Define a global variable.
 
 Miscellaneous Options:
 

--- a/tests/Util/HandleGlobalsTest.php
+++ b/tests/Util/HandleGlobalsTest.php
@@ -78,10 +78,14 @@ class HandleGlobalsTest extends TestCase
     }
 
     /**
-     * Workaround to call protected methods
-     * https://stackoverflow.com/questions/249664/best-practices-to-test-protected-methods-with-phpunit
+     * Workaround to call protected methods.
+     *
+     * See https://stackoverflow.com/questions/249664/best-practices-to-test-protected-methods-with-phpunit for details.
+     *
+     * @param string $name name of method in (hardcoded) Command class
      */
-    protected static function getMethod($name) {
+    protected static function getMethod($name)
+    {
         $class = new \ReflectionClass('PHPUnit\TextUI\Command');    // hardcoded class
         $method = $class->getMethod($name);
         $method->setAccessible(true);

--- a/tests/Util/HandleGlobalsTest.php
+++ b/tests/Util/HandleGlobalsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\TextUI\Command;
+
+class HandleGlobalsTest extends TestCase
+{
+    /**
+     * @var Handler
+     */
+    private static $command;
+    private $arguments;
+    private static $handleGlobalsMadePublic;
+
+    public static function setUpBeforeClass()
+    {
+        self::$command = new Command;
+        self::$handleGlobalsMadePublic = self::getMethod('handleGlobals');
+    }
+
+    protected function setUp()
+    {
+        // create array of global assignments as they would be set on the command line (using -g)
+        $this->arguments['globals'] = [
+            "myGlobalBool=true",
+            "myGlobalInt=99",
+            "myGlobalFloat=3.3",
+            "myGlobalString=mysql:host=y;dbname=z",
+            "myGlobalHash=['bar'=>'baz']",
+            "myGlobalNull=null",
+            "myGlobalEmpty="
+        ];
+    }
+
+    public static function tearDownAfterClass()
+    {
+        unset(
+            $GLOBALS['myGlobalBool'],
+            $GLOBALS['myGlobalInt'],
+            $GLOBALS['myGlobalFloat'],
+            $GLOBALS['myGlobalString'],
+            $GLOBALS['myGlobalHash'],
+            $GLOBALS['myGlobalNull'],
+            $GLOBALS['myGlobalEmpty']
+        );
+    }
+
+    public function testGlobalBoolOption()
+    {
+        // call protected Commnd::handleGlobals() method
+        //self::$command->handleGlobals($this->arguments['globals']);   // cannot simply call a protected method
+        self::$handleGlobalsMadePublic->invokeArgs(self::$command, [$this->arguments['globals']]);  // workaround to call protected method
+
+        $this->assertTrue($GLOBALS['myGlobalBool'], "Expected a global \$GLOBAL[myGlobalBool] to be defined");
+
+        $this->assertEquals($GLOBALS['myGlobalInt'], 99, "Expected a global \$GLOBAL[myGlobalInt] to be defined");
+
+        $this->assertEquals(round($GLOBALS['myGlobalFloat'], 1), round((float)3.3, 1), "Expected a global \$GLOBAL[myGlobalFloat] to be defined");
+
+        $this->assertEquals($GLOBALS['myGlobalString'], "mysql:host=y;dbname=z", "Expected a global \$GLOBAL[myGlobalString] to be defined");
+
+        $this->assertEquals($GLOBALS['myGlobalHash']["bar"], "baz", "Expected a global \$GLOBAL[myGlobalHash] to be defined");
+
+        $this->assertNull($GLOBALS['myGlobalNull'], "Expected a global \$GLOBAL[myGlobalNull] to be defined");
+
+        $this->assertEmpty($GLOBALS['myGlobalEmpty'], "Expected a global \$GLOBAL[myGlobalEmpty] to be defined");
+    }
+
+    /**
+     * Workaround to call protected methods
+     * https://stackoverflow.com/questions/249664/best-practices-to-test-protected-methods-with-phpunit
+     */
+    protected static function getMethod($name) {
+        $class = new \ReflectionClass('PHPUnit\TextUI\Command');    // hardcoded class
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method;
+    }
+}


### PR DESCRIPTION
Adds new command line option (-g) that enables the user to assign global variables (... well, from the command line).  The highlights are:
- implemented with eval() in the Command class
- includes a revision to the command line help output (and revised .phpt tests of the output)
- includes a unit test of the new Command::handleGlobals() method (using reflection to test protected method)
- the command line option globals are similar to, but **override**, the globals specified in the phpunit.xml configuration file (using < php >< var >)

Example usage:
```$ phpunit -v -g myInt=5 -g myBool=true -g myValue=null -g myStr="good stuff" -g myArr='["foo"=>"bar"]' MyTest```
