### PR TITLE
Fix JsonMatches for [] and {}

### DIFF
--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -45,7 +45,7 @@ final class Json
      */
     public static function canonicalize(string $json): array
     {
-        $decodedJson = \json_decode($json, true);
+        $decodedJson = \json_decode($json);
 
         if (\json_last_error()) {
             return [true, null];
@@ -66,7 +66,17 @@ final class Json
     private static function recursiveSort(&$json): void
     {
         if (\is_array($json) === false) {
-            return;
+            // If the object is not empty, change it to an associative array
+            // so we can sort the keys (and we will still re-encode it
+            // correctly, since PHP encodes associative arrays as JSON objects.)
+            // But EMPTY objects MUST remain empty objects. (Otherwise we will
+            // re-encode it as a JSON array rather than a JSON object.)
+            // See #2919.
+            if (\is_object($json) && count((array) $json) > 0) {
+                $json = (array) $json;
+            } else {
+                return;
+            }
         }
 
         \ksort($json);

--- a/tests/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/Framework/Constraint/JsonMatchesTest.php
@@ -77,6 +77,7 @@ class JsonMatchesTest extends TestCase
             'single boolean valid json'               => [true, 'true', 'true'],
             'single number valid json'                => [true, '5.3', '5.3'],
             'single null valid json'                  => [true, 'null', 'null'],
+            'objects are not arrays'                  => [false, '{}', '[]']
         ];
     }
 


### PR DESCRIPTION
This commit fixes #2919 (assertJsonStringEqualsJsonString empty object
matches empty array).

We had a problem where JsonMatches would report that the JSON string
'{}' matches the JSON string '[]'. This bug was due to the fact that
Json::canonicalize() was converting JSON strings to PHP arrays. In a PHP
array, there is no difference between an empty associative array and an
empty indexed array, so Json::canonicalize() did not distinguish between
them either. The solution we apply here is to deserialize JSON into
objects (rather than associative arrays) so that PHP _can_ distinguish
between an empty object and an empty array. If the object is not empty,
we still ultimately convert it to an associative array so we can sort
its keys.