### PR TITLE
PHPStan level 1 in tests/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
         - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
       script:
         - vendor/bin/phpstan analyse --level=0 -c phpstan.neon src
-        - vendor/bin/phpstan analyse --level=0 -c phpstan-tests.neon tests
+        - vendor/bin/phpstan analyse --level=1 -c phpstan-tests.neon tests
     - stage: Style
       php: 7.2
       env: php-cs-fixer

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -4,6 +4,15 @@ parameters:
         - '#Issue244Exception::__construct\(\) does not call parent constructor from Exception.#'
         - '#Issue244ExceptionIntCode::__construct\(\) does not call parent constructor from Exception.#'
 
+        # these constants are defined in PHPUnit configuration XML, so they can't be detected in PHPStan
+        - '#Constant PHPUNIT_1330 not found.#'
+        - '#Constant FOO not found.#'
+        - '#Constant BAR not found.#'
+
+        # global constants does not work properly in PHPStan yet https://github.com/phpstan/phpstan/issues/768
+        - '#Constant TEST_FILES_PATH not found.#'
+        - '#Constant GITHUB_ISSUE not found.#'
+
     excludes_analyse:
         # duplicated classname OneTest
         - tests/_files/phpunit-example-extension/tests/OneTest.php


### PR DESCRIPTION
This enables [PHPStan](https://github.com/sebastianbergmann/phpunit/issues/3018) level 1 for `tests/`.

I prefer to use _"small steps"_ approach, so I will create a separate PR for bumping the level for `src/` as there are some issues that needs tackling first.