### PR TITLE
Support indexed arrays in ArraySubset

### DIFF
--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -117,6 +117,8 @@ class ArraySubset extends Constraint
 
                                 if (!empty($recursed)) {
                                     $intersect[$key] = $recursed;
+
+                                    break;
                                 }
                             }
                         }

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -59,97 +59,16 @@ class ArraySubset extends Constraint
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
-        // Anonymous function that checks whether the given array is
-        // associative.
-        $is_associative = function (array $array): bool {
-            return \array_reduce(\array_keys($array), function (bool $carry, $key): bool {
-                return $carry || \is_string($key);
-            }, false);
-        };
-
-        // Anonymous function that compares the two given values using either
-        // strict or loose comparisons.
-        $strict  = $this->strict;
-        $compare = function ($first, $second) use ($strict): bool {
-            return $strict ? $first === $second : $first == $second;
-        };
-
-        // Anonymous function that sorts the given multidimensional array.
-        $deep_sort = function (array &$array) use (&$deep_sort, $is_associative): void {
-            foreach ($array as &$value) {
-                if (\is_array($value)) {
-                    $deep_sort($value);
-                }
-            }
-
-            if ($is_associative($array)) {
-                \ksort($array);
-            } else {
-                \sort($array);
-            }
-        };
-
-        $array_intersect_recursive = function (array $array, array $subset) use (&$array_intersect_recursive, $is_associative, $compare): array {
-            $intersect = [];
-
-            if ($is_associative($subset)) {
-                // If the subset is an associative array, get the intersection
-                // while preserving the keys.
-                foreach ($subset as $key => $subset_value) {
-                    if (\array_key_exists($key, $array)) {
-                        $array_value = $array[$key];
-
-                        if (\is_array($subset_value) && \is_array($array_value)) {
-                            $intersect[$key] = $array_intersect_recursive($array_value, $subset_value);
-                        } elseif ($compare($subset_value, $array_value)) {
-                            $intersect[$key] = $array_value;
-                        }
-                    }
-                }
-            } else {
-                // If the subset is an indexed array, loop over all entries in
-                // the haystack and check if they match the ones in the subset.
-                foreach ($array as $array_value) {
-                    if (\is_array($array_value)) {
-                        foreach ($subset as $key => $subset_value) {
-                            if (\is_array($subset_value)) {
-                                $recursed = $array_intersect_recursive($array_value, $subset_value);
-
-                                if (!empty($recursed)) {
-                                    $intersect[$key] = $recursed;
-
-                                    break;
-                                }
-                            }
-                        }
-                    } else {
-                        foreach ($subset as $key => $subset_value) {
-                            if (!\is_array($subset_value) && $compare(
-                                $subset_value,
-                                $array_value
-                            )) {
-                                $intersect[$key] = $array_value;
-
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            return $intersect;
-        };
-
         //type cast $other & $this->subset as an array to allow
         //support in standard array functions.
         $other        = $this->toArray($other);
         $this->subset = $this->toArray($this->subset);
 
-        $intersect = $array_intersect_recursive($other, $this->subset);
-        $deep_sort($intersect);
-        $deep_sort($this->subset);
+        $intersect = $this->arrayIntersectRecursive($other, $this->subset);
+        $this->deepSort($intersect);
+        $this->deepSort($this->subset);
 
-        $result = $compare($intersect, $this->subset);
+        $result = $this->compare($intersect, $this->subset);
 
         if ($returnResult) {
             return $result;
@@ -208,5 +127,84 @@ class ArraySubset extends Constraint
 
         // Keep BC even if we know that array would not be the expected one
         return (array) $other;
+    }
+
+    private function isAssociative(array $array): bool
+    {
+        return \array_reduce(\array_keys($array), function (bool $carry, $key): bool {
+            return $carry || \is_string($key);
+        }, false);
+    }
+
+    private function compare($first, $second): bool
+    {
+        return $this->strict ? $first === $second : $first == $second;
+    }
+
+    private function deepSort(array &$array): void
+    {
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                $this->deepSort($value);
+            }
+        }
+
+        if ($this->isAssociative($array)) {
+            \ksort($array);
+        } else {
+            \sort($array);
+        }
+    }
+
+    private function arrayIntersectRecursive(array $array, array $subset): array
+    {
+        $intersect = [];
+
+        if ($this->isAssociative($subset)) {
+            // If the subset is an associative array, get the intersection while
+            // preserving the keys.
+            foreach ($subset as $key => $subset_value) {
+                if (\array_key_exists($key, $array)) {
+                    $array_value = $array[$key];
+
+                    if (\is_array($subset_value) && \is_array($array_value)) {
+                        $intersect[$key] = $this->arrayIntersectRecursive($array_value, $subset_value);
+                    } elseif ($this->compare($subset_value, $array_value)) {
+                        $intersect[$key] = $array_value;
+                    }
+                }
+            }
+        } else {
+            // If the subset is an indexed array, loop over all entries in the
+            // haystack and check if they match the ones in the subset.
+            foreach ($array as $array_value) {
+                if (\is_array($array_value)) {
+                    foreach ($subset as $key => $subset_value) {
+                        if (\is_array($subset_value)) {
+                            $recursed = $this->arrayIntersectRecursive($array_value, $subset_value);
+
+                            if (!empty($recursed)) {
+                                $intersect[$key] = $recursed;
+
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    foreach ($subset as $key => $subset_value) {
+                        if (!\is_array($subset_value) && $this->compare(
+                            $subset_value,
+                            $array_value
+                          )) {
+                            $intersect[$key] = $array_value;
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $intersect;
     }
 }

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -59,18 +59,95 @@ class ArraySubset extends Constraint
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
+        // Anonymous function that checks whether the given array is
+        // associative.
+        $is_associative = function (array $array): bool {
+            return \array_reduce(\array_keys($array), function (bool $carry, $key): bool {
+                return $carry || \is_string($key);
+            }, false);
+        };
+
+        // Anonymous function that compares the two given values using either
+        // strict or loose comparisons.
+        $strict  = $this->strict;
+        $compare = function ($first, $second) use ($strict): bool {
+            return $strict ? $first === $second : $first == $second;
+        };
+
+        // Anonymous function that sorts the given multidimensional array.
+        $deep_sort = function (array &$array) use (&$deep_sort, $is_associative): void {
+            foreach ($array as &$value) {
+                if (\is_array($value)) {
+                    $deep_sort($value);
+                }
+            }
+
+            if ($is_associative($array)) {
+                \ksort($array);
+            } else {
+                \sort($array);
+            }
+        };
+
+        $array_intersect_recursive = function (array $array, array $subset) use (&$array_intersect_recursive, $is_associative, $compare): array {
+            $intersect = [];
+
+            if ($is_associative($subset)) {
+                // If the subset is an associative array, get the intersection
+                // while preserving the keys.
+                foreach ($subset as $key => $subset_value) {
+                    if (\array_key_exists($key, $array)) {
+                        $array_value = $array[$key];
+
+                        if (\is_array($subset_value) && \is_array($array_value)) {
+                            $intersect[$key] = $array_intersect_recursive($array_value, $subset_value);
+                        } elseif ($compare($subset_value, $array_value)) {
+                            $intersect[$key] = $array_value;
+                        }
+                    }
+                }
+            } else {
+                // If the subset is an indexed array, loop over all entries in
+                // the haystack and check if they match the ones in the subset.
+                foreach ($array as $array_value) {
+                    if (\is_array($array_value)) {
+                        foreach ($subset as $key => $subset_value) {
+                            if (\is_array($subset_value)) {
+                                $recursed = $array_intersect_recursive($array_value, $subset_value);
+
+                                if (!empty($recursed)) {
+                                    $intersect[$key] = $recursed;
+                                }
+                            }
+                        }
+                    } else {
+                        foreach ($subset as $key => $subset_value) {
+                            if (!\is_array($subset_value) && $compare(
+                                $subset_value,
+                                $array_value
+                            )) {
+                                $intersect[$key] = $array_value;
+
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return $intersect;
+        };
+
         //type cast $other & $this->subset as an array to allow
         //support in standard array functions.
         $other        = $this->toArray($other);
         $this->subset = $this->toArray($this->subset);
 
-        $patched = \array_replace_recursive($other, $this->subset);
+        $intersect = $array_intersect_recursive($other, $this->subset);
+        $deep_sort($intersect);
+        $deep_sort($this->subset);
 
-        if ($this->strict) {
-            $result = $other === $patched;
-        } else {
-            $result = $other == $patched;
-        }
+        $result = $compare($intersect, $this->subset);
 
         if ($returnResult) {
             return $result;
@@ -78,9 +155,9 @@ class ArraySubset extends Constraint
 
         if (!$result) {
             $f = new ComparisonFailure(
-                $patched,
+                $this->subset,
                 $other,
-                \print_r($patched, true),
+                \print_r($this->subset, true),
                 \print_r($other, true)
             );
 

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -159,13 +159,17 @@ class AssertTest extends TestCase
             'd' => ['a2' => ['a3' => 'item a3', 'b3' => 'item b3']]
         ];
 
+        $this->assertArraySubset(['a' => 'item a'], $array);
         $this->assertArraySubset(['a' => 'item a', 'c' => ['a2' => 'item a2']], $array);
         $this->assertArraySubset(['a' => 'item a', 'd' => ['a2' => ['b3' => 'item b3']]], $array);
+        $this->assertArraySubset(['b' => 'item b', 'd' => ['a2' => ['b3' => 'item b3']]], $array);
 
         $arrayAccessData = new \ArrayObject($array);
 
+        $this->assertArraySubset(['a' => 'item a'], $arrayAccessData);
         $this->assertArraySubset(['a' => 'item a', 'c' => ['a2' => 'item a2']], $arrayAccessData);
         $this->assertArraySubset(['a' => 'item a', 'd' => ['a2' => ['b3' => 'item b3']]], $arrayAccessData);
+        $this->assertArraySubset(['b' => 'item b', 'd' => ['a2' => ['b3' => 'item b3']]], $arrayAccessData);
 
         try {
             $this->assertArraySubset(['a' => 'bad value'], $array);
@@ -174,6 +178,39 @@ class AssertTest extends TestCase
 
         try {
             $this->assertArraySubset(['d' => ['a2' => ['bad index' => 'item b3']]], $array);
+        } catch (AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testAssertArraySubsetWithIndexedArrays(): void
+    {
+        $array = [
+            'item a',
+            'item b',
+            ['a2' => 'item a2', 'b2' => 'item b2'],
+            ['a2' => ['a3' => 'item a3', 'b3' => 'item b3']]
+        ];
+
+        $this->assertArraySubset(['item a', ['a2' => 'item a2']], $array);
+        $this->assertArraySubset(['item a', ['a2' => ['b3' => 'item b3']]], $array);
+        $this->assertArraySubset(['item b', ['a2' => ['b3' => 'item b3']]], $array);
+
+        $arrayAccessData = new \ArrayObject($array);
+
+        $this->assertArraySubset(['item a', ['a2' => 'item a2']], $arrayAccessData);
+        $this->assertArraySubset(['item a', ['a2' => ['b3' => 'item b3']]], $arrayAccessData);
+        $this->assertArraySubset(['item b', ['a2' => ['b3' => 'item b3']]], $arrayAccessData);
+
+        try {
+            $this->assertArraySubset(['bad value'], $array);
+        } catch (AssertionFailedError $e) {
+        }
+
+        try {
+            $this->assertArraySubset([['a2' => ['bad index' => 'item b3']]], $array);
         } catch (AssertionFailedError $e) {
             return;
         }

--- a/tests/Framework/Constraint/ArraySubsetTest.php
+++ b/tests/Framework/Constraint/ArraySubsetTest.php
@@ -17,28 +17,144 @@ class ArraySubsetTest extends ConstraintTestCase
     public static function evaluateDataProvider()
     {
         return [
-            'loose array subset and array other' => [
+            'loose associative array subset and array other' => [
                 'expected' => true,
                 'subset'   => ['bar' => 0],
                 'other'    => ['foo' => '', 'bar' => '0'],
                 'strict'   => false
             ],
-            'strict array subset and array other' => [
+            'strict associative array subset and array other' => [
                 'expected' => false,
                 'subset'   => ['bar' => 0],
                 'other'    => ['foo' => '', 'bar' => '0'],
                 'strict'   => true
             ],
-            'loose array subset and ArrayObject other' => [
+            'loose associative array subset and ArrayObject other' => [
                 'expected' => true,
                 'subset'   => ['bar' => 0],
                 'other'    => new \ArrayObject(['foo' => '', 'bar' => '0']),
                 'strict'   => false
             ],
-            'strict ArrayObject subset and array other' => [
+            'strict associative ArrayObject subset and array other' => [
                 'expected' => true,
                 'subset'   => new \ArrayObject(['bar' => 0]),
                 'other'    => ['foo' => '', 'bar' => 0],
+                'strict'   => true
+            ],
+            'loose indexed array subset and array other' => [
+                'expected' => true,
+                'subset'   => [0],
+                'other'    => ['', '0'],
+                'strict'   => false
+            ],
+            'strict indexed array subset and array other' => [
+                'expected' => false,
+                'subset'   => [0],
+                'other'    => ['', '0'],
+                'strict'   => true
+            ],
+            'loose indexed array subset and ArrayObject other' => [
+                'expected' => true,
+                'subset'   => [0],
+                'other'    => new \ArrayObject(['', '0']),
+                'strict'   => false
+            ],
+            'strict indexed ArrayObject subset and array other' => [
+                'expected' => true,
+                'subset'   => new \ArrayObject([0]),
+                'other'    => ['', 0],
+                'strict'   => true
+            ],
+            'loose unordered indexed array subset and array other' => [
+                'expected' => true,
+                'subset'   => [0, '1'],
+                'other'    => ['1', '2', '0'],
+                'strict'   => false
+            ],
+            'strict unordered indexed array subset and array other' => [
+                'expected' => false,
+                'subset'   => [0, '1'],
+                'other'    => ['1', '2', '0'],
+                'strict'   => true
+            ],
+            'loose unordered indexed array subset and ArrayObject other' => [
+                'expected' => true,
+                'subset'   => [0, '1'],
+                'other'    => new \ArrayObject(['1', '2', '0']),
+                'strict'   => false
+            ],
+            'strict unordered indexed ArrayObject subset and array other' => [
+                'expected' => true,
+                'subset'   => new \ArrayObject([0, '1']),
+                'other'    => ['1', '2', 0],
+                'strict'   => true
+            ],
+            'loose unordered multidimensional indexed array subset and array other' => [
+                'expected' => true,
+                'subset'   => [
+                    [[3, 4], 2],
+                    '10',
+                ],
+                'other'    => [
+                    0 => '1',
+                    'a' => [
+                      'aa' => '2',
+                      'ab' => [5, 4, 3],
+                      'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
+                'strict'   => false
+            ],
+            'strict unordered multidimensional indexed array subset and array other' => [
+                'expected' => false,
+                'subset'   => [
+                    [[3, 4], 2],
+                    '10',
+                ],
+                'other'    => [
+                    0 => '1',
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
+                'strict'   => true
+            ],
+            'loose unordered multidimensional indexed array subset and ArrayObject other' => [
+                'expected' => true,
+                'subset'   => [
+                    [[3, 4], 2],
+                    '10',
+                ],
+                'other'    => new \ArrayObject([
+                    0 => '1',
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ]),
+                'strict'   => false
+            ],
+            'strict unordered multidimensional indexed ArrayObject subset and array other' => [
+                'expected' => true,
+                'subset'   => new \ArrayObject([
+                    [[3, 4], '2'],
+                    '10',
+                ]),
+                'other'    => [
+                    0 => '1',
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
                 'strict'   => true
             ],
         ];

--- a/tests/Framework/Constraint/ArraySubsetTest.php
+++ b/tests/Framework/Constraint/ArraySubsetTest.php
@@ -96,7 +96,7 @@ class ArraySubsetTest extends ConstraintTestCase
                     '10',
                 ],
                 'other'    => [
-                    0 => '1',
+                    0   => '1',
                     'a' => [
                       'aa' => '2',
                       'ab' => [5, 4, 3],
@@ -113,7 +113,7 @@ class ArraySubsetTest extends ConstraintTestCase
                     '10',
                 ],
                 'other'    => [
-                    0 => '1',
+                    0   => '1',
                     'a' => [
                         'aa' => '2',
                         'ab' => [5, 4, 3],
@@ -130,7 +130,7 @@ class ArraySubsetTest extends ConstraintTestCase
                     '10',
                 ],
                 'other'    => new \ArrayObject([
-                    0 => '1',
+                    0   => '1',
                     'a' => [
                         'aa' => '2',
                         'ab' => [5, 4, 3],
@@ -147,7 +147,7 @@ class ArraySubsetTest extends ConstraintTestCase
                     '10',
                 ]),
                 'other'    => [
-                    0 => '1',
+                    0   => '1',
                     'a' => [
                         'aa' => '2',
                         'ab' => [5, 4, 3],


### PR DESCRIPTION
This fixes #3101 and earlier efforts #2781 and #2069.

I have added support for indexed arrays, and it is now possible to correctly check multidimensional arrays. It allows to match indexed arrays that are out of order, so for example if you have an array `[0, 1, 2, 3]` you can assert that `[3, 1]` is a valid subset.

Because of this out-of-order matching there is a known limitation, the code loops over the data set and checks every data point and returns on the first match. This means it will generate a false positive if multiple identical values are present in the subset. For example if an array `[0, 1, 2, 3]` is given and you assert the subset `[0, 1, 1, 2]` then it will return `TRUE` even though `1` is present only once in the data set. I wasn't sure if the added complexity for supporting this edge case is worth it.

This is my first contribution to PHPUnit and I am not sure on a few points:

1. I would like to include this in both PHPUnit 6 and 7, but I don't know the procedure to follow. This PR is rolled against the current master. Can this be backported or am I supposed to roll this for PHPUnit 6 first?
2. I am heavily relying on anonymous functions, I don't know if this fits the code style of PHPUnit, or would it be prefered to rework this using private methods?