### PR TITLE
Fix: Remove unused private field

### DIFF
--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -49,11 +49,6 @@ class IsEqual extends Constraint
     private $ignoreCase = false;
 
     /**
-     * @var SebastianBergmann\Comparator\ComparisonFailure
-     */
-    private $lastFailure;
-
-    /**
      * @param mixed $value
      * @param float $delta
      * @param int   $maxDepth


### PR DESCRIPTION
This PR

* [x] removes an unused `private` field