### PR TITLE
Fix: Do not use deprecated configuration for binary_operator_spaces fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,8 +14,10 @@ return PhpCsFixer\Config::create()
         [
             'array_syntax' => ['syntax' => 'short'],
             'binary_operator_spaces' => [
-                'align_double_arrow' => true,
-                'align_equals' => true
+                'operators' => [
+                    '=' => 'align',
+                    '=>' => 'align',
+                ],
             ],
             'blank_line_after_namespace' => true,
             'blank_line_before_statement' => [


### PR DESCRIPTION
This PR

* [x] uses the non-deprecated configuration for `binary_operator_spaces`, as suggested by `php-cs-fixer` itself

h/t @dnaber-de 