### PR TITLE
AssertContains - handle empty string in string.

### DIFF
--- a/src/Framework/Constraint/StringContains.php
+++ b/src/Framework/Constraint/StringContains.php
@@ -52,6 +52,10 @@ class StringContains extends Constraint
      */
     protected function matches($other)
     {
+        if ('' === $this->string) {
+            return true;
+        }
+
         if ($this->ignoreCase) {
             return \mb_stripos($other, $this->string) !== false;
         }

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -93,6 +93,11 @@ class AssertTest extends TestCase
         $this->assertContainsOnlyInstancesOf(\Book::class, $test2);
     }
 
+    public function testAssertContainsEmptyStringInString()
+    {
+        $this->assertContains('', 'test');
+    }
+
     public function testAssertArrayHasKeyThrowsExceptionForInvalidFirstArgument()
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/2520

This PR make the following assert pass:
```
$this->assertContains('', 'test');
```

previous:
```
There was 1 error:

1) myTest::testA
mb_strpos(): Empty delimiter

/home/possum/work/phpunit/src/Framework/Constraint/StringContains.php:59

```
