### PR TITLE
Make `<exclude>` work even if it's a parent of `<directory>`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phar-io/version": "^1.0",
         "phpspec/prophecy": "^1.7",
         "phpunit/php-code-coverage": "^5.2.2",
-        "phpunit/php-file-iterator": "^1.4.2",
+        "phpunit/php-file-iterator": "1.4.x-dev#f7c4bddb6acca98ba2e754545a24dfdcb8513461",
         "phpunit/php-text-template": "^1.2.1",
         "phpunit/php-timer": "^1.0.9",
         "phpunit/phpunit-mock-objects": "^4.0.3",

--- a/tests/Regression/GitHub/2815.phpt
+++ b/tests/Regression/GitHub/2815.phpt
@@ -1,0 +1,23 @@
+--TEST--
+GH-2815: exclude should work even if <exclude> if a parent of <directory>
+--FILE--
+<?php
+
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = __DIR__ . '/2815/phpunit2815.xml';
+$_SERVER['argv'][3] = '--debug';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+Configuration: %s
+
+
+
+Time: %s, Memory: %s
+
+No tests executed!

--- a/tests/Regression/GitHub/2815/phpunit2815.xml
+++ b/tests/Regression/GitHub/2815/phpunit2815.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.4/phpunit.xsd"
+         verbose="true">
+    <testsuite>
+        <directory suffix="Test.php">tests/*/integrational</directory>
+        <exclude>tests/mysuite</exclude>
+    </testsuite>
+</phpunit>

--- a/tests/Regression/GitHub/2815/tests/mysuite/integrational/Issue2815Test.php
+++ b/tests/Regression/GitHub/2815/tests/mysuite/integrational/Issue2815Test.php
@@ -1,0 +1,9 @@
+<?php
+
+class Issue2815Test extends \PHPUnit\Framework\TestCase
+{
+    public function testMe()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This pull request contains a test case for #2815. As soon as sebastianbergmann/php-file-iterator#30 is fixed and another release is cut, version requirement in phpunit should be updated, and this test case will pass.

I'll be glad to do help with that a fixed version of php-file-iterator is released (leaving possibility for whoever can push to phpunit add commits into this branch).

Also, do I need to cherry-pick it on top of the master branch and create another pull request?