### PR TITLE
Breakfast: rerun defects first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@
 /tests/TextUI/*.out
 /tests/TextUI/*.php
 /vendor
-
+/.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
+         cacheResult="true"
          verbose="true">
     <testsuites>
         <testsuite name="small">

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -167,8 +167,13 @@
     <xs:simpleType name="executionOrderType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="default"/>
-            <xs:enumeration value="reverse"/>
+            <xs:enumeration value="defects"/>
+            <xs:enumeration value="depends"/>
+            <xs:enumeration value="depends,defects"/>
             <xs:enumeration value="random"/>
+            <xs:enumeration value="reverse"/>
+            <xs:enumeration value="depends,random"/>
+            <xs:enumeration value="depends,reverse"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="fileFilterType">
@@ -216,6 +221,8 @@
         <xs:attribute name="backupGlobals" type="xs:boolean" default="false"/>
         <xs:attribute name="backupStaticAttributes" type="xs:boolean" default="false"/>
         <xs:attribute name="bootstrap" type="xs:anyURI"/>
+        <xs:attribute name="cacheResult" type="xs:boolean"/>
+        <xs:attribute name="cacheResultFile" type="xs:anyURI"/>
         <xs:attribute name="cacheTokens" type="xs:boolean"/>
         <xs:attribute name="colors" type="xs:boolean" default="false"/>
         <xs:attribute name="columns" type="columnsType" default="80"/>
@@ -228,6 +235,7 @@
         <xs:attribute name="printerClass" type="xs:string" default="PHPUnit\TextUI\ResultPrinter"/>
         <xs:attribute name="printerFile" type="xs:anyURI"/>
         <xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnDefect" type="xs:boolean" default="false"/>
         <xs:attribute name="stopOnError" type="xs:boolean" default="false"/>
         <xs:attribute name="stopOnFailure" type="xs:boolean" default="false"/>
         <xs:attribute name="stopOnWarning" type="xs:boolean" default="false"/>

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -177,6 +177,11 @@ class TestResult implements Countable
     /**
      * @var bool
      */
+    protected $stopOnDefect = false;
+
+    /**
+     * @var bool
+     */
     protected $lastTestFailed = false;
 
     /**
@@ -229,7 +234,7 @@ class TestResult implements Countable
                 $test->markAsRisky();
             }
 
-            if ($this->stopOnRisky) {
+            if ($this->stopOnRisky || $this->stopOnDefect) {
                 $this->stop();
             }
         } elseif ($t instanceof IncompleteTest) {
@@ -274,7 +279,7 @@ class TestResult implements Countable
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {
-        if ($this->stopOnWarning) {
+        if ($this->stopOnWarning || $this->stopOnDefect) {
             $this->stop();
         }
 
@@ -301,7 +306,7 @@ class TestResult implements Countable
                 $test->markAsRisky();
             }
 
-            if ($this->stopOnRisky) {
+            if ($this->stopOnRisky || $this->stopOnDefect) {
                 $this->stop();
             }
         } elseif ($e instanceof IncompleteTest) {
@@ -322,7 +327,7 @@ class TestResult implements Countable
             $this->failures[] = new TestFailure($test, $e);
             $notifyMethod     = 'addFailure';
 
-            if ($this->stopOnFailure) {
+            if ($this->stopOnFailure || $this->stopOnDefect) {
                 $this->stop();
             }
         }
@@ -1009,6 +1014,14 @@ class TestResult implements Countable
     public function stopOnSkipped(bool $flag): void
     {
         $this->stopOnSkipped = $flag;
+    }
+
+    /**
+     * Enables or disables the stopping for defects: error, failure, warning
+     */
+    public function stopOnDefect(bool $flag): void
+    {
+        $this->stopOnDefect = $flag;
     }
 
     /**

--- a/src/Runner/ResultCacheExtension.php
+++ b/src/Runner/ResultCacheExtension.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+final class ResultCacheExtension implements AfterSuccessfulTestHook, AfterSkippedTestHook, AfterRiskyTestHook, AfterIncompleteTestHook, AfterTestErrorHook, AfterTestWarningHook, AfterTestFailureHook, AfterLastTestHook
+{
+    /**
+     * @var TestResultCacheInterface
+     */
+    private $cache;
+
+    public function __construct(TestResultCache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function flush(): void
+    {
+        $this->cache->persist();
+    }
+
+    public function executeAfterSuccessfulTest(string $test, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+    }
+
+    public function executeAfterIncompleteTest(string $test, string $message, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+        $this->cache->setState($testName, BaseTestRunner::STATUS_INCOMPLETE);
+    }
+
+    public function executeAfterRiskyTest(string $test, string $message, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+        $this->cache->setState($testName, BaseTestRunner::STATUS_RISKY);
+    }
+
+    public function executeAfterSkippedTest(string $test, string $message, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+        $this->cache->setState($testName, BaseTestRunner::STATUS_SKIPPED);
+    }
+
+    public function executeAfterTestError(string $test, string $message, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+        $this->cache->setState($testName, BaseTestRunner::STATUS_ERROR);
+    }
+
+    public function executeAfterTestFailure(string $test, string $message, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+        $this->cache->setState($testName, BaseTestRunner::STATUS_FAILURE);
+    }
+
+    public function executeAfterTestWarning(string $test, string $message, float $time): void
+    {
+        $testName = $this->getTestName($test);
+        $this->cache->setTime($testName, \round($time, 3));
+        $this->cache->setState($testName, BaseTestRunner::STATUS_WARNING);
+    }
+
+    public function executeAfterLastTest(): void
+    {
+        $this->flush();
+    }
+
+    /**
+     * @param string $test A long description format of the current test
+     *
+     * @return string The test name without TestSuiteClassName:: and @dataprovider details
+     */
+    private function getTestName(string $test): string
+    {
+        $matches = [];
+
+        if (\preg_match('/^(?:\S+::)?(?<name>\S+)(?:(?<data> with data set (?:#\d+|"[^"]+"))\s\()?/', $test, $matches)) {
+            $test = $matches['name'];
+
+            if (isset($matches['data'])) {
+                $test .= $matches['data'];
+            }
+        }
+
+        return $test;
+    }
+}

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -32,9 +32,42 @@ final class TestSuiteSorter
     public const ORDER_REVERSED = 2;
 
     /**
+     * @var int
+     */
+    public const ORDER_DEFECTS_FIRST = 3;
+
+    /**
+     * List of sorting weights for all test result codes. A higher number gives higher priority.
+     */
+    private const DEFECT_SORT_WEIGHT = [
+        BaseTestRunner::STATUS_ERROR      => 6,
+        BaseTestRunner::STATUS_FAILURE    => 5,
+        BaseTestRunner::STATUS_WARNING    => 4,
+        BaseTestRunner::STATUS_INCOMPLETE => 3,
+        BaseTestRunner::STATUS_RISKY      => 2,
+        BaseTestRunner::STATUS_SKIPPED    => 1,
+        BaseTestRunner::STATUS_UNKNOWN    => 0
+    ];
+
+    /**
+     * @var array<string, int> Associative array of (string => DEFECT_SORT_WEIGHT) elements
+     */
+    private $defectSortOrder = [];
+
+    /**
+     * @var TestResultCacheInterface
+     */
+    private $cache;
+
+    public function __construct(?TestResultCacheInterface $cache = null)
+    {
+        $this->cache = $cache ?? new NullTestResultCache;
+    }
+
+    /**
      * @throws Exception
      */
-    public function reorderTestsInSuite(Test $suite, int $order, bool $resolveDependencies): void
+    public function reorderTestsInSuite(Test $suite, int $order, bool $resolveDependencies, int $orderDefects): void
     {
         if ($order !== self::ORDER_DEFAULT && $order !== self::ORDER_REVERSED && $order !== self::ORDER_RANDOMIZED) {
             throw new Exception(
@@ -42,16 +75,25 @@ final class TestSuiteSorter
             );
         }
 
-        if ($suite instanceof TestSuite && !empty($suite->tests())) {
+        if ($orderDefects !== self::ORDER_DEFAULT && $orderDefects !== self::ORDER_DEFECTS_FIRST) {
+            throw new Exception(
+                '$orderDefects must be one of TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_DEFECTS_FIRST'
+            );
+        }
+
+        if ($suite instanceof TestSuite) {
             foreach ($suite as $_suite) {
-                $this->reorderTestsInSuite($_suite, $order, $resolveDependencies);
+                $this->reorderTestsInSuite($_suite, $order, $resolveDependencies, $orderDefects);
             }
 
-            $this->sort($suite, $order, $resolveDependencies);
+            if ($orderDefects === self::ORDER_DEFECTS_FIRST) {
+                $this->addSuiteToDefectSortOrder($suite);
+            }
+            $this->sort($suite, $order, $resolveDependencies, $orderDefects);
         }
     }
 
-    private function sort(TestSuite $suite, int $order, bool $resolveDependencies): void
+    private function sort(TestSuite $suite, int $order, bool $resolveDependencies, int $orderDefects): void
     {
         if (empty($suite->tests())) {
             return;
@@ -63,9 +105,27 @@ final class TestSuiteSorter
             $suite->setTests($this->randomize($suite->tests()));
         }
 
+        if ($orderDefects === self::ORDER_DEFECTS_FIRST && $this->cache !== null) {
+            $suite->setTests($this->sortDefectsFirst($suite->tests()));
+        }
+
         if ($resolveDependencies && !($suite instanceof DataProviderTestSuite) && $this->suiteOnlyContainsTests($suite)) {
             $suite->setTests($this->resolveDependencies($suite->tests()));
         }
+    }
+
+    private function addSuiteToDefectSortOrder(TestSuite $suite): void
+    {
+        $max = 0;
+
+        foreach ($suite->tests() as $test) {
+            if (!isset($this->defectSortOrder[$test->getName()])) {
+                $this->defectSortOrder[$test->getName()] = self::DEFECT_SORT_WEIGHT[$this->cache->getState($test->getName())];
+                $max                                     = \max($max, $this->defectSortOrder[$test->getName()]);
+            }
+        }
+
+        $this->defectSortOrder[$suite->getName()] = $max;
     }
 
     private function suiteOnlyContainsTests(TestSuite $suite): bool
@@ -85,6 +145,40 @@ final class TestSuiteSorter
         \shuffle($tests);
 
         return $tests;
+    }
+
+    private function sortDefectsFirst(array $tests): array
+    {
+        \usort($tests, function ($left, $right) {
+            return $this->cmpDefectPriorityAndTime($left, $right);
+        });
+
+        return $tests;
+    }
+
+    /**
+     * Comparator callback function to sort tests for "reach failure as fast as possible":
+     * 1. sort tests by defect weight defined in self::DEFECT_SORT_WEIGHT
+     * 2. when tests are equally defective, sort the fastest to the front
+     * 3. do not reorder successful tests
+     */
+    private function cmpDefectPriorityAndTime(Test $a, Test $b): int
+    {
+        $priorityA = $this->defectSortOrder[$a->getName()] ?? 0;
+        $priorityB = $this->defectSortOrder[$b->getName()] ?? 0;
+
+        if ($priorityB <=> $priorityA) {
+            // Sort defect weight descending
+            return $priorityB <=> $priorityA;
+        }
+
+        if ($priorityA || $priorityB) {
+            // Sort test duration ascending
+            return $this->cache->getTime($a->getName()) <=> $this->cache->getTime($b->getName());
+        }
+
+        // do not change execution order
+        return 0;
     }
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -68,6 +68,8 @@ class Command
     protected $longOptions = [
         'atleast-version='          => null,
         'bootstrap='                => null,
+        'cache-result'              => null,
+        'cache-result-file='        => null,
         'check-version'             => null,
         'colors=='                  => null,
         'columns='                  => null,
@@ -103,6 +105,7 @@ class Command
         'no-coverage'               => null,
         'no-logging'                => null,
         'no-extensions'             => null,
+        'order-by='                 => null,
         'printer='                  => null,
         'process-isolation'         => null,
         'repeat='                   => null,
@@ -113,6 +116,7 @@ class Command
         'reverse-list'              => null,
         'static-backup'             => null,
         'stderr'                    => null,
+        'stop-on-defect'            => null,
         'stop-on-error'             => null,
         'stop-on-failure'           => null,
         'stop-on-warning'           => null,
@@ -291,6 +295,16 @@ class Command
 
                 case '--bootstrap':
                     $this->arguments['bootstrap'] = $option[1];
+
+                    break;
+
+                case '--cache-result':
+                    $this->arguments['cacheResult'] = true;
+
+                    break;
+
+                case '--cache-result-file':
+                    $this->arguments['cacheResultFile'] = $option[1];
 
                     break;
 
@@ -490,6 +504,11 @@ class Command
 
                     break;
 
+                case '--order-by':
+                    $this->handleOrderByOption($option[1]);
+
+                    break;
+
                 case '--process-isolation':
                     $this->arguments['processIsolation'] = true;
 
@@ -502,6 +521,11 @@ class Command
 
                 case '--stderr':
                     $this->arguments['stderr'] = true;
+
+                    break;
+
+                case '--stop-on-defect':
+                    $this->arguments['stopOnDefect'] = true;
 
                     break;
 
@@ -693,7 +717,7 @@ class Command
                     break;
 
                 case '--random-order':
-                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
+                    $this->handleOrderByOption('random');
 
                     break;
 
@@ -703,7 +727,7 @@ class Command
                     break;
 
                 case '--resolve-dependencies':
-                    $this->arguments['resolveDependencies'] = true;
+                    $this->handleOrderByOption('depends');
 
                     break;
 
@@ -713,7 +737,7 @@ class Command
                     break;
 
                 case '--reverse-order':
-                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
+                    $this->handleOrderByOption('reverse');
 
                     break;
 
@@ -1098,6 +1122,7 @@ Test Execution Options:
   --columns <n>               Number of columns to use for progress output
   --columns max               Use maximum number of columns for progress output
   --stderr                    Write to STDERR instead of STDOUT
+  --stop-on-defect            Stop execution upon first not-passed test
   --stop-on-error             Stop execution upon first error
   --stop-on-failure           Stop execution upon first error or failure
   --stop-on-warning           Stop execution upon first warning
@@ -1118,9 +1143,9 @@ Test Execution Options:
   --printer <printer>         TestListener implementation to use
 
   --resolve-dependencies      Resolve dependencies between tests
-  --random-order              Run tests in random order
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
-  --reverse-order             Run tests last-to-first
+  --cache-result              Write run result to cache to enable ordering tests defects-first
 
 Configuration Options:
 
@@ -1133,6 +1158,7 @@ Configuration Options:
   --include-path <path(s)>    Prepend PHP's include_path with given path(s)
   -d key[=value]              Sets a php.ini value
   --generate-configuration    Generate configuration file with suggested settings
+  --cache-result-file==<FILE> Specify result cache path and filename
 
 Miscellaneous Options:
 
@@ -1292,5 +1318,37 @@ EOT;
         }
 
         return TestRunner::SUCCESS_EXIT;
+    }
+
+    private function handleOrderByOption(string $value): void
+    {
+        foreach (\explode(',', $value) as $order) {
+            switch ($order) {
+                case 'default':
+                    $this->arguments['executionOrder']        = TestSuiteSorter::ORDER_DEFAULT;
+                    $this->arguments['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFAULT;
+                    $this->arguments['resolveDependencies']   = false;
+
+                    break;
+                case 'reverse':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
+
+                    break;
+                case 'random':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
+
+                    break;
+                case 'defects':
+                    $this->arguments['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFECTS_FIRST;
+
+                    break;
+                case 'depends':
+                    $this->arguments['resolveDependencies'] = true;
+
+                    break;
+                default:
+                    $this->exitWithErrorMessage("unrecognized --order-by option: $order");
+            }
+        }
     }
 }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -25,9 +25,12 @@ use PHPUnit\Runner\Filter\Factory;
 use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
 use PHPUnit\Runner\Filter\NameFilterIterator;
 use PHPUnit\Runner\Hook;
+use PHPUnit\Runner\NullTestResultCache;
+use PHPUnit\Runner\ResultCacheExtension;
 use PHPUnit\Runner\StandardTestSuiteLoader;
 use PHPUnit\Runner\TestHook;
 use PHPUnit\Runner\TestListenerAdapter;
+use PHPUnit\Runner\TestResultCache;
 use PHPUnit\Runner\TestSuiteLoader;
 use PHPUnit\Runner\TestSuiteSorter;
 use PHPUnit\Runner\Version;
@@ -174,10 +177,23 @@ class TestRunner extends BaseTestRunner
             \mt_srand($arguments['randomOrderSeed']);
         }
 
-        if ($arguments['executionOrder'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['resolveDependencies']) {
-            $sorter = new TestSuiteSorter;
+        if ($arguments['cacheResult']) {
+            if (isset($arguments['cacheResultFile'])) {
+                $cache = new TestResultCache($arguments['cacheResultFile']);
+            } else {
+                $cache = new TestResultCache;
+            }
+            $this->extensions[] = new ResultCacheExtension($cache);
+        }
 
-            $sorter->reorderTestsInSuite($suite, $arguments['executionOrder'], $arguments['resolveDependencies']);
+        if ($arguments['executionOrder'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['executionOrderDefects'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['resolveDependencies']) {
+            if (!isset($cache)) {
+                $cache = new NullTestResultCache;
+            }
+            $cache->load();
+            $sorter = new TestSuiteSorter($cache);
+
+            $sorter->reorderTestsInSuite($suite, $arguments['executionOrder'], $arguments['resolveDependencies'], $arguments['executionOrderDefects']);
 
             unset($sorter);
         }
@@ -251,6 +267,10 @@ class TestRunner extends BaseTestRunner
 
         if ($arguments['stopOnSkipped']) {
             $result->stopOnSkipped(true);
+        }
+
+        if ($arguments['stopOnDefect']) {
+            $result->stopOnDefect(true);
         }
 
         if ($arguments['registerMockObjectsFromTestArgumentsRecursively']) {
@@ -806,6 +826,18 @@ class TestRunner extends BaseTestRunner
                 $arguments['bootstrap'] = $phpunitConfiguration['bootstrap'];
             }
 
+            if (isset($phpunitConfiguration['cacheResult']) && !isset($arguments['cacheResult'])) {
+                $arguments['cacheResult'] = $phpunitConfiguration['cacheResult'];
+            }
+
+            if (isset($phpunitConfiguration['cacheResultFile']) && !isset($arguments['cacheResultFile'])) {
+                $arguments['cacheResultFile'] = $phpunitConfiguration['cacheResultFile'];
+            }
+
+            if (isset($phpunitConfiguration['cacheTokens']) && !isset($arguments['cacheTokens'])) {
+                $arguments['cacheTokens'] = $phpunitConfiguration['cacheTokens'];
+            }
+
             if (isset($phpunitConfiguration['cacheTokens']) && !isset($arguments['cacheTokens'])) {
                 $arguments['cacheTokens'] = $phpunitConfiguration['cacheTokens'];
             }
@@ -832,6 +864,10 @@ class TestRunner extends BaseTestRunner
 
             if (isset($phpunitConfiguration['processIsolation']) && !isset($arguments['processIsolation'])) {
                 $arguments['processIsolation'] = $phpunitConfiguration['processIsolation'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnDefect']) && !isset($arguments['stopOnDefect'])) {
+                $arguments['stopOnDefect'] = $phpunitConfiguration['stopOnDefect'];
             }
 
             if (isset($phpunitConfiguration['stopOnError']) && !isset($arguments['stopOnError'])) {
@@ -928,6 +964,10 @@ class TestRunner extends BaseTestRunner
 
             if (isset($phpunitConfiguration['executionOrder']) && !isset($arguments['executionOrder'])) {
                 $arguments['executionOrder'] = $phpunitConfiguration['executionOrder'];
+            }
+
+            if (isset($phpunitConfiguration['executionOrderDefects']) && !isset($arguments['executionOrderDefects'])) {
+                $arguments['executionOrderDefects'] = $phpunitConfiguration['executionOrderDefects'];
             }
 
             if (isset($phpunitConfiguration['resolveDependencies']) && !isset($arguments['resolveDependencies'])) {
@@ -1116,6 +1156,7 @@ class TestRunner extends BaseTestRunner
         $arguments['backupStaticAttributes']                          = $arguments['backupStaticAttributes'] ?? null;
         $arguments['beStrictAboutChangesToGlobalState']               = $arguments['beStrictAboutChangesToGlobalState'] ?? null;
         $arguments['beStrictAboutResourceUsageDuringSmallTests']      = $arguments['beStrictAboutResourceUsageDuringSmallTests'] ?? false;
+        $arguments['cacheResult']                                     = $arguments['cacheResult'] ?? true;
         $arguments['cacheTokens']                                     = $arguments['cacheTokens'] ?? false;
         $arguments['colors']                                          = $arguments['colors'] ?? ResultPrinter::COLOR_DEFAULT;
         $arguments['columns']                                         = $arguments['columns'] ?? 80;
@@ -1130,6 +1171,7 @@ class TestRunner extends BaseTestRunner
         $arguments['excludeGroups']                                   = $arguments['excludeGroups'] ?? [];
         $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? false;
         $arguments['failOnWarning']                                   = $arguments['failOnWarning'] ?? false;
+        $arguments['executionOrderDefects']                           = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
         $arguments['groups']                                          = $arguments['groups'] ?? [];
         $arguments['processIsolation']                                = $arguments['processIsolation'] ?? false;
         $arguments['processUncoveredFilesFromWhitelist']              = $arguments['processUncoveredFilesFromWhitelist'] ?? false;
@@ -1148,6 +1190,7 @@ class TestRunner extends BaseTestRunner
         $arguments['stopOnRisky']                                     = $arguments['stopOnRisky'] ?? false;
         $arguments['stopOnSkipped']                                   = $arguments['stopOnSkipped'] ?? false;
         $arguments['stopOnWarning']                                   = $arguments['stopOnWarning'] ?? false;
+        $arguments['stopOnDefect']                                    = $arguments['stopOnDefect'] ?? false;
         $arguments['strictCoverage']                                  = $arguments['strictCoverage'] ?? false;
         $arguments['testdoxExcludeGroups']                            = $arguments['testdoxExcludeGroups'] ?? [];
         $arguments['testdoxGroups']                                   = $arguments['testdoxGroups'] ?? [];

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -27,6 +27,8 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
  * <phpunit backupGlobals="false"
  *          backupStaticAttributes="false"
  *          bootstrap="/path/to/bootstrap.php"
+ *          cacheResult="false"
+ *          cacheResultFile=".phpunit.result.cache"
  *          cacheTokens="false"
  *          columns="80"
  *          colors="false"
@@ -38,6 +40,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
  *          disableCodeCoverageIgnore="false"
  *          forceCoversAnnotation="false"
  *          processIsolation="false"
+ *          stopOnDefect="false"
  *          stopOnError="false"
  *          stopOnFailure="false"
  *          stopOnWarning="false"
@@ -65,6 +68,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
  *          reverseDefectList="false"
  *          registerMockObjectsFromTestArgumentsRecursively="false"
  *          executionOrder="default"
+ *          executionOrderDefects="default"
  *          resolveDependencies="false">
  *   <testsuites>
  *     <testsuite name="My Test Suite">
@@ -716,6 +720,13 @@ final class Configuration
             );
         }
 
+        if ($root->hasAttribute('stopOnDefect')) {
+            $result['stopOnDefect'] = $this->getBoolean(
+                (string) $root->getAttribute('stopOnDefect'),
+                false
+            );
+        }
+
         if ($root->hasAttribute('stopOnError')) {
             $result['stopOnError'] = $this->getBoolean(
                 (string) $root->getAttribute('stopOnError'),
@@ -908,21 +919,45 @@ final class Configuration
             );
         }
 
+        if ($root->hasAttribute('cacheResult')) {
+            $result['cacheResult'] = $this->getBoolean(
+                (string) $root->getAttribute('cacheResult'),
+                false
+            );
+        }
+
+        if ($root->hasAttribute('cacheResultFile')) {
+            $result['cacheResultFile'] = $this->toAbsolutePath(
+                (string) $root->getAttribute('cacheResultFile')
+            );
+        }
+
         if ($root->hasAttribute('executionOrder')) {
-            switch ((string) $root->getAttribute('executionOrder')) {
-                case 'random':
-                    $result['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
+            foreach (\explode(',', $root->getAttribute('executionOrder')) as $order) {
+                switch ($order) {
+                    case 'default':
+                        $result['executionOrder']        = TestSuiteSorter::ORDER_DEFAULT;
+                        $result['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFAULT;
+                        $result['resolveDependencies']   = false;
 
-                    break;
+                        break;
+                    case 'reverse':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
 
-                case 'reverse':
-                    $result['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
+                        break;
+                    case 'random':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
 
-                    break;
+                        break;
+                    case 'defects':
+                        $result['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFECTS_FIRST;
 
-                default:
-                    $result['executionOrder'] = TestSuiteSorter::ORDER_DEFAULT;
+                        break;
+                    case 'depends':
+                        $result['resolveDependencies'] = true;
 
+                        break;
+                }
             }
         }
 

--- a/src/Util/NullTestResultCache.php
+++ b/src/Util/NullTestResultCache.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+class NullTestResultCache implements TestResultCacheInterface
+{
+    public function getState($testName): int
+    {
+        return BaseTestRunner::STATUS_UNKNOWN;
+    }
+
+    public function getTime($testName): float
+    {
+        return 0;
+    }
+
+    public function load(): void
+    {
+    }
+
+    public function persist(): void
+    {
+    }
+}

--- a/src/Util/TestResultCache.php
+++ b/src/Util/TestResultCache.php
@@ -1,0 +1,179 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+class TestResultCache implements \Serializable, TestResultCacheInterface
+{
+    /**
+     * @var string
+     */
+    public const DEFAULT_RESULT_CACHE_FILENAME = '.phpunit.result.cache';
+
+    /**
+     * Provide extra protection against incomplete or corrupt caches
+     *
+     * @var array<string, string>
+     */
+    private const ALLOWED_CACHE_TEST_STATUSES = [
+        BaseTestRunner::STATUS_SKIPPED,
+        BaseTestRunner::STATUS_INCOMPLETE,
+        BaseTestRunner::STATUS_FAILURE,
+        BaseTestRunner::STATUS_ERROR,
+        BaseTestRunner::STATUS_RISKY,
+        BaseTestRunner::STATUS_WARNING
+    ];
+
+    /**
+     * Path and filename for result cache file
+     *
+     * @var string
+     */
+    private $cacheFilename;
+
+    /**
+     * The list of defective tests
+     *
+     * <code>
+     * // Mark a test skipped
+     * $this->defects[$testName] = BaseTestRunner::TEST_SKIPPED;
+     * </code>
+     *
+     * @var array array<string, int>
+     */
+    private $defects = [];
+
+    /**
+     * The list of execution duration of suites and tests (in seconds)
+     *
+     * <code>
+     * // Record running time for test
+     * $this->times[$testName] = 1.234;
+     * </code>
+     *
+     * @var array<string, float>
+     */
+    private $times = [];
+
+    public function __construct($filename = null)
+    {
+        $this->cacheFilename = $filename ?? $_ENV['PHPUNIT_RESULT_CACHE'] ?? self::DEFAULT_RESULT_CACHE_FILENAME;
+    }
+
+    public function persist(): void
+    {
+        $this->saveToFile();
+    }
+
+    public function saveToFile(): void
+    {
+        if (\defined('PHPUNIT_TESTSUITE_RESULTCACHE')) {
+            return;
+        }
+
+        \file_put_contents(
+            $this->cacheFilename,
+            \serialize($this)
+        );
+    }
+
+    public function setState(string $testName, int $state): void
+    {
+        if ($state !== BaseTestRunner::STATUS_PASSED) {
+            $this->defects[$testName] = $state;
+        }
+    }
+
+    public function getState($testName): int
+    {
+        return $this->defects[$testName] ?? BaseTestRunner::STATUS_UNKNOWN;
+    }
+
+    public function setTime(string $testName, float $time): void
+    {
+        $this->times[$testName] = $time;
+    }
+
+    public function getTime($testName): float
+    {
+        return $this->times[$testName] ?? 0;
+    }
+
+    public function load(): void
+    {
+        $this->clear();
+
+        if (\is_file($this->cacheFilename) === false) {
+            return;
+        }
+
+        $cacheData = @\file_get_contents($this->cacheFilename);
+
+        // @codeCoverageIgnoreStart
+        if ($cacheData === false) {
+            return;
+        }
+        // @codeCoverageIgnoreEnd
+
+        $cache = @\unserialize($cacheData, ['allowed_classes' => [self::class]]);
+
+        if ($cache === false) {
+            return;
+        }
+
+        if ($cache instanceof self) {
+            /* @var \PHPUnit\Runner\TestResultCache */
+            $cache->copyStateToCache($this);
+        }
+    }
+
+    public function copyStateToCache(self $targetCache): void
+    {
+        foreach ($this->defects as $name => $state) {
+            $targetCache->setState($name, $state);
+        }
+
+        foreach ($this->times as $name => $time) {
+            $targetCache->setTime($name, $time);
+        }
+    }
+
+    public function clear(): void
+    {
+        $this->defects = [];
+        $this->times   = [];
+    }
+
+    public function serialize(): string
+    {
+        return \serialize([
+            'defects' => $this->defects,
+            'times'   => $this->times
+        ]);
+    }
+
+    public function unserialize($serialized): void
+    {
+        $data = \unserialize($serialized);
+
+        if (isset($data['times'])) {
+            foreach ($data['times'] as $testName => $testTime) {
+                $this->times[$testName] = (float) $testTime;
+            }
+        }
+
+        if (isset($data['defects'])) {
+            foreach ($data['defects'] as $testName => $testResult) {
+                if (\in_array($testResult, self::ALLOWED_CACHE_TEST_STATUSES, true)) {
+                    $this->defects[$testName] = $testResult;
+                }
+            }
+        }
+    }
+}

--- a/src/Util/TestResultCacheInterface.php
+++ b/src/Util/TestResultCacheInterface.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+interface TestResultCacheInterface
+{
+    public function getState($testName): int;
+
+    public function getTime($testName): float;
+
+    public function load(): void;
+
+    public function persist(): void;
+}

--- a/tests/Runner/ResultCacheExtensionTest.php
+++ b/tests/Runner/ResultCacheExtensionTest.php
@@ -1,0 +1,139 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCaseTest;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite;
+
+/**
+ * @group test-reorder
+ */
+class ResultCacheExtensionTest extends TestCase
+{
+    /**
+     * @var TestResultCache
+     */
+    protected $cache;
+
+    /**
+     * @var ResultCacheExtension
+     */
+    protected $extension;
+
+    /**
+     * @var TestResult
+     */
+    protected $result;
+
+    protected function setUp(): void
+    {
+        $this->cache     = new TestResultCache;
+        $this->extension = new ResultCacheExtension($this->cache);
+
+        $listener = new TestListenerAdapter;
+        $listener->add($this->extension);
+
+        $this->result   = new TestResult;
+        $this->result->addListener($listener);
+    }
+
+    /**
+     * @dataProvider longTestNamesDataprovider
+     */
+    public function testStripsDataproviderParametersFromTestName(string $testName, string $expectedTestName): void
+    {
+        $test = new TestCaseTest($testName);
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_ERROR, $this->cache->getState($expectedTestName));
+    }
+
+    public function longTestNamesDataprovider(): array
+    {
+        return [
+            'ClassName::testMethod' => [
+                TestCaseTest::class . '::testSomething',
+                'testSomething'],
+            'ClassName::testMethod and data set number and vardump' => [
+                TestCaseTest::class . '::testMethod with data set #123 (\'a\', "A", 0, false)',
+                'testMethod with data set #123'],
+            'ClassName::testMethod and data set name and vardump' => [
+                TestCaseTest::class . '::testMethod with data set "data name" (\'a\', "A\", 0, false)',
+                'testMethod with data set "data name"'],
+        ];
+    }
+
+    public function testError(): void
+    {
+        $test = new \TestError('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_ERROR, $this->cache->getState('test_name'));
+    }
+
+    public function testFailure(): void
+    {
+        $test = new \Failure('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_FAILURE, $this->cache->getState('test_name'));
+    }
+
+    public function testSkipped(): void
+    {
+        $test = new \TestSkipped('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_SKIPPED, $this->cache->getState('test_name'));
+    }
+
+    public function testIncomplete(): void
+    {
+        $test = new \TestIncomplete('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_INCOMPLETE, $this->cache->getState('test_name'));
+    }
+
+    public function testPassedTestsOnlyCacheTime(): void
+    {
+        $test = new \Success('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_UNKNOWN, $this->cache->getState('test_name'));
+    }
+
+    public function testWarning(): void
+    {
+        $test = new \TestWarning('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_WARNING, $this->cache->getState('test_name'));
+    }
+
+    public function testRisky(): void
+    {
+        $test = new \TestRisky('test_name');
+        $test->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_RISKY, $this->cache->getState('test_name'));
+    }
+
+    public function testEmptySuite(): void
+    {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\EmptyTestCaseTest::class);
+        $suite->run($this->result);
+
+        $this->assertSame(BaseTestRunner::STATUS_WARNING, $this->cache->getState('Warning'));
+    }
+}

--- a/tests/Runner/TestSuiteSorterTest.php
+++ b/tests/Runner/TestSuiteSorterTest.php
@@ -7,78 +7,338 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-namespace PHPUnit\Framework;
+namespace PHPUnit\Runner;
 
-use PHPUnit\Runner\TestSuiteSorter;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
 
+/**
+ * @group test-reorder
+ */
 class TestSuiteSorterTest extends TestCase
 {
     /**
-     * @var TestSuite
+     * Constants to improve clarity of @dataprovider
      */
-    private $suite;
+    private const IGNORE_DEPENDENCIES  = false;
 
-    public function setup()
+    private const RESOLVE_DEPENDENCIES = true;
+
+    public function testThrowsExceptionWhenUsingInvalidOrderOption()
     {
-        $this->suite = new TestSuite;
-        $this->suite->addTestSuite(\MultiDependencyTest::class);
+        $suite = new TestSuite;
+        $suite->addTestSuite(\MultiDependencyTest::class);
+        $sorter = new TestSuiteSorter();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('$order must be one of TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_REVERSED, or TestSuiteSorter::ORDER_RANDOMIZED');
+        $sorter->reorderTestsInSuite($suite, -1, false, TestSuiteSorter::ORDER_DEFAULT);
+    }
+
+    public function testThrowsExceptionWhenUsingInvalidOrderDefectsOption()
+    {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\MultiDependencyTest::class);
+        $sorter = new TestSuiteSorter();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('$orderDefects must be one of TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_DEFECTS_FIRST');
+        $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_DEFAULT, false, -1);
     }
 
     /**
-     * @dataProvider suiteSorterOptionsProvider
+     * @dataProvider suiteSorterOptionPermutationsProvider
      */
-    public function testSuiteSorterOptions(int $order, bool $resolveDependencies, array $expected)
+    public function testShouldNotAffectEmptyTestSuite(int $order, bool $resolveDependencies, int $orderDefects)
     {
-        $sorter = new TestSuiteSorter();
-        $sorter->reorderTestsInSuite($this->suite, $order, $resolveDependencies);
+        $sorter = new TestSuiteSorter;
+        $suite  = new TestSuite;
 
-        $this->assertEquals($expected, $this->getTestExecutionOrder());
+        $this->assertSame([], $suite->tests());
+
+        $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, $orderDefects);
+
+        $this->assertSame([], $suite->tests());
     }
 
-    public function testSuitSorterRandomize()
+    /**
+     * @dataProvider commonSorterOptionsProvider
+     */
+    public function testBasicExecutionOrderOptions(int $order, bool $resolveDependencies, array $expected)
     {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\MultiDependencyTest::class);
+        $sorter = new TestSuiteSorter();
+
+        $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, TestSuiteSorter::ORDER_DEFAULT);
+
+        $this->assertSame($expected, $this->getTestExecutionOrder($suite));
+    }
+
+    public function testCanSetRandomizationWithASeed()
+    {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\MultiDependencyTest::class);
+        $sorter = new TestSuiteSorter();
+
         \mt_srand(54321);
-        $sorter = new TestSuiteSorter();
-        $sorter->reorderTestsInSuite($this->suite, TestSuiteSorter::ORDER_RANDOMIZED, false);
+        $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_RANDOMIZED, false, TestSuiteSorter::ORDER_DEFAULT);
 
-        $this->assertEquals(['testTwo', 'testFour', 'testFive', 'testThree', 'testOne'], $this->getTestExecutionOrder());
+        $this->assertSame(['testTwo', 'testFour', 'testFive', 'testThree', 'testOne'], $this->getTestExecutionOrder($suite));
     }
 
-    public function testSuitSorterRandomizeResolve()
+    public function testCanSetRandomizationWithASeedAndResolveDependencies()
     {
-        \mt_srand(54321);
+        $suite = new TestSuite;
+        $suite->addTestSuite(\MultiDependencyTest::class);
         $sorter = new TestSuiteSorter();
-        $sorter->reorderTestsInSuite($this->suite, TestSuiteSorter::ORDER_RANDOMIZED, true);
 
-        $this->assertEquals(['testTwo', 'testFive', 'testOne', 'testThree', 'testFour'], $this->getTestExecutionOrder());
+        \mt_srand(54321);
+        $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_RANDOMIZED, true, TestSuiteSorter::ORDER_DEFAULT);
+
+        $this->assertSame(['testTwo', 'testFive', 'testOne', 'testThree', 'testFour'], $this->getTestExecutionOrder($suite));
     }
 
-    public function suiteSorterOptionsProvider(): array
+    /**
+     * @dataProvider defectsSorterOptionsProvider
+     */
+    public function testSuiteSorterDefectsOptions(int $order, bool $resolveDependencies, array $runState, array $expected)
+    {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\MultiDependencyTest::class);
+
+        $cache = new TestResultCache();
+
+        foreach ($runState as $testName => $data) {
+            $cache->setState($testName, $data['state']);
+            $cache->setTime($testName, $data['time']);
+        }
+
+        $sorter  = new TestSuiteSorter($cache);
+        $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, TestSuiteSorter::ORDER_DEFECTS_FIRST);
+
+        $this->assertSame($expected, $this->getTestExecutionOrder($suite));
+    }
+
+    /**
+     * A @dataprovider for basic execution reordering options based on MultiDependencyTest
+     * This class has the following relevant properties:
+     * - it has five tests 'testOne' ... 'testFive'
+     * - 'testThree' @depends on both 'testOne' and 'testTwo'
+     * - 'testFour' @depends on 'MultiDependencyTest::testThree' to test FQN @depends
+     * - 'testFive' has no dependencies
+     */
+    public function commonSorterOptionsProvider(): array
     {
         return [
             'default' => [
                 TestSuiteSorter::ORDER_DEFAULT,
-                false,
+                self::IGNORE_DEPENDENCIES,
                 ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+
+            // Activating dependency resolution should have no effect under normal circumstances
             'resolve default' => [
                 TestSuiteSorter::ORDER_DEFAULT,
-                true,
+                self::IGNORE_DEPENDENCIES,
                 ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+
+            // Reversing without checks should give a simple reverse order
             'reverse' => [
                 TestSuiteSorter::ORDER_REVERSED,
-                false,
+                self::IGNORE_DEPENDENCIES,
                 ['testFive', 'testFour', 'testThree', 'testTwo', 'testOne']],
+
+            // Reversing with resolution still allows testFive to move to front, testTwo before testOne
             'resolve reverse' => [
                 TestSuiteSorter::ORDER_REVERSED,
-                true,
+                self::RESOLVE_DEPENDENCIES,
                 ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour']],
         ];
     }
 
-    private function getTestExecutionOrder()
+    /**
+     * A @dataprovider for testing defects execution reordering options based on MultiDependencyTest
+     * This class has the following relevant properties:
+     * - it has five tests 'testOne' ... 'testFive'
+     * - 'testThree' @depends on both 'testOne' and 'testTwo'
+     * - 'testFour' @depends on 'MultiDependencyTest::testThree' to test FQN @depends
+     * - 'testFive' has no dependencies
+     */
+    public function defectsSorterOptionsProvider(): array
+    {
+        return [
+            // The most simple situation should work as normal
+            'default, no defects' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                ],
+                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+
+            // Running with an empty cache should not spook the TestSuiteSorter
+            'default, empty result cache' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    // empty result cache
+                ],
+                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+
+            // testFive is independent and can be moved to the front
+            'default, testFive skipped' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                ],
+                ['testFive', 'testOne', 'testTwo', 'testThree', 'testFour']],
+
+            // Defects in testFive and testTwo, but the faster testFive should be run first
+            'default, testTwo testFive skipped' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 0],
+                ],
+                ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour']],
+
+            // Skipping testThree will move it to the front when ignoring dependencies
+            'default, testThree skipped' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                ],
+                ['testThree', 'testOne', 'testTwo', 'testFour', 'testFive']],
+
+            // Skipping testThree will move it to the front but behind its dependencies
+            'default resolve, testThree skipped' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::RESOLVE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                ],
+                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
+
+            // Skipping testThree will move it to the front and keep the others reversed
+            'reverse, testThree skipped' => [
+                TestSuiteSorter::ORDER_REVERSED,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                ],
+                ['testThree', 'testFive', 'testFour', 'testTwo', 'testOne']],
+
+            // Demonstrate a limit of the dependency resolver: after sorting defects to the front,
+            // the resolver will mark testFive done before testThree because of dependencies
+            'default resolve, testThree skipped, testFive fast' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::RESOLVE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 0],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                ],
+                ['testFive', 'testOne', 'testTwo', 'testThree', 'testFour']],
+
+            // Torture test
+            // - incomplete TestResultCache
+            // - skipped testThree: will move it to the front as far as possible
+            // - testOne and testTwo are required before testThree, but can be reversed locally
+            // - testFive is independent will remain reversed up front
+            'reverse resolve, testThree skipped' => [
+                TestSuiteSorter::ORDER_REVERSED,
+                self::RESOLVE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
+                ],
+                ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour']],
+
+            // Make sure the dependency resolver is not confused by failing tests.
+            // Scenario: Four has a @depends on Three and fails. Result: Three is still run first
+            // testFive also fails but can be moved around freely and will be up front.
+            'depends first, then defects' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::RESOLVE_DEPENDENCIES,
+                [
+                    'testOne'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testThree' => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
+                    'testFour'  => ['state' => BaseTestRunner::STATUS_FAILURE, 'time' => 1],
+                    'testFive'  => ['state' => BaseTestRunner::STATUS_FAILURE, 'time' => 1],
+                ],
+                ['testFive', 'testOne', 'testTwo', 'testThree', 'testFour']],
+        ];
+    }
+
+    /**
+     * @see https://github.com/lstrojny/phpunit-clever-and-smart/issues/38
+     */
+    public function testCanHandleSuiteWithEmptyTestCase()
+    {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\EmptyTestCaseTest::class);
+
+        $sorter = new TestSuiteSorter();
+
+        $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_DEFAULT, false, TestSuiteSorter::ORDER_DEFAULT);
+
+        $this->assertSame(\EmptyTestCaseTest::class, $suite->tests()[0]->getName());
+        $this->assertSame('No tests found in class "EmptyTestCaseTest".', $suite->tests()[0]->tests()[0]->getMessage());
+    }
+
+    public function suiteSorterOptionPermutationsProvider()
+    {
+        $orderValues        = [TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_REVERSED, TestSuiteSorter::ORDER_RANDOMIZED];
+        $resolveValues      = [false, true];
+        $orderDefectsValues = [TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_DEFECTS_FIRST];
+
+        $data = [];
+
+        foreach ($orderValues as $order) {
+            foreach ($resolveValues as $resolve) {
+                foreach ($orderDefectsValues as $orderDefects) {
+                    $data[] = [$order, $resolve, $orderDefects];
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    private function getTestExecutionOrder(TestSuite $suite): array
     {
         return \array_map(function ($test) {
             return $test->getName();
-        }, $this->suite->tests()[0]->tests());
+        }, $suite->tests()[0]->tests());
     }
 }

--- a/tests/TextUI/cache-result.phpt
+++ b/tests/TextUI/cache-result.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit --reverse-order --cache-result --cache-result-file MultiDependencyTest ./tests/_files/MultiDependencyTest.php
+--FILE--
+<?php
+$target = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--reverse-order';
+$_SERVER['argv'][3] = '--cache-result';
+$_SERVER['argv'][4] = '--cache-result-file=' . $target;
+$_SERVER['argv'][5] = 'MultiDependencyTest';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main(false);
+
+print file_get_contents($target);
+
+unlink($target);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.SS..                                                               5 / 5 (100%)
+
+Time: %s, Memory: %s
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 5, Assertions: 3, Skipped: 2.
+C:30:"PHPUnit\Runner\TestResultCache":%d:{a:2:{s:7:"defects";a:2:{s:8:"testFour";i:1;s:9:"testThree";i:1;}s:5:"times";a:5:{s:8:"testFive";d:%f;s:8:"testFour";d:%f;s:9:"testThree";d:%f;s:7:"testTwo";d:%f;s:7:"testOne";d:%f;}}}

--- a/tests/TextUI/defects-first-order-via-cli.phpt
+++ b/tests/TextUI/defects-first-order-via-cli.phpt
@@ -1,29 +1,30 @@
 --TEST--
-phpunit --verbose --order-by=reverse ../_files/DependencySuccessTest.php
+phpunit --order-by=defects MultiDependencyTest ./tests/_files/MultiDependencyTest.php
 --FILE--
 <?php
+$tmpResultCache = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/../_files/MultiDependencyTest_result_cache.txt'));
+
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
-$_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--order-by=reverse';
-$_SERVER['argv'][5] = '--resolve-dependencies';
-$_SERVER['argv'][6] = 'MultiDependencyTest';
-$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][3] = '--order-by=defects';
+$_SERVER['argv'][4] = '--cache-result-file=' . $tmpResultCache;
+$_SERVER['argv'][5] = 'MultiDependencyTest';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
-?>
+
+unlink($tmpResultCache);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-Runtime:       %s
-
 Test 'MultiDependencyTest::testFive' started
 Test 'MultiDependencyTest::testFive' ended
-Test 'MultiDependencyTest::testTwo' started
-Test 'MultiDependencyTest::testTwo' ended
 Test 'MultiDependencyTest::testOne' started
 Test 'MultiDependencyTest::testOne' ended
+Test 'MultiDependencyTest::testTwo' started
+Test 'MultiDependencyTest::testTwo' ended
 Test 'MultiDependencyTest::testThree' started
 Test 'MultiDependencyTest::testThree' ended
 Test 'MultiDependencyTest::testFour' started

--- a/tests/TextUI/execution-order-options-via-config.phpt
+++ b/tests/TextUI/execution-order-options-via-config.phpt
@@ -1,22 +1,17 @@
 --TEST--
-phpunit --verbose --order-by=reverse ../_files/DependencySuccessTest.php
+phpunit -c ../_files/configuration_stop_on_defect.xml MultiDependencyTest ./tests/_files/MultiDependencyTest.php
 --FILE--
 <?php
-$_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--debug';
-$_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--order-by=reverse';
-$_SERVER['argv'][5] = '--resolve-dependencies';
-$_SERVER['argv'][6] = 'MultiDependencyTest';
-$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][1] = '--debug';
+$_SERVER['argv'][2] = '-c';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/configuration_execution_order_options.xml';
+$_SERVER['argv'][4] = 'MultiDependencyTest';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
-?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
-
-Runtime:       %s
 
 Test 'MultiDependencyTest::testFive' started
 Test 'MultiDependencyTest::testFive' ended

--- a/tests/TextUI/help.phpt
+++ b/tests/TextUI/help.phpt
@@ -64,6 +64,7 @@ Test Execution Options:
   --columns <n>               Number of columns to use for progress output
   --columns max               Use maximum number of columns for progress output
   --stderr                    Write to STDERR instead of STDOUT
+  --stop-on-defect            Stop execution upon first not-passed test
   --stop-on-error             Stop execution upon first error
   --stop-on-failure           Stop execution upon first error or failure
   --stop-on-warning           Stop execution upon first warning
@@ -84,9 +85,9 @@ Test Execution Options:
   --printer <printer>         TestListener implementation to use
 
   --resolve-dependencies      Resolve dependencies between tests
-  --random-order              Run tests in random order
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
-  --reverse-order             Run tests last-to-first
+  --cache-result              Write run result to cache to enable ordering tests defects-first
 
 Configuration Options:
 
@@ -99,6 +100,7 @@ Configuration Options:
   --include-path <path(s)>    Prepend PHP's include_path with given path(s)
   -d key[=value]              Sets a php.ini value
   --generate-configuration    Generate configuration file with suggested settings
+  --cache-result-file==<FILE> Specify result cache path and filename
 
 Miscellaneous Options:
 

--- a/tests/TextUI/help2.phpt
+++ b/tests/TextUI/help2.phpt
@@ -65,6 +65,7 @@ Test Execution Options:
   --columns <n>               Number of columns to use for progress output
   --columns max               Use maximum number of columns for progress output
   --stderr                    Write to STDERR instead of STDOUT
+  --stop-on-defect            Stop execution upon first not-passed test
   --stop-on-error             Stop execution upon first error
   --stop-on-failure           Stop execution upon first error or failure
   --stop-on-warning           Stop execution upon first warning
@@ -85,9 +86,9 @@ Test Execution Options:
   --printer <printer>         TestListener implementation to use
 
   --resolve-dependencies      Resolve dependencies between tests
-  --random-order              Run tests in random order
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
-  --reverse-order             Run tests last-to-first
+  --cache-result              Write run result to cache to enable ordering tests defects-first
 
 Configuration Options:
 
@@ -100,6 +101,7 @@ Configuration Options:
   --include-path <path(s)>    Prepend PHP's include_path with given path(s)
   -d key[=value]              Sets a php.ini value
   --generate-configuration    Generate configuration file with suggested settings
+  --cache-result-file==<FILE> Specify result cache path and filename
 
 Miscellaneous Options:
 

--- a/tests/TextUI/order-by-default-invalid-via-cli.phpt
+++ b/tests/TextUI/order-by-default-invalid-via-cli.phpt
@@ -1,0 +1,19 @@
+--TEST--
+phpunit --order-by=default,foobar
+--FILE--
+<?php
+$tmpResultCache = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/../_files/MultiDependencyTest_result_cache.txt'));
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--debug';
+$_SERVER['argv'][3] = '--order-by=default,foobar';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+
+unlink($tmpResultCache);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+unrecognized --order-by option: foobar

--- a/tests/TextUI/stop-on-defect-via-cli.phpt
+++ b/tests/TextUI/stop-on-defect-via-cli.phpt
@@ -1,0 +1,25 @@
+--TEST--
+phpunit --stop-on-defect StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--stop-on-defect';
+$_SERVER['argv'][3] = 'StopOnWarningTestSuite';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/StopOnWarningTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+W
+
+Time: %s, Memory: %s
+
+There was 1 warning:
+
+1) Warning
+No tests found in class "NoTestCases".
+
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/TextUI/stop-on-defect-via-config.phpt
+++ b/tests/TextUI/stop-on-defect-via-config.phpt
@@ -1,0 +1,25 @@
+--TEST--
+phpunit -c ../_files/configuration_stop_on_defect.xml StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/configuration_stop_on_defect.xml';
+$_SERVER['argv'][3] = 'StopOnWarningTestSuite';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/StopOnWarningTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+W
+
+Time: %s, Memory: %s
+
+There was 1 warning:
+
+1) Warning
+No tests found in class "NoTestCases".
+
+WARNINGS!
+Tests: 1, Assertions: 0, Warnings: 1.

--- a/tests/TextUI/stop-on-error-via-cli.phpt
+++ b/tests/TextUI/stop-on-error-via-cli.phpt
@@ -1,0 +1,27 @@
+--TEST--
+phpunit --stop-on-error StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--stop-on-error';
+$_SERVER['argv'][3] = 'StopOnErrorTestSuite';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/StopOnErrorTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+IE
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) StopOnErrorTestSuite::testWithError
+Error: StopOnErrorTestSuite_error
+
+%s%etests%e_files%eStopOnErrorTestSuite.php:%d
+
+ERRORS!
+Tests: 2, Assertions: 1, Errors: 1, Incomplete: 1.

--- a/tests/TextUI/stop-on-error-via-config.phpt
+++ b/tests/TextUI/stop-on-error-via-config.phpt
@@ -1,0 +1,27 @@
+--TEST--
+phpunit -c ../_files/configuration_stop_on_error.xml StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/configuration_stop_on_error.xml';
+$_SERVER['argv'][4] = 'StopOnErrorTestSuite';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/StopOnErrorTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+IE
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) StopOnErrorTestSuite::testWithError
+Error: StopOnErrorTestSuite_error
+
+%s%etests%e_files%eStopOnErrorTestSuite.php:%d
+
+ERRORS!
+Tests: 2, Assertions: 1, Errors: 1, Incomplete: 1.

--- a/tests/TextUI/stop-on-incomplete-via-cli.phpt
+++ b/tests/TextUI/stop-on-incomplete-via-cli.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --stop-on-error StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--stop-on-incomplete';
+$_SERVER['argv'][3] = 'StopOnErrorTestSuite';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/StopOnErrorTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+I
+
+Time: %s, Memory: %s
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 0, Incomplete: 1.

--- a/tests/TextUI/stop-on-incomplete-via-config.phpt
+++ b/tests/TextUI/stop-on-incomplete-via-config.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit -c ../_files/configuration_stop_on_incomplete.xml StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/configuration_stop_on_incomplete.xml';
+$_SERVER['argv'][4] = 'StopOnErrorTestSuite';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/StopOnErrorTestSuite.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+I
+
+Time: %s, Memory: %s
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 0, Incomplete: 1.

--- a/tests/TextUI/test-order-randomized-with-dependency-resolution.phpt
+++ b/tests/TextUI/test-order-randomized-with-dependency-resolution.phpt
@@ -1,10 +1,10 @@
 --TEST--
-phpunit --random-order --resolve-dependencies ../_files/MultiDependencyTest.php
+phpunit --order-by=random --resolve-dependencies ../_files/MultiDependencyTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--verbose';
-$_SERVER['argv'][3] = '--random-order';
+$_SERVER['argv'][3] = '--order-by=random';
 $_SERVER['argv'][4] = '--resolve-dependencies';
 $_SERVER['argv'][5] = 'MultiDependencyTest';
 $_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -37,7 +37,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenTrueInConfigurationFile(): void
     {
-        $configurationFilename =  \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.true.xml';
+        $configurationFilename = \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.true.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -46,7 +46,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenFalseInConfigurationFile(): void
     {
-        $configurationFilename =  \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.false.xml';
+        $configurationFilename = \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.false.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -55,7 +55,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenEmptyInConfigurationFile(): void
     {
-        $configurationFilename =  \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.empty.xml';
+        $configurationFilename = \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.empty.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -64,7 +64,7 @@ class ConfigurationTest extends TestCase
 
     public function testShouldReadColorsWhenInvalidInConfigurationFile(): void
     {
-        $configurationFilename =  \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
+        $configurationFilename = \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -73,16 +73,19 @@ class ConfigurationTest extends TestCase
 
     public function testInvalidConfigurationGeneratesValidationErrors(): void
     {
-        $configurationFilename =  \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
+        $configurationFilename = \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.colors.invalid.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
 
         $this->assertTrue($configurationInstance->hasValidationErrors());
-        $this->assertArraySubset([1 => ["Element 'phpunit', attribute 'colors': 'Something else' is not a valid value of the atomic type 'xs:boolean'."]], $configurationInstance->getValidationErrors());
+        $this->assertArraySubset(
+            [1 => ["Element 'phpunit', attribute 'colors': 'Something else' is not a valid value of the atomic type 'xs:boolean'."]],
+            $configurationInstance->getValidationErrors()
+        );
     }
 
-    public function testNonIntegerValueReturnsDefault(): void
+    public function testShouldUseDefaultValuesForInvalidIntegers(): void
     {
-        $configurationFilename =  \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.columns.default.xml';
+        $configurationFilename = \dirname(__DIR__) . \DIRECTORY_SEPARATOR . '_files' . \DIRECTORY_SEPARATOR . 'configuration.columns.default.xml';
         $configurationInstance = Configuration::getInstance($configurationFilename);
         $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
 
@@ -92,9 +95,11 @@ class ConfigurationTest extends TestCase
     /**
      * @dataProvider configurationRootOptionsProvider
      *
+     * @group test-reorder
+     *
      * @param bool|int|string $expected
      */
-    public function testConfigurationRootOptions(string $optionName, string $optionValue, $expected): void
+    public function testShouldParseXmlConfigurationRootAttributes(string $optionName, string $optionValue, $expected): void
     {
         $tmpFilename = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'phpunit.' . $optionName . \uniqid() . '.xml';
         $xml         = "<phpunit $optionName='$optionValue'></phpunit>" . \PHP_EOL;
@@ -111,24 +116,45 @@ class ConfigurationTest extends TestCase
 
     public function configurationRootOptionsProvider(): array
     {
+        $tmpFilePath = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR;
+
         return [
-            ['executionOrder', 'default', TestSuiteSorter::ORDER_DEFAULT],
-            ['executionOrder', 'random', TestSuiteSorter::ORDER_RANDOMIZED],
-            ['executionOrder', 'reverse', TestSuiteSorter::ORDER_REVERSED],
-            ['columns', 'max', 'max'],
-            ['stopOnFailure', 'true', true],
-            ['stopOnWarning', 'true', true],
-            ['stopOnIncomplete', 'true', true],
-            ['stopOnRisky', 'true', true],
-            ['stopOnSkipped', 'true', true],
-            ['failOnWarning', 'true', true],
-            ['failOnRisky', 'true', true],
-            ['disableCodeCoverageIgnore', 'true', true],
-            ['processIsolation', 'true', true],
-            ['testSuiteLoaderFile', '/path/to/file', '/path/to/file'],
-            ['reverseDefectList', 'true', true],
-            ['registerMockObjectsFromTestArgumentsRecursively', 'true', true],
+            'executionOrder default'                                        => ['executionOrder', 'default', TestSuiteSorter::ORDER_DEFAULT],
+            'executionOrder random'                                         => ['executionOrder', 'random', TestSuiteSorter::ORDER_RANDOMIZED],
+            'executionOrder reverse'                                        => ['executionOrder', 'reverse', TestSuiteSorter::ORDER_REVERSED],
+            'cacheResult false'                                             => ['cacheResult', 'false', false],
+            'cacheResult true'                                              => ['cacheResult', 'true', true],
+            'cacheResultFile absolute path'                                 => ['cacheResultFile', '/path/to/result/cache', '/path/to/result/cache'],
+            'columns'                                                       => ['columns', 'max', 'max'],
+            'stopOnFailure'                                                 => ['stopOnFailure', 'true', true],
+            'stopOnWarning'                                                 => ['stopOnWarning', 'true', true],
+            'stopOnIncomplete'                                              => ['stopOnIncomplete', 'true', true],
+            'stopOnRisky'                                                   => ['stopOnRisky', 'true', true],
+            'stopOnSkipped'                                                 => ['stopOnSkipped', 'true', true],
+            'failOnWarning'                                                 => ['failOnWarning', 'true', true],
+            'failOnRisky'                                                   => ['failOnRisky', 'true', true],
+            'disableCodeCoverageIgnore'                                     => ['disableCodeCoverageIgnore', 'true', true],
+            'processIsolation'                                              => ['processIsolation', 'true', true],
+            'testSuiteLoaderFile absolute path'                             => ['testSuiteLoaderFile', '/path/to/file', '/path/to/file'],
+            'reverseDefectList'                                             => ['reverseDefectList', 'true', true],
+            'registerMockObjectsFromTestArgumentsRecursively'               => ['registerMockObjectsFromTestArgumentsRecursively', 'true', true],
         ];
+    }
+
+    public function testShouldParseXmlConfigurationExecutionOrderCombined(): void
+    {
+        $tmpFilename = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'phpunit.' . \uniqid() . '.xml';
+        $xml         = "<phpunit executionOrder='depends,defects'></phpunit>" . \PHP_EOL;
+        \file_put_contents($tmpFilename, $xml);
+
+        $configurationInstance = Configuration::getInstance($tmpFilename);
+        $this->assertFalse($configurationInstance->hasValidationErrors(), 'option causes validation error');
+
+        $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
+        $this->assertSame(TestSuiteSorter::ORDER_DEFECTS_FIRST, $configurationValues['executionOrderDefects']);
+        $this->assertSame(true, $configurationValues['resolveDependencies']);
+
+        @\unlink($tmpFilename);
     }
 
     public function testFilterConfigurationIsReadCorrectly(): void
@@ -461,8 +487,9 @@ class ConfigurationTest extends TestCase
                 'failOnWarning'                              => false,
                 'failOnRisky'                                => false,
                 'ignoreDeprecatedCodeUnitsFromCodeCoverage'  => false,
-                'executionOrder'                             => 0,
-                'resolveDependencies'                        => false
+                'executionOrder'                             => TestSuiteSorter::ORDER_DEFAULT,
+                'executionOrderDefects'                      => TestSuiteSorter::ORDER_DEFAULT,
+                'resolveDependencies'                        => false,
             ],
             $this->configuration->getPHPUnitConfiguration()
         );

--- a/tests/Util/NullTestResultCacheTest.php
+++ b/tests/Util/NullTestResultCacheTest.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Runner\NullTestResultCache;
+
+/**
+ * @group test-reorder
+ */
+class NullTestResultCacheTest extends TestCase
+{
+    public function testHasWorkingStubs(): void
+    {
+        $cache = new NullTestResultCache;
+        $cache->load();
+        $cache->persist();
+
+        $this->assertSame(BaseTestRunner::STATUS_UNKNOWN, $cache->getState('testName'));
+        $this->assertSame(0.0, $cache->getTime('testName'));
+    }
+}

--- a/tests/Util/TestResultCacheTest.php
+++ b/tests/Util/TestResultCacheTest.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Runner\TestResultCache;
+
+/**
+ * @group test-reorder
+ */
+class TestResultCacheTest extends TestCase
+{
+    public function testReadsCacheFromProvidedFilename(): void
+    {
+        $cacheFile = \dirname(__DIR__) . '/_files/MultiDependencyTest_result_cache.txt';
+        $cache     = new TestResultCache($cacheFile);
+        $cache->load();
+
+        $this->assertSame(BaseTestRunner::STATUS_UNKNOWN, $cache->getState('testOne'));
+        $this->assertSame(BaseTestRunner::STATUS_SKIPPED, $cache->getState('testFive'));
+    }
+
+    public function testDoesClearCacheBeforeLoad(): void
+    {
+        $cacheFile = \dirname(__DIR__) . '/_files/MultiDependencyTest_result_cache.txt';
+        $cache     = new TestResultCache($cacheFile);
+        $cache->setState('someTest', BaseTestRunner::STATUS_FAILURE);
+
+        $this->assertSame(BaseTestRunner::STATUS_UNKNOWN, $cache->getState('testFive'));
+
+        $cache->load();
+
+        $this->assertSame(BaseTestRunner::STATUS_UNKNOWN, $cache->getState('someTest'));
+        $this->assertSame(BaseTestRunner::STATUS_SKIPPED, $cache->getState('testFive'));
+    }
+
+    public function testShouldNotSerializePassedTestsAsDefectButTimeIsStored(): void
+    {
+        $cache = new TestResultCache;
+        $cache->setState('testOne', BaseTestRunner::STATUS_PASSED);
+        $cache->setTime('testOne', 123);
+
+        $data = \serialize($cache);
+        $this->assertSame('C:30:"PHPUnit\Runner\TestResultCache":64:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:1:{s:7:"testOne";d:123;}}}', $data);
+    }
+
+    public function testCanPersistCacheToFile(): void
+    {
+        // Create a cache with one result and store it
+        $cacheFile = \tempnam(\sys_get_temp_dir(), 'phpunit_');
+        $cache     = new TestResultCache($cacheFile);
+        $testName  = 'test' . \uniqid();
+        $cache->setState($testName, BaseTestRunner::STATUS_SKIPPED);
+        $cache->persist();
+        unset($cache);
+
+        // Load the cache we just created
+        $loadedCache = new TestResultCache($cacheFile);
+        $loadedCache->load();
+        $this->assertSame(BaseTestRunner::STATUS_SKIPPED, $loadedCache->getState($testName));
+
+        // Clean up
+        \unlink($cacheFile);
+    }
+
+    public function testShouldReturnEmptyCacheWhenFileDoesNotExist(): void
+    {
+        $cache = new TestResultCache('/a/wrong/path/file');
+        $cache->load();
+
+        $this->assertTrue($this->isSerializedEmptyCache(\serialize($cache)));
+    }
+
+    public function testShouldReturnEmptyCacheFromInvalidFile(): void
+    {
+        $cacheFile = \tempnam(\sys_get_temp_dir(), 'phpunit_');
+        \file_put_contents($cacheFile, '<certainly not serialized php>');
+
+        $cache = new TestResultCache($cacheFile);
+        $cache->load();
+
+        $this->assertTrue($this->isSerializedEmptyCache(\serialize($cache)));
+    }
+
+    public function isSerializedEmptyCache(string $data): bool
+    {
+        return $data === 'C:30:"PHPUnit\Runner\TestResultCache":44:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:0:{}}}';
+    }
+}

--- a/tests/_files/MultiDependencyTest_result_cache.txt
+++ b/tests/_files/MultiDependencyTest_result_cache.txt
@@ -1,0 +1,1 @@
+C:30:"PHPUnit\Runner\TestResultCache":157:{a:2:{s:7:"defects";a:1:{s:8:"testFive";i:1;}s:5:"times";a:5:{s:7:"testOne";d:0;s:7:"testTwo";d:0;s:9:"testThree";d:0;s:8:"testFour";d:0;s:8:"testFive";d:0;}}}

--- a/tests/_files/StopOnErrorTestSuite.php
+++ b/tests/_files/StopOnErrorTestSuite.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class StopOnErrorTestSuite extends \PHPUnit\Framework\TestCase
+{
+    public function testIncomplete()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testWithError()
+    {
+        $this->assertTrue(true);
+
+        throw new Error('StopOnErrorTestSuite_error');
+    }
+
+    public function testThatIsNeverReached()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/_files/TestRisky.php
+++ b/tests/_files/TestRisky.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class TestRisky extends TestCase
+{
+    protected function runTest(): void
+    {
+        $this->markAsRisky();
+    }
+}

--- a/tests/_files/TestWarning.php
+++ b/tests/_files/TestWarning.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class TestWarning extends TestCase
+{
+    protected function runTest(): void
+    {
+        throw new \PHPUnit\Framework\Warning();
+    }
+}

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -31,8 +31,7 @@
          timeoutForMediumTests="10"
          timeoutForLargeTests="60"
          verbose="false"
-         executionOrder="default"
-         resolveDependencies="false">
+         executionOrder="default">
     <testsuites>
         <testsuite name="My Test Suite">
             <directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">/path/to/files</directory>

--- a/tests/_files/configuration_execution_order_options.xml
+++ b/tests/_files/configuration_execution_order_options.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit executionOrder="reverse"
+         resolveDependencies="true"
+         cacheResultFile="MultiDependencyTest_result_cache.txt">
+
+    <php>
+        <const name="PHPUNIT_TESTSUITE_RESULTCACHE" value="true"/>
+    </php>
+</phpunit>

--- a/tests/_files/configuration_stop_on_defect.xml
+++ b/tests/_files/configuration_stop_on_defect.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit stopOnDefect="true" />

--- a/tests/_files/configuration_stop_on_error.xml
+++ b/tests/_files/configuration_stop_on_error.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit stopOnError="true" />

--- a/tests/_files/configuration_stop_on_incomplete.xml
+++ b/tests/_files/configuration_stop_on_incomplete.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit stopOnIncomplete="true" />


### PR DESCRIPTION
## Use case
Rerun defective unit tests first to speed up the red-green-refactor cycle!

Test results and timings are shared between tests runs using a cache. This allows for sorting defective tests to the front of the execution order using an additional sorter. This new sort option is compatible with existing test ordering options.

This project is a followup to my previous work on [reordering test execution](https://github.com/epdenouden/phpunit/wiki/PHPUnit-test-running-order-management). The code is available in my [Breakfast development branch](https://github.com/epdenouden/phpunit/tree/breakfast).

## Summary of changes
- the `TestSuiteSorter` gains the ability to sort suites and tests by priority of defects and execution time
- added a `ResultCacheExtension` to gather result and timing information during test runs
- added a `TestResultCache` for sharing of result state between runs
- added caching of run results using CLI flag `--cache-result` and configuration attribute `cacheResult='true'`
- added sorting defects to run as quick as possible with CLI flag `--order-by=defects` and configuration attribute `executionOrder='defects'`
- ability to specifiy the cache filename using CLI flag `--cache-result-file` and configuration attribute `cacheResultFile`
- more extensive testing of sorting scenarios

## How to test
1. To activate storing the results of a run use `--cache-result`:

   ```
   phpunit --cache-result
   ```
2. For this example we switch the cache on for every run by adding the attribute `cacheResult="true"` to the `<phpunit>` element in `phpunit.xml`.

   ```xml
   <phpunit cacheResult="true"> <-- no other changes required --></phpunit>
   ```
3. Break `TestCaseTest` by running it backwards:

   ```
   phpunit --order-by=reverse tests/Framework/TestCaseTest.php
   ```
4. Look at the cache file. By default this is `.phpunit.result.cache` in the PHPUnit working directory.
5. Break `TestCaseTest` again with the sorting feature turning on:

   ```
   phpunit --order-by=defects tests/Framework/TestCaseTest.php
   ```
5. The skipped tests are still there but are run immediately now, but still fail. This is easily avoided by asking the sorter to keep dependencies in mind:

   ```
   phpunit --order-by=depends,defects tests/Framework/TestCaseTest.php
   ```

## Design considerations
Like the _New Order_ feature the aim is for a robust system with sane defaults that silently does its work and is easily maintained by other developers:
- Require as little new configuration as possible. Just add `cacheResult="true"` to your configuration and it silently does its work.
- Add no extra output as PHPUnit often lives in automated pipelines and dev scripts.
- Provide robust and maintainable code. This feature also provides a lot of new test coverage for functionality from #3092.
- Implemented a simplistic cache on purpose. Obviously people might want more complex caches based on users, groups, configuration, git hash, etc etc. Let's see what people need.
