### PR TITLE
Fixes #3031 - now based on 7.0.2

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -748,7 +748,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->status        = BaseTestRunner::STATUS_FAILURE;
             $this->statusMessage = $e->getMessage();
         } catch (Throwable $_e) {
-            $e = $_e;
+            $e                   = $_e;
+            $this->status        = BaseTestRunner::STATUS_ERROR;
+            $this->statusMessage = $_e->getMessage();
         }
 
         $this->mockObjects = [];

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -178,6 +178,14 @@ class TestCaseTest extends TestCase
         $this->assertEquals(BaseTestRunner::STATUS_ERROR, $test->getStatus());
     }
 
+    public function testExceptionInTestIsDetectedInTeardown(): void
+    {
+        $test   = new \ExceptionInTestDetectedInTeardown('testSomething');
+        $test->run();
+
+        $this->assertTrue($test->exceptionDetected);
+    }
+
     public function testNoArgTestCasePasses(): void
     {
         $result = new TestResult;

--- a/tests/_files/ExceptionInTestDetectedInTeardown.php
+++ b/tests/_files/ExceptionInTestDetectedInTeardown.php
@@ -1,0 +1,21 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+use PHPUnit\Runner\BaseTestRunner;
+
+class ExceptionInTestDetectedInTeardown extends TestCase
+{
+    public $exceptionDetected = false;
+    
+    public function testSomething()
+    {
+        throw new Exception;
+    }
+
+    protected function tearDown(): void
+    {
+        if (BaseTestRunner::STATUS_ERROR == $this->getStatus()) {
+            $this->exceptionDetected = true;
+        }
+    }
+}


### PR DESCRIPTION
getStatus() now detects thrown Exception inside tearDown().

I have made this same pull request before but based on master. I should have done this one instead, based on the latest stable release.