### PR TITLE
Second `yield from` is not called from a data provider #2693

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -524,7 +524,7 @@ class Test
                 }
 
                 if ($data instanceof Traversable) {
-                    $data = \iterator_to_array($data);
+                    $data = \iterator_to_array($data, false);
                 }
 
                 if (\is_array($data)) {


### PR DESCRIPTION
Prevents key override when move iterator to array.