### PR TITLE
Ensure that assertSame generates diff for arrays

### DIFF
--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -92,6 +92,16 @@ class IsIdentical extends Constraint
                 );
             }
 
+            // if both values are array, make sure a diff is generated
+            if (\is_array($this->value) && \is_array($other)) {
+                $f = new SebastianBergmann\Comparator\ComparisonFailure(
+                    $this->value,
+                    $other,
+                    $this->exporter->export($this->value),
+                    $this->exporter->export($other)
+                );
+            }
+
             $this->fail($other, $description, $f);
         }
     }
@@ -135,6 +145,10 @@ class IsIdentical extends Constraint
 
         if (\is_string($this->value) && \is_string($other)) {
             return 'two strings are identical';
+        }
+
+        if (\is_array($this->value) && \is_array($other)) {
+            return 'two arrays are identical';
         }
 
         return parent::failureDescription($other);

--- a/tests/Framework/Constraint/IsIdenticalTest.php
+++ b/tests/Framework/Constraint/IsIdenticalTest.php
@@ -98,4 +98,94 @@ EOF
 
         $this->fail();
     }
+
+    public function testConstraintIsIdenticalArrayDiff(): void
+    {
+        $expected = [1, 2, 3, 4, 5, 6];
+        $actual   = [1, 2, 33, 4, 5, 6];
+
+        $constraint = new IsIdentical($expected);
+
+        try {
+            $constraint->evaluate($actual, 'custom message');
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame(
+                <<<EOF
+custom message
+Failed asserting that two arrays are identical.
+--- Expected
++++ Actual
+@@ @@
+ Array &0 (
+     0 => 1
+     1 => 2
+-    2 => 3
++    2 => 33
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testConstraintIsIdenticalNestedArrayDiff(): void
+    {
+        $expected = [
+            ['A' => 'B'],
+            [
+                'C' => [
+                    'D',
+                    'E',
+                ],
+            ],
+        ];
+        $actual = [
+            ['A' => 'C'],
+            [
+                'C' => [
+                    'C',
+                    'E',
+                    'F'
+                ],
+            ],
+        ];
+        $constraint = new IsIdentical($expected);
+
+        try {
+            $constraint->evaluate($actual, 'custom message');
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+custom message
+Failed asserting that two arrays are identical.
+--- Expected
++++ Actual
+@@ @@
+ Array &0 (
+     0 => Array &1 (
+-        'A' => 'B'
++        'A' => 'C'
+     )
+     1 => Array &2 (
+         'C' => Array &3 (
+-            0 => 'D'
++            0 => 'C'
+             1 => 'E'
++            2 => 'F'
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
 }


### PR DESCRIPTION
Fixes #2169.

With this patch, the arrays are diffed for `assertSame()` similarly to `assertEquals()`:

```php
<?php declare(strict_types = 1);

use PHPUnit\Framework\TestCase;

class ArrayDiffTest extends TestCase
{
	public function testEquality()
	{
		$this->assertEquals(
			[1, 2, 3, 4, 5, 6],
			[1, 2, 33, 4, 5, 6]
		);
	}

	public function testSame()
	{
		$this->assertSame(
			[1, 2, 3, 4, 5, 6],
			[1, 2, 33, 4, 5, 6]
		);
	}
```

```
1) ArrayDiffTest::testEquality
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => 1
     1 => 2
-    2 => 3
+    2 => 33


2) ArrayDiffTest::testSame
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
     0 => 1
     1 => 2
-    2 => 3
+    2 => 33

```


I also tested it with PHPStorm and it fixes [the diffing issue](https://youtrack.jetbrains.com/issue/WI-31705) there as well:

![image](https://user-images.githubusercontent.com/353372/35471589-5a196518-035e-11e8-9312-2ea83fc789ac.png)

## Questions:
1) is this a correct approach?
2) Wouldn't is be better to merge it to 6.5 branch? 