### PR TITLE
Remove remnants of non-namespaced code

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -210,7 +210,7 @@
     <xs:attribute name="convertNoticesToExceptions" type="xs:boolean" default="true"/>
     <xs:attribute name="convertWarningsToExceptions" type="xs:boolean" default="true"/>
     <xs:attribute name="forceCoversAnnotation" type="xs:boolean" default="false"/>
-    <xs:attribute name="printerClass" type="xs:string" default="PHPUnit_TextUI_ResultPrinter"/>
+    <xs:attribute name="printerClass" type="xs:string" default="PHPUnit\TextUI\ResultPrinter"/>
     <xs:attribute name="printerFile" type="xs:anyURI"/>
     <xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
     <xs:attribute name="stopOnError" type="xs:boolean" default="false"/>
@@ -232,7 +232,7 @@
     <xs:attribute name="timeoutForSmallTests" type="xs:integer" default="1"/>
     <xs:attribute name="timeoutForMediumTests" type="xs:integer" default="10"/>
     <xs:attribute name="timeoutForLargeTests" type="xs:integer" default="60"/>
-    <xs:attribute name="testSuiteLoaderClass" type="xs:string" default="PHPUnit_Runner_StandardTestSuiteLoader"/>
+    <xs:attribute name="testSuiteLoaderClass" type="xs:string" default="PHPUnit\Runner\StandardTestSuiteLoader"/>
     <xs:attribute name="testSuiteLoaderFile" type="xs:anyURI"/>
     <xs:attribute name="defaultTestSuite" type="xs:string" default=""/>
     <xs:attribute name="verbose" type="xs:boolean" default="false"/>

--- a/tests/Util/XmlTest.php
+++ b/tests/Util/XmlTest.php
@@ -38,7 +38,7 @@ class XmlTest extends TestCase
         }
 
         $this->assertNull($e, \sprintf(
-            'PHPUnit_Util_XML::prepareString("\x%02x") should not crash DomDocument',
+            '\PHPUnit\Util\Xml::prepareString("\x%02x") should not crash DomDocument',
             \ord($char)
         ));
     }

--- a/tests/_files/SampleArrayAccess.php
+++ b/tests/_files/SampleArrayAccess.php
@@ -3,7 +3,7 @@
  * Sample class that implements ArrayAccess copied from
  * http://www.php.net/manual/en/class.arrayaccess.php
  * with some minor changes
- * This class required for PHPUnit_Framework_Constraint_ArrayHasKey testing
+ * This class required for \PHPUnit\Framework\Constraint\ArrayHasKey testing
  */
 class SampleArrayAccess implements ArrayAccess
 {


### PR DESCRIPTION
There were some pieces of code or documentation referencing classes starting with `PHPUnit_`

Related to https://github.com/sebastianbergmann/phpunit-documentation-english/issues/23