### PR TITLE
PHP errors converted to exception always fail the test

### DIFF
--- a/tests/Regression/GitHub/3010.phpt
+++ b/tests/Regression/GitHub/3010.phpt
@@ -1,0 +1,26 @@
+--TEST--
+GH-3010: undefined index cause the test to fail
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue3010Test';
+$_SERVER['argv'][3] = __DIR__ . '/3010/Issue3010Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) Issue3010Test::testOne
+PHPUnit\Framework\Exception: Undefined index: index in %s%e3010%eUndefinedIndex.php; line %d
+%A
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.

--- a/tests/Regression/GitHub/3010/Issue3010Test.php
+++ b/tests/Regression/GitHub/3010/Issue3010Test.php
@@ -1,0 +1,13 @@
+<?php
+include __DIR__ . '/UndefinedIndex.php';
+
+class Issue3010Test extends PHPUnit\Framework\TestCase
+{
+    public function testOne()
+    {
+        $u = new UndefinedIndex();
+        $r = $u->hello([]);
+
+        $this->assertSame(0, $r);
+    }
+}

--- a/tests/Regression/GitHub/3010/UndefinedIndex.php
+++ b/tests/Regression/GitHub/3010/UndefinedIndex.php
@@ -1,0 +1,20 @@
+<?php
+
+class UndefinedIndex
+{
+    public function hello(array $a)
+    {
+        try {
+            $this->world($a);
+        } catch (\Throwable $e) {
+            return 0;
+        }
+
+        return 1;
+    }
+
+    public function world(array $a)
+    {
+        return $a['index'];
+    }
+}


### PR DESCRIPTION
As I've tried describe in #3003 there is possibility that php error converted to exception will be caught in user code and then test will passing (false positive).

@sebastianbergmann said:
> When an error, notice, warning, etc. is converted to an exception then that exception will cause a test to fail. Unless the test expects the exception.

But unfortunately it does not happen when user code caught that exception.

This PR adds checks if any error->exception conversion has been made in the test, and if so the test is failing.

Here we have two separate commits - first with failing test and the second with fix.

**Interesting fact:** as the build shows we have FALSE-POSITIVE test cases in PHPUnit !
The problem is in:
https://github.com/sebastianbergmann/phpunit/blob/79d95733a7342f6472957fcc0b96c85fbde086da/tests/Runner/PhptTestCaseTest.php#L127-L144
to specify in mocking `runJob` method. Only first invocation is mocked to return array but unfortunately that method is called twice:
1. https://github.com/sebastianbergmann/phpunit/blob/9c692830988283dcc8e571b6118a012e62bbaedd/src/Runner/PhptTestCase.php#L327
2. https://github.com/sebastianbergmann/phpunit/blob/9c692830988283dcc8e571b6118a012e62bbaedd/src/Runner/PhptTestCase.php#L164
and also after the second execution of the method we try to access `stdout` index of the array (but on the second call we got error, because only first invocation was mocked to return array) - see:             https://github.com/sebastianbergmann/phpunit/blob/9c692830988283dcc8e571b6118a012e62bbaedd/src/Runner/PhptTestCase.php#L172

And there we got converted notice to error, so the result of the test is **wrong**.

/cc @weierophinney @dofos