### PR TITLE
Skip test from annotation

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -673,6 +673,21 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         }
     }
 
+    protected function setMarkTestSkippedFromAnnotation()
+    {
+        try {
+            $testSkipped = \PHPUnit\Util\Test::getTestSkipped(
+                \get_class($this),
+                $this->name
+            );
+
+            if ($testSkipped !== false) {
+                $this->markTestSkipped($testSkipped);
+            }
+        } catch (ReflectionException $e) {
+        }
+    }
+
     /**
      * @param bool $useErrorHandler
      */
@@ -928,6 +943,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 }
             }
 
+            $this->setMarkTestSkippedFromAnnotation();
             $this->setExpectedExceptionFromAnnotation();
             $this->setDoesNotPerformAssertionsFromAnnotation();
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -673,6 +673,10 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         }
     }
 
+    /**
+     * Mark test skipped if testSkipped annotation exists in
+     * class or method definition
+     */
     protected function setMarkTestSkippedFromAnnotation()
     {
         try {

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -34,6 +34,7 @@ class Test
     const REGEX_DATA_PROVIDER               = '/@dataProvider\s+([a-zA-Z0-9._:-\\\\x7f-\xff]+)/';
     const REGEX_TEST_WITH                   = '/@testWith\s+/';
     const REGEX_EXPECTED_EXCEPTION          = '(@expectedException\s+([:.\w\\\\x7f-\xff]+)(?:[\t ]+(\S*))?(?:[\t ]+(\S*))?\s*$)m';
+    const REGEX_TEST_SKIPPED                = '/@testSkipped(\s+.*)?/';
     const REGEX_REQUIRES_VERSION            = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m';
     const REGEX_REQUIRES_VERSION_CONSTRAINT = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<constraint>[\d\t -.|~^]+)[ \t]*\r?$/m';
     const REGEX_REQUIRES_OS                 = '/@requires\s+(?P<name>OS(?:FAMILY)?)\s+(?P<value>.+?)[ \t]*\r?$/m';
@@ -405,6 +406,25 @@ class Test
             return [
                 'class' => $class, 'code' => $code, 'message' => $message, 'message_regex' => $messageRegExp
             ];
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $className
+     * @param string $methodName
+     *
+     * @return string|false
+     */
+    public static function getTestSkipped($className, $methodName)
+    {
+        $reflector  = new ReflectionMethod($className, $methodName);
+        $docComment = $reflector->getDocComment();
+        $docComment = \substr($docComment, 3, -2);
+
+        if (\preg_match(self::REGEX_TEST_SKIPPED, $docComment, $matches)) {
+            return trim($matches[1]);
         }
 
         return false;

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -412,6 +412,8 @@ class Test
     }
 
     /**
+     * Check testSkipped annotation in class or method definition
+     *
      * @param string $className
      * @param string $methodName
      *
@@ -419,12 +421,14 @@ class Test
      */
     public static function getTestSkipped($className, $methodName)
     {
-        $reflector  = new ReflectionMethod($className, $methodName);
-        $docComment = $reflector->getDocComment();
-        $docComment = \substr($docComment, 3, -2);
+        $classReflector = new ReflectionClass($className);
+        $methodReflection = $classReflector->getMethod($methodName);
 
-        if (\preg_match(self::REGEX_TEST_SKIPPED, $docComment, $matches)) {
-            return trim($matches[1]);
+        foreach ([$classReflector, $methodReflection] as $reflection) {
+            $docComment = \substr($reflection->getDocComment(), 3, -2);
+            if (\preg_match(self::REGEX_TEST_SKIPPED, $docComment, $matches)) {
+                return trim($matches[1]);
+            }
         }
 
         return false;

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -44,7 +44,8 @@ class SuiteTest extends TestCase
         $suite->addTest(new self('testIncompleteTestDataProvider'));
         $suite->addTest(new self('testRequirementsBeforeClassHook'));
         $suite->addTest(new self('testDoNotSkipInheritedClass'));
-        $suite->addTest(new self('testSkippedFromAnnotation'));
+        $suite->addTest(new self('testSkippedFromMethodAnnotation'));
+        $suite->addTest(new self('testSkippedFromClassAnnotation'));
 
         return $suite;
     }
@@ -235,14 +236,25 @@ class SuiteTest extends TestCase
         $this->assertCount(2, $result);
     }
 
-    public function testSkippedFromAnnotation()
+    public function testSkippedFromMethodAnnotation()
     {
-        $suite = new TestSuite(\PHPUnit\TestSkippedFromAnnotation::class);
+        $suite = new TestSuite(\PHPUnit\TestSkippedFromMethodAnnotation::class);
 
         $suite->run($this->result);
 
         $this->assertEquals(2, $this->result->count());
         $this->assertEquals(2, $this->result->skippedCount());
+        $this->assertEquals(0, $this->result->failureCount());
+    }
+
+    public function testSkippedFromClassAnnotation()
+    {
+        $suite = new TestSuite(\PHPUnit\TestSkippedFromClassAnnotation::class);
+
+        $suite->run($this->result);
+
+        $this->assertEquals(1, $this->result->count());
+        $this->assertEquals(1, $this->result->skippedCount());
         $this->assertEquals(0, $this->result->failureCount());
     }
 }

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -237,7 +237,7 @@ class SuiteTest extends TestCase
 
     public function testSkippedFromAnnotation()
     {
-        $suite = new TestSuite(\TestSkippedFromAnnotation::class);
+        $suite = new TestSuite(\PHPUnit\TestSkippedFromAnnotation::class);
 
         $suite->run($this->result);
 

--- a/tests/Framework/SuiteTest.php
+++ b/tests/Framework/SuiteTest.php
@@ -44,6 +44,7 @@ class SuiteTest extends TestCase
         $suite->addTest(new self('testIncompleteTestDataProvider'));
         $suite->addTest(new self('testRequirementsBeforeClassHook'));
         $suite->addTest(new self('testDoNotSkipInheritedClass'));
+        $suite->addTest(new self('testSkippedFromAnnotation'));
 
         return $suite;
     }
@@ -232,5 +233,16 @@ class SuiteTest extends TestCase
         $result = $suite->run();
 
         $this->assertCount(2, $result);
+    }
+
+    public function testSkippedFromAnnotation()
+    {
+        $suite = new TestSuite(\TestSkippedFromAnnotation::class);
+
+        $suite->run($this->result);
+
+        $this->assertEquals(2, $this->result->count());
+        $this->assertEquals(2, $this->result->skippedCount());
+        $this->assertEquals(0, $this->result->failureCount());
     }
 }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\CodeCoverageException;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
+use PHPUnit\TestSkippedFromClassAnnotation;
 
 class TestTest extends TestCase
 {
@@ -1007,5 +1008,7 @@ class TestTest extends TestCase
         $this->assertEquals('', Test::getTestSkipped(\My\Space\TestSkippedTest::class, 'skippedTestWithoutComment'));
 
         $this->assertEquals('some smart comment', Test::getTestSkipped(\My\Space\TestSkippedTest::class, 'skippedTestWithComment'));
+
+        $this->assertEquals('', Test::getTestSkipped(TestSkippedFromClassAnnotation::class, 'testSkipped'));
     }
 }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -999,4 +999,13 @@ class TestTest extends TestCase
         $this->assertArrayHasKey('theClassAnnotation', $result['class']);
         $this->assertArrayHasKey('theTraitAnnotation', $result['class']);
     }
+
+    public function testGetTestSkipped()
+    {
+        $this->assertFalse(Test::getTestSkipped(\My\Space\TestSkippedTest::class, 'notSkippedTest'));
+
+        $this->assertEquals('', Test::getTestSkipped(\My\Space\TestSkippedTest::class, 'skippedTestWithoutComment'));
+
+        $this->assertEquals('some smart comment', Test::getTestSkipped(\My\Space\TestSkippedTest::class, 'skippedTestWithComment'));
+    }
 }

--- a/tests/_files/TestSkippedFromAnnotation.php
+++ b/tests/_files/TestSkippedFromAnnotation.php
@@ -1,0 +1,22 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class TestSkippedFromAnnotation extends TestCase
+{
+    /**
+     * @testSkipped
+     */
+    public function testSkipped()
+    {
+        $this->fail();
+    }
+
+    /**
+     * @testSkipped some smart comment
+     */
+    public function testSkippedWithComment()
+    {
+        $this->fail();
+    }
+}

--- a/tests/_files/TestSkippedFromAnnotation.php
+++ b/tests/_files/TestSkippedFromAnnotation.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace PHPUnit;
+
 use PHPUnit\Framework\TestCase;
 
 class TestSkippedFromAnnotation extends TestCase

--- a/tests/_files/TestSkippedFromClassAnnotation.php
+++ b/tests/_files/TestSkippedFromClassAnnotation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PHPUnit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @testSkipped
+ */
+class TestSkippedFromClassAnnotation extends TestCase
+{
+    public function testSkipped()
+    {
+        $this->fail();
+    }
+}

--- a/tests/_files/TestSkippedFromMethodAnnotation.php
+++ b/tests/_files/TestSkippedFromMethodAnnotation.php
@@ -4,7 +4,7 @@ namespace PHPUnit;
 
 use PHPUnit\Framework\TestCase;
 
-class TestSkippedFromAnnotation extends TestCase
+class TestSkippedFromMethodAnnotation extends TestCase
 {
     /**
      * @testSkipped

--- a/tests/_files/TestSkippedTest.php
+++ b/tests/_files/TestSkippedTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace My\Space;
+
+class TestSkippedTest extends \PHPUnit\Framework\TestCase
+{
+    public function notSkippedTest()
+    {
+    }
+
+    /**
+     * @testSkipped
+     */
+    public function skippedTestWithoutComment()
+    {
+    }
+
+    /**
+     * @testSkipped some smart comment
+     */
+    public function skippedTestWithComment()
+    {
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,4 +28,5 @@ require_once TEST_FILES_PATH . 'Singleton.php';
 require_once TEST_FILES_PATH . 'Mockable.php';
 require_once TEST_FILES_PATH . 'CoverageNamespacedFunctionTest.php';
 require_once TEST_FILES_PATH . 'NamespaceCoveredFunction.php';
-require_once TEST_FILES_PATH . 'TestSkippedFromAnnotation.php';
+require_once TEST_FILES_PATH . 'TestSkippedFromMethodAnnotation.php';
+require_once TEST_FILES_PATH . 'TestSkippedFromClassAnnotation.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,3 +28,4 @@ require_once TEST_FILES_PATH . 'Singleton.php';
 require_once TEST_FILES_PATH . 'Mockable.php';
 require_once TEST_FILES_PATH . 'CoverageNamespacedFunctionTest.php';
 require_once TEST_FILES_PATH . 'NamespaceCoveredFunction.php';
+require_once TEST_FILES_PATH . 'TestSkippedFromAnnotation.php';


### PR DESCRIPTION
Issue: #2875
Description: allow to skip test from class or method annotation
Example 1:
```php
class TestSkippedFromAnnotation extends TestCase
{
    /**
     * @testSkipped
     */
    public function testSkipped()
    {
        // test will be skipped
    }

    /**
     * @testSkipped some smart comment
     */
    public function testSkippedWithComment()
    {
        // test will be skipped
    }
}
```

Example 2:
```php
/**
 * @testSkipped
 */
class TestSkippedFromClassAnnotation extends TestCase
{
    public function testSkipped()
    {
        // test will be skipped
    }
}
```
Note 2: I named it `@testSkipped` and not `@skipTest` as was proposed to be more consistent with method `markTestSkipped()`