### PR TITLE
Show valid exception message in TeamCity logger in case of ExceptionWrapper

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -11,7 +11,6 @@
 namespace PHPUnit\Util\Log;
 
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Test;
@@ -337,9 +336,9 @@ class TeamCity extends ResultPrinter
     {
         $message = '';
 
-        if (!$e instanceof Exception) {
-            if (\strlen(\get_class($e)) != 0) {
-                $message .= \get_class($e);
+        if ($e instanceof ExceptionWrapper) {
+            if (\strlen($e->getClassName()) != 0) {
+                $message .= $e->getClassName();
             }
 
             if (\strlen($message) != 0 && \strlen($e->getMessage()) != 0) {

--- a/tests/TextUI/teamcity-inner-exceptions.phpt
+++ b/tests/TextUI/teamcity-inner-exceptions.phpt
@@ -25,7 +25,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testStarted name='testNestedExceptions' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest::testNestedExceptions' flowId='%d']
 
-##teamcity[testFailed name='testNestedExceptions' message='One' details=' %s%etests%e_files%eExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s%etests%e_files%eExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s%etests%e_files%eExceptionStackTest.php:20|n ' flowId='%d']
+##teamcity[testFailed name='testNestedExceptions' message='Exception : One' details=' %s%etests%e_files%eExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s%etests%e_files%eExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s%etests%e_files%eExceptionStackTest.php:20|n ' flowId='%d']
 
 ##teamcity[testFinished name='testNestedExceptions' duration='%d' flowId='%d']
 


### PR DESCRIPTION
Hello! This change is fixing [WI-37135](https://youtrack.jetbrains.com/issue/WI-37135) for PHPUnit 5.0+ since your version of TeamCity printer is used for these versions. We fixed this for our printer already (e.g. for PHPUnit below 5.0) by similar change.

