### PR TITLE
Include files with namespaced functions in autoload-dev in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,9 @@
         ],
         "files": [
             "src/Framework/Assert/Functions.php",
-            "tests/_files/CoveredFunction.php"
+            "tests/_files/CoverageNamespacedFunctionTest.php",
+            "tests/_files/CoveredFunction.php",
+            "tests/_files/NamespaceCoveredFunction.php"
         ]
     },
     "extra": {


### PR DESCRIPTION
Some files with functions were included and some were not.

This is a fix for an issue detected by PHPStan (level 0) - https://github.com/sebastianbergmann/phpunit/pull/2980.