### PR TITLE
Travis - add libxml2-utils for xmllint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: php
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - libxml2-utils
+
+
 php:
   - 7.0
   - 7.0snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
     packages:
       - libxml2-utils
 
-
 php:
   - 7.0
   - 7.0snapshot


### PR DESCRIPTION
Test to see if this fixes the;

```
The command "xmllint --noout --schema phpunit.xsd phpunit.xml" exited with 127.
0.18s$ xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml
The program 'xmllint' is currently not installed. To run 'xmllint' please ask your administrator to install the package 'libxml2-utils'
The command "xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml" exited with 127.
0.17s$ xmllint --noout --schema phpunit.xsd tests/_files/configuration_empty.xml
The program 'xmllint' is currently not installed. To run 'xmllint' please ask your administrator to install the package 'libxml2-utils'
The command "xmllint --noout --schema phpunit.xsd tests/_files/configuration_empty.xml" exited with 127.
0.17s$ xmllint --noout --schema phpunit.xsd tests/_files/configuration_xinclude.xml -xinclude
The program 'xmllint' is currently not installed. To run 'xmllint' please ask your administrator to install the package 'libxml2-utils'
The command "xmllint --noout --schema phpunit.xsd tests/_files/configuration_xinclude.xml -xinclude" exited with 127.
```

issue people see on Travis here lately.

(ping @ArturGoldyn)