### PR TITLE
Fix #2974 - Invalid Chars in JUnit XML

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -372,10 +372,9 @@ class JUnit extends Printer implements TestListener
         $this->testSuiteTimes[$this->testSuiteLevel] += $time;
 
         if (\method_exists($test, 'hasOutput') && $test->hasOutput()) {
-            $systemOut = $this->document->createElement('system-out');
-
-            $systemOut->appendChild(
-                $this->document->createTextNode($test->getActualOutput())
+            $systemOut = $this->document->createElement(
+                'system-out',
+                Xml::prepareString($test->getActualOutput())
             );
 
             $this->currentTestCase->appendChild($systemOut);


### PR DESCRIPTION
JUnit XML (produced with --log-junit) is invalid (and won't be opened by
some programs) if it contains invalid XML characters in the <system-out>
node. Fix this by sanitizing text before adding it to the XML.

This fixes #2974.