### PR TITLE
Add expectExceptionObject that takes \Exception

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -633,6 +633,22 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     }
 
     /**
+     * @param $exception \Exception
+     *
+     * @throws Exception
+     */
+    public function expectExceptionObject($exception)
+    {
+        if (!\is_a($exception, \Exception::class)) {
+            throw InvalidArgumentHelper::factory(1, 'exception');
+        }
+
+        $this->expectException(get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+        $this->expectExceptionCode($exception->getCode());
+    }
+
+    /**
      * @param bool $flag
      */
     public function setRegisterMockObjectsFromTestArgumentsRecursively($flag)


### PR DESCRIPTION
When writing tests I commonly write:

```php
$this->expectException(MyException::class);
$this->expectExceptionMessage(MyException::whatWentWrong($that));
```

I use such static create methods to construct exceptions. This helps with keeping the exception message consistent, refactorable and autocompletable by my IDE. Very similar to `PHPUnit\Util\InvalidArgumentHelper::factory`.

Up to now I carried around a custom implementation:

```
protected function expectExceptionObject(\Exception $e) {
    $this->expectException(get_class($e));
    $this->expectExceptionMessage($e->getMessage());
    $this->expectExceptionCode($e->getCode());
}
```

So ... let's get it upstream :)