### PR TITLE
Fix tests for #2591 to work regardless of php.ini error settings

### DIFF
--- a/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-xdebug.phpt
+++ b/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-xdebug.phpt
@@ -30,19 +30,9 @@ PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase
 PHP Stack trace:
 %a
 
-Fatal error: Class 'PHPUnit\Framework\TestCase' not found in %s on line %s
-
-Call Stack:
-%a
-
 2) Issue2591_SeparateFunctionNoPreserveTest::testGlobalString
 PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
 PHP Stack trace:
-%a
-
-Fatal error: Class 'PHPUnit\Framework\TestCase' not found in %s on line %s
-
-Call Stack:
 %a
 
 ERRORS!

--- a/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap.phpt
+++ b/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap.phpt
@@ -27,11 +27,9 @@ There were 2 errors:
 
 1) Issue2591_SeparateFunctionNoPreserveTest::testChangedGlobalString
 PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
-Fatal error: Class 'PHPUnit\Framework\TestCase' not found %s
 
 2) Issue2591_SeparateFunctionNoPreserveTest::testGlobalString
 PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
-Fatal error: Class 'PHPUnit\Framework\TestCase' not found %s
 
 ERRORS!
 Tests: 2, Assertions: 0, Errors: 2.

--- a/tests/Regression/GitHub/2591/bootstrapNoBootstrap.php
+++ b/tests/Regression/GitHub/2591/bootstrapNoBootstrap.php
@@ -1,4 +1,7 @@
 <?php
+ini_set('display_errors', 0);
+ini_set('log_errors', 1);
+
 $globalString                          = 'Hello';
 
 // require __DIR__ . '/../../../bootstrap.php';


### PR DESCRIPTION
The log_errors and display_errors settings were interfering with the actual test output,
causing the tests to fail under some circumstances (i.e. default php.ini values).