### PR TITLE
Require code coverage version that fixes directory creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phar-io/manifest": "^1.0.1",
         "phar-io/version": "^1.0",
         "phpspec/prophecy": "^1.7",
-        "phpunit/php-code-coverage": "^6.0",
+        "phpunit/php-code-coverage": "^6.0.1",
         "phpunit/php-file-iterator": "^1.4.3",
         "phpunit/php-text-template": "^1.2.1",
         "phpunit/php-timer": "^2.0",


### PR DESCRIPTION
The problem from issue https://github.com/sebastianbergmann/php-code-coverage/issues/584 has ongoing effect for libraries, if they are tested with lowest dependencies.

The only alternatives I came up with were either creating the folders upfront all locking code coverage package in each individual library.

I hope the pinned version can be pinned here, because otherwise the lowest deps testing will need to be changed at a lot of places.