### PR TITLE
--list-tests output shows number of available tests

### DIFF
--- a/src/Util/TextTestListRenderer.php
+++ b/src/Util/TextTestListRenderer.php
@@ -18,7 +18,7 @@ final class TextTestListRenderer
 {
     public function render(TestSuite $suite): string
     {
-        $buffer = 'Available test(s):' . PHP_EOL;
+        $buffer = \sprintf('%d available test(s):%s', $suite->count(), PHP_EOL);
 
         foreach (new \RecursiveIteratorIterator($suite->getIterator()) as $test) {
             if ($test instanceof TestCase) {

--- a/tests/TextUI/list-tests-dataprovider.phpt
+++ b/tests/TextUI/list-tests-dataprovider.phpt
@@ -12,7 +12,7 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-Available test(s):
+4 available test(s):
  - DataProviderTest::testAdd#0
  - DataProviderTest::testAdd#1
  - DataProviderTest::testAdd#2


### PR DESCRIPTION
Instead of outputing something like 

```plain
Available test(s):
 - PHPUnit\Framework\AssertTest::testFail
 - PHPUnit\Framework\AssertTest::testAssertSplObjectStorageContainsObject
 - PHPUnit\Framework\AssertTest::testAssertArrayContainsObject
 - PHPUnit\Framework\AssertTest::testAssertArrayContainsString
```

change `--list-tests` in order to output something like

```plain
4 available test(s):
 - PHPUnit\Framework\AssertTest::testFail
 - PHPUnit\Framework\AssertTest::testAssertSplObjectStorageContainsObject
 - PHPUnit\Framework\AssertTest::testAssertArrayContainsObject
 - PHPUnit\Framework\AssertTest::testAssertArrayContainsString
```