### PR TITLE
Fix comparison changed in the CS commit

### DIFF
--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -346,7 +346,7 @@ final class Configuration
                     continue;
                 }
 
-                if (!$node->tagName === 'arguments') {
+                if ($node->tagName !== 'arguments') {
                     continue;
                 }
 


### PR DESCRIPTION
I was trying what happens when I enable higher [PHPStan level](https://github.com/sebastianbergmann/phpunit/pull/2980) and I discovered this bug.

It was broken recently during a CS fix https://github.com/sebastianbergmann/phpunit/commit/3a9494be34135e5d42964ec7f5f17605e736a2c7#diff-29dd5adc8f5a89b298b28f4629b83e79R334