### PR TITLE
if data is null set it to empty array

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -272,7 +272,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->setName($name);
         }
 
-        $this->data     = $data;
+	$this->data     = $data;
+	
         $this->dataName = $dataName;
     }
 
@@ -626,7 +627,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             } else {
                 $codeCoverageFilter = null;
             }
-
             $data               = \var_export(\serialize($this->data), true);
             $dataName           = \var_export($this->dataName, true);
             $dependencyInput    = \var_export(\serialize($this->dependencyInput), true);
@@ -1132,10 +1132,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 'PHPUnit\Framework\TestCase::$name must not be null.'
             );
         }
-
-        $testArguments = \array_merge($this->data, $this->dependencyInput);
-
-        $this->registerMockObjectsFromTestArguments($testArguments);
+	
+	$testArguments = \array_merge($this->data, $this->dependencyInput);
+	
+	if (is_null($testArguments)) {
+		$testArguments = [];
+	}
+	
+	$this->registerMockObjectsFromTestArguments($testArguments);
 
         try {
             $testResult = $this->{$this->name}(...\array_values($testArguments));

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -272,8 +272,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->setName($name);
         }
 
-	$this->data     = $data;
-	
+        $this->data     = $data;
+
         $this->dataName = $dataName;
     }
 
@@ -1132,14 +1132,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 'PHPUnit\Framework\TestCase::$name must not be null.'
             );
         }
-	
-	$testArguments = \array_merge($this->data, $this->dependencyInput);
-	
-	if (is_null($testArguments)) {
-		$testArguments = [];
-	}
-	
-	$this->registerMockObjectsFromTestArguments($testArguments);
+
+        $testArguments = \array_merge($this->data, $this->dependencyInput);
+
+        if (\is_null($testArguments)) {
+            $testArguments = [];
+        }
+
+        $this->registerMockObjectsFromTestArguments($testArguments);
 
         try {
             $testResult = $this->{$this->name}(...\array_values($testArguments));


### PR DESCRIPTION
I have found a situation where I get an error:

PHPUnit\Framework\TestCase::registerMockObjectsFromTestArguments() must be of the type array, null given, called in phar:///usr/bin/phpunit/phpunit/Framework/TestCase.php on line 1145

It is called by $this->data being NULL instead of an empty array in certain situations. This causes $testArguments to be null. 

This is a little fix that sets it to an empty array in this situation and passes all of the tests.