### PR TITLE
More test coverage of Configuration

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -223,6 +223,7 @@
     <xs:attribute name="convertErrorsToExceptions" type="xs:boolean" default="true"/>
     <xs:attribute name="convertNoticesToExceptions" type="xs:boolean" default="true"/>
     <xs:attribute name="convertWarningsToExceptions" type="xs:boolean" default="true"/>
+    <xs:attribute name="disableCodeCoverageIgnore" type="xs:boolean" default="false"/>
     <xs:attribute name="forceCoversAnnotation" type="xs:boolean" default="false"/>
     <xs:attribute name="printerClass" type="xs:string" default="PHPUnit\TextUI\ResultPrinter"/>
     <xs:attribute name="printerFile" type="xs:anyURI"/>

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -35,6 +35,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
  *          convertErrorsToExceptions="true"
  *          convertNoticesToExceptions="true"
  *          convertWarningsToExceptions="true"
+ *          disableCodeCoverageIgnore="false"
  *          forceCoversAnnotation="false"
  *          processIsolation="false"
  *          stopOnError="false"

--- a/tests/_files/configuration.columns.default.xml
+++ b/tests/_files/configuration.columns.default.xml
@@ -1,0 +1,1 @@
+<phpunit columns="invalid value"></phpunit>


### PR DESCRIPTION
Some minor housekeeping while checking coverage of Configuration for execution options.

- test and provider to test root attributes in isolation
- test root config attributes not covered elsewhere
- test validation errors reusing existing 'invalid colors' test
- indirectly test integer default value of attribute via 'columns'
- add 'disableCodeCoverageIgnore' found in missing coverage to schema