### PR TITLE
WIP / POC - start of fixing tests with diff 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   matrix:
     - DEPENDENCIES="high"
     - DEPENDENCIES="low"
+  global:
+    - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest --prefer-stable"
 
 sudo: false
 
@@ -19,8 +21,9 @@ before_install:
   - composer clear-cache
 
 install:
-  - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable; fi
-  - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable --prefer-lowest; fi
+  - if [[ "$DEPENDENCIES" = 'high' ]]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS; fi
+  - if [[ "$DEPENDENCIES" = 'low' ]]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS --prefer-lowest; fi
+  - composer info -D | sort
 
 before_script:
   - echo 'zend.assertions=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "platform": {
             "php": "7.0.0"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "optimize-autoloader": true
     },
     "suggest": {
         "phpunit/php-invoker": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "phpunit/php-timer": "^1.0.6",
         "phpunit/phpunit-mock-objects": "^4.0",
         "sebastian/comparator": "^2.0",
-        "sebastian/diff": "^1.4.3 || ^2.0",
         "sebastian/environment": "^3.0.2",
         "sebastian/exporter": "^3.1",
         "sebastian/global-state": "^1.1 || ^2.0",
@@ -45,7 +44,8 @@
         "sebastian/version": "^2.0"
     },
     "require-dev": {
-        "ext-PDO": "*"
+        "ext-PDO": "*",
+        "sebastian/diff": "^2.0"
     },
     "conflict": {
         "phpunit/dbunit": "<3.0",
@@ -78,6 +78,7 @@
             "tests/_files/CoveredFunction.php"
         ]
     },
+    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "6.2.x-dev"

--- a/tests/Framework/ConstraintTest.php
+++ b/tests/Framework/ConstraintTest.php
@@ -644,10 +644,8 @@ Failed asserting that two strings are equal.
 -b\\n
 +p\\n
 @@ @@
- i\\n
 -j\\n
 +w\\n
- k'
 
 EOF
             ],
@@ -669,7 +667,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => 0
 +    0 => 1
- )
 
 EOF
             ],
@@ -681,7 +678,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => true
 +    0 => 'true'
- )
 
 EOF
             ],
@@ -695,10 +691,6 @@ Failed asserting that two arrays are equal.
      1 => Array (
 -        0 => 1
 +        0 => 4
-     )
-     2 => Array (...)
-     3 => 3
- )
 
 EOF
             ],
@@ -719,7 +711,6 @@ Failed asserting that two objects are equal.
 @@ @@
  stdClass Object (
 -    'foo' => 'bar'
- )
 
 EOF
             ],
@@ -738,18 +729,11 @@ Failed asserting that two objects are equal.
 -            0 => 1
 +            0 => 4
 @@ @@
-         'foo' => 'a\\n
 -        b\\n
 +        p\\n
 @@ @@
-         i\\n
 -        j\\n
 +        w\\n
-         k'
-     )
-     'self' => stdClass Object (...)
-     'c' => stdClass Object (...)
- )
 
 EOF
             ],
@@ -820,10 +804,6 @@ Failed asserting that two objects are equal.
 -    '$bhash' => Array &1 (
 +SplObjectStorage Object &$storage2hash (
 +    '$bhash' => Array &0 (
-         'obj' => stdClass Object &$bhash ()
-         'inf' => null
-     )
- )
 
 EOF
             ];

--- a/tests/Regression/GitHub/503.phpt
+++ b/tests/Regression/GitHub/503.phpt
@@ -25,8 +25,8 @@ Failed asserting that two strings are identical.
 +++ Actual
 @@ @@
  #Warning: Strings contain different line endings!
- 'foo
- '
+-'foo
++'foo
 
 %s:%i
 

--- a/tests/Regression/GitHub/581.phpt
+++ b/tests/Regression/GitHub/581.phpt
@@ -31,10 +31,6 @@ Failed asserting that two objects are equal.
      3 => 4
 -    4 => 5
 +    4 => 1
-     5 => 6
-     6 => 7
-     7 => 8
- )
 
 %s:%i
 

--- a/tests/TextUI/exception-stack.phpt
+++ b/tests/TextUI/exception-stack.phpt
@@ -27,7 +27,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => 1
 +    0 => 2
- )
 
 
 %s:%i
@@ -41,7 +40,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => 1
 +    0 => 2
- )
 
 %s:%i
 

--- a/tests/TextUI/failure-isolation.phpt
+++ b/tests/TextUI/failure-isolation.phpt
@@ -27,7 +27,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => 1
 +    0 => 2
- )
 
 %s:%i
 
@@ -46,7 +45,6 @@ Failed asserting that two objects are equal.
  stdClass Object (
 -    'foo' => 'bar'
 +    'bar' => 'foo'
- )
 
 %s:%i
 
@@ -76,7 +74,6 @@ Failed asserting that two strings are equal.
  'foo\n
 -bar\n
 +baz\n
- '
 
 %s:%i
 
@@ -132,7 +129,6 @@ Failed asserting that string matches format description.
 +++ Actual
 @@ @@
 -FOO
--
 +...BAR...
 
 %s:%i

--- a/tests/TextUI/failure-reverse-list.phpt
+++ b/tests/TextUI/failure-reverse-list.phpt
@@ -24,7 +24,6 @@ Failed asserting that string matches format description.
 +++ Actual
 @@ @@
 -FOO
--
 +...BAR...
 
 %s:%d
@@ -84,7 +83,6 @@ Failed asserting that two strings are equal.
  'foo\n
 -bar\n
 +baz\n
- '
 
 %s:%d
 
@@ -114,7 +112,6 @@ Failed asserting that two objects are equal.
  stdClass Object (
 -    'foo' => 'bar'
 +    'bar' => 'foo'
- )
 
 %s:%d
 
@@ -133,7 +130,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => 1
 +    0 => 2
- )
 
 %s:%d
 

--- a/tests/TextUI/failure.phpt
+++ b/tests/TextUI/failure.phpt
@@ -26,7 +26,6 @@ Failed asserting that two arrays are equal.
  Array (
 -    0 => 1
 +    0 => 2
- )
 
 %s:%i
 
@@ -45,7 +44,6 @@ Failed asserting that two objects are equal.
  stdClass Object (
 -    'foo' => 'bar'
 +    'bar' => 'foo'
- )
 
 %s:%i
 
@@ -75,7 +73,6 @@ Failed asserting that two strings are equal.
  'foo\n
 -bar\n
 +baz\n
- '
 
 %s:%i
 
@@ -131,7 +128,6 @@ Failed asserting that string matches format description.
 +++ Actual
 @@ @@
 -FOO
--
 +...BAR...
 
 %s:%i

--- a/tests/TextUI/teamcity-inner-exceptions.phpt
+++ b/tests/TextUI/teamcity-inner-exceptions.phpt
@@ -19,7 +19,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testStarted name='testPrintingChildException' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest::testPrintingChildException' flowId='%d']
 
-##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n )|n' details=' %s%etests%e_files%eExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n  )|n |n %s%etests%e_files%eExceptionStackTest.php:10|n ' flowId='%d']
+##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n' details=' %s%etests%e_files%eExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n |n %s%etests%e_files%eExceptionStackTest.php:10|n ' flowId='%d']
 
 ##teamcity[testFinished name='testPrintingChildException' duration='%d' flowId='%d']
 


### PR DESCRIPTION
Changes in `composer.json` should be reverted in the end.... but lets first fix the tests and see if all is OK with diff 2.x

Alright... so... the issue there is now is that `comparator` v.2 is released with a `diff only` output format.
This means we don't get the udiff `@@ @@` header.
Tried to correct here https://github.com/sebastianbergmann/comparator/pull/40

Other way would be to change the `diff only` output builder  to be just like `udiff` in the `diff` package. Than in correct the output builder used by `comparator` in `comparator 3`. This can be done because `diff 2` is not released yet.