### PR TITLE
Fix StringMatchesFormatDescription with \r\n

### DIFF
--- a/src/Framework/Constraint/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/StringMatchesFormatDescription.php
@@ -29,11 +29,26 @@ class StringMatchesFormatDescription extends RegularExpression
     {
         parent::__construct(
             $this->createPatternFromFormat(
-                \preg_replace('/\r\n/', "\n", $string)
+                $this->convertNewlines($string)
             )
         );
 
         $this->string = $string;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other Value or object to evaluate.
+     *
+     * @return bool
+     */
+    protected function matches($other): bool
+    {
+        return parent::matches(
+            $this->convertNewlines($other)
+        );
     }
 
     protected function failureDescription($other): string
@@ -43,8 +58,8 @@ class StringMatchesFormatDescription extends RegularExpression
 
     protected function additionalFailureDescription($other): string
     {
-        $from = \preg_split('(\r\n|\r|\n)', $this->string);
-        $to   = \preg_split('(\r\n|\r|\n)', $other);
+        $from = \explode("\n", $this->string);
+        $to   = \explode("\n", $this->convertNewlines($other));
 
         foreach ($from as $index => $line) {
             if (isset($to[$index]) && $line !== $to[$index]) {
@@ -99,5 +114,10 @@ class StringMatchesFormatDescription extends RegularExpression
         $string = \str_replace('%%', '%', $string);
 
         return '/^' . $string . '$/s';
+    }
+
+    private function convertNewlines($text): string
+    {
+        return \preg_replace('/\r\n/', "\n", $text);
     }
 }

--- a/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -10,9 +10,11 @@
 
 namespace PHPUnit\Framework\Constraint;
 
+use PHPUnit\Framework\ExpectationFailedException;
+
 class StringMatchesFormatDescriptionTest extends ConstraintTestCase
 {
-    public function testConstraintStringMatches(): void
+    public function testConstraintStringMatchesCharacter(): void
     {
         $constraint = new StringMatchesFormatDescription('*%c*');
 
@@ -22,7 +24,7 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
-    public function testConstraintStringMatches2(): void
+    public function testConstraintStringMatchesString(): void
     {
         $constraint = new StringMatchesFormatDescription('*%s*');
 
@@ -32,7 +34,7 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
-    public function testConstraintStringMatches3(): void
+    public function testConstraintStringMatchesInteger(): void
     {
         $constraint = new StringMatchesFormatDescription('*%i*');
 
@@ -42,7 +44,7 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
-    public function testConstraintStringMatches4(): void
+    public function testConstraintStringMatchesUnsignedInt(): void
     {
         $constraint = new StringMatchesFormatDescription('*%d*');
 
@@ -52,7 +54,7 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
-    public function testConstraintStringMatches5(): void
+    public function testConstraintStringMatchesHexadecimal(): void
     {
         $constraint = new StringMatchesFormatDescription('*%x*');
 
@@ -62,7 +64,7 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
-    public function testConstraintStringMatches6(): void
+    public function testConstraintStringMatchesFloat(): void
     {
         $constraint = new StringMatchesFormatDescription('*%f*');
 
@@ -70,5 +72,41 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertTrue($constraint->evaluate('*1.0*', '', true));
         $this->assertEquals('matches PCRE pattern "/^\*[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesNewline(): void
+    {
+        $constraint = new StringMatchesFormatDescription("\r\n");
+
+        $this->assertFalse($constraint->evaluate("*\r\n", '', true));
+        $this->assertTrue($constraint->evaluate("\r\n", '', true));
+        $this->assertEquals("matches PCRE pattern \"/^\n$/s\"", $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testFailureMessageWithNewlines(): void
+    {
+        $constraint = new StringMatchesFormatDescription("%c\nfoo\n%c");
+
+        try
+        {
+            $constraint->evaluate("*\nbar\n*");
+            $this->fail('Expected ExpectationFailedException, but it was not thrown.');
+        }
+        catch (ExpectationFailedException $e)
+        {
+            $expected = <<<EOD
+Failed asserting that string matches format description.
+--- Expected
++++ Actual
+@@ @@
+ *
+-foo
++bar
+ *
+
+EOD;
+            $this->assertEquals($expected, $e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
This is a proposed fix for #3040.

There was a bug in that the following assertion would fail, even though
it should pass:

    $this->assertStringMatchesFormat("\r\n", "\r\n");

Obviously, we would expect a string to match itself. The bug was due to
newline conversion - `\r\n` was being converted to `\n` on the pattern,
but not on the string to be matched against.

In order to be compatible with existing behavior, we need to continue
converting `\r\n` to `\n` in the pattern. (Otherwise, users who expect
this behavior may have tests fail that would have previously passed.)
Therefore, the only option for fixing the bug is to also sanitize the
string to be matched. This commit makes that change, and provides some
additional tests to verify the behavior.