### PR TITLE
Malformed withConsecutive doesn't raise errors

### DIFF
--- a/tests/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -65,4 +65,22 @@ class ConsecutiveParametersTest extends TestCase
 
         $mock->foo('invalid');
     }
+
+    public function testMalformedConstraintIntegrationExpectingException(): void
+    {
+        $mock = $this->getMockBuilder(stdClass::class)
+                     ->setMethods(['foo'])
+                     ->getMock();
+
+        $mock->expects($this->any())
+             ->method('foo')
+             ->withConsecutive(
+                 // Note the absence of array
+                 $this->stringContains('bar')
+             );
+
+        $this->expectException(\PHPUnit\Exception::class);
+
+        $mock->foo('invalid');
+    }
 }


### PR DESCRIPTION
References:

1. https://github.com/sebastianbergmann/phpunit-mock-objects/pull/359
1. https://github.com/sebastianbergmann/phpunit-mock-objects/pull/393

Each `withConsecutive` parameter should be an array (or Traversable) in order to be used by [./src/Framework/MockObject/Matcher/ConsecutiveParameters.php](https://github.com/sebastianbergmann/phpunit/blob/8fa2aff0793e896be20f3e85585c827bc5e60530/src/Framework/MockObject/Matcher/ConsecutiveParameters.php#L47) and I would expect an error if the expectation is malformed.

Instead the test passes, but should fail.