### PR TITLE
Prevent the TestCase constructor from being overridden

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -176,6 +176,17 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             return;
         }
 
+        if ($constructor->class !== TestCase::class) {
+            $this->addTest(
+                self::warning(
+                    sprintf(
+                        'Class "%s" overrides the constructor, you should override the `setUp()` method instead.',
+                        $theClass->getName()
+                    )
+                )
+            );
+        }
+
         foreach ($theClass->getMethods() as $method) {
             $this->addTestMethod($theClass, $method);
         }

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -32,6 +32,7 @@ class SuiteTest extends TestCase
         $suite->addTest(new self('testNoTestCaseClass'));
         $suite->addTest(new self('testNotExistingTestCase'));
         $suite->addTest(new self('testNotPublicTestCase'));
+        $suite->addTest(new self('testConstructorOverrideTestCase'));
         $suite->addTest(new self('testNotVoidTestCase'));
         $suite->addTest(new self('testOneTestCase'));
         $suite->addTest(new self('testShadowedTests'));
@@ -102,6 +103,19 @@ class SuiteTest extends TestCase
         $suite = new TestSuite(\NotPublicTestCase::class);
 
         $this->assertCount(2, $suite);
+    }
+
+    public function testConstructorOverrideTestCase()
+    {
+        $suite = new TestSuite(\ConstructorOverrideTestCase::class);
+
+        $suite->run($this->result);
+
+        $warnings = $this->result->warnings();
+        $firstWarning = \array_shift($warnings);
+        $message = $firstWarning->failedTest()->getMessage();
+
+        $this->assertContains('Class "ConstructorOverrideTestCase" overrides the constructor', $message);
     }
 
     public function testNotVoidTestCase()

--- a/tests/_files/ConstructorOverrideTestCase.php
+++ b/tests/_files/ConstructorOverrideTestCase.php
@@ -1,0 +1,14 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ConstructorOverrideTestCase extends TestCase
+{
+    public function __construct()
+    {
+    }
+
+    public function testOne()
+    {
+        $this->assertFalse(true);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,7 @@ require_once TEST_FILES_PATH . 'InheritedTestCase.php';
 require_once TEST_FILES_PATH . 'NoTestCaseClass.php';
 require_once TEST_FILES_PATH . 'NoTestCases.php';
 require_once TEST_FILES_PATH . 'NotPublicTestCase.php';
+require_once TEST_FILES_PATH . 'ConstructorOverrideTestCase.php';
 require_once TEST_FILES_PATH . 'NotVoidTestCase.php';
 require_once TEST_FILES_PATH . 'OverrideTestCase.php';
 require_once TEST_FILES_PATH . 'RequirementsClassBeforeClassHookTest.php';


### PR DESCRIPTION
The `TestCase` class relies on this constructor being called, by making it final we prevent developers from shooting themselves in the foot by overriding it (#621, #540, #1164)