### PR TITLE
Fixed faulty phpunit-mock-objects lower-bound version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpunit/php-file-iterator": "^1.4.3",
         "phpunit/php-text-template": "^1.2.1",
         "phpunit/php-timer": "^2.0",
-        "phpunit/phpunit-mock-objects": "^6.1",
+        "phpunit/phpunit-mock-objects": "^6.1.1",
         "sebastian/comparator": "^2.1",
         "sebastian/diff": "^3.0",
         "sebastian/environment": "^3.1",


### PR DESCRIPTION
This fixes the issue described in #3094.

:spiral_notepad: It may be worth checking why your unit tests didn't detect this failure. There's probably a missing test for `getObjectForTrait()`.