### PR TITLE
Forced environment variables do not affect getenv()

### DIFF
--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -561,7 +561,7 @@ class Configuration
             $value = $data['value'];
             $force = isset($data['force']) ? $data['force'] : false;
 
-            if (false === \getenv($name)) {
+            if ($force || false === \getenv($name)) {
                 \putenv("{$name}={$value}");
             }
 

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -310,6 +310,20 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('putenv', \getenv('foo'));
     }
 
+    /**
+     * @backupGlobals enabled
+     *
+     * @see https://github.com/sebastianbergmann/phpunit/issues/1181
+     */
+    public function testHandlePHPConfigurationDoesOverwriteVariablesFromPutEnvWhenForced()
+    {
+        \putenv('foo_force=putenv');
+        $this->configuration->handlePHPConfiguration();
+
+        $this->assertEquals('forced', $_ENV['foo_force']);
+        $this->assertEquals('forced', \getenv('foo_force'));
+    }
+
     public function testPHPUnitConfigurationIsReadCorrectly()
     {
         $this->assertEquals(


### PR DESCRIPTION
We've noticed that when forcing environment variables from a phpunit.xml file, it will set `$_ENV` appropriately, but will fail to reflect the same change to environment variables that existed in the calling environment when attempting to retrieve them through `getenv()`.

All existing tests pass. 