### PR TITLE
Fix phpdoc on createMock()

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1745,7 +1745,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * Returns a test double for the specified class.
      *
-     * @param string $originalClassName
+     * @param string|string[] $originalClassName
      *
      * @throws Exception
      * @throws ReflectionException


### PR DESCRIPTION
Hi,

This fixes an error raised by phpstan (static analysis)

> Parameter 1 $originalClassName of method PHPUnit\Framework\TestCase::createMock() expects string, array<int, string> given.

And can be traced back to https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L1198