### PR TITLE
Add ArrayHasKeyValuePair assertion

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -15,6 +15,7 @@ use Countable;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
+use PHPUnit\Framework\Constraint\ArrayHasKeyValuePair;
 use PHPUnit\Framework\Constraint\ArraySubset;
 use PHPUnit\Framework\Constraint\Attribute;
 use PHPUnit\Framework\Constraint\Callback;
@@ -105,6 +106,40 @@ abstract class Assert
         $constraint = new ArrayHasKey($key);
 
         static::assertThat($array, $constraint, $message);
+    }
+
+    /**
+     * Asserts that an array has a specified key value pair.
+     *
+     * @param int|string        $key
+     * @param mixed             $value
+     * @param array|ArrayAccess $array
+     * @param string            $message
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     * @throws \Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertArrayHasKeyValuePair($key, $value, $array, string $message = ''): void
+    {
+        if (!(\is_int($key) || \is_string($key))) {
+            throw InvalidArgumentHelper::factory(
+                1,
+                'integer or string'
+            );
+        }
+
+        if (!(\is_array($array) || $array instanceof ArrayAccess)) {
+            throw InvalidArgumentHelper::factory(
+                3,
+                'array or ArrayAccess'
+            );
+        }
+
+        $constraint = new ArrayHasKeyValuePair($key, $value);
+
+        self::assertThat($array, $constraint, $message);
     }
 
     /**

--- a/src/Framework/Constraint/ArrayHasKeyValuePair.php
+++ b/src/Framework/Constraint/ArrayHasKeyValuePair.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use ArrayAccess;
+
+/**
+ * Constraint which asserts that an array contains a given key value pair.
+ *
+ * An array key and value are passed in a constructor
+ */
+class ArrayHasKeyValuePair extends Constraint
+{
+    /**
+     * @var int|string
+     */
+    protected $key;
+
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * @param int|string $key
+     * @param mixed      $value
+     */
+    public function __construct($key, $value)
+    {
+        parent::__construct();
+
+        $this->key   = $key;
+        $this->value = $value;
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return \sprintf(
+          'has the %s => %s key value pair',
+          $this->exporter->export($this->key),
+          $this->exporter->export($this->value)
+        );
+    }
+
+    protected function matches($other): bool
+    {
+        if (\is_array($other)) {
+            return \array_key_exists($this->key, $other) && $other[$this->key] === $this->value;
+        }
+
+        if ($other instanceof ArrayAccess) {
+            return $other->offsetExists($this->key) && $other[$this->key] === $this->value;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @return string
+     */
+    protected function failureDescription($other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+}

--- a/src/Framework/Constraint/ArrayHasKeyValuePair.php
+++ b/src/Framework/Constraint/ArrayHasKeyValuePair.php
@@ -48,9 +48,9 @@ class ArrayHasKeyValuePair extends Constraint
     public function toString(): string
     {
         return \sprintf(
-          'has the %s => %s key value pair',
-          $this->exporter->export($this->key),
-          $this->exporter->export($this->value)
+            'has the %s => %s key value pair',
+            $this->exporter->export($this->key),
+            $this->exporter->export($this->value)
         );
     }
 

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -139,6 +139,61 @@ class AssertTest extends TestCase
         $this->assertArrayHasKey(1, ['foo']);
     }
 
+    public function testAssertArrayHasKeyValuePairThrowsExceptionForInvalidFirstArgument(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->assertArrayHasKeyValuePair(null, 'foo', []);
+    }
+
+    public function testAssertArrayHasKeyValuePairThrowsExceptionForInvalidThirdArgument(): void
+    {
+        $this->expectException(Exception::class);
+
+        $this->assertArrayHasKeyValuePair(0, 'foo', null);
+    }
+
+    public function testAssertArrayHasKeyValuePair()
+    {
+        $array = [
+            'a' => 'foo',
+            100 => 'bar',
+            'b' => [1, 2, 3]
+        ];
+
+        $this->assertArrayHasKeyValuePair('a', 'foo', $array);
+        $this->assertArrayHasKeyValuePair(100, 'bar', $array);
+        $this->assertArrayHasKeyValuePair('100', 'bar', $array);
+        $this->assertArrayHasKeyValuePair('b', [1, 2, 3], $array);
+    }
+
+    public function testAssertArrayHasKeyValuePairWithWrongKey()
+    {
+        $array = [123 => 'foo'];
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasKeyValuePair('wrong key', 'foo', $array);
+    }
+
+    public function testAssertArrayHasKeyValuePairWithWrongValue()
+    {
+        $array = ['a' => 'foo'];
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasKeyValuePair('a', 'wrong value', $array);
+    }
+
+    public function testAssertArrayHasKeyValuePairIsNotRecursive()
+    {
+        $array = ['a' => ['foo' => 'bar']];
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayHasKeyValuePair('foo', 'bar', $array);
+    }
+
     public function testAssertArraySubset(): void
     {
         $array = [

--- a/tests/Framework/Constraint/ArrayHasKeyValuePairTest.php
+++ b/tests/Framework/Constraint/ArrayHasKeyValuePairTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestFailure;
+
+class ArrayHasKeyValuePairTest extends ConstraintTestCase
+{
+    /**
+     * @dataProvider keyValueMessageProvider
+     *
+     * @param mixed $key
+     * @param mixed $value
+     * @param mixed $message
+     */
+    public function testConstraintArrayHasKeyValuePair($key, $value, $message): void
+    {
+        $constraint = new ArrayHasKeyValuePair($key, $value);
+
+        $this->assertFalse($constraint->evaluate([], '', true));
+        $this->assertEquals($message, $constraint->toString());
+        $this->assertCount(1, $constraint);
+
+        try {
+            $constraint->evaluate([]);
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that an array {$message}.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function keyValueMessageProvider()
+    {
+        return [
+            [0, 123, 'has the 0 => 123 key value pair'],
+            ['foo', 'bar', "has the 'foo' => 'bar' key value pair"],
+            ['arr', [1, 2, 3], "has the 'arr' => Array &0 (\n    0 => 1\n    1 => 2\n    2 => 3\n) key value pair"]
+        ];
+    }
+}


### PR DESCRIPTION
```
In order to assert that an array has a specific key => value pair
As a developer
I want to use nice, simple and clean assertion
```

Currently to check if array contains specific key => value pair we have three options. All of them allow us to avoid raising an error if the key is not present in the array.

1) Make two assertions (making two assertions is annoying)
```php
$response = json_decode($this->httpClient->get('someUrl'), true);
Assert::assertArrayHasKey('errorCode', $response);
Assert::assertEquals(404001, $response['errorCode']);
```

2) Assert subset exists (dangerous as it's recursive, not very clear)
```php
$response = json_decode($this->httpClient->get('someUrl'), true);
Assert::assertArraySubset(['errorCode' => 404001], $response);
```

3) Use null coalescing operator (only in php >=7.0)
```php
$response = json_decode($this->httpClient->get('someUrl'), true);
Assert::assertEquals(404001, $response['errorCode'] ?? null);
```

Perhaps there are some more options but I suggested only the most concise ones. 

My suggestion is to introduce a new assertion called `ArrayHasKeyValuePair` which accepts `key`, `value` and `array` parameters. `ArrayHasKeyValuePair` is not recursive and basically is a combination of `ArrayHasKey` + value identity comparison. It's more semantic and simple to understand than all above options.

To compare with other testing frameworks in Hamcrest you can make the same assertion in 1 line of code: 
```
assertThat($response, hasKeyValuePair('errorCode', 401002));
```

Please let me know your thoughts. Happy to update docs once the PR is accepted.