### PR TITLE
Fix for #3156 depends dataprovider broken

### DIFF
--- a/src/Framework/DataProviderTestSuite.php
+++ b/src/Framework/DataProviderTestSuite.php
@@ -22,6 +22,10 @@ class DataProviderTestSuite extends TestSuite
     public function setDependencies(array $dependencies): void
     {
         $this->dependencies = $dependencies;
+
+        foreach ($this->tests as $test) {
+            $test->setDependencies($dependencies);
+        }
     }
 
     public function getDependencies(): array

--- a/tests/Regression/GitHub/3156/Issue3156Test.php
+++ b/tests/Regression/GitHub/3156/Issue3156Test.php
@@ -14,7 +14,7 @@ namespace Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class TestTest extends TestCase
+class Issue3156Test extends TestCase
 {
     public function testConstants(): stdClass
     {

--- a/tests/Regression/GitHub/3156/Issue3156Test.php
+++ b/tests/Regression/GitHub/3156/Issue3156Test.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+namespace Test;
+use PHPUnit\Framework\TestCase;
+use \stdClass;
+
+class TestTest extends TestCase
+{
+
+    public function testConstants(): stdClass
+    {
+        $this->assertStringEndsWith('/', "/");
+        return new stdClass();
+    }
+
+    public function dataSelectOperatorsProvider(): array
+    {
+        return [
+            ["1"],
+            ["2"]
+        ];
+    }
+
+    /**
+     * @depends testConstants
+     * @dataProvider dataSelectOperatorsProvider
+     *
+     * @return void
+     */
+    public function testDependsRequire(string $val, stdClass $obj): void
+    {
+        $this->assertStringEndsWith('/', "/");
+    }
+}

--- a/tests/Regression/GitHub/3156/Issue3156Test.php
+++ b/tests/Regression/GitHub/3156/Issue3156Test.php
@@ -1,35 +1,42 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Test;
+
 use PHPUnit\Framework\TestCase;
-use \stdClass;
+use stdClass;
 
 class TestTest extends TestCase
 {
-
     public function testConstants(): stdClass
     {
-        $this->assertStringEndsWith('/', "/");
+        $this->assertStringEndsWith('/', '/');
+
         return new stdClass();
     }
 
     public function dataSelectOperatorsProvider(): array
     {
         return [
-            ["1"],
-            ["2"]
+            ['1'],
+            ['2']
         ];
     }
 
     /**
      * @depends testConstants
      * @dataProvider dataSelectOperatorsProvider
-     *
-     * @return void
      */
     public function testDependsRequire(string $val, stdClass $obj): void
     {
-        $this->assertStringEndsWith('/', "/");
+        $this->assertStringEndsWith('/', '/');
     }
 }


### PR DESCRIPTION
Fix #3156 by restoring code for dependencies in dataproviders
    
The `@depends` annotation is used to supply additional parameters in combination with `@dataprovider`. For this to work the dependencies of the dataprovider suite need to be copied over to each individual test.
