### PR TITLE
Adding support for partial string matches within TraversableContains 

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -186,7 +186,8 @@ abstract class Assert
             $constraint = new TraversableContains(
                 $needle,
                 $checkForObjectIdentity,
-                $checkForNonObjectIdentity
+                $checkForNonObjectIdentity,
+                $ignoreCase
             );
         } elseif (\is_string($haystack)) {
             if (!\is_string($needle)) {

--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -33,18 +33,24 @@ class TraversableContains extends Constraint
     protected $value;
 
     /**
+     * @var bool
+     */
+    protected $ignoreCase;
+
+    /**
      * @param mixed $value
      * @param bool  $checkForObjectIdentity
      * @param bool  $checkForNonObjectIdentity
      *
      * @throws \PHPUnit\Framework\Exception
      */
-    public function __construct($value, bool $checkForObjectIdentity = true, bool $checkForNonObjectIdentity = false)
+    public function __construct($value, bool $checkForObjectIdentity = true, bool $checkForNonObjectIdentity = false, $ignoreCase = false)
     {
         parent::__construct();
 
         $this->checkForObjectIdentity    = $checkForObjectIdentity;
         $this->checkForNonObjectIdentity = $checkForNonObjectIdentity;
+        $this->ignoreCase = $ignoreCase;
         $this->value                     = $value;
     }
 
@@ -78,6 +84,10 @@ class TraversableContains extends Constraint
 
         if (\is_object($this->value)) {
             foreach ($other as $element) {
+                if(\is_string($this->value) && \is_string($element)) {
+                    return $this->matchesString($element);
+                }
+
                 if ($this->checkForObjectIdentity && $element === $this->value) {
                     return true;
                 }
@@ -88,6 +98,10 @@ class TraversableContains extends Constraint
             }
         } else {
             foreach ($other as $element) {
+                if(\is_string($this->value) && \is_string($element)) {
+                    return $this->matchesString($element);
+                }
+
                 if ($this->checkForNonObjectIdentity && $element === $this->value) {
                     return true;
                 }
@@ -99,6 +113,27 @@ class TraversableContains extends Constraint
         }
 
         return false;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other when both $other and
+     * $this->needle are strings. Returns true if the constraint is met, false
+     * otherwise.
+     *
+     * @param $other
+     * @return bool
+     */
+    protected function matchesString($other)
+    {
+        if ('' === $this->value) {
+            return true;
+        }
+
+        if ($this->ignoreCase) {
+            return \mb_stripos($other, $this->value) !== false;
+        }
+
+        return \mb_strpos($other, $this->value) !== false;
     }
 
     /**

--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -84,7 +84,7 @@ class TraversableContains extends Constraint
 
         if (\is_object($this->value)) {
             foreach ($other as $element) {
-                if(\is_string($this->value) && \is_string($element)) {
+                if (\is_string($this->value) && \is_string($element)) {
                     return $this->matchesString($element);
                 }
 
@@ -98,7 +98,7 @@ class TraversableContains extends Constraint
             }
         } else {
             foreach ($other as $element) {
-                if(\is_string($this->value) && \is_string($element)) {
+                if (\is_string($this->value) && \is_string($element)) {
                     return $this->matchesString($element);
                 }
 

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -70,6 +70,29 @@ class AssertTest extends TestCase
         $this->assertContains('foo', ['bar']);
     }
 
+    public function testAssertArrayContainsNonCaseSensitiveStringInString(): void
+    {
+        $this->assertContains('Foo', ['foo'], '', true);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertContains('Foo', ['foo'], '', false);
+    }
+
+    public function testAssertArrayContainsPartialStringInString(): void
+    {
+        $this->assertContains('bar', ['foo bar']);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertContains('cake', ['foo bar']);
+    }
+
+    public function testAssertArrayContainsEmptyStringInString(): void
+    {
+        $this->assertContains('', ['foo', 'bar']);
+    }
+
     public function testAssertArrayContainsNonObject(): void
     {
         $this->assertContains('foo', [true]);


### PR DESCRIPTION
Currently `assertContains` will behave in the following way:
```
$this->assertContains('foo', 'foo bar'); // Passes, allowing partial match
$this->assertContains('foo', ['foo', 'bar']); // Passes
$this->assertContains('foo', ['foo bar']); // Fails, expects an exact match
```

This pull request will allow the third assertion to pass by enabling the same partial string matching used when both the expected and actual values are both strings available when the actual value is a type of `Traversable` containing strings.
