### PR TITLE
Issue/2724

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -283,6 +283,14 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                 }
             }
 
+            if ($runClassInSeparateProcess) {
+                $test->setRunClassInSeparateProcess(true);
+
+                if ($preserveGlobalState !== null) {
+                    $test->setPreserveGlobalState($preserveGlobalState);
+                }
+            }
+
             if ($backupSettings['backupGlobals'] !== null) {
                 $test->setBackupGlobals($backupSettings['backupGlobals']);
             }

--- a/tests/Regression/GitHub/2591-separate-class-preserve-no-bootstrap.phpt
+++ b/tests/Regression/GitHub/2591-separate-class-preserve-no-bootstrap.phpt
@@ -14,17 +14,22 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-E..                                                                 3 / 3 (100%)
+E.E                                                                 3 / 3 (100%)
 
 Time: %s, Memory: %s
 
-There was 1 error:
+There were 2 errors:
 
 1) Issue2591_SeparateClassPreserveTest::testOriginalGlobalString
 Undefined index: globalString
 
 %sSeparateClassPreserveTest.php:%d
 
+2) Issue2591_SeparateClassPreserveTest::testGlobalString
+Undefined index: globalString
+
+%sSeparateClassPreserveTest.php:%s
+
 ERRORS!
-Tests: 3, Assertions: 2, Errors: 1.
+Tests: 3, Assertions: 1, Errors: 2.
 

--- a/tests/Regression/GitHub/2591/SeparateClassPreserveTest.php
+++ b/tests/Regression/GitHub/2591/SeparateClassPreserveTest.php
@@ -14,13 +14,15 @@ class Issue2591_SeparateClassPreserveTest extends TestCase
 
     public function testChangedGlobalString()
     {
-        $GLOBALS['globalString'] = 'Hello!';
-        $this->assertEquals('Hello!', $GLOBALS['globalString']);
+        $value = 'Hello! I am changed from inside!';
+
+        $GLOBALS['globalString'] = $value;
+        $this->assertEquals($value, $GLOBALS['globalString']);
     }
 
     public function testGlobalString()
     {
-        $this->assertEquals('Hello!', $GLOBALS['globalString']);
+        $this->assertEquals('Hello', $GLOBALS['globalString']);
     }
 
 }

--- a/tests/Regression/GitHub/2724-diff-pid-from-master-process.phpt
+++ b/tests/Regression/GitHub/2724-diff-pid-from-master-process.phpt
@@ -8,7 +8,7 @@ $_SERVER['argv'][3] = __DIR__ . '/2724/SeparateClassRunMethodInNewProcessTest.ph
 
 require __DIR__ . '/../../bootstrap.php';
 
-file_put_contents(__DIR__ . '/2724/parent_process_id.txt', posix_getpid());
+file_put_contents(__DIR__ . '/2724/parent_process_id.txt', getmypid());
 
 PHPUnit\TextUI\Command::main();
 ?>

--- a/tests/Regression/GitHub/2724-diff-pid-from-master-process.phpt
+++ b/tests/Regression/GitHub/2724-diff-pid-from-master-process.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GH-2724: Missing initialization of setRunClassInSeparateProcess() for tests without data providers
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'SeparateClassRunMethodInNewProcessTest';
+$_SERVER['argv'][3] = __DIR__ . '/2724/SeparateClassRunMethodInNewProcessTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+file_put_contents(__DIR__ . '/2724/parent_process_id.txt', posix_getpid());
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 3 assertions)

--- a/tests/Regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
+++ b/tests/Regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @runClassInSeparateProcess
+ */
+class SeparateClassRunMethodInNewProcessTest extends PHPUnit\Framework\TestCase
+{
+    const PROCESS_ID_FILE_PATH = __DIR__ . '/parent_process_id.txt';
+    const INITIAL_MASTER_PID = 0;
+    const INITIAL_PID1 = 1;
+
+    public static $masterPid = self::INITIAL_MASTER_PID;
+    public static $pid1 = self::INITIAL_PID1;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        if (file_exists(self::PROCESS_ID_FILE_PATH)) {
+            static::$masterPid = (int) file_get_contents(self::PROCESS_ID_FILE_PATH);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+
+        if (file_exists(self::PROCESS_ID_FILE_PATH)) {
+            unlink(self::PROCESS_ID_FILE_PATH);
+        }
+    }
+
+    public function testMethodShouldGetDifferentPidThanMaster()
+    {
+        static::$pid1 = posix_getpid();
+
+        $this->assertNotEquals(self::INITIAL_PID1, static::$pid1);
+        $this->assertNotEquals(self::INITIAL_MASTER_PID, static::$masterPid);
+
+        $this->assertNotEquals(static::$pid1, static::$masterPid);
+    }
+}

--- a/tests/Regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
+++ b/tests/Regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
@@ -32,7 +32,7 @@ class SeparateClassRunMethodInNewProcessTest extends PHPUnit\Framework\TestCase
 
     public function testMethodShouldGetDifferentPidThanMaster()
     {
-        static::$pid1 = posix_getpid();
+        static::$pid1 = getmypid();
 
         $this->assertNotEquals(self::INITIAL_PID1, static::$pid1);
         $this->assertNotEquals(self::INITIAL_MASTER_PID, static::$masterPid);

--- a/tests/Regression/GitHub/2725-separate-class-before-after-pid.phpt
+++ b/tests/Regression/GitHub/2725-separate-class-before-after-pid.phpt
@@ -12,7 +12,6 @@ PHPUnit\TextUI\Command::main();
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 ..                                                                  2 / 2 (100%)
-@afterClass output - PID difference should be zero: 0
 
 Time: %s, Memory: %s
 

--- a/tests/Regression/GitHub/2725/BeforeAfterClassPidTest.php
+++ b/tests/Regression/GitHub/2725/BeforeAfterClassPidTest.php
@@ -9,22 +9,24 @@ use PHPUnit\Framework\TestCase;
  */
 class BeforeAfterClassPidTest extends TestCase
 {
+    const PID_VARIABLE = 'current_pid';
+
     /**
      * @beforeClass
      */
     public static function showPidBefore()
     {
-        $GLOBALS['PID_BEFORE'] = getmypid();
+        $GLOBALS[static::PID_VARIABLE] = getmypid();
     }
 
-    public function testComparePids()
+    public function testMethod1WithItsBeforeAndAfter()
     {
-        $this->assertEquals($GLOBALS['PID_BEFORE'], getmypid());
+        $this->assertEquals($GLOBALS[static::PID_VARIABLE], getmypid());
     }
 
-    public function testThatClassDidNotReload()
+    public function testMethod2WithItsBeforeAndAfter()
     {
-        $this->assertEquals($GLOBALS['PID_BEFORE'], getmypid());
+        $this->assertEquals($GLOBALS[static::PID_VARIABLE], getmypid());
     }
 
     /**
@@ -32,6 +34,10 @@ class BeforeAfterClassPidTest extends TestCase
      */
     public static function showPidAfter()
     {
-        echo "\n@afterClass output - PID difference should be zero: " . ($GLOBALS['PID_BEFORE'] - getmypid());
+        if ($GLOBALS[static::PID_VARIABLE] - getmypid() !== 0) {
+            echo "\n@afterClass output - PID difference should be zero!";
+        }
+
+        unset($GLOBALS[static::PID_VARIABLE]);
     }
 }


### PR DESCRIPTION
TestCase with @runClassInSeparateProcess was being executed in main thread, therefore some tests were passing because tests were executing in the same process.

After making the changes in TestSuite, every method will be executed in it's own process when @runClassInSeparateProcess is used, and tests were updated accordingly. 