### PR TITLE
Add asserts to test exceptions thrown by functional callable functions

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2525,6 +2525,50 @@ abstract class Assert
     }
 
     /**
+     * Asserts that a given exception is thrown by a callable function
+     *
+     * @param string $expectedException
+     * @param callable $evaluation
+     * @param string $message
+     *
+     * @throws AssertionFailedError
+     * @throws Exception
+     * @throws \Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertException(string $expectedException, callable $evaluation, string $message = ''): void
+    {
+        try{
+            call_user_func($evaluation);
+            throw new AssertionFailedError($message);
+        }catch(\Exception $actualException){
+            static::assertInstanceOf($expectedException, $actualException, $message);
+        }
+    }
+
+    /**
+     * Asserts that a callable functions do not throws an exception
+     *
+     * @param string $notExpectedException
+     * @param callable $evaluation
+     * @param string $message
+     *
+     * @throws AssertionFailedError
+     * @throws Exception
+     * @throws \Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertNotException(string $notExpectedException, callable $evaluation, string $message = ''): void
+    {
+        try{
+            call_user_func($evaluation);
+            throw new AssertionFailedError($message);
+        }catch(\Exception $actualException){
+            static::assertNotInstanceOf($notExpectedException, $actualException, $message);
+        }
+    }
+
+    /**
      * @throws Exception
      */
     public static function logicalAnd(): LogicalAnd

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2538,10 +2538,10 @@ abstract class Assert
      */
     public static function assertException(string $expectedException, callable $evaluation, string $message = ''): void
     {
-        try{
+        try {
             call_user_func($evaluation);
             throw new AssertionFailedError($message);
-        }catch(\Exception $actualException){
+        } catch (\Exception $actualException) {
             static::assertInstanceOf($expectedException, $actualException, $message);
         }
     }
@@ -2560,10 +2560,10 @@ abstract class Assert
      */
     public static function assertNotException(string $notExpectedException, callable $evaluation, string $message = ''): void
     {
-        try{
+        try {
             call_user_func($evaluation);
             throw new AssertionFailedError($message);
-        }catch(\Exception $actualException){
+        } catch (\Exception $actualException) {
             static::assertNotInstanceOf($notExpectedException, $actualException, $message);
         }
     }

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1724,6 +1724,38 @@ function assertJsonFileNotEqualsJsonFile(string $expectedFile, string $actualFil
     Assert::assertJsonFileNotEqualsJsonFile(...\func_get_args());
 }
 
+/**
+ * Asserts that a given exception is thrown by a callable function
+ *
+ * @param string $expectedException
+ * @param callable $evaluation
+ * @param string $message
+ *
+ * @throws Exception
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ */
+function assertException(string $expectedException, callable $evaluation, string $message = ''): void
+{
+    Assert::assertException(...\func_get_args());
+}
+
+/**
+ * Asserts that a given exception is thrown by a callable function
+ *
+ * @param string $notExpectedException
+ * @param callable $evaluation
+ * @param string $message
+ *
+ * @throws Exception
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ */
+function assertNotException(string $notExpectedException, callable $evaluation, string $message = ''): void
+{
+    Assert::assertNotException(...\func_get_args());
+}
+
 function logicalAnd(): LogicalAnd
 {
     return Assert::logicalAnd(...\func_get_args());

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -2570,30 +2570,30 @@ XML;
 
     public function testAssertException(): void
     {
-        $this->assertException(\NewException::class, function(){
+        $this->assertException(\NewException::class, function () {
             throw new \NewException();
         });
 
-        $this->assertException(\Exception::class, function(){
+        $this->assertException(\Exception::class, function () {
             throw new \NewException();
         });
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertException(\NewException::class, function(){
+        $this->assertException(\NewException::class, function () {
             throw new \DummyException();
         });
     }
 
     public function testAssertNotException(): void
     {
-        $this->assertNotException(\NewException::class, function(){
+        $this->assertNotException(\NewException::class, function () {
             throw new \DummyException();
         });
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertNotException(\NewException::class, function(){
+        $this->assertNotException(\NewException::class, function () {
             throw new \NewException();
         });
     }

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -2568,6 +2568,36 @@ XML;
         $this->assertStringNotMatchesFormatFile($this->filesDirectory . 'expectedFileFormat.txt', "FOO\n");
     }
 
+    public function testAssertException(): void
+    {
+        $this->assertException(\NewException::class, function(){
+            throw new \NewException();
+        });
+
+        $this->assertException(\Exception::class, function(){
+            throw new \NewException();
+        });
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertException(\NewException::class, function(){
+            throw new \DummyException();
+        });
+    }
+
+    public function testAssertNotException(): void
+    {
+        $this->assertNotException(\NewException::class, function(){
+            throw new \DummyException();
+        });
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertNotException(\NewException::class, function(){
+            throw new \NewException();
+        });
+    }
+
     /**
      * @return array<string, string[]>
      */


### PR DESCRIPTION
The ```assertException()``` method mentioned on https://thephp.cc/news/2016/02/questioning-phpunit-best-practices