### PR TITLE
Added expectNotToPerformAssertions method

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -636,6 +636,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->expectExceptionCode($exception->getCode());
     }
 
+    public function expectNotToPerformAssertions()
+    {
+        $this->doesNotPerformAssertions = true;
+    }
+
     /**
      * @param bool $flag
      */

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -322,6 +322,17 @@ class TestCaseTest extends TestCase
         $this->assertCount(1, $result);
     }
 
+    public function testDoesNotPerformAssertions()
+    {
+        $test = new \DoNoAssertionTestCase('testNothing');
+        $test->expectNotToPerformAssertions();
+
+        $result = $test->run();
+
+        $this->assertEquals(0, $result->riskyCount());
+        $this->assertCount(1, $result);
+    }
+
     /**
      * @backupGlobals enabled
      */

--- a/tests/_files/DoNoAssertionTestCase.php
+++ b/tests/_files/DoNoAssertionTestCase.php
@@ -1,0 +1,9 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class DoNoAssertionTestCase extends TestCase
+{
+    public function testNothing()
+    {
+    }
+}


### PR DESCRIPTION
Explicit method for `doesNotPerformAssertions`, see https://github.com/sebastianbergmann/phpunit/issues/2484#issuecomment-344407383