### PR TITLE
Tell contributors to use php-cs-fixer-v2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Due to time constraints, we are not always able to respond as quickly as we woul
 This project comes with a configuration file for [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (`.php_cs`) that you can use to (re)format your sourcecode for compliance with this project's coding guidelines:
 
 ```bash
-$ wget http://get.sensiolabs.org/php-cs-fixer.phar
+$ wget http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar -O php-cs-fixer.phar
 
 $ php php-cs-fixer.phar fix
 ```


### PR DESCRIPTION
php-cs-fixer v1 does not work with the current settings because it does not recognise [some of] them