### PR TITLE
remove redundant '@throws \Exception'

### DIFF
--- a/src/Framework/Constraint/ArrayHasKey.php
+++ b/src/Framework/Constraint/ArrayHasKey.php
@@ -38,7 +38,6 @@ class ArrayHasKey extends Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string
@@ -77,7 +76,6 @@ class ArrayHasKey extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -58,7 +58,6 @@ class ArraySubset extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */
@@ -96,7 +95,6 @@ class ArraySubset extends Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string
@@ -114,7 +112,6 @@ class ArraySubset extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/Attribute.php
+++ b/src/Framework/Constraint/Attribute.php
@@ -45,7 +45,6 @@ class Attribute extends Composite
      * @param bool   $returnResult Whether to return a result or throw an exception
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \PHPUnit\Framework\Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *

--- a/src/Framework/Constraint/Composite.php
+++ b/src/Framework/Constraint/Composite.php
@@ -44,7 +44,6 @@ abstract class Composite extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */

--- a/src/Framework/Constraint/ExceptionCode.php
+++ b/src/Framework/Constraint/ExceptionCode.php
@@ -55,7 +55,6 @@ class ExceptionCode extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/GreaterThan.php
+++ b/src/Framework/Constraint/GreaterThan.php
@@ -33,7 +33,6 @@ class GreaterThan extends Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -131,7 +131,6 @@ class IsEqual extends Constraint
      * Returns a string representation of the constraint.
      *
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return string
      */

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -61,7 +61,6 @@ class IsIdentical extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */
@@ -110,7 +109,6 @@ class IsIdentical extends Constraint
      * Returns a string representation of the constraint.
      *
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return string
      */
@@ -133,7 +131,6 @@ class IsIdentical extends Constraint
      * @param mixed $other evaluated value or object
      *
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return string
      */

--- a/src/Framework/Constraint/IsInstanceOf.php
+++ b/src/Framework/Constraint/IsInstanceOf.php
@@ -70,7 +70,6 @@ class IsInstanceOf extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/IsJson.php
+++ b/src/Framework/Constraint/IsJson.php
@@ -54,7 +54,6 @@ class IsJson extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -85,7 +85,6 @@ class JsonMatches extends Constraint
      * @throws ExpectationFailedException
      * @throws \PHPUnit\Framework\Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
     {

--- a/src/Framework/Constraint/LessThan.php
+++ b/src/Framework/Constraint/LessThan.php
@@ -33,7 +33,6 @@ class LessThan extends Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/LogicalAnd.php
+++ b/src/Framework/Constraint/LogicalAnd.php
@@ -67,7 +67,6 @@ class LogicalAnd extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */

--- a/src/Framework/Constraint/LogicalNot.php
+++ b/src/Framework/Constraint/LogicalNot.php
@@ -109,7 +109,6 @@ class LogicalNot extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */
@@ -164,7 +163,6 @@ class LogicalNot extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/LogicalOr.php
+++ b/src/Framework/Constraint/LogicalOr.php
@@ -64,7 +64,6 @@ class LogicalOr extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */

--- a/src/Framework/Constraint/LogicalXor.php
+++ b/src/Framework/Constraint/LogicalXor.php
@@ -64,7 +64,6 @@ class LogicalXor extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */

--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -51,7 +51,6 @@ class TraversableContains extends Constraint
     /**
      * Returns a string representation of the constraint.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string
@@ -112,7 +111,6 @@ class TraversableContains extends Constraint
      *
      * @param mixed $other evaluated value or object
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/Constraint/TraversableContainsOnly.php
+++ b/src/Framework/Constraint/TraversableContainsOnly.php
@@ -61,7 +61,6 @@ class TraversableContainsOnly extends Constraint
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return mixed
      */

--- a/src/Framework/IncompleteTestCase.php
+++ b/src/Framework/IncompleteTestCase.php
@@ -66,7 +66,6 @@ class IncompleteTestCase extends TestCase
     /**
      * Returns a string representation of the test case.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/SkippedTestCase.php
+++ b/src/Framework/SkippedTestCase.php
@@ -66,7 +66,6 @@ class SkippedTestCase extends TestCase
     /**
      * Returns a string representation of the test case.
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      *
      * @return string

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -308,7 +308,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * Returns a string representation of the test case.
      *
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function toString(): string
     {
@@ -348,7 +347,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     /**
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function getName(bool $withDataSet = true): ?string
     {
@@ -363,7 +361,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * Returns the size of the test.
      *
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function getSize(): int
     {
@@ -375,7 +372,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     /**
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function hasSize(): bool
     {
@@ -384,7 +380,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     /**
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function isSmall(): bool
     {
@@ -393,7 +388,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     /**
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function isMedium(): bool
     {
@@ -402,7 +396,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     /**
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function isLarge(): bool
     {
@@ -553,7 +546,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * @throws SebastianBergmann\CodeCoverage\RuntimeException
      * @throws SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function run(TestResult $result = null): TestResult
     {
@@ -1875,7 +1867,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @throws RiskyTestError
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      * @throws \InvalidArgumentException
      */
     private function restoreGlobalState(): void
@@ -1956,7 +1947,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @throws RiskyTestError
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      * @throws \InvalidArgumentException
      */
     private function compareGlobalStateSnapshots(Snapshot $before, Snapshot $after): void
@@ -2045,7 +2035,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      * @throws SebastianBergmann\ObjectEnumerator\InvalidArgumentException
      * @throws SebastianBergmann\ObjectReflector\InvalidArgumentException
      * @throws SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     private function registerMockObjectsFromTestArguments(array $testArguments, array &$visited = []): void
     {

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -401,7 +401,6 @@ class TestResult implements Countable
      * @param Test  $test
      * @param float $time
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function endTest(Test $test, $time): void
@@ -615,7 +614,6 @@ class TestResult implements Countable
      * @throws OriginalCoveredCodeNotExecutedException
      * @throws OriginalMissingCoversAnnotationException
      * @throws UnintentionallyCoveredCodeException
-     * @throws \Exception
      * @throws \ReflectionException
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
      * @throws \SebastianBergmann\CodeCoverage\RuntimeException

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -678,7 +678,6 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
      * Runs the tests and collects their result in a TestResult.
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     public function run(TestResult $result = null): TestResult
     {

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -105,7 +105,6 @@ class PhptTestCase implements Test, SelfDescribing
      * @throws \SebastianBergmann\CodeCoverage\RuntimeException
      * @throws \SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return TestResult
      */
@@ -315,7 +314,6 @@ class PhptTestCase implements Test, SelfDescribing
      * @param array      $settings
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      *
      * @return bool
      */

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -317,7 +317,6 @@ class JUnit extends Printer implements TestListener
      *
      * @param Test $test
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function startTest(Test $test): void

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -185,7 +185,6 @@ abstract class AbstractPhpProcess
      * @param Test       $test
      * @param TestResult $result
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function runTestJob($job, Test $test, TestResult $result): void
@@ -273,7 +272,6 @@ abstract class AbstractPhpProcess
      * @param string     $stderr
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \Exception
      */
     private function processChildResult(Test $test, TestResult $result, $stdout, $stderr): void
     {

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -248,7 +248,6 @@ abstract class ResultPrinter extends Printer implements TestListener
      *
      * @param Test $test
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function startTest(Test $test): void

--- a/src/Util/TestDox/XmlResultPrinter.php
+++ b/src/Util/TestDox/XmlResultPrinter.php
@@ -173,7 +173,6 @@ class XmlResultPrinter extends Printer implements TestListener
      * @param Test  $test
      * @param float $time
      *
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function endTest(Test $test, float $time): void

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -223,7 +223,6 @@ class AssertTest extends TestCase
      *
      * @throws Exception
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertArraySubsetRaisesExceptionForInvalidArguments($partial, $subject): void
@@ -539,7 +538,6 @@ class AssertTest extends TestCase
      * @param mixed $ignoreCase
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertEqualsSucceeds($a, $b, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
@@ -557,7 +555,6 @@ class AssertTest extends TestCase
      * @param mixed $ignoreCase
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertEqualsFails($a, $b, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
@@ -577,7 +574,6 @@ class AssertTest extends TestCase
      * @param mixed $ignoreCase
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertNotEqualsSucceeds($a, $b, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
@@ -595,7 +591,6 @@ class AssertTest extends TestCase
      * @param mixed $ignoreCase
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertNotEqualsFails($a, $b, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
@@ -612,7 +607,6 @@ class AssertTest extends TestCase
      * @param mixed $b
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertSameSucceeds($a, $b): void
@@ -627,7 +621,6 @@ class AssertTest extends TestCase
      * @param mixed $b
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertSameFails($a, $b): void
@@ -644,7 +637,6 @@ class AssertTest extends TestCase
      * @param mixed $b
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertNotSameSucceeds($a, $b): void
@@ -659,7 +651,6 @@ class AssertTest extends TestCase
      * @param mixed $b
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertNotSameFails($a, $b): void
@@ -2368,7 +2359,6 @@ XML;
      * @param mixed $actual
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertJsonStringEqualsJsonStringErrorRaised($expected, $actual): void
@@ -2394,7 +2384,6 @@ XML;
      * @param mixed $actual
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testAssertJsonStringNotEqualsJsonStringErrorRaised($expected, $actual): void

--- a/tests/Framework/Constraint/ArraySubsetTest.php
+++ b/tests/Framework/Constraint/ArraySubsetTest.php
@@ -21,7 +21,6 @@ class ArraySubsetTest extends ConstraintTestCase
      * @param bool               $strict
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @dataProvider evaluateDataProvider
      */

--- a/tests/Framework/Constraint/IsJsonTest.php
+++ b/tests/Framework/Constraint/IsJsonTest.php
@@ -18,7 +18,6 @@ class IsJsonTest extends ConstraintTestCase
      * @param mixed $expected
      * @param mixed $jsonOther
      *
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */

--- a/tests/Framework/Constraint/JsonMatchesErrorMessageProviderTest.php
+++ b/tests/Framework/Constraint/JsonMatchesErrorMessageProviderTest.php
@@ -20,7 +20,6 @@ class JsonMatchesErrorMessageProviderTest extends TestCase
      * @param mixed $expected
      * @param mixed $type
      *
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -39,7 +38,6 @@ class JsonMatchesErrorMessageProviderTest extends TestCase
      * @param mixed $error
      * @param mixed $prefix
      *
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */

--- a/tests/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/Framework/Constraint/JsonMatchesTest.php
@@ -23,7 +23,6 @@ class JsonMatchesTest extends ConstraintTestCase
      * @param mixed $jsonValue
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function testEvaluate($expected, $jsonOther, $jsonValue): void
@@ -40,7 +39,6 @@ class JsonMatchesTest extends ConstraintTestCase
      * @param mixed $jsonValue
      *
      * @throws ExpectationFailedException
-     * @throws \Exception
      * @throws \PHPUnit\Framework\AssertionFailedError
      * @throws \PHPUnit\Framework\Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -442,7 +442,6 @@ class ConfigurationTest extends TestCase
      * @param Configuration $actualConfiguration
      *
      * @throws Exception
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */

--- a/tests/Util/JsonTest.php
+++ b/tests/Util/JsonTest.php
@@ -21,7 +21,6 @@ class JsonTest extends TestCase
      * @param mixed $expected
      * @param mixed $expectError
      *
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -52,7 +51,6 @@ class JsonTest extends TestCase
      * @param mixed $actual
      * @param mixed $expected
      *
-     * @throws \Exception
      * @throws \PHPUnit\Framework\Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -115,7 +115,6 @@ class TestTest extends TestCase
      * @param mixed $result
      *
      * @throws Warning
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -332,7 +331,6 @@ class TestTest extends TestCase
      *
      * @throws Exception
      * @throws Warning
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -514,7 +512,6 @@ class TestTest extends TestCase
      * @param mixed $result
      *
      * @throws Warning
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -790,7 +787,6 @@ class TestTest extends TestCase
      * @param mixed $lines
      *
      * @throws CodeCoverageException
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */

--- a/tests/Util/XmlTest.php
+++ b/tests/Util/XmlTest.php
@@ -20,7 +20,6 @@ class XmlTest extends TestCase
      *
      * @param mixed $char
      *
-     * @throws \Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */


### PR DESCRIPTION
All of the declarations are removed except one in `\PHPUnit\Util\ErrorHandler::handleErrorOnce` where it seems to be in place.

The fix introduced a couple more "Missing @throws tag(s)" warnings. I've checked and all such warnings at the moment relate to unhandled `\ReflectionException`. I'm not sure how to properly handle it. The exception doesn't extend `\RuntimeException` thus considered checked. Declaring it with `@throws` will require pulling it through all the callers. It doesn't look to me like a way to go. Probably, it's better to handle the exception where it's thrown and re-throw wrapped in a runtime exception.