### PR TITLE
Fix: Use mock builder to build mocks of abstract classes

### DIFF
--- a/tests/Framework/Constraint/LogicalAndTest.php
+++ b/tests/Framework/Constraint/LogicalAndTest.php
@@ -21,7 +21,7 @@ final class LogicalAndTest extends TestCase
         $count = 5;
 
         $constraints = \array_map(function () use ($other) {
-            $constraint = $this->createMock(Constraint::class);
+            $constraint = $this->getMockBuilder(Constraint::class)->getMock();
 
             $constraint
                 ->expects($this->once())

--- a/tests/Framework/Constraint/LogicalOrTest.php
+++ b/tests/Framework/Constraint/LogicalOrTest.php
@@ -21,7 +21,7 @@ final class LogicalOrTest extends TestCase
         $count = 5;
 
         $constraints = \array_map(function () use ($other) {
-            $constraint = $this->createMock(Constraint::class);
+            $constraint = $this->getMockBuilder(Constraint::class)->getMock();
 
             $constraint
                 ->expects($this->once())

--- a/tests/Framework/Constraint/LogicalXorTest.php
+++ b/tests/Framework/Constraint/LogicalXorTest.php
@@ -23,7 +23,7 @@ final class LogicalXorTest extends TestCase
         $constraints = \array_map(function () use ($other) {
             static $count = 0;
 
-            $constraint = $this->createMock(Constraint::class);
+            $constraint = $this->getMockBuilder(Constraint::class)->getMock();
 
             $constraint
                 ->expects($this->once())


### PR DESCRIPTION
This PR

* [x] uses `getMockForAbstractClass()` instead of `createMock()`

Fixes #2826.
Follows #2824.

🤦‍♂️ Apologies for [arguing](https://github.com/sebastianbergmann/phpunit/pull/2824#issuecomment-338509775) that the build failure is unrelated to the previously proposed changes - of course, `Constraint` is an `abstract` class, and thus, I assume `getMockForAbstractClass()` should be used instead of `createMock()`.