### PR TITLE
fix expectExceptionObject method

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -629,7 +629,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * Information for expected exception class, expected exception message, and
      * expected exception code are retrieved from a given Exception object.
      */
-    public function expectExceptionObject(Exception $exception)
+    public function expectExceptionObject(\Exception $exception)
     {
         $this->expectException(\get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());


### PR DESCRIPTION
Fix expectExceptionObject method. Now it expects generic Exception object instead of PHPUnit exception.