### PR TITLE
PHPUnit exits with error status code when php-error was converted to exception

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -27,6 +27,7 @@ use PHPUnit\Runner\StandardTestSuiteLoader;
 use PHPUnit\Runner\TestSuiteLoader;
 use PHPUnit\Runner\Version;
 use PHPUnit\Util\Configuration;
+use PHPUnit\Util\ErrorHandler;
 use PHPUnit\Util\Log\JUnit;
 use PHPUnit\Util\Log\TeamCity;
 use PHPUnit\Util\Printer;
@@ -632,6 +633,14 @@ class TestRunner extends BaseTestRunner
                     );
                 }
             }
+        }
+
+        if ($stack = ErrorHandler::getErrorStack()) {
+            $result->addError(
+                new TestSuite(),
+                new Exception('Some PHP errors were converted to exceptions'),
+                microtime(true)
+            );
         }
 
         if ($exit) {


### PR DESCRIPTION
By default PHPUnit converts all php errors (notices/warnings/...) to exceptions. As I can guess it is to fail (have exit status !== 0) when we have some notice/warning/... etc. We can disable it in configuration (option: `convert*ToExceptions` -https://phpunit.de/manual/current/en/appendixes.configuration.html) but then we are not going to have exit error code !== 0 on notice/warning/...

Unfortunately it converting php errors to exceptions could cause some fals positive cases.
I've created simple repository to demonstrate one:
https://github.com/webimpress/phpunit-error-conversion

Basically when we have code:
```php
function myFunction() {
  try {
    // some code where we get notice/warning/....
    // it will be converted by PHPUnit to exception
  } catch (Exception $e) {
    // and that exception will be caught here and the result will be 0
    // but in real call execution (without PHPUnit) there is not going to be any exception
    return 0;
  }
  return 1;
}
```

I think then we should always return exit code 1 when we converted something to exceptions and display some information about it.

In this PR I modify only a bit TestRunner to check `ErrorHandler` and converted php-errors.
Probably we need also similar check in `Command`:
https://github.com/sebastianbergmann/phpunit/blob/master/src/TextUI/Command.php#L212-L216

I don't know the whole flow in PHPUnit so I just want to point the issue and I hope you can find the best solution.

Please remember I'm giving very simple example to understand where is the problem. You can argue that this code is wrong and it shouldn't be written like that. But imho the testing tool shouldn't affect the subject of testing.