### PR TITLE
Improve tests for INI-options via XML-configuration <php> element

### DIFF
--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -286,7 +286,7 @@ class ConfigurationTest extends TestCase
                         \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.',
                         '/path/to/lib'
                     ],
-                'ini'    => ['foo' => ['value' => 'bar'], 'highlight.keyword' => ['value' => '#123456'], 'highlight.string' => ['value' => 'TEST_CONFIG_INI_CONSTANT']],
+                'ini'    => ['foo' => ['value' => 'bar'], 'highlight.keyword' => ['value' => '#123456'], 'highlight.string' => ['value' => 'TEST_FILES_PATH']],
                 'const'  => ['FOO' => ['value' => false], 'BAR' => ['value' => true]],
                 'var'    => ['foo' => ['value' => false]],
                 'env'    => ['foo' => ['value' => true], 'bar' => ['value' => 'true', 'verbatim' => true], 'foo_force' => ['value' => 'forced', 'force' => true]],
@@ -306,7 +306,6 @@ class ConfigurationTest extends TestCase
      */
     public function testPHPConfigurationIsHandledCorrectly(): void
     {
-        \define('TEST_CONFIG_INI_CONSTANT', '#234567');
         $savedIniHighlightKeyword = \ini_get('highlight.keyword');
         $savedIniHighlightString  = \ini_get('highlight.string');
 
@@ -315,7 +314,7 @@ class ConfigurationTest extends TestCase
         $path = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.' . PATH_SEPARATOR . '/path/to/lib';
         $this->assertStringStartsWith($path, \ini_get('include_path'));
         $this->assertEquals('#123456', \ini_get('highlight.keyword'));
-        $this->assertEquals(TEST_CONFIG_INI_CONSTANT, \ini_get('highlight.string'));
+        $this->assertEquals(TEST_FILES_PATH, \ini_get('highlight.string'));
         $this->assertFalse(\FOO);
         $this->assertTrue(\BAR);
         $this->assertFalse($GLOBALS['foo']);

--- a/tests/Util/ConfigurationTest.php
+++ b/tests/Util/ConfigurationTest.php
@@ -286,7 +286,7 @@ class ConfigurationTest extends TestCase
                         \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.',
                         '/path/to/lib'
                     ],
-                'ini'    => ['foo' => ['value' => 'bar']],
+                'ini'    => ['foo' => ['value' => 'bar'], 'highlight.keyword' => ['value' => '#123456'], 'highlight.string' => ['value' => 'TEST_CONFIG_INI_CONSTANT']],
                 'const'  => ['FOO' => ['value' => false], 'BAR' => ['value' => true]],
                 'var'    => ['foo' => ['value' => false]],
                 'env'    => ['foo' => ['value' => true], 'bar' => ['value' => 'true', 'verbatim' => true], 'foo_force' => ['value' => 'forced', 'force' => true]],
@@ -306,10 +306,16 @@ class ConfigurationTest extends TestCase
      */
     public function testPHPConfigurationIsHandledCorrectly(): void
     {
+        \define('TEST_CONFIG_INI_CONSTANT', '#234567');
+        $savedIniHighlightKeyword = \ini_get('highlight.keyword');
+        $savedIniHighlightString  = \ini_get('highlight.string');
+
         $this->configuration->handlePHPConfiguration();
 
         $path = \dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . '.' . PATH_SEPARATOR . '/path/to/lib';
         $this->assertStringStartsWith($path, \ini_get('include_path'));
+        $this->assertEquals('#123456', \ini_get('highlight.keyword'));
+        $this->assertEquals(TEST_CONFIG_INI_CONSTANT, \ini_get('highlight.string'));
         $this->assertFalse(\FOO);
         $this->assertTrue(\BAR);
         $this->assertFalse($GLOBALS['foo']);
@@ -321,6 +327,9 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('bar', $_SERVER['foo']);
         $this->assertEquals('bar', $_FILES['foo']);
         $this->assertEquals('bar', $_REQUEST['foo']);
+
+        \ini_set('highlight.keyword', $savedIniHighlightKeyword);
+        \ini_set('highlight.string', $savedIniHighlightString);
     }
 
     /**

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -143,6 +143,8 @@
         <includePath>.</includePath>
         <includePath>/path/to/lib</includePath>
         <ini name="foo" value="bar"/>
+        <ini name="highlight.keyword" value="#123456"/>
+        <ini name="highlight.string" value="TEST_CONFIG_INI_CONSTANT"/>
         <const name="FOO" value="false"/>
         <const name="BAR" value="true"/>
         <var name="foo" value="false"/>

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -144,7 +144,7 @@
         <includePath>/path/to/lib</includePath>
         <ini name="foo" value="bar"/>
         <ini name="highlight.keyword" value="#123456"/>
-        <ini name="highlight.string" value="TEST_CONFIG_INI_CONSTANT"/>
+        <ini name="highlight.string" value="TEST_FILES_PATH"/>
         <const name="FOO" value="false"/>
         <const name="BAR" value="true"/>
         <var name="foo" value="false"/>

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -65,7 +65,7 @@
     <includePath>/path/to/lib</includePath>
     <ini name="foo" value="bar"/>
     <ini name="highlight.keyword" value="#123456"/>
-    <ini name="highlight.string" value="TEST_CONFIG_INI_CONSTANT"/>
+    <ini name="highlight.string" value="TEST_FILES_PATH"/>
     <const name="FOO" value="false"/>
     <const name="BAR" value="true"/>
     <var name="foo" value="false"/>

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -64,6 +64,8 @@
     <includePath>.</includePath>
     <includePath>/path/to/lib</includePath>
     <ini name="foo" value="bar"/>
+    <ini name="highlight.keyword" value="#123456"/>
+    <ini name="highlight.string" value="TEST_CONFIG_INI_CONSTANT"/>
     <const name="FOO" value="false"/>
     <const name="BAR" value="true"/>
     <var name="foo" value="false"/>


### PR DESCRIPTION
While experimenting with various ways of feeding PHPUnit external parameters. Found a small improvement based on missing coverage.

- ini_get() for `foo` was not tested
- setting `foo` didn't work because it isn't a PHP config setting
- add test for setting a valid PHP option with a scalar value
- add test for setting a valid PHP option referencing an existing constant