### PR TITLE
Make test for #3107 less picky about working directory

### DIFF
--- a/tests/Regression/GitHub/3107/issue-3107-test.phpt
+++ b/tests/Regression/GitHub/3107/issue-3107-test.phpt
@@ -17,7 +17,7 @@ Issue3107\Issue3107Test
    │
    │ Error: Call to undefined function %Sdoes_not_exist()
    │ 
-   │ %s%ephpunit%etests%eRegression%eGitHub%e3107%eIssue3107Test.php:%d
+   │ %s%etests%eRegression%eGitHub%e3107%eIssue3107Test.php:%d
    │ 
 
 Time: %s, Memory: %s


### PR DESCRIPTION
The test would fail when running from directory with a name different from `phpunit`, for example when I'm working in `phpunit-new-order`:

```
1) /Users/ewout/proj/phpunit-new-order/tests/Regression/GitHub/3107/issue-3107-test.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
    │
    │ Error: Call to undefined function Issue3107\does_not_exist()
    │ 
-   │ %s%ephpunit%etests%eRegression%eGitHub%e3107%eIssue3107Test.php:%d
+   │ /Users/ewout/proj/phpunit-new-order/tests/Regression/GitHub/3107/Issue3107Test.php:18
    │ 
```

