### PR TITLE
Catch and display errors during bootstrapping when using testdox printer

### DIFF
--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -16,6 +16,9 @@ parameters:
         # This access to undefined property is legit
         - '#Access to an undefined property SplObjectStorage::\$foo#'
 
+        # intentionally non existent function in tests/Regression/GitHub/3107/Issue3107Test.php
+        - '#Function does_not_exist not found#'
+
     excludes_analyse:
         # duplicated classname OneTest
         - tests/_files/phpunit-example-extension/tests/OneTest.php

--- a/src/Util/TestDox/BootstrappingTestResult.php
+++ b/src/Util/TestDox/BootstrappingTestResult.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\TestDox;
+
+use Throwable;
+
+final class BootstrappingTestResult implements TestResult
+{
+    /**
+     * @var bool
+     */
+    private $successful = true;
+
+    /**
+     * @return null|Throwable
+     */
+    private $throwable;
+
+    /**
+     * @var string
+     */
+    private $symbol;
+
+    public function isTestSuccessful(): bool
+    {
+        return $this->successful;
+    }
+
+    public function fail(
+        string $symbol,
+        Throwable $throwable,
+        bool $verbose = false
+    ): void {
+        $this->successful = false;
+        $this->symbol     = $symbol;
+        $this->throwable  = $throwable;
+    }
+
+    public function setRuntime(float $runtime): void
+    {
+    }
+
+    public function toString(?TestResult $previousTestResult, $verbose = false): string
+    {
+        if (null === $this->throwable) {
+            return '';
+        }
+
+        return \sprintf(
+            " %s %s in %s:%d\n%s",
+            $this->symbol,
+            $this->throwable->getMessage(),
+            $this->throwable->getFile(),
+            $this->throwable->getLine(),
+            $this->indentedTrace($this->throwable->getTraceAsString())
+        );
+    }
+
+    private function indentedTrace(string $trace): string
+    {
+        return \sprintf(
+            "   │\n%s\n",
+            \implode(
+                "\n",
+                \array_map(
+                    function (string $text) {
+                        return \sprintf('   │ %s', $text);
+                    },
+                    \explode("\n", $trace)
+                )
+            )
+        );
+    }
+}

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -16,7 +16,8 @@ use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\TextUI\ResultPrinter;
-use PHPUnit\Util\TestDox\TestResult as TestDoxTestResult;
+use PHPUnit\Util\TestDox\RunningTestResult as TestDoxTestResult;
+use PHPUnit\Util\TestDox\TestResult as TestResultInterface;
 use SebastianBergmann\Timer\Timer;
 
 /**
@@ -26,7 +27,7 @@ use SebastianBergmann\Timer\Timer;
 class CliTestDoxPrinter extends ResultPrinter
 {
     /**
-     * @var TestDoxTestResult
+     * @var TestResultInterface
      */
     private $currentTestResult;
 
@@ -50,6 +51,8 @@ class CliTestDoxPrinter extends ResultPrinter
         parent::__construct($out, $verbose, $colors, $debug, $numberOfColumns, $reverse);
 
         $this->prettifier = new NamePrettifier;
+
+        $this->currentTestResult = new BootstrappingTestResult();
     }
 
     public function startTest(Test $test): void
@@ -94,14 +97,17 @@ class CliTestDoxPrinter extends ResultPrinter
 
     public function endTest(Test $test, float $time): void
     {
-        if (!$test instanceof TestCase && !$test instanceof PhptTestCase) {
+        if (
+            !$test instanceof TestCase &&
+            !$test instanceof PhptTestCase &&
+            !$this->currentTestResult instanceof BootstrappingTestResult
+        ) {
             return;
         }
 
         parent::endTest($test, $time);
 
         $this->currentTestResult->setRuntime($time);
-
         $this->write($this->currentTestResult->toString($this->previousTestResult, $this->verbose));
 
         $this->previousTestResult = $this->currentTestResult;
@@ -115,7 +121,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->currentTestResult->fail(
             $this->formatWithColor('fg-yellow', '✘'),
-            (string) $t
+            $t
         );
     }
 
@@ -123,7 +129,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->currentTestResult->fail(
             $this->formatWithColor('fg-yellow', '✘'),
-            (string) $e
+            $e
         );
     }
 
@@ -131,7 +137,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->currentTestResult->fail(
             $this->formatWithColor('fg-red', '✘'),
-            (string) $e
+            $e
         );
     }
 
@@ -139,7 +145,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->currentTestResult->fail(
             $this->formatWithColor('fg-yellow', '∅'),
-            (string) $t,
+            $t,
             true
         );
     }
@@ -148,7 +154,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->currentTestResult->fail(
             $this->formatWithColor('fg-yellow', '☢'),
-            (string) $t,
+            $t,
             true
         );
     }
@@ -157,7 +163,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->currentTestResult->fail(
             $this->formatWithColor('fg-yellow', '→'),
-            (string) $t,
+            $t,
             true
         );
     }

--- a/src/Util/TestDox/RunningTestResult.php
+++ b/src/Util/TestDox/RunningTestResult.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Util\TestDox;
+
+use Throwable;
+
+final class RunningTestResult implements TestResult
+{
+    /**
+     * @var callable
+     */
+    private $colorize;
+
+    /**
+     * @var string
+     */
+    private $testClass;
+
+    /**
+     * @var string
+     */
+    private $testMethod;
+
+    /**
+     * @var bool
+     */
+    private $testSuccesful;
+
+    /**
+     * @var string
+     */
+    private $symbol;
+
+    /**
+     * @var string
+     */
+    private $additionalInformation;
+
+    /**
+     * @var bool
+     */
+    private $additionalInformationVerbose;
+
+    /**
+     * @var float
+     */
+    private $runtime;
+
+    public function __construct(callable $colorize, string $testClass, string $testMethod)
+    {
+        $this->colorize              = $colorize;
+        $this->testClass             = $testClass;
+        $this->testMethod            = $testMethod;
+        $this->testSuccesful         = true;
+        $this->symbol                = ($this->colorize)('fg-green', '✔');
+        $this->additionalInformation = '';
+    }
+
+    public function isTestSuccessful(): bool
+    {
+        return $this->testSuccesful;
+    }
+
+    public function fail(string $symbol, Throwable $throwable, bool $verbose = false): void
+    {
+        $this->testSuccesful                = false;
+        $this->symbol                       = $symbol;
+        $this->additionalInformation        = (string) $throwable;
+        $this->additionalInformationVerbose = $verbose;
+    }
+
+    public function setRuntime(float $runtime): void
+    {
+        $this->runtime = $runtime;
+    }
+
+    public function toString(?TestResult $previousTestResult, $verbose = false): string
+    {
+        return \sprintf(
+            "%s%s %s %s%s\n%s",
+            $previousTestResult && $previousTestResult->additionalInformationPrintable($verbose) ? "\n" : '',
+            $this->getClassNameHeader($previousTestResult ? $previousTestResult->testClass : null),
+            $this->symbol,
+            $this->testMethod,
+            $verbose ? ' ' . $this->getFormattedRuntime() : '',
+            $this->getFormattedAdditionalInformation($verbose)
+        );
+    }
+
+    private function getClassNameHeader(?string $previousTestClass): string
+    {
+        $className = '';
+
+        if ($this->testClass !== $previousTestClass) {
+            if (null !== $previousTestClass) {
+                $className = "\n";
+            }
+
+            $className .= \sprintf("%s\n", $this->testClass);
+        }
+
+        return $className;
+    }
+
+    private function getFormattedRuntime(): string
+    {
+        if ($this->runtime > 5) {
+            return ($this->colorize)('fg-red', \sprintf('[%.2f ms]', $this->runtime * 1000));
+        }
+
+        if ($this->runtime > 1) {
+            return ($this->colorize)('fg-yellow', \sprintf('[%.2f ms]', $this->runtime * 1000));
+        }
+
+        return \sprintf('[%.2f ms]', $this->runtime * 1000);
+    }
+
+    private function getFormattedAdditionalInformation($verbose): string
+    {
+        if (!$this->additionalInformationPrintable($verbose)) {
+            return '';
+        }
+
+        return \sprintf(
+            "   │\n%s\n",
+            \implode(
+                "\n",
+                \array_map(
+                    function (string $text) {
+                        return \sprintf('   │ %s', $text);
+                    },
+                    \explode("\n", $this->additionalInformation)
+                )
+            )
+        );
+    }
+
+    private function additionalInformationPrintable(bool $verbose): bool
+    {
+        if ($this->additionalInformation === '') {
+            return false;
+        }
+
+        if ($this->additionalInformationVerbose && !$verbose) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Util/TestDox/TestResult.php
+++ b/src/Util/TestDox/TestResult.php
@@ -9,147 +9,19 @@
  */
 namespace PHPUnit\Util\TestDox;
 
-final class TestResult
+use Throwable;
+
+interface TestResult
 {
-    /**
-     * @var callable
-     */
-    private $colorize;
+    public function isTestSuccessful(): bool;
 
-    /**
-     * @var string
-     */
-    private $testClass;
+    public function fail(
+        string $symbol,
+        Throwable $throwable,
+        bool $verbose = false
+    ): void;
 
-    /**
-     * @var string
-     */
-    private $testMethod;
+    public function setRuntime(float $runtime): void;
 
-    /**
-     * @var bool
-     */
-    private $testSuccesful;
-
-    /**
-     * @var string
-     */
-    private $symbol;
-
-    /**
-     * @var string
-     */
-    private $additionalInformation;
-
-    /**
-     * @var bool
-     */
-    private $additionalInformationVerbose;
-
-    /**
-     * @var float
-     */
-    private $runtime;
-
-    public function __construct(callable $colorize, string $testClass, string $testMethod)
-    {
-        $this->colorize              = $colorize;
-        $this->testClass             = $testClass;
-        $this->testMethod            = $testMethod;
-        $this->testSuccesful         = true;
-        $this->symbol                = ($this->colorize)('fg-green', '✔');
-        $this->additionalInformation = '';
-    }
-
-    public function isTestSuccessful(): bool
-    {
-        return $this->testSuccesful;
-    }
-
-    public function fail(string $symbol, string $additionalInformation, bool $additionalInformationVerbose = false): void
-    {
-        $this->testSuccesful                = false;
-        $this->symbol                       = $symbol;
-        $this->additionalInformation        = $additionalInformation;
-        $this->additionalInformationVerbose = $additionalInformationVerbose;
-    }
-
-    public function setRuntime(float $runtime): void
-    {
-        $this->runtime = $runtime;
-    }
-
-    public function toString(?self $previousTestResult, $verbose = false): string
-    {
-        return \sprintf(
-            "%s%s %s %s%s\n%s",
-            $previousTestResult && $previousTestResult->additionalInformationPrintable($verbose) ? "\n" : '',
-            $this->getClassNameHeader($previousTestResult ? $previousTestResult->testClass : null),
-            $this->symbol,
-            $this->testMethod,
-            $verbose ? ' ' . $this->getFormattedRuntime() : '',
-            $this->getFormattedAdditionalInformation($verbose)
-        );
-    }
-
-    private function getClassNameHeader(?string $previousTestClass): string
-    {
-        $className = '';
-
-        if ($this->testClass !== $previousTestClass) {
-            if (null !== $previousTestClass) {
-                $className = "\n";
-            }
-
-            $className .= \sprintf("%s\n", $this->testClass);
-        }
-
-        return $className;
-    }
-
-    private function getFormattedRuntime(): string
-    {
-        if ($this->runtime > 5) {
-            return ($this->colorize)('fg-red', \sprintf('[%.2f ms]', $this->runtime * 1000));
-        }
-
-        if ($this->runtime > 1) {
-            return ($this->colorize)('fg-yellow', \sprintf('[%.2f ms]', $this->runtime * 1000));
-        }
-
-        return \sprintf('[%.2f ms]', $this->runtime * 1000);
-    }
-
-    private function getFormattedAdditionalInformation($verbose): string
-    {
-        if (!$this->additionalInformationPrintable($verbose)) {
-            return '';
-        }
-
-        return \sprintf(
-            "   │\n%s\n",
-            \implode(
-                "\n",
-                \array_map(
-                    function (string $text) {
-                        return \sprintf('   │ %s', $text);
-                    },
-                    \explode("\n", $this->additionalInformation)
-                )
-            )
-        );
-    }
-
-    private function additionalInformationPrintable(bool $verbose): bool
-    {
-        if ($this->additionalInformation === '') {
-            return false;
-        }
-
-        if ($this->additionalInformationVerbose && !$verbose) {
-            return false;
-        }
-
-        return true;
-    }
+    public function toString(?self $previousTestResult, $verbose = false): string;
 }

--- a/tests/Regression/GitHub/3107/Issue3107Test.php
+++ b/tests/Regression/GitHub/3107/Issue3107Test.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Issue3107;
+
+use PHPUnit\Framework\TestCase;
+
+class Issue3107Test extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        does_not_exist();
+    }
+
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Regression/GitHub/3107/issue-3107-test.phpt
+++ b/tests/Regression/GitHub/3107/issue-3107-test.phpt
@@ -1,0 +1,28 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/3107
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--process-isolation';
+$_SERVER['argv'][3] = '--testdox';
+$_SERVER['argv'][4] = __DIR__ . '/Issue3107Test.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+ ✘ Call to undefined function %Sdoes_not_exist() in %s:%d
+%A
+%A
+%A
+%A
+%A
+%A
+%A
+
+Time: %s, Memory: %s
+
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.


### PR DESCRIPTION
Fixes #3107 

It changes quite some stuff around, not sure if you're fine with breaking BC for this. If not, we'd need to find a different solution.

Example output:

![screenshot from 2018-04-28 17-52-54](https://user-images.githubusercontent.com/1059790/39398376-0f32271e-4b0d-11e8-9daf-7e7409048e7c.png)
