### PR TITLE
Some minor performance optimizations

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2375,20 +2375,16 @@ abstract class Assert
         static::assertThat($actualJson, new LogicalNot($constraintExpected), $message);
     }
 
-    public static function logicalAnd(): LogicalAnd
+    public static function logicalAnd(Constraint ...$constraints): LogicalAnd
     {
-        $constraints = \func_get_args();
-
         $constraint = new LogicalAnd;
         $constraint->setConstraints($constraints);
 
         return $constraint;
     }
 
-    public static function logicalOr(): LogicalOr
+    public static function logicalOr(Constraint ...$constraints): LogicalOr
     {
-        $constraints = \func_get_args();
-
         $constraint = new LogicalOr;
         $constraint->setConstraints($constraints);
 
@@ -2400,10 +2396,8 @@ abstract class Assert
         return new LogicalNot($constraint);
     }
 
-    public static function logicalXor(): LogicalXor
+    public static function logicalXor(Constraint ...$constraints): LogicalXor
     {
-        $constraints = \func_get_args();
-
         $constraint = new LogicalXor;
         $constraint->setConstraints($constraints);
 

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -262,7 +262,7 @@ class InvocationMocker implements MethodNameMatch
             );
         }
 
-        if (\is_string($constraint) && !\in_array(\strtolower($constraint), $this->configurableMethods)) {
+        if (\is_string($constraint) && !\in_array(\strtolower($constraint), $this->configurableMethods, true)) {
             throw new RuntimeException(
                 \sprintf(
                     'Trying to configure method "%s" which cannot be configured because it does not exist, has not been specified, is final, or is static',

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -40,7 +40,7 @@ class Generator
     /**
      * @var array
      */
-    private $blacklistedMethodNames = [
+    private const BLACKLISTED_METHOD_NAMES = [
         '__CLASS__'       => true,
         '__DIR__'         => true,
         '__FILE__'        => true,
@@ -239,7 +239,7 @@ class Generator
             $methods   = $mockedMethods;
 
             foreach ($reflector->getMethods() as $method) {
-                if ($method->isAbstract() && !\in_array($method->getName(), $methods)) {
+                if ($method->isAbstract() && !\in_array($method->getName(), $methods, true)) {
                     $methods[] = $method->getName();
                 }
             }
@@ -466,7 +466,7 @@ class Generator
             $nameEnd   = \strpos($method, '(');
             $name      = \substr($method, $nameStart, $nameEnd - $nameStart);
 
-            if (empty($methods) || \in_array($name, $methods)) {
+            if (empty($methods) || \in_array($name, $methods, true)) {
                 $args    = \explode(
                     ',',
                     \substr(
@@ -812,7 +812,7 @@ class Generator
 
         $method = '';
 
-        if (!\in_array('method', $methods) && (!isset($class) || !$class->hasMethod('method'))) {
+        if (!\in_array('method', $methods, true) && (!isset($class) || !$class->hasMethod('method'))) {
             $methodTemplate = $this->getTemplate('mocked_class_method.tpl');
 
             $method = $methodTemplate->render();
@@ -1102,7 +1102,7 @@ class Generator
      */
     private function isMethodNameBlacklisted($name)
     {
-        return isset($this->blacklistedMethodNames[$name]);
+        return isset(self::BLACKLISTED_METHOD_NAMES[$name]);
     }
 
     /**

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -30,16 +30,6 @@ class Generator
     /**
      * @var array
      */
-    private static $cache = [];
-
-    /**
-     * @var Text_Template[]
-     */
-    private static $templates = [];
-
-    /**
-     * @var array
-     */
     private const BLACKLISTED_METHOD_NAMES = [
         '__CLASS__'       => true,
         '__DIR__'         => true,
@@ -52,6 +42,16 @@ class Generator
         '__clone'         => true,
         '__halt_compiler' => true,
     ];
+
+    /**
+     * @var array
+     */
+    private static $cache = [];
+
+    /**
+     * @var Text_Template[]
+     */
+    private static $templates = [];
 
     /**
      * Returns a mock object for the specified class.
@@ -97,7 +97,7 @@ class Generator
         if (\is_array($type)) {
             $type = \array_unique(
                 \array_map(
-                    function ($type) {
+                    function ($type): string {
                         if ($type === 'Traversable' ||
                             $type === '\\Traversable' ||
                             $type === '\\Iterator') {

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -104,10 +104,8 @@ class MockBuilder
 
     /**
      * Creates a mock object using a fluent interface.
-     *
-     * @return MockObject
      */
-    public function getMock()
+    public function getMock(): MockObject
     {
         $object = $this->generator->getMock(
             $this->type,
@@ -131,10 +129,8 @@ class MockBuilder
 
     /**
      * Creates a mock object for an abstract class using a fluent interface.
-     *
-     * @return MockObject
      */
-    public function getMockForAbstractClass()
+    public function getMockForAbstractClass(): MockObject
     {
         $object = $this->generator->getMockForAbstractClass(
             $this->type,
@@ -154,10 +150,8 @@ class MockBuilder
 
     /**
      * Creates a mock object for a trait using a fluent interface.
-     *
-     * @return MockObject
      */
-    public function getMockForTrait()
+    public function getMockForTrait(): MockObject
     {
         $object = $this->generator->getMockForTrait(
             $this->type,

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -56,6 +56,8 @@ use Throwable;
 
 abstract class TestCase extends Assert implements Test, SelfDescribing
 {
+    private const LOCALE_CATEGORIES = [LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME];
+
     /**
      * @var bool
      */
@@ -157,7 +159,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     private $locale = [];
 
     /**
-     * @var array
+     * @var MockObject[]
      */
     private $mockObjects = [];
 
@@ -1266,8 +1268,6 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             );
         }
     }
-
-    private const LOCALE_CATEGORIES = [LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME];
 
     /**
      * This method is a wrapper for the setlocale() function that automatically

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1267,6 +1267,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         }
     }
 
+    private const LOCALE_CATEGORIES = [LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME];
+
     /**
      * This method is a wrapper for the setlocale() function that automatically
      * resets the locale to its original value after the test is run.
@@ -1281,15 +1283,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
         [$category, $locale] = $args;
 
-        $categories = [
-            LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME
-        ];
-
         if (\defined('LC_MESSAGES')) {
             $categories[] = LC_MESSAGES;
         }
 
-        if (!\in_array($category, $categories)) {
+        if (!\in_array($category, self::LOCALE_CATEGORIES, true)) {
             throw new Exception;
         }
 

--- a/src/Runner/Filter/ExcludeGroupFilterIterator.php
+++ b/src/Runner/Filter/ExcludeGroupFilterIterator.php
@@ -13,6 +13,6 @@ class ExcludeGroupFilterIterator extends GroupFilterIterator
 {
     protected function doAccept(string $hash): bool
     {
-        return !\in_array($hash, $this->groupTests);
+        return !\in_array($hash, $this->groupTests, true);
     }
 }

--- a/src/Runner/Filter/GroupFilterIterator.php
+++ b/src/Runner/Filter/GroupFilterIterator.php
@@ -16,7 +16,7 @@ use RecursiveIterator;
 abstract class GroupFilterIterator extends RecursiveFilterIterator
 {
     /**
-     * @var array
+     * @var string[]
      */
     protected $groupTests = [];
 
@@ -25,7 +25,7 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
         parent::__construct($iterator);
 
         foreach ($suite->getGroupDetails() as $group => $tests) {
-            if (\in_array($group, $groups)) {
+            if (\in_array($group, $groups, true)) {
                 $testHashes = \array_map(
                     'spl_object_hash',
                     $tests

--- a/src/Runner/Filter/IncludeGroupFilterIterator.php
+++ b/src/Runner/Filter/IncludeGroupFilterIterator.php
@@ -13,6 +13,6 @@ class IncludeGroupFilterIterator extends GroupFilterIterator
 {
     protected function doAccept(string $hash): bool
     {
-        return \in_array($hash, $this->groupTests);
+        return \in_array($hash, $this->groupTests, true);
     }
 }

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -40,6 +40,8 @@ class ResultPrinter extends Printer implements TestListener
     public const COLOR_ALWAYS  = 'always';
     public const COLOR_DEFAULT = self::COLOR_NEVER;
 
+    private const AVAILABLE_COLORS = [self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS];
+
     /**
      * @var array
      */
@@ -127,8 +129,6 @@ class ResultPrinter extends Printer implements TestListener
      * @var bool
      */
     private $defectListPrinted = false;
-
-    private const AVAILABLE_COLORS = [self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS];
 
     /**
      * Constructor.

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -128,6 +128,8 @@ class ResultPrinter extends Printer implements TestListener
      */
     private $defectListPrinted = false;
 
+    private const AVAILABLE_COLORS = [self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS];
+
     /**
      * Constructor.
      *
@@ -144,12 +146,10 @@ class ResultPrinter extends Printer implements TestListener
     {
         parent::__construct($out);
 
-        $availableColors = [self::COLOR_NEVER, self::COLOR_AUTO, self::COLOR_ALWAYS];
-
-        if (!\in_array($colors, $availableColors)) {
+        if (!\in_array($colors, self::AVAILABLE_COLORS, true)) {
             throw InvalidArgumentHelper::factory(
                 3,
-                \vsprintf('value from "%s", "%s" or "%s"', $availableColors)
+                \vsprintf('value from "%s", "%s" or "%s"', self::AVAILABLE_COLORS)
             );
         }
 

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -129,7 +129,7 @@ final class GlobalState
         $blacklist[] = 'GLOBALS';
 
         foreach (\array_keys($GLOBALS) as $key) {
-            if (!$GLOBALS[$key] instanceof Closure && !\in_array($key, $blacklist)) {
+            if (!$GLOBALS[$key] instanceof Closure && !\in_array($key, $blacklist, true)) {
                 $result .= \sprintf(
                     '$GLOBALS[\'%s\'] = %s;' . "\n",
                     $key,


### PR DESCRIPTION
* Use strict `in_array()` so that the new `ZEND_IN_ARRAY ` opcode can be used
* Use splat operator instead of `func_get_args()` where applicable. 