### PR TITLE
Add PhpStorm meta file

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PHPSTORM_META {
+    override(
+        \PHPUnit\Framework\TestCase::createMock(0),
+        map([
+            '' => '@|\PHPUnit\Framework\MockObject\MockObject',
+        ])
+    );
+    override(
+        \PHPUnit_Framework_TestCase::createMock(0),
+        map([
+            '' => '@|\PHPUnit_Framework_MockObject_MockObject',
+        ])
+    );
+}


### PR DESCRIPTION
This allows you to do this with code completion in PhpStorm:
```
$mock = $this->createMock(MyClass::class);
$mock->doWhatClassDoes();
$mock->expects($this->any());
```
Class methods are suggested as well as mock methods. 

Unfortunately, it's [not currently possible](https://youtrack.jetbrains.com/issue/WI-37065) to set up this behavior with MockBuilder - the information about the mocked class is lost with the first call. 

Moved from https://github.com/sebastianbergmann/phpunit-mock-objects/pull/399. It makes sense to have it in the main repo as it specifies the behavior of TestCase class. 