### PR TITLE
Fix: Use blank_line_before_statement fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -18,7 +18,11 @@ return PhpCsFixer\Config::create()
                 'align_equals' => true
             ],
             'blank_line_after_namespace' => true,
-            'blank_line_before_return' => true,
+            'blank_line_before_statement' => [
+                'statements' => [
+                    'return',
+                ],
+            ],
             'braces' => true,
             'cast_spaces' => true,
             'concat_space' => ['spacing' => 'one'],


### PR DESCRIPTION
This PR

* [x] uses the `blank_line_before_statement` fixer instead of the deprecated `blank_line_before_return` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.7.1#usage>

>**blank_line_before_statement** [`@Symfony`]
>
>An empty line feed must precede any configured statement.
>
>Configuration options:
>
>* `statements` (`array`): list of statements which must be preceded by an empty line; defaults to `['break', 'continue', 'declare', 'return', 'throw', 'try']`