### PR TITLE
Expose TestCase::$dataName

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1951,7 +1951,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @return int|string
      */
-    public function dataID()
+    public function dataName()
     {
         return $this->dataName;
     }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1948,6 +1948,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         return \is_string($this->dataName) ? $this->dataName : '';
     }
 
+    /**
+     * @return int|string
+     */
+    public function dataID()
+    {
+        return $this->dataName;
+    }
+
     public function registerComparator(Comparator $comparator)
     {
         ComparatorFactory::getInstance()->register($comparator);


### PR DESCRIPTION
It would be useful to have this property accessible. I use it to set the breakpoint in PHPStorm:

![expla](https://user-images.githubusercontent.com/4203089/32937740-ed0370f2-cb79-11e7-8242-fe01620fce02.png)

If this is already possible I am sorry but I couldn't find it.

Thanks.