### PR TITLE
Add the ability to specify environment variable requirements

### DIFF
--- a/tests/_files/RequirementsClassDocBlockTest.php
+++ b/tests/_files/RequirementsClassDocBlockTest.php
@@ -14,6 +14,7 @@
  * @requires OS Linux
  * @requires function testFuncClass
  * @requires extension testExtClass
+ * @requires env TEST_ENV dev|ci
  */
 class RequirementsClassDocBlockTest
 {

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -454,4 +454,19 @@ class RequirementsTest extends TestCase
     public function testSettingDisplayErrorsOn(): void
     {
     }
+
+    /**
+     * @requires env TEST_ENV dev|ci
+     */
+    public function testEnvironmentVariableRegEx(): void
+    {
+    }
+
+    /**
+     * @requires env TEST_ENV dev|ci
+     * @requires env OTHER_ENV .*
+     */
+    public function testEnvironmentMultiple(): void
+    {
+    }
 }

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -316,6 +316,16 @@ class TestTest extends TestCase
                     'extension_versions' => ['testExtOne' => ['version' => '99', 'operator' => '>=']],
                 ],
             ],
+            ['testEnvironmentVariableRegEx',
+                [
+                    'env' => ['TEST_ENV' => 'dev|ci'],
+                ],
+            ],
+            ['testEnvironmentMultiple',
+                [
+                    'env' => ['TEST_ENV' => 'dev|ci', 'OTHER_ENV' => '.*'],
+                ],
+            ],
         ];
     }
 
@@ -489,6 +499,9 @@ class TestTest extends TestCase
                 'testExtClass',
                 'testExtMethod',
             ],
+            'env' => [
+                'TEST_ENV' => 'dev|ci',
+            ],
         ];
 
         $this->assertEquals(
@@ -560,6 +573,13 @@ class TestTest extends TestCase
             ['testVersionConstraintCaretMajor', [
                 'PHP version does not match the required constraint ^1.0.',
                 'PHPUnit version does not match the required constraint ^2.0.',
+            ]],
+            ['testEnvironmentVariableRegEx', [
+                'Environment variable TEST_ENV matching /dev|ci/i is required',
+            ]],
+            ['testEnvironmentMultiple', [
+                'Environment variable TEST_ENV matching /dev|ci/i is required',
+                'Environment variable OTHER_ENV matching /.*/i is required',
             ]],
         ];
     }


### PR DESCRIPTION
Hello!

In one of the projects, I'm using PHPUnit to run tests that are partially configured using environment variables. Due to that, some of them need to be skipped based on certain variable values. In this PR I've added a new feature to the `@requires` annotation that allows you to specify environment variable name and regular expression that it has to match. For example:
```php
/**
 * @requires env SOME_ENV_VARIABLE some_value
 */
```
or:
```php
/**
 * @requires env STAGE ^dev|ci$
 */
```

The additional `@requires env` annotation would save us the need to add if statement in the test body and skip tests "manually".

Please let me know what you think.