### PR TITLE
Add required attrib in config generator template

### DIFF
--- a/src/Util/ConfigurationGenerator.php
+++ b/src/Util/ConfigurationGenerator.php
@@ -25,7 +25,7 @@ class ConfigurationGenerator
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
-    <testsuite>
+    <testsuite name="default">
         <directory suffix="Test.php">{tests_directory}</directory>
     </testsuite>
 


### PR DESCRIPTION
minor bug fix.

Add required attribute `name` at `testsuite` element in configuration generator template.
This is required by xsd.
https://github.com/sebastianbergmann/phpunit/blob/514f081cd66f09aafe8f00d20ac4f91f356690db/phpunit.xsd#L267