### PR TITLE
Fix invalid class reference

### DIFF
--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -34,7 +34,7 @@ class TestTest extends TestCase
         );
 
         $this->assertArraySubset(
-            ['class' => \Foo\Bar\Baz::class, 'code' => null, 'message' => ''],
+            ['class' => 'Foo\Bar\Baz', 'code' => null, 'message' => ''],
             Test::getExpectedException(\ExceptionTest::class, 'testThree')
         );
 


### PR DESCRIPTION
`\Foo\Bar\Baz` is used as a dummy class in there and it actually does not exist.

Class `\Foo\Bar\Baz` exists only in `phpunit\php-token-stream\tests\_fixture\classExtendsNamespacedClass.php` which is completely unrelated and not autoloaded.

This is a fix for an issue detected by PHPStan (level 0) - https://github.com/sebastianbergmann/phpunit/pull/2980.
