### PR TITLE
Added expectExpectation* methods for forward compatibility

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -481,6 +481,92 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * @param string $exception
+     *
+     * @since Method available since Release 4.9.0
+     */
+    public function expectException($exception)
+    {
+        if (!is_string($exception)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->expectedException = $exception;
+    }
+
+    /**
+     * @param int|string $code
+     *
+     * @throws PHPUnit_Framework_Exception
+     *
+     * @since Method available since Release 4.9.0
+     */
+    public function expectExceptionCode($code)
+    {
+        if (!$this->expectedException) {
+            $this->expectedException = \Exception::class;
+        }
+
+        if (!is_int($code) && !is_string($code)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'integer or string');
+        }
+
+        $this->expectedExceptionCode = $code;
+    }
+
+    /**
+     * @param string $message
+     *
+     * @throws PHPUnit_Framework_Exception
+     *
+     * @since Method available since Release 4.9.0
+     */
+    public function expectExceptionMessage($message)
+    {
+        if (!$this->expectedException) {
+            $this->expectedException = \Exception::class;
+        }
+
+        if (!is_string($message)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->expectedExceptionMessage = $message;
+    }
+
+    /**
+     * @param string $messageRegExp
+     *
+     * @throws PHPUnit_Framework_Exception
+     *
+     * @since Method available since Release 4.9.0
+     */
+    public function expectExceptionMessageRegExp($messageRegExp)
+    {
+        if (!is_string($messageRegExp)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'string');
+        }
+
+        $this->expectedExceptionMessageRegExp = $messageRegExp;
+    }
+
+    /**
+     * Sets up an expectation for an exception to be raised by the code under test.
+     * Information for expected exception class, expected exception message, and
+     * expected exception code are retrieved from a given Exception object.
+     *
+     * @param \Exception $exception
+     *
+     * @since Method available since Release 4.9.0
+     */
+    public function expectExceptionObject(\Exception $exception)
+    {
+        $this->expectException(\get_class($exception));
+        $this->expectExceptionMessage($exception->getMessage());
+        $this->expectExceptionCode($exception->getCode());
+    }
+
+    /**
      * @since  Method available since Release 3.4.0
      */
     protected function setExpectedExceptionFromAnnotation()


### PR DESCRIPTION
Hi !

I do know 4.x is not maintained anymore, yet please consider this PR.

For almost 2 years, suggested best practice for testing exceptions is to use `expectException*` methods (ref: https://thephp.cc/news/2016/02/questioning-phpunit-best-practices).

Previous best practice, `setExpectedException*` works on 4.x and 5.x, yet not on 6.x (by purpose).
New best practice `expectException*` introduced on 6.x, and forward compatibility layer was added to 5.x only.
That created situation, where the only solution that works on 4.x, 5.x and 6.x is `@expectedException*` annotations.

There are still some projects that operates on PHP 5.3-5.5 (also dead), and for those project the only valid PHPUnit is 4.x. Forward compatibility layer at PHPUnit is really great, it allows to write code that is ready for next PHPUnit version when one cannot make the upgrade yet.
Sadly, it doesn't work quite well for removing the expectation annotation, as it requires to first use `setExpectedException*` methods while being only on 4.x and want to follow best practices, and then change it (2nd code change) to `expectException*` as soon as upgrading PHPUnit, what is more - this step is obligatory as `setExpectedException*` is no longer existing thus tests are crashing.

With those new methods backported, it would create better DX as:
- same code for handling expectations would work on all 4.x, 5.x and 6.x, currently it's only possible via annotation
- the codebase would be modified less often during automated code upgrade.

If you consider this PR valid, steps that I find needed:
- create 4.9 branch and change base branch for this PR
- `expectExceptionObject` method shall be merged into 5.x as well, as currently it exists only on 6.x; if you don't want to merge 4.x->5.x, let me know and I will prepare new PR
- upgrade PHP CS Fixer annotation fixer rule to respect this change (I will handle it if this PR will get merged)
