### PR TITLE
issue/2830: @runClassInSeparateProcess fails for tests with a @dataPr…

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -780,7 +780,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 'isStrictAboutTodoAnnotatedTests'            => $isStrictAboutTodoAnnotatedTests,
                 'isStrictAboutResourceUsageDuringSmallTests' => $isStrictAboutResourceUsageDuringSmallTests,
                 'codeCoverageFilter'                         => $codeCoverageFilter,
-                'configurationFilePath'                      => $configurationFilePath
+                'configurationFilePath'                      => $configurationFilePath,
+                'name'                                       => $this->getName(false),
             ];
 
             if (!$runEntireClass) {

--- a/src/Util/PHP/Template/TestCaseClass.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseClass.tpl.dist
@@ -47,7 +47,7 @@ function __phpunit_run_isolated_test()
     $result->beStrictAboutTodoAnnotatedTests({isStrictAboutTodoAnnotatedTests});
     $result->beStrictAboutResourceUsageDuringSmallTests({isStrictAboutResourceUsageDuringSmallTests});
 
-    $test = new {className}(null, unserialize('{data}'), '{dataName}');
+    $test = new {className}('{name}', unserialize('{data}'), '{dataName}');
     $test->setDependencyInput(unserialize('{dependencyInput}'));
     $test->setInIsolation(TRUE);
 

--- a/tests/Regression/GitHub/2830.phpt
+++ b/tests/Regression/GitHub/2830.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-2830: @runClassInSeparateProcess fails for tests with a @dataProvider
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'Issue2830';
+$_SERVER['argv'][3] = __DIR__ . '/2830/Issue2830Test.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/Regression/GitHub/2830/Issue2830Test.php
+++ b/tests/Regression/GitHub/2830/Issue2830Test.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @runClassInSeparateProcess
+ */
+class Issue2830Test extends PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider simpleDataProvider
+     */
+    public function testMethodUsesDataProvider()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function simpleDataProvider()
+    {
+        return [
+            ['foo'],
+        ];
+    }
+}


### PR DESCRIPTION
This will fix the Exception with message "PHPUnit\Framework\TestCase::$name must not be null" that appears as was described in the ticket. 