### PR TITLE
Fix for #2922 - incorrect "No tests found in class PHPUnit\Framework\*" which happens when there is a test class with @group and provider throwing exception in it, plus tests are ran with --exclude-group for that group, plus there is another class called later (after handing the class from above), and finally when the name of that another class does not match it's file name

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -348,7 +348,7 @@ class PHPUnit_Framework_TestSuite implements PHPUnit_Framework_Test, PHPUnit_Fra
         }
 
         foreach ($newClasses as $className) {
-            if ($className === 'PHPUnit_Framework_TestSuite_DataProvider') {
+            if (strpos($className, 'PHPUnit_Framework') === 0) {
                 continue;
             }
 

--- a/tests/TextUI/dataprovider-issue-2922.phpt
+++ b/tests/TextUI/dataprovider-issue-2922.phpt
@@ -1,0 +1,18 @@
+--TEST--
+phpunit --exclude-group=foo ../_files/DataProviderIssue2922
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--exclude-group=foo';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/DataProviderIssue2922';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit_TextUI_Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/_files/DataProviderIssue2922/FirstTest.php
+++ b/tests/_files/DataProviderIssue2922/FirstTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Foo\DataProviderIssue2922;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group foo
+ */
+class FirstTest extends TestCase
+{
+    /**
+     * @dataProvider provide
+     */
+    public function testFirst($x)
+    {
+        $this->assertTrue(true);
+    }
+
+    public function provide()
+    {
+        throw new \FooException();
+    }
+}

--- a/tests/_files/DataProviderIssue2922/FirstTest.php
+++ b/tests/_files/DataProviderIssue2922/FirstTest.php
@@ -19,6 +19,6 @@ class FirstTest extends TestCase
 
     public function provide()
     {
-        throw new \FooException();
+        throw new \Exception();
     }
 }

--- a/tests/_files/DataProviderIssue2922/SecondTest.php
+++ b/tests/_files/DataProviderIssue2922/SecondTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Foo\DataProviderIssue2922;
+
+use PHPUnit\Framework\TestCase;
+
+// the name of the class cannot match file name - if they match all is fine
+class SecondHelloWorldTest extends TestCase
+{
+    public function testSecond()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Fixes #2922

I have replaced the silly `if` in `TestSuite.php` with more general approach - checking if the class belongs to `PHPUnit\Framework`.