### PR TITLE
Allow returning null result

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1033,7 +1033,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->outputCallback = $callback;
     }
 
-    public function getTestResultObject(): TestResult
+    public function getTestResultObject(): ?TestResult
     {
         return $this->result;
     }

--- a/tests/Framework/TestCaseTest.php
+++ b/tests/Framework/TestCaseTest.php
@@ -721,6 +721,12 @@ class TestCaseTest extends TestCase
         $this->assertSame($data, $test->myTestData);
     }
 
+    public function testGettingNullTestResultObject()
+    {
+        $test = new \Success();
+        $this->assertNull($test->getTestResultObject());
+    }
+
     /**
      * @return array<string, array>
      */


### PR DESCRIPTION
This can and does happen with Symfony's phpunit-bridge listener. Apart
for that, this property is not guaranteed to be not null (there is a
setter and no constructor requirement), so the return type hint should
reflect that.
See https://github.com/symfony/symfony/issues/26861