### PR TITLE
Adding additional test cases for #assertContains

### DIFF
--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -93,6 +93,24 @@ class AssertTest extends TestCase
         $this->assertContainsOnlyInstancesOf(\Book::class, $test2);
     }
 
+    public function testAssertContainsPartialStringInString(): void
+    {
+        $this->assertContains('bar', 'foo bar');
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertContains('cake', 'foo bar');
+    }
+
+    public function testAssertContainsNonCaseSensitiveStringInString(): void
+    {
+        $this->assertContains('Foo', 'foo', '', true);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertContains('Foo', 'foo', '', false);
+    }
+
     public function testAssertContainsEmptyStringInString(): void
     {
         $this->assertContains('', 'test');


### PR DESCRIPTION
When working on #2936 I noticed the test cases for `assertContains` only tested if empty strings passed. I'm unsure if additional cases were left out for any specific reason so I decided to submit them as a separate PR. 

This PR includes two new test cases for `assertContains`:
- Ensuring it does it passes for partial strings
- Ensuring it obeys the `$ignoreCase` parameter