### PR TITLE
Performance optimizations.

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1138,23 +1138,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->registerMockObjectsFromTestArguments($testArguments);
 
         try {
-            // only use reflection to invoke the method if we have to
-            if ($testArguments) {
-                try {
-                    $class  = new ReflectionClass($this);
-                    $method = $class->getMethod($this->name);
-                } catch (ReflectionException $e) {
-                    $this->fail($e->getMessage());
-                }
-
-                $testResult = $method->invokeArgs($this, $testArguments);
-            } else {
-                if (!method_exists($this, $this->name)) {
-                    $this->fail(sprintf('Method %s does not exist', $this->name));
-                }
-
-                $testResult =  $this->{$this->name}();
-            }
+            $testResult = $this->{$this->name}(...array_values($testArguments));
         } catch (Throwable $t) {
             $exception = $t;
         }

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -183,12 +183,11 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         }
 
         foreach ($theClass->getMethods() as $method) {
-            // how can we handle this better? In our code base we have a base class we extend with lots of convenience methods that would not be skipped here and eventually get passed to addTestMethod
-            if ($method->getDeclaringClass()->getName() === TestCase::class) {
+            if ($method->getDeclaringClass()->getName() === Assert::class) {
                 continue;
             }
 
-            if ($method->getDeclaringClass()->getName() === Assert::class) {
+            if ($method->getDeclaringClass()->getName() === TestCase::class) {
                 continue;
             }
 

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -183,7 +183,12 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         }
 
         foreach ($theClass->getMethods() as $method) {
+            // how can we handle this better? In our code base we have a base class we extend with lots of convenience methods that would not be skipped here and eventually get passed to addTestMethod
             if ($method->getDeclaringClass()->getName() === TestCase::class) {
+                continue;
+            }
+
+            if ($method->getDeclaringClass()->getName() === Assert::class) {
                 continue;
             }
 

--- a/tests/Framework/TestSuiteTest.php
+++ b/tests/Framework/TestSuiteTest.php
@@ -27,32 +27,6 @@ class TestSuiteTest extends TestCase
         $this->result = null;
     }
 
-    public static function suite()
-    {
-        $suite = new TestSuite;
-
-        $suite->addTest(new self('testAddTestSuite'));
-        $suite->addTest(new self('testInheritedTests'));
-        $suite->addTest(new self('testNoTestCases'));
-        $suite->addTest(new self('testNoTestCaseClass'));
-        $suite->addTest(new self('testNotExistingTestCase'));
-        $suite->addTest(new self('testNotPublicTestCase'));
-        $suite->addTest(new self('testNotVoidTestCase'));
-        $suite->addTest(new self('testOneTestCase'));
-        $suite->addTest(new self('testShadowedTests'));
-        $suite->addTest(new self('testBeforeClassAndAfterClassAnnotations'));
-        $suite->addTest(new self('testBeforeClassWithDataProviders'));
-        $suite->addTest(new self('testBeforeAnnotation'));
-        $suite->addTest(new self('testTestWithAnnotation'));
-        $suite->addTest(new self('testSkippedTestDataProvider'));
-        $suite->addTest(new self('testTestDataProviderDependency'));
-        $suite->addTest(new self('testIncompleteTestDataProvider'));
-        $suite->addTest(new self('testRequirementsBeforeClassHook'));
-        $suite->addTest(new self('testDoNotSkipInheritedClass'));
-
-        return $suite;
-    }
-
     public function testAddTestSuite(): void
     {
         $suite = new TestSuite(\OneTestCase::class);
@@ -89,17 +63,6 @@ class TestSuiteTest extends TestCase
         $this->expectException(Exception::class);
 
         new TestSuite(\NoTestCaseClass::class);
-    }
-
-    public function testNotExistingTestCase(): void
-    {
-        $suite = new self('notExistingMethod');
-
-        $suite->run($this->result);
-
-        $this->assertEquals(0, $this->result->errorCount());
-        $this->assertEquals(1, $this->result->failureCount());
-        $this->assertCount(1, $this->result);
     }
 
     public function testNotPublicTestCase(): void


### PR DESCRIPTION
@sebastianbergmann What do you think about these changes? In our test suite with 10000+ tests and 30000+ assertions, it gives us a 10-15% performance boost. If we can get rid of the method_exists call and just let PHP fail, it makes it a bit faster too.

And see my comment in TestSuite.php. We have a base class we extend from that has many non test methods which end up getting passed to `addTestMethod` but I am not sure how we can make that work more generically.

<img src="https://pbs.twimg.com/media/DV7O0nsVAAANcJu.jpg" />

<img src="https://pbs.twimg.com/media/DV7y-BSWkAMFsX0.jpg" />