### PR TITLE
Add phpunit.xsd into the phar file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -125,6 +125,8 @@
     <target name="-phar-prepare" depends="clean,install-dependencies">
         <mkdir dir="${basedir}/build/phar"/>
 
+        <copy file="${basedir}/phpunit.xsd" tofile="${basedir}/build/phar/phpunit.xsd"/>
+
         <exec executable="${basedir}/build/phar-manifest.php" output="${basedir}/build/phar/manifest.txt"/>
 
         <copy file="${basedir}/vendor/phpunit/php-code-coverage/LICENSE" tofile="${basedir}/build/phar/php-code-coverage/LICENSE"/>


### PR DESCRIPTION
At the PHPUnit Code Sprint in Hamburg a validation of the phpunit configuration xml file against xsd has been added. Unfortunately the xsd file need for the validation is missing in the builded phar. This pull request extends build command by adding the xsd file inside the phar file during phar building procces.