### PR TITLE
#2675 PHP Warnings throw exception despite phpunit.xml settings

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -850,7 +850,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     'isStrictAboutResourceUsageDuringSmallTests' => $isStrictAboutResourceUsageDuringSmallTests,
                     'codeCoverageFilter'                         => $codeCoverageFilter,
                     'configurationFilePath'                      => $configurationFilePath,
-                    'configurationFilePath'                      => $configurationFilePath,
                     'convertDeprecatedToExceptions'              => $convertDeprecatedToExceptions,
                     'convertNoticeToExceptions'                  => $convertNoticeToExceptions,
                     'convertWarningToExceptions'                 => $convertWarningToExceptions,

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
 use PHPUnit\Framework\Constraint\ExceptionCode;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use PHPUnit\Framework\Constraint\ExceptionMessageRegularExpression;
+use PHPUnit\Framework\Error\Deprecated;
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\Error\Warning as ErrorWarning;
 use PHPUnit_Framework_MockObject_Generator;
 use PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
 use PHPUnit_Framework_MockObject_Matcher_InvokedAtIndex;
@@ -787,6 +790,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $enforcesTimeLimit                          = $result->enforcesTimeLimit() ? 'true' : 'false';
             $isStrictAboutTodoAnnotatedTests            = $result->isStrictAboutTodoAnnotatedTests() ? 'true' : 'false';
             $isStrictAboutResourceUsageDuringSmallTests = $result->isStrictAboutResourceUsageDuringSmallTests() ? 'true' : 'false';
+            $convertDeprecatedToExceptions              = Deprecated::$enabled ? 'true' : 'false';
+            $convertNoticeToExceptions                  = Notice::$enabled ? 'true' : 'false';
+            $convertWarningToExceptions                 = ErrorWarning::$enabled ? 'true' : 'false';
 
             if (\defined('PHPUNIT_COMPOSER_INSTALL')) {
                 $composerAutoload = \var_export(PHPUNIT_COMPOSER_INSTALL, true);
@@ -843,7 +849,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     'isStrictAboutTodoAnnotatedTests'            => $isStrictAboutTodoAnnotatedTests,
                     'isStrictAboutResourceUsageDuringSmallTests' => $isStrictAboutResourceUsageDuringSmallTests,
                     'codeCoverageFilter'                         => $codeCoverageFilter,
-                    'configurationFilePath'                      => $configurationFilePath
+                    'configurationFilePath'                      => $configurationFilePath,
+                    'configurationFilePath'                      => $configurationFilePath,
+                    'convertDeprecatedToExceptions'              => $convertDeprecatedToExceptions,
+                    'convertNoticeToExceptions'                  => $convertNoticeToExceptions,
+                    'convertWarningToExceptions'                 => $convertWarningToExceptions,
                 ]
             );
 

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -41,6 +41,10 @@ function __phpunit_run_isolated_test()
         );
     }
 
+    PHPUnit\Framework\Error\Deprecated::$enabled = {convertDeprecatedToExceptions};
+    PHPUnit\Framework\Error\Notice::$enabled = {convertNoticeToExceptions};
+    PHPUnit\Framework\Error\Warning::$enabled = {convertWarningToExceptions};
+
     $result->beStrictAboutTestsThatDoNotTestAnything({isStrictAboutTestsThatDoNotTestAnything});
     $result->beStrictAboutOutputDuringTests({isStrictAboutOutputDuringTests});
     $result->enforceTimeLimit({enforcesTimeLimit});


### PR DESCRIPTION
[issues-2675](https://github.com/sebastianbergmann/phpunit/issues/2675)
I have start fix that. Now `$enabled`-Variables from class: `PHPUnit\Framework\Error\Deprecated`, `PHPUnit\Framework\Error\Notice` and `PHPUnit\Framework\Error\Warning` are set in `src/Util/PHP/Template/TestCaseMethod.tpl.dist`. 

I do believe there is another bug, the error is still there