### PR TITLE
PHPStan level 2 tests/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
       install: travis_retry composer update --prefer-dist --prefer-stable
       script:
         - vendor/bin/phpstan analyse --level=0 -c phpstan.neon src
-        - vendor/bin/phpstan analyse --level=1 -c phpstan-tests.neon tests
+        - vendor/bin/phpstan analyse --level=2 -c phpstan-tests.neon tests
     - stage: Static Code Analysis
       php: 7.2
       env: php-cs-fixer

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -13,6 +13,9 @@ parameters:
         - '#Constant TEST_FILES_PATH not found.#'
         - '#Constant GITHUB_ISSUE not found.#'
 
+        # This access to undefined property is legit
+        - '#Access to an undefined property SplObjectStorage::\$foo#'
+
     excludes_analyse:
         # duplicated classname OneTest
         - tests/_files/phpunit-example-extension/tests/OneTest.php

--- a/tests/Regression/GitHub/2137/Issue2137Test.php
+++ b/tests/Regression/GitHub/2137/Issue2137Test.php
@@ -4,8 +4,8 @@ class Issue2137Test extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider provideBrandService
      *
-     * @param $provided
-     * @param $expected
+     * @param mixed $provided
+     * @param mixed $expected
      *
      * @throws Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
@@ -29,8 +29,8 @@ class Issue2137Test extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider provideBrandService
      *
-     * @param $provided
-     * @param $expected
+     * @param mixed $provided
+     * @param mixed $expected
      *
      * @throws Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException


### PR DESCRIPTION
Bumping PHPStan level to 2 for `tests/` required only small fix to PHPDoc and ignoring one error, so I kept it all in one PR.