### PR TITLE
Consistency: testdox for method that is written in snake-case now starts with uppercase

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -63,7 +63,9 @@ final class NamePrettifier
             $this->strings[] = $string;
         }
 
-        if (\strpos($name, 'test') === 0) {
+        if (\strpos($name, 'test_') === 0) {
+            $name = \substr($name, 5);
+        } elseif (\strpos($name, 'test') === 0) {
             $name = \substr($name, 4);
         }
 

--- a/tests/Util/TestDox/NamePrettifierTest.php
+++ b/tests/Util/TestDox/NamePrettifierTest.php
@@ -43,6 +43,7 @@ class NamePrettifierTest extends TestCase
         $this->assertEquals('This is a test', $this->namePrettifier->prettifyTestMethod('testThisIsATest'));
         $this->assertEquals('This is a test', $this->namePrettifier->prettifyTestMethod('testThisIsATest2'));
         $this->assertEquals('This is a test', $this->namePrettifier->prettifyTestMethod('this_is_a_test'));
+        $this->assertEquals('This is a test', $this->namePrettifier->prettifyTestMethod('test_this_is_a_test'));
         $this->assertEquals('Foo for bar is 0', $this->namePrettifier->prettifyTestMethod('testFooForBarIs0'));
         $this->assertEquals('Foo for baz is 1', $this->namePrettifier->prettifyTestMethod('testFooForBazIs1'));
         $this->assertEquals('This has a 123 in its name', $this->namePrettifier->prettifyTestMethod('testThisHasA123InItsName'));


### PR DESCRIPTION
Currently testdox prints the test names with a lowercase letter when you write them like this: `public function test_this_method()`, whereas it would start with an uppercase letter if you named your method like this: `public function testThisMethod()`. This commit fixes that. 