### PR TITLE
Update AppVeyor build PHP versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/php-%PHP_VERSION%-x86.zip
+  - IF NOT EXIST php-installed.txt appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-x86.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini


### PR DESCRIPTION
Those files are no longer available:
- http://windows.php.net/downloads/releases/php-7.1.12-Win32-VC14-x86.zip
- http://windows.php.net/downloads/releases/php-7.2.0-Win32-VC15-x86.zip

Those are available:
- http://windows.php.net/downloads/releases/php-7.1.13-Win32-VC14-x86.zip
- http://windows.php.net/downloads/releases/php-7.2.1-Win32-VC15-x86.zip

Symfony hosts the binary files itself - see its [appveyor.yml](https://github.com/symfony/symfony/blob/0d975ccdba10387b90ccaa27f8448c3c088e4aba/appveyor.yml#L18). Maybe the similar approach can be taken here to prevent suddenly broken builds.