### PR TITLE
Feature/method covers overrides class covers nothing

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -134,6 +134,7 @@ final class Test
         );
 
         $linesShouldBeCovered = self::shouldLinesBeCoveredForAnnotions($annotations);
+
         if ($linesShouldBeCovered === false) {
             return false;
         }
@@ -1098,7 +1099,9 @@ final class Test
 
     /**
      * Should any coverage be generated.
+     *
      * @param $annotations
+     *
      * @return bool
      */
     private static function shouldLinesBeCoveredForAnnotions($annotations)

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -133,7 +133,8 @@ final class Test
             $methodName
         );
 
-        if (isset($annotations['class']['coversNothing']) || isset($annotations['method']['coversNothing'])) {
+        $linesShouldBeCovered = self::shouldLinesBeCoveredForAnnotions($annotations);
+        if ($linesShouldBeCovered === false) {
             return false;
         }
 
@@ -1093,5 +1094,27 @@ final class Test
             '$1',
             $version
         );
+    }
+
+    /**
+     * Should any coverage be generated.
+     * @param $annotations
+     * @return bool
+     */
+    private static function shouldLinesBeCoveredForAnnotions($annotations)
+    {
+        if (isset($annotations['method']['coversNothing'])) {
+            return false;
+        }
+
+        if (isset($annotations['method']['covers'])) {
+            return true;
+        }
+
+        if (isset($annotations['class']['coversNothing'])) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Util/TestTest.php
+++ b/tests/Util/TestTest.php
@@ -797,6 +797,8 @@ class TestTest extends TestCase
             $expected = [
               TEST_FILES_PATH . 'NamespaceCoveredClass.php' => $lines
             ];
+        } elseif ($test === 'CoverageCoversOverridesCoversNothingTest') {
+            $expected = [TEST_FILES_PATH . 'CoveredClass.php' => $lines];
         } elseif ($test === 'CoverageNoneTest') {
             $expected = [];
         } elseif ($test === 'CoverageNothingTest') {
@@ -1024,7 +1026,11 @@ class TestTest extends TestCase
           [
             'CoverageNothingTest',
             false
-          ]
+          ],
+          [
+            'CoverageCoversOverridesCoversNothingTest',
+            \range(29, 33)
+          ],
         ];
     }
 

--- a/tests/_files/CoverageCoversOverridesCoversNothingTest.php
+++ b/tests/_files/CoverageCoversOverridesCoversNothingTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class CoverageCoversOverridesCoversNothingTest extends TestCase
+{
+    /**
+     * @covers CoveredClass::publicMethod
+     */
+    public function testSomething(): void
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}


### PR DESCRIPTION
Implements https://github.com/sebastianbergmann/php-code-coverage/issues/611 aka allows a 'method covers' annotation to override the 'class coversNothing' annotation.

Reasonably chance this might need to wait until PHPUnit 7.2.0