### PR TITLE
Attempt to open the file instead of using is_readable to get around issue with Windows and network shares

### DIFF
--- a/src/Util/Fileloader.php
+++ b/src/Util/Fileloader.php
@@ -36,7 +36,9 @@ class Fileloader
         //current working directory.
         $localFile = __DIR__ . DIRECTORY_SEPARATOR . $filename;
 
-        if (!$includePathFilename || !\is_readable($includePathFilename) || $includePathFilename === $localFile) {
+        $isReadable = @\fopen($includePathFilename, 'r') !== false;
+
+        if (!$includePathFilename || !$isReadable || $includePathFilename === $localFile) {
             throw new Exception(
                 \sprintf('Cannot open file "%s".' . "\n", $filename)
             );


### PR DESCRIPTION
PHP on windows has an issue with files on network shares where a file is not considered to be readable if the owner is different to the one running the process, even though the data in the file can actually be read. This can be demonstrated by running a few commands

| Command | Output |
| --- | --- |
| `php -r "var_dump(file_get_contents('.\tests\Bootstrap.php'));"` | 'string of data' |
| `php -r "var_dump(is_readable('.\tests\Bootstrap.php'));"` | false |
| `php -r "var_dump(fopen('.\tests\Bootstrap.php', 'f'));"` | stream |
| `php -r "var_dump(fopen('.\tests\Bootstrap_wrong_name.php', 'r'));"` | false |

This change is to try and open the file to validate it, which looks like the intention of the function in this case.

I came across this after running in to the problem from #1024