### PR TITLE
Restore PHPT code coverage support

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -205,10 +205,22 @@ class PhptTestCase implements Test, SelfDescribing
                 $this->phpUtil->setArgs($sections['ARGS']);
             }
 
+            if ($result->getCollectCodeCoverageInformation()) {
+                $code = $this->renderForCoverage($code);
+            }
+
             PHP_Timer::start();
 
             $jobResult = $this->phpUtil->runJob($code, $settings);
             $time      = PHP_Timer::stop();
+
+            if ($result->getCollectCodeCoverageInformation()) {
+                $coverage = $this->cleanupForCoverage();
+
+                if ($coverage !== false) {
+                    $result->getCodeCoverage()->append($coverage, $this);
+                }
+            }
 
             try {
                 $this->assertPhptExpectation($sections, $jobResult['stdout']);
@@ -419,6 +431,58 @@ class PhptTestCase implements Test, SelfDescribing
             ],
             $code
         );
+    }
+
+    private function getCoverageFiles()
+    {
+        $baseDir          = dirname($this->filename) . DIRECTORY_SEPARATOR;
+        $basename         = basename($this->filename, 'phpt');
+        $coverageFilename = $baseDir . $basename . 'coverage';
+
+        return [
+            'coverage' => $coverageFilename,
+        ];
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return string
+     */
+    private function renderForCoverage($code)
+    {
+        $files = $this->getCoverageFiles();
+
+        $template = new Text_Template(
+            __DIR__ . '/../Util/PHP/Template/PhptTestCase.tpl'
+        );
+
+        if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+            $composerAutoload = var_export(PHPUNIT_COMPOSER_INSTALL, true);
+        } else {
+            $composerAutoload = '\'\'';
+        }
+
+        if (defined('__PHPUNIT_PHAR__')) {
+            $phar = var_export(__PHPUNIT_PHAR__, true);
+        } else {
+            $phar = '\'\'';
+        }
+
+        if (!defined('PHPUNIT_COMPOSER_INSTALL') && !defined('__PHPUNIT_PHAR__')) {
+            $composerAutoload = var_export(__DIR__ . '/../../vendor/autoload.php', true);
+        }
+
+        $template->setVar(
+            [
+                'composerAutoload' => $composerAutoload,
+                'phar'             => $phar,
+                'job'              => $code,
+                'coverageFile'     => $files['coverage']
+            ]
+        );
+
+        return $template->render();
     }
 
     /**

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -486,6 +486,21 @@ class PhptTestCase implements Test, SelfDescribing
     }
 
     /**
+     * @return array
+     */
+    private function cleanupForCoverage()
+    {
+        $files    = $this->getCoverageFiles();
+        $coverage = @unserialize(file_get_contents($files['coverage']));
+
+        foreach ($files as $file) {
+            @unlink($file);
+        }
+
+        return $coverage;
+    }
+
+    /**
      * Parse --INI-- section key value pairs and return as array.
      *
      * @param string

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -52,6 +52,11 @@ class GlobalState
         for ($i = \count($files) - 1; $i > 0; $i--) {
             $file = $files[$i];
 
+            if (!empty($GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST']) &&
+                \in_array($file, $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'])) {
+                continue;
+            }
+
             if ($prefix !== false && \strpos($file, $prefix) === 0) {
                 continue;
             }

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -264,7 +264,7 @@ abstract class AbstractPhpProcess
         $buffer = '';
 
         foreach ($settings as $setting) {
-            $buffer .= ' -d ' . $setting;
+            $buffer .= ' -d ' . \escapeshellarg($setting);
         }
 
         return $buffer;

--- a/src/Util/PHP/Template/PhptTestCase.tpl.dist
+++ b/src/Util/PHP/Template/PhptTestCase.tpl.dist
@@ -3,8 +3,11 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 $composerAutoload = {composerAutoload};
 $phar             = {phar};
+$autoPrependFile  = {autoPrependFile};
 
 ob_start();
+
+$GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'][] = '{job}';
 
 if ($composerAutoload) {
     require_once $composerAutoload;
@@ -13,13 +16,31 @@ if ($composerAutoload) {
     require $phar;
 }
 
-$coverage =	new CodeCoverage();
+{globals}
+$coverage = null;
 
-register_shutdown_function(function() use ($coverage) {
-	file_put_contents('{coverageFile}', serialize($coverage->stop()));
+if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
+    require_once $GLOBALS['__PHPUNIT_BOOTSTRAP'];
+}
+
+if (class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
+    $coverage =	new CodeCoverage(null);
+    $coverage->start(__FILE__);
+}
+
+register_shutdown_function(function() use ($coverage, $autoPrependFile) {
+    $output = null;
+    if ($coverage) {
+        $output = $coverage->stop();
+    }
+    file_put_contents('{coverageFile}', serialize($output));
 });
 
-$coverage->start(__FILE__);
-
 ob_end_clean();
-?>{job}
+
+if ($autoPrependFile) {
+    require $autoPrependFile;
+    $includes = get_included_files();
+    $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'][] = array_pop($includes);
+    unset($includes);
+}

--- a/src/Util/PHP/Template/PhptTestCase.tpl.dist
+++ b/src/Util/PHP/Template/PhptTestCase.tpl.dist
@@ -1,0 +1,25 @@
+<?php
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+
+$composerAutoload = {composerAutoload};
+$phar             = {phar};
+
+ob_start();
+
+if ($composerAutoload) {
+    require_once $composerAutoload;
+    define('PHPUNIT_COMPOSER_INSTALL', $composerAutoload);
+} else if ($phar) {
+    require $phar;
+}
+
+$coverage =	new CodeCoverage();
+
+register_shutdown_function(function() use ($coverage) {
+	file_put_contents('{coverageFile}', serialize($coverage->stop()));
+});
+
+$coverage->start(__FILE__);
+
+ob_end_clean();
+?>{job}

--- a/tests/TextUI/code-coverage-phpt.phpt
+++ b/tests/TextUI/code-coverage-phpt.phpt
@@ -9,14 +9,16 @@ if (!extension_loaded('xdebug')) {
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--colors=never';
-$_SERVER['argv'][3] = '--coverage-text=php://stdout';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/phpt-for-coverage.phpt';
-$_SERVER['argv'][5] = '--whitelist';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/CoveredClass.php';
+$_SERVER['argv'][2] = '--bootstrap';
+$_SERVER['argv'][3] = __DIR__ . '/../bootstrap.php';
+$_SERVER['argv'][4] = '--colors=never';
+$_SERVER['argv'][5] = '--coverage-text=php://stdout';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/phpt-for-coverage.phpt';
+$_SERVER['argv'][7] = '--whitelist';
+$_SERVER['argv'][8] = __DIR__ . '/../_files/CoveredClass.php';
 
 require __DIR__ . '/../bootstrap.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/TextUI/code-coverage-phpt.phpt
+++ b/tests/TextUI/code-coverage-phpt.phpt
@@ -1,0 +1,41 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout ../_files/phpt-for-coverage.phpt --whitelist ../_files/CoveredClass.php
+--SKIPIF--
+<?php
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+?>
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/phpt-for-coverage.phpt';
+$_SERVER['argv'][5] = '--whitelist';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/CoveredClass.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (2/2)%w
+  Methods: 100.00% (6/6)%w
+  Lines:   100.00% (12/12)
+
+CoveredClass
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  7/  7)
+CoveredParentClass
+  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  5/  5)

--- a/tests/Util/PHP/AbstractPhpProcessTest.php
+++ b/tests/Util/PHP/AbstractPhpProcessTest.php
@@ -59,7 +59,7 @@ class AbstractPhpProcessTest extends TestCase
             'display_errors=1',
         ];
 
-        $expectedCommandFormat  = '%s -d allow_url_fopen=1 -d auto_append_file= -d display_errors=1';
+        $expectedCommandFormat  = "%s -d 'allow_url_fopen=1' -d 'auto_append_file=' -d 'display_errors=1'";
         $actualCommand          = $this->phpProcess->getCommand($settings);
 
         $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);

--- a/tests/Util/PHP/AbstractPhpProcessTest.php
+++ b/tests/Util/PHP/AbstractPhpProcessTest.php
@@ -59,7 +59,7 @@ class AbstractPhpProcessTest extends TestCase
             'display_errors=1',
         ];
 
-        $expectedCommandFormat  = "%s -d 'allow_url_fopen=1' -d 'auto_append_file=' -d 'display_errors=1'";
+        $expectedCommandFormat  = "%s -d %callow_url_fopen=1%c -d %cauto_append_file=%c -d %cdisplay_errors=1%c";
         $actualCommand          = $this->phpProcess->getCommand($settings);
 
         $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);


### PR DESCRIPTION
Fixes #2175. Because files added by require and auto_prepend_file features both end up in the included files list from `GlobalState`, a new global variable was necessary to purposely ignore those files, otherwise you'll run into an infinite loop when doing tests in process isolation.

Also cleans up some of the complexity issues reported in `phpmd`.