### PR TITLE
Improved dependency resolver and tests

### DIFF
--- a/tests/Runner/TestSuiteSorterTest.php
+++ b/tests/Runner/TestSuiteSorterTest.php
@@ -36,6 +36,24 @@ class TestSuiteSorterTest extends TestCase
         $this->assertEquals($expected, $this->getTestExecutionOrder());
     }
 
+    public function testSuitSorterRandomize()
+    {
+        \mt_srand(54321);
+        $sorter = new TestSuiteSorter();
+        $sorter->reorderTestsInSuite($this->suite, TestSuiteSorter::ORDER_RANDOMIZED, false);
+
+        $this->assertEquals(['testTwo', 'testFour', 'testFive', 'testThree', 'testOne'], $this->getTestExecutionOrder());
+    }
+
+    public function testSuitSorterRandomizeResolve()
+    {
+        \mt_srand(54321);
+        $sorter = new TestSuiteSorter();
+        $sorter->reorderTestsInSuite($this->suite, TestSuiteSorter::ORDER_RANDOMIZED, true);
+
+        $this->assertEquals(['testTwo', 'testFive', 'testOne', 'testThree', 'testFour'], $this->getTestExecutionOrder());
+    }
+
     public function suiteSorterOptionsProvider(): array
     {
         return [

--- a/tests/Runner/TestSuiteSorterTest.php
+++ b/tests/Runner/TestSuiteSorterTest.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\Framework;
+
+use PHPUnit\Runner\TestSuiteSorter;
+
+class TestSuiteSorterTest extends TestCase
+{
+    /**
+     * @var TestSuite
+     */
+    private $suite;
+
+    public function setup()
+    {
+        $this->suite = new TestSuite;
+        $this->suite->addTestSuite(\MultiDependencyTest::class);
+    }
+
+    /**
+     * @dataProvider suiteSorterOptionsProvider
+     */
+    public function testSuiteSorterOptions(int $order, bool $resolveDependencies, array $expected)
+    {
+        $sorter = new TestSuiteSorter();
+        $sorter->reorderTestsInSuite($this->suite, $order, $resolveDependencies);
+
+        $this->assertEquals($expected, $this->getTestExecutionOrder());
+    }
+
+    public function suiteSorterOptionsProvider(): array
+    {
+        return [
+            'default' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                false,
+                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+            'resolve default' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                true,
+                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+            'reverse' => [
+                TestSuiteSorter::ORDER_REVERSED,
+                false,
+                ['testFive', 'testFour', 'testThree', 'testTwo', 'testOne']],
+            'resolve reverse' => [
+                TestSuiteSorter::ORDER_REVERSED,
+                true,
+                ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour']],
+        ];
+    }
+
+    private function getTestExecutionOrder()
+    {
+        return \array_map(function ($test) {
+            return $test->getName();
+        }, $this->suite->tests()[0]->tests());
+    }
+}

--- a/tests/TextUI/dependencies3-isolation.phpt
+++ b/tests/TextUI/dependencies3-isolation.phpt
@@ -12,8 +12,8 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Time: %s, Memory: %s
 
-OK (4 tests, 5 assertions)
+OK (5 tests, 6 assertions)

--- a/tests/TextUI/dependencies3.phpt
+++ b/tests/TextUI/dependencies3.phpt
@@ -12,8 +12,8 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Time: %s, Memory: %s
 
-OK (4 tests, 5 assertions)
+OK (5 tests, 6 assertions)

--- a/tests/TextUI/test-order-randomized-seed-with-dependency-resolution.phpt
+++ b/tests/TextUI/test-order-randomized-seed-with-dependency-resolution.phpt
@@ -20,10 +20,12 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Runtime:       %s
 Random seed:   54321
 
-Test 'MultiDependencyTest::testOne' started
-Test 'MultiDependencyTest::testOne' ended
 Test 'MultiDependencyTest::testTwo' started
 Test 'MultiDependencyTest::testTwo' ended
+Test 'MultiDependencyTest::testFive' started
+Test 'MultiDependencyTest::testFive' ended
+Test 'MultiDependencyTest::testOne' started
+Test 'MultiDependencyTest::testOne' ended
 Test 'MultiDependencyTest::testThree' started
 Test 'MultiDependencyTest::testThree' ended
 Test 'MultiDependencyTest::testFour' started
@@ -32,4 +34,4 @@ Test 'MultiDependencyTest::testFour' ended
 
 Time: %s, Memory: %s
 
-OK (4 tests, 5 assertions)
+OK (5 tests, 6 assertions)

--- a/tests/TextUI/test-order-randomized-with-dependency-resolution.phpt
+++ b/tests/TextUI/test-order-randomized-with-dependency-resolution.phpt
@@ -18,8 +18,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Runtime:       %s
 Random seed:   %d
 
-....                                                                4 / 4 (100%)
+.....                                                               5 / 5 (100%)
 
 Time: %s, Memory: %s
 
-OK (4 tests, 5 assertions)
+OK (5 tests, 6 assertions)

--- a/tests/TextUI/test-order-reversed-with-dependency-resolution.phpt
+++ b/tests/TextUI/test-order-reversed-with-dependency-resolution.phpt
@@ -18,6 +18,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime:       %s
 
+Test 'MultiDependencyTest::testFive' started
+Test 'MultiDependencyTest::testFive' ended
 Test 'MultiDependencyTest::testTwo' started
 Test 'MultiDependencyTest::testTwo' ended
 Test 'MultiDependencyTest::testOne' started
@@ -30,4 +32,4 @@ Test 'MultiDependencyTest::testFour' ended
 
 Time: %s, Memory: %s
 
-OK (4 tests, 5 assertions)
+OK (5 tests, 6 assertions)

--- a/tests/TextUI/test-order-reversed-without-dependency-resolution.phpt
+++ b/tests/TextUI/test-order-reversed-without-dependency-resolution.phpt
@@ -18,6 +18,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime:       %s
 
+Test 'MultiDependencyTest::testFive' started
+Test 'MultiDependencyTest::testFive' ended
 Test 'MultiDependencyTest::testFour' started
 Test 'MultiDependencyTest::testFour' ended
 Test 'MultiDependencyTest::testThree' started
@@ -39,4 +41,4 @@ This test depends on "MultiDependencyTest::testThree" to pass.
 This test depends on "MultiDependencyTest::testOne" to pass.
 
 OK, but incomplete, skipped, or risky tests!
-Tests: 4, Assertions: 2, Skipped: 2.
+Tests: 5, Assertions: 3, Skipped: 2.

--- a/tests/_files/MultiDependencyTest.php
+++ b/tests/_files/MultiDependencyTest.php
@@ -45,4 +45,9 @@ class MultiDependencyTest extends TestCase
     {
         $this->assertTrue(true);
     }
+
+    public function testFive()
+    {
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
## Summary
Changes to test execution order can result in unexpected defects and create uncertainty, which is the exact opposite of what we want. The dependency resolver is improved to be more hands-off and leave more tests in original order.

### Why: backwards compatibility
During development of the test execution reordering feature #3092 backwards compatibility was discussed. [Automatic dependency resolution](https://github.com/epdenouden/phpunit/wiki/PHPUnit-test-running-order-management#demo-3-handling-dependencies) will be optional in 7.x and [default for 8.x](https://github.com/sebastianbergmann/phpunit/issues/3133).

### How: improved dependency manager
The current resolver has a speed optimization that always sorts all independent tests to the front before looking at tests with dependencies. While this produces a _technically correct_ execution order, it produces 'noise' by moving tests around more than necessary. The simplified resolver returns a more natural execution order:

|#|Original order|after noisy resolver|after quiet resolver|
|:--|:--|:--|:--|
|1|`A_independent`|`A_independent`|`A_independent`|
|2|`B_dep_on_A`|`C_independent`|`B_dep_on_A`|
|3|`C_independent`|`E_independent`|`C_independent`|
|4|`D_dep_on_C`|`B_dep_on_A`|`D_dep_on_C`|
|5|`E_independent`|`D_dep_on_C`|`E_independent`|

## Changed functionality and impact
- no noticeable difference in performance or resource footprint
- no difference in configuration and input
- output is functionally unchanged, however the order might be slightly different; this only shows up using `--debug` or relying on an exact sequence of tests when logging

## Software design and testing
- make dependency resolution optional again: https://github.com/sebastianbergmann/phpunit/commit/8fa2aff0793e896be20f3e85585c827bc5e60530
- the `TestSuiteSorter` dependency resolver now is simpler and checks all tests at least once
- all interfaces between components stay the same
- add [isolation tests](https://github.com/epdenouden/phpunit/blob/test-reorder-quiet-resolve/tests/Runner/TestSuiteSorterTest.php) for the `TestSuiteSorter`
- keep the current `TextUI` end-to-end tests
