### PR TITLE
Strip of remaining s\ when TestDox classname starts with Tests\

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -39,6 +39,12 @@ final class NamePrettifier
             $title = \substr($title, \strlen('Test'));
         }
 
+        # When a class name starts with Tests\\ we should strip off the
+        # remaining s\\, since Test is removed above
+        if (\substr($name, 0, \strlen('Tests')) === 'Tests') {
+            $title = \substr($title, \strlen('s\\'));
+        }
+
         if ($title[0] === '\\') {
             $title = \substr($title, 1);
         }

--- a/tests/Util/TestDox/NamePrettifierTest.php
+++ b/tests/Util/TestDox/NamePrettifierTest.php
@@ -35,6 +35,7 @@ class NamePrettifierTest extends TestCase
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('TestFoo'));
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('TestFooTest'));
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('Test\FooTest'));
+        $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('Tests\FooTest'));
     }
 
     public function testTestNameIsConvertedToASentence(): void


### PR DESCRIPTION
A lot of projects, including for example Laravel, start their test classes with the Tests namespace. 
When using TestDox our testclass is reported with a leading s\\. 
Look at the example below. 

![image](https://user-images.githubusercontent.com/6575697/36844704-16adcc5a-1d54-11e8-9386-260ff75166d4.png)

This commit fixes that.