### PR TITLE
Add assertIsCountable assertion

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Constraint\DirectoryExists;
 use PHPUnit\Framework\Constraint\FileExists;
 use PHPUnit\Framework\Constraint\GreaterThan;
 use PHPUnit\Framework\Constraint\IsAnything;
+use PHPUnit\Framework\Constraint\IsCountable;
 use PHPUnit\Framework\Constraint\IsEmpty;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\IsFalse;
@@ -515,6 +516,39 @@ abstract class Assert
             static::readAttribute($haystackClassOrObject, $haystackAttributeName),
             $message
         );
+    }
+
+    /**
+     * Asserts that a haystack is countable.
+     *
+     * @param array|\Countable $haystack
+     * @param string           $message
+     */
+    public static function assertIsCountable($haystack, $message = '')
+    {
+        if (!$haystack instanceof Countable &&
+            !\is_array($haystack)) {
+            throw InvalidArgumentHelper::factory(1, 'countable');
+        }
+
+        $constraint = new IsCountable;
+
+        static::assertThat($haystack, $constraint, $message);
+    }
+
+    /**
+     * Asserts that a haystack is not countable.
+     *
+     * @param mixed  $haystack
+     * @param string $message
+     */
+    public static function assertNotIsCountable($haystack, $message = '')
+    {
+        $constraint = new LogicalNot(
+            new IsCountable
+        );
+
+        static::assertThat($haystack, $constraint, $message);
     }
 
     /**

--- a/src/Framework/Constraint/IsCountable.php
+++ b/src/Framework/Constraint/IsCountable.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use Countable;
+
+/**
+ * Constraint that asserts that the value it is countable.
+ */
+class IsCountable extends Constraint
+{
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        return $other instanceof Countable || \is_array($other);
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'is countable';
+    }
+}

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -2763,6 +2763,27 @@ XML;
         $this->assertCount(2, [1, 2, 3]);
     }
 
+    public function testAssertIsCountable()
+    {
+        $this->assertIsCountable(new \ArrayObject);
+        $this->assertIsCountable([1, 2, 3]);
+
+        $this->expectException(Exception::class);
+
+        $this->assertIsCountable(1);
+    }
+
+
+    public function testAssertNotIsCountable()
+    {
+        $this->assertNotIsCountable(1);
+        $this->assertNotIsCountable('1');
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertNotIsCountable([1, 2, 3]);
+    }
+
     public function testAssertCountTraversable()
     {
         $this->assertCount(2, new \ArrayIterator([1, 2]));


### PR DESCRIPTION
With this PR, I want to propose a new assertion: `assertIsCountable`.

### Motivation
In `PHP 7.2`, if the `count` function tries to count something that isn't an `array` or implements the `Countable` interface, it throws a warning. We _could_ check with `PHP` if the variable is countable if there were an `is_countable` function. So, makes perfect sense to test it with an `assertIsCountable` assertion.