### PR TITLE
DX: PHP CS Fixer default finder is looking for .php by default, no need to claim it again

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -165,6 +165,5 @@ return PhpCsFixer\Config::create()
         ->in(__DIR__ . '/build')
         ->in(__DIR__ . '/src')
         ->in(__DIR__ . '/tests')
-        ->name('*.php')
         ->notName('*.phpt')
     );


### PR DESCRIPTION
As we are using default finder and then revoke .phpt, and not using raw finder and then filter to .php,
we don't need to filter to .php again, as default finder already does that