### PR TITLE
Enable phpstan/phpstan-phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
       env: PHPStan
       before_install:
         - travis_retry ./build/tools/composer require --no-update phpunit/php-invoker:^2.0
+        - travis_retry ./build/tools/composer require --no-update phpstan/phpstan-phpunit:0.9.4
       install: travis_retry ./build/tools/composer update --prefer-dist --prefer-stable
       script:
         - ./build/tools/phpstan analyse --level=0 src

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
             "src/Framework/Assert/Functions.php",
             "tests/_files/CoverageNamespacedFunctionTest.php",
             "tests/_files/CoveredFunction.php",
+            "tests/_files/FunctionCallback.php",
             "tests/_files/NamespaceCoveredFunction.php"
         ]
     },

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
 parameters:
     ignoreErrors:
         # parent calls are intentionally omitted
@@ -20,20 +23,18 @@ parameters:
         - '#Function does_not_exist not found#'
 
         # https://github.com/sebastianbergmann/phpunit/issues/3129
-        - '#Access to an undefined property PHPUnit\\Framework\\MockObject\\MockObject::\$constructorArgs#'
-        - '#Access to an undefined property PHPUnit\\Framework\\MockObject\\MockObject::\$constructorCalled#'
-        - '#Access to an undefined property PHPUnit\\Framework\\MockObject\\MockObject::\$cloned#'
-        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::foo()#'
+        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject&stdClass::foo()#'
+        - '#Call to an undefined method Foo&PHPUnit\\Framework\\MockObject\\MockObject::bar()#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::bar()#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::doSomething()#'
-        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::wrong()#'
-        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::right()#'
-        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::staticMethod()#'
+        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject&SomeClass::wrong()#'
+        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject&SomeClass::right()#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::returnAnything()#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::mockableMethod()#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::anotherMockableMethod()#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::someMethod()#'
-        - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject::callback()#'
+        - '#Method AnInterface::doSomething\(\) invoked with 2 parameters, 0 required#'
+        - '#Method AnInterface::doSomething\(\) invoked with 3 parameters, 0 required#'
         - '#Call to an undefined method object::ohHai#'
         - '#Call to static method bar\(\) on an unknown class Legacy#'
         - '#Class ACustomClassName not found#'

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -37,7 +37,6 @@ parameters:
         - '#Call to an undefined method object::ohHai#'
         - '#Call to static method bar\(\) on an unknown class Legacy#'
         - '#Class ACustomClassName not found#'
-        - '#Function functionCallback not found while trying to analyse it - autoloading is probably not configured properly#'
         - '#Result of method ClassWithAllPossibleReturnTypes::methodWithVoidReturnTypeDeclaration\(\) \(void\) is used#'
 
     excludes_analyse:


### PR DESCRIPTION
Improves fix for #3129 from 2ef1018ee0f4a5d44c399604b0ed7defe3c01cdc.

[phpstan-phpunit](https://github.com/phpstan/phpstan-phpunit) extension helps with analysis of the mocks (e.g. when you mock a real class with methods). It resolves some of the ignored errors, but the others are caused by new methods being defined while mocking, which I think are fine to ignore.