### PR TITLE
Add PHPStan (level 0) as a build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,14 @@ after_success:
 notifications:
   email: false
 
+jobs:
+  include:
+    - stage: Code Quality
+      php: 7.2
+      env: PHPStan
+      install: travis_retry composer update --prefer-dist --prefer-stable
+      before_script:
+        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
+      script:
+        - vendor/bin/phpstan analyse --level=0 -c phpstan.neon src
+        - vendor/bin/phpstan analyse --level=0 -c phpstan-tests.neon tests

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -1,0 +1,10 @@
+parameters:
+    ignoreErrors:
+        # parent calls are intentionally omitted
+        - '#Issue244Exception::__construct\(\) does not call parent constructor from Exception.#'
+        - '#Issue244ExceptionIntCode::__construct\(\) does not call parent constructor from Exception.#'
+
+    excludes_analyse:
+        # duplicated classname OneTest
+        - tests/_files/phpunit-example-extension/tests/OneTest.php
+        - tests/Regression/Trac/783/OneTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    ignoreErrors:
+        # phpunit/php-invoker is an optional dependency
+        - '#Class SebastianBergmann\\Invoker\\Invoker not found.#'
+        - '#Instantiated class SebastianBergmann\\Invoker\\Invoker not found.#'
+        - '#Caught class SebastianBergmann\\Invoker\\TimeoutException not found.#'


### PR DESCRIPTION
> Depends on https://github.com/sebastianbergmann/phpunit/pull/2978 and https://github.com/sebastianbergmann/phpunit/pull/2979. After they are merged, I will rebase this one.

This is inspired by https://github.com/sebastianbergmann/phpunit/pull/2935 (I hope that @mikeSimonson won't get angry with me :-) ), but some things are done differently:

- ~~I used a specific phpstan/phpstan version to prevent build breakage when new checks are added to PHPStan (It would probably fail on unrelated PRs)~~
- I have enabled only Level 0 checks
- PHPStan is configured to analyze both `src` and `tests` (with different configs to allow separately ignore errors)

