### PR TITLE
Added assert methods

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Constraint\ArraySubset;
 use PHPUnit\Framework\Constraint\Attribute;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;
+use PHPUnit\Framework\Constraint\ClassHasMethod;
 use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\Count;
@@ -1577,6 +1578,54 @@ abstract class Assert
             $object,
             new LogicalNot(
                 new ObjectHasAttribute($attributeName)
+            ),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that an object has a specified method.
+     *
+     * @param string $methodName
+     * @param string|object $classOrObject
+     * @param string $message
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     */
+    public static function assertClassHasMethod(string $methodName, $classOrObject, string $message = ''): void
+    {
+        if (is_string($classOrObject) && !class_exists($classOrObject)) {
+            throw InvalidArgumentHelper::factory(2, 'valid class name');
+        }
+
+        static::assertThat(
+            $classOrObject,
+            new ClassHasMethod($methodName),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that an object does not have a specified method.
+     *
+     * @param string $methodName
+     * @param $classOrObject
+     * @param string $message
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     */
+    public static function assertClassNotHasMethod(string $methodName, $classOrObject, string $message = ''): void
+    {
+        if (is_string($classOrObject) && !class_exists($classOrObject)) {
+            throw InvalidArgumentHelper::factory(2, 'valid class name');
+        }
+
+        static::assertThat(
+            $classOrObject,
+            new LogicalNot(
+                new ClassHasMethod($methodName)
             ),
             $message
         );

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1117,6 +1117,37 @@ function assertObjectNotHasAttribute(string $attributeName, $object, string $mes
     Assert::assertObjectNotHasAttribute(...\func_get_args());
 }
 
+
+/**
+ * Asserts that an object has a specified method.
+ *
+ * @param string $methodName
+ * @param string|object $classOrObject
+ * @param string $message
+ *
+ * @throws Exception
+ * @throws ExpectationFailedException
+ */
+function assertClassHasMethod(string $methodName, $classOrObject, string $message = ''): void
+{
+    Assert::assertClassHasMethod(...\func_get_args());
+}
+
+/**
+ * Asserts that an object does not have a specified method.
+ *
+ * @param string $methodName
+ * @param $classOrObject
+ * @param string $message
+ *
+ * @throws Exception
+ * @throws ExpectationFailedException
+ */
+function assertClassNotHasMethod(string $methodName, $classOrObject, string $message = ''): void
+{
+    Assert::assertClassNotHasMethod(...\func_get_args());
+}
+
 /**
  * Asserts that two variables have the same type and value.
  * Used on objects, it asserts that two variables reference

--- a/src/Framework/Constraint/ClassHasMethod.php
+++ b/src/Framework/Constraint/ClassHasMethod.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: wg
- * Date: 04.01.18
- * Time: 16:54
- */
 
 namespace PHPUnit\Framework\Constraint;
 

--- a/src/Framework/Constraint/ClassHasMethod.php
+++ b/src/Framework/Constraint/ClassHasMethod.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: wg
+ * Date: 04.01.18
+ * Time: 16:54
+ */
+
+namespace PHPUnit\Framework\Constraint;
+
+use ReflectionClass;
+
+class ClassHasMethod extends Constraint
+{
+    /**
+     * @var string
+     */
+    protected $methodName;
+
+    public function __construct(string $methodName)
+    {
+        parent::__construct();
+
+        $this->methodName = $methodName;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return \sprintf(
+            'has method "%s"',
+            $this->methodName
+        );
+    }
+
+    /**
+     * Evaluates the constraint for method $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other value or object to evaluate
+     *
+     * @return bool
+     */
+    protected function matches($other): bool
+    {
+        $class = new ReflectionClass($other);
+
+        return $class->hasMethod($this->methodName);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @return string
+     */
+    protected function failureDescription($other): string
+    {
+        return \sprintf(
+            '%sclass "%s" %s',
+            \is_object($other) ? 'object of ' : 'class of ',
+            \is_object($other) ? \get_class($other) : $other,
+            $this->toString()
+        );
+    }
+}

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -34,6 +34,32 @@ class AssertTest extends TestCase
 
         throw new AssertionFailedError('Fail did not throw fail exception');
     }
+    
+    public function testAssertClassHasMethod(): void
+    {
+        $stubClass = new class {
+            private function methodOne() {}
+            protected function methodTwo() {}
+            public function methodThree() {}
+        };
+
+        $this->assertClassHasMethod('methodOne', get_class($stubClass));
+        $this->assertClassHasMethod('methodTwo', $stubClass);
+        $this->assertClassHasMethod('methodThree', $stubClass);
+
+        $this->expectException(Exception::class);
+        $this->assertClassHasMethod('notExistsMethod', 'NotExistsClass');
+    }
+
+    public function testAssertClassNotHasMethod(): void
+    {
+        $stubClass = new class {};
+
+        $this->assertClassNotHasMethod('notExistsMethod', $stubClass);
+
+        $this->expectException(Exception::class);
+        $this->assertClassNotHasMethod('notExistsMethod', 'NotExistsClass');
+    }
 
     public function testAssertSplObjectStorageContainsObject(): void
     {


### PR DESCRIPTION
This PR is an addition presenting two assert-methods: assertClassHasMethod and assertClassNotHasMethod.

I often use these methods in my work as a reverse engineering tool.

```php
assertClassHasMethod($methodName, $classOrObject, $message);
assertClassNotHasMethod($methodName, $classOrObject, $message);
```

For example:

```php
namespace Example;

class TargetClass
{
    public function targetMethod()
    {
        //
    }
}

```

```php
namespace Example\Tests;

use Example\TargetClass;
use PHPUnit\Framework\TestCase;

class ExampleTest extends TestCase
{
    public function testAssertClassHasMethod()
    {
        $stubClass = new class {
            private function targetMethod() {}
        };

        $this->assertClassHasMethod('targetMethod', $stubClass);
        $this->assertClassHasMethod('targetMethod', TargetClass::class);
    }

    public function testAssertClassNotHasMethod()
    {
        $stubClass = new class {};

        $this->assertClassNotHasMethod('notExistsMethod', $stubClass);
    }
}

```
