### PR TITLE
Enhancement: Allow to construct constraint from constraints

### DIFF
--- a/src/Framework/Constraint/LogicalAnd.php
+++ b/src/Framework/Constraint/LogicalAnd.php
@@ -26,6 +26,15 @@ class LogicalAnd extends Constraint
      */
     protected $lastConstraint;
 
+    public static function fromConstraints(Constraint ...$constraints): self
+    {
+        $instance = new self();
+
+        $instance->constraints = \array_values($constraints);
+
+        return $instance;
+    }
+
     /**
      * @param Constraint[] $constraints
      *

--- a/src/Framework/Constraint/LogicalOr.php
+++ b/src/Framework/Constraint/LogicalOr.php
@@ -21,6 +21,15 @@ class LogicalOr extends Constraint
      */
     protected $constraints = [];
 
+    public static function fromConstraints(Constraint ...$constraints): self
+    {
+        $instance = new self();
+
+        $instance->constraints = \array_values($constraints);
+
+        return $instance;
+    }
+
     /**
      * @param Constraint[] $constraints
      */

--- a/src/Framework/Constraint/LogicalXor.php
+++ b/src/Framework/Constraint/LogicalXor.php
@@ -21,6 +21,15 @@ class LogicalXor extends Constraint
      */
     protected $constraints = [];
 
+    public static function fromConstraints(Constraint ...$constraints): self
+    {
+        $instance = new self();
+
+        $instance->constraints = \array_values($constraints);
+
+        return $instance;
+    }
+
     /**
      * @param Constraint[] $constraints
      */

--- a/tests/Framework/Constraint/LogicalAndTest.php
+++ b/tests/Framework/Constraint/LogicalAndTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Framework\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\LogicalAnd;
+use PHPUnit\Framework\TestCase;
+
+final class LogicalAndTest extends TestCase
+{
+    public function testFromConstraintsReturnsConstraint()
+    {
+        $other = 'Foo';
+        $count = 5;
+
+        $constraints = \array_map(function () use ($other) {
+            $constraint = $this->createMock(Constraint::class);
+
+            $constraint
+                ->expects($this->once())
+                ->method('evaluate')
+                ->with($this->identicalTo($other))
+                ->willReturn(true);
+
+            return $constraint;
+        }, \array_fill(0, $count, null));
+
+        $constraint = LogicalAnd::fromConstraints(...$constraints);
+
+        $this->assertInstanceOf(LogicalAnd::class, $constraint);
+        $this->assertTrue($constraint->evaluate($other, '', true));
+    }
+}

--- a/tests/Framework/Constraint/LogicalOrTest.php
+++ b/tests/Framework/Constraint/LogicalOrTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Framework\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\LogicalOr;
+use PHPUnit\Framework\TestCase;
+
+final class LogicalOrTest extends TestCase
+{
+    public function testFromConstraintsReturnsConstraint()
+    {
+        $other = 'Foo';
+        $count = 5;
+
+        $constraints = \array_map(function () use ($other) {
+            $constraint = $this->createMock(Constraint::class);
+
+            $constraint
+                ->expects($this->once())
+                ->method('evaluate')
+                ->with($this->identicalTo($other))
+                ->willReturn(false);
+
+            return $constraint;
+        }, \array_fill(0, $count, null));
+
+        $constraint = LogicalOr::fromConstraints(...$constraints);
+
+        $this->assertInstanceOf(LogicalOr::class, $constraint);
+        $this->assertFalse($constraint->evaluate($other, '', true));
+    }
+}

--- a/tests/Framework/Constraint/LogicalXorTest.php
+++ b/tests/Framework/Constraint/LogicalXorTest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Framework\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\LogicalXor;
+use PHPUnit\Framework\TestCase;
+
+final class LogicalXorTest extends TestCase
+{
+    public function testFromConstraintsReturnsConstraint()
+    {
+        $other = 'Foo';
+        $count = 5;
+
+        $constraints = \array_map(function () use ($other) {
+            static $count = 0;
+
+            $constraint = $this->createMock(Constraint::class);
+
+            $constraint
+                ->expects($this->once())
+                ->method('evaluate')
+                ->with($this->identicalTo($other))
+                ->willReturn($count % 2 === 1);
+
+            ++$count;
+
+            return $constraint;
+        }, \array_fill(0, $count, null));
+
+        $constraint = LogicalXor::fromConstraints(...$constraints);
+
+        $this->assertInstanceOf(LogicalXor::class, $constraint);
+        $this->assertTrue($constraint->evaluate($other, '', true));
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a named constructor `fromConstraints(Constraint ...$constraints)` to `LogicalAnd`, `LogicalOr`, and `LogicalXor` constraints

💁‍♂️ Not sure if this change is something that should rather be proposed for a different repository (if you know what I mean), but when composing constraints, this seems a bit useful to me.

### Before

```php
$constraint = new LogicalOr();

$constraint->setConstraints([
    new IsInstanceOf(\stdClass::class),
    new IsEqual('Foo')
]);

self::assertThat($other, $constraint);
```

### After

```php
$constraint = LogicalOr::fromConstraints(
    new IsInstanceOf(\stdClass::class),
    new IsEqual('Foo')
);

self::assertThat($other, $constraint);
```