### PR TITLE
PHPUnit shouldn't crash when a test suite contains both *.phpt files and unconventionally named tests

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -305,7 +305,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                 }
             }
 
-            if (!$suiteMethod && !$testClass->isAbstract()) {
+            if (!$suiteMethod && !$testClass->isAbstract() && $testClass->isSubclassOf(TestCase::class)) {
                 $this->addTest(new self($testClass));
             }
         } else {

--- a/tests/Regression/GitHub/2972.phpt
+++ b/tests/Regression/GitHub/2972.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-2972: Test suite shouldn't fail when it contains both *.phpt files and unconventionally named tests
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = __DIR__ . '/2972/';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)

--- a/tests/Regression/GitHub/2972/issue-2972-test.phpt
+++ b/tests/Regression/GitHub/2972/issue-2972-test.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Just a sample test dor issue 2972, does not actually test anything
+--FILE--
+<?php
+echo "Hello world\n";
+?>
+===DONE===
+--EXPECT--
+Hello world
+===DONE===

--- a/tests/Regression/GitHub/2972/issue-2972-test.phpt
+++ b/tests/Regression/GitHub/2972/issue-2972-test.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Just a sample test dor issue 2972, does not actually test anything
+Just a sample test for issue 2972, does not actually test anything
 --FILE--
 <?php
 echo "Hello world\n";

--- a/tests/Regression/GitHub/2972/unconventiallyNamedIssue2972Test.php
+++ b/tests/Regression/GitHub/2972/unconventiallyNamedIssue2972Test.php
@@ -1,0 +1,10 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class Issue2972Test extends TestCase
+{
+    public function testHello()
+    {
+        $this->assertNotEmpty('Hello world!');
+    }
+}

--- a/tests/Regression/GitHub/2972/unconventiallyNamedIssue2972Test.php
+++ b/tests/Regression/GitHub/2972/unconventiallyNamedIssue2972Test.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Issue2972;
+
 use PHPUnit\Framework\TestCase;
 
 class Issue2972Test extends TestCase


### PR DESCRIPTION
Should fix #2972 and probably #2950 .