### PR TITLE
Enhancement: Mark tests as risky when they claim not to perform assertions but do

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -814,6 +814,17 @@ class TestResult implements Countable
                 ),
                 $time
             );
+        } elseif ($this->beStrictAboutTestsThatDoNotTestAnything &&
+            $test->doesNotPerformAssertions() &&
+            $test->getNumAssertions() > 0) {
+            $this->addFailure(
+                $test,
+                new RiskyTestError(\sprintf(
+                    'This test is annotated with "@doesNotPerformAssertions" but performed %d assertions',
+                    $test->getNumAssertions()
+                )),
+                $time
+            );
         } elseif ($this->beStrictAboutOutputDuringTests && $test->hasOutput()) {
             $this->addFailure(
                 $test,

--- a/tests/TextUI/report-tests-performing-assertions-when-annotated-with-does-not-perform-assertions.phpt
+++ b/tests/TextUI/report-tests-performing-assertions-when-annotated-with-does-not-perform-assertions.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit NothingTest ../_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'DoesNotPerformAssertionsButPerformingAssertionsTest';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+R                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) DoesNotPerformAssertionsButPerformingAssertionsTest::testFalseAndTrueAreStillFine
+This test is annotated with "@doesNotPerformAssertions" but performed 2 assertions
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 2, Risky: 1.

--- a/tests/_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php
+++ b/tests/_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php
@@ -1,0 +1,14 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class DoesNotPerformAssertionsButPerformingAssertionsTest extends TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testFalseAndTrueAreStillFine()
+    {
+        $this->assertFalse(false);
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR

* [x] marks tests as risky when the claim not to perform assertions (using the `@doesNotPerformAssertions` annotation), but then actually do perform assertions

Fixes #2958.