### PR TITLE
Allow symfony/yaml:4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/php-timer": "^1.0.6",
         "phpunit/phpunit-mock-objects": "^3.2",
         "phpspec/prophecy": "^1.6.2",
-        "symfony/yaml": "~2.1|~3.0",
+        "symfony/yaml": "~2.1|~3.0|~4.0",
         "sebastian/comparator": "^1.2.4",
         "sebastian/diff": "^1.4.3",
         "sebastian/environment": "^1.3.4 || ^2.0",


### PR DESCRIPTION
This PR allow to use PHPUnit in projects with symfony/yaml:4.0.0-BETA1 dependency.

With `"prefer-stable": false`, `"minimum_stability": "beta"` and `"platform":"7.1.3"` all tests (except  tests/Regression/GitHub/873-php5.phpt with "PHP 5 is required") are passed.