### PR TITLE
fix stdout in testcase

### DIFF
--- a/src/Util/PHP/Template/TestCaseClass.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseClass.tpl.dist
@@ -47,6 +47,11 @@ function __phpunit_run_isolated_test()
     $result->beStrictAboutTodoAnnotatedTests({isStrictAboutTodoAnnotatedTests});
     $result->beStrictAboutResourceUsageDuringSmallTests({isStrictAboutResourceUsageDuringSmallTests});
 
+    // If testcase open stdout and close it, the output will be lost.
+    // So we open it manually.
+    $stdout = fopen('php://stdout', 'w');
+
+    /** @var TestCase $test */
     $test = new {className}('{name}', unserialize('{data}'), '{dataName}');
     $test->setDependencyInput(unserialize('{dependencyInput}'));
     $test->setInIsolation(TRUE);
@@ -59,8 +64,8 @@ function __phpunit_run_isolated_test()
     }
 
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
-    if ($stdout = stream_get_contents(STDOUT)) {
-        $output = $stdout . $output;
+    if ($testcaseOutput = stream_get_contents(STDOUT)) {
+        $output = $testcaseOutput . $output;
         $streamMetaData = stream_get_meta_data(STDOUT);
         if (!empty($streamMetaData['stream_type']) && 'STDIO' === $streamMetaData['stream_type']) {
             @ftruncate(STDOUT, 0);
@@ -76,6 +81,7 @@ function __phpunit_run_isolated_test()
         'output'        => $output
       )
     );
+    fclose($stdout);
 }
 
 $configurationFilePath = '{configurationFilePath}';

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -48,6 +48,10 @@ function __phpunit_run_isolated_test()
     $result->beStrictAboutTodoAnnotatedTests({isStrictAboutTodoAnnotatedTests});
     $result->beStrictAboutResourceUsageDuringSmallTests({isStrictAboutResourceUsageDuringSmallTests});
 
+    // If testcase open stdout and close it, the output will be lost.
+    // So we open it manually.
+    $stdout = fopen('php://stdout', 'w');
+
     /** @var TestCase $test */
     $test = new {className}('{methodName}', unserialize('{data}'), '{dataName}');
     $test->setDependencyInput(unserialize('{dependencyInput}'));
@@ -61,8 +65,8 @@ function __phpunit_run_isolated_test()
     }
 
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
-    if ($stdout = stream_get_contents(STDOUT)) {
-        $output = $stdout . $output;
+    if ($testcaseOutput = stream_get_contents(STDOUT)) {
+        $output = $testcaseOutput . $output;
         $streamMetaData = stream_get_meta_data(STDOUT);
         if (!empty($streamMetaData['stream_type']) && 'STDIO' === $streamMetaData['stream_type']) {
             @ftruncate(STDOUT, 0);
@@ -78,6 +82,7 @@ function __phpunit_run_isolated_test()
         'output'        => $output
       )
     );
+    fclose($stdout);
 }
 
 $configurationFilePath = '{configurationFilePath}';

--- a/tests/Regression/GitHub/2725-separate-class-before-after-pid.phpt
+++ b/tests/Regression/GitHub/2725-separate-class-before-after-pid.phpt
@@ -12,7 +12,6 @@ PHPUnit\TextUI\Command::main();
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 ..                                                                  2 / 2 (100%)
-@afterClass output - PID difference should be zero: 0
 
 Time: %s, Memory: %s
 

--- a/tests/Regression/GitHub/2725/BeforeAfterClassPidTest.php
+++ b/tests/Regression/GitHub/2725/BeforeAfterClassPidTest.php
@@ -32,6 +32,10 @@ class BeforeAfterClassPidTest extends TestCase
      */
     public static function showPidAfter()
     {
-        echo "\n@afterClass output - PID difference should be zero: " . ($GLOBALS['PID_BEFORE'] - getmypid());
+        if ($GLOBALS['PID_BEFORE'] != getmypid()) {
+            echo "\n@afterClass output - PID difference should be zero\n";
+            echo "PID_BEFORE: {$GLOBALS['PID_BEFORE']}\n";
+            echo "mypid: " . getmypid() . "\n";
+        }
     }
 }

--- a/tests/Regression/GitHub/3167/3167-class.phpt
+++ b/tests/Regression/GitHub/3167/3167-class.phpt
@@ -1,0 +1,27 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/pull/3167 for class
+--FILE--
+<?php
+$__stdout = fopen('php://stdout', 'w');
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][]  = 'Issue3167ClassTest';
+$_SERVER['argv'][]  = __DIR__ . '/Issue3167ClassTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+F                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) Issue3167ClassTest::testSTDOUT
+Failed asserting that false is true.
+
+%sIssue3167ClassTest.php:21
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/Regression/GitHub/3167/3167-method.phpt
+++ b/tests/Regression/GitHub/3167/3167-method.phpt
@@ -1,0 +1,27 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/pull/3167 for method
+--FILE--
+<?php
+$__stdout = fopen('php://stdout', 'w');
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][]  = 'Issue3167MethodTest';
+$_SERVER['argv'][]  = __DIR__ . '/Issue3167MethodTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+F                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) Issue3167MethodTest::testSTDOUT
+Failed asserting that false is true.
+
+%sIssue3167MethodTest.php:21
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/Regression/GitHub/3167/Issue3167ClassTest.php
+++ b/tests/Regression/GitHub/3167/Issue3167ClassTest.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runClassInSeparateProcess
+ */
+class Issue3167ClassTest extends TestCase
+{
+    public function testSTDOUT(): void
+    {
+        $fp = \fopen('php://stdout', 'w');
+        \fclose($fp);
+        $this->assertTrue(false);
+    }
+}

--- a/tests/Regression/GitHub/3167/Issue3167MethodTest.php
+++ b/tests/Regression/GitHub/3167/Issue3167MethodTest.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class Issue3167MethodTest extends TestCase
+{
+    public function testSTDOUT(): void
+    {
+        $fp = \fopen('php://stdout', 'w');
+        \fclose($fp);
+        $this->assertTrue(false);
+    }
+}


### PR DESCRIPTION
For testcase:
```php
<?php

use PHPUnit\Framework\TestCase;

/**
 * @runTestsInSeparateProcesses
 */
class ATest extends TestCase
{
    public function testA()
    {
        $res = fopen('php://stdout','w');
        fclose($res);
        $this->assertEquals(1, 2);
    }
}
```
Because child php process stdout will closed after testA, phpunit cannot get error in child process, so will mark this case passed.
**Phpunit should open standalone `php://stdout`**.

---
Some logging library, such as [log4php](https://github.com/apache/logging-log4php/blob/master/src/main/php/appenders/LoggerAppenderConsole.php#L44), will open standalone `php://stdout`, And then the subprocess test result will lost.