### PR TITLE
Add support for checking subsets that contain duplicate values to ArraySubset

### DIFF
--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -149,7 +149,7 @@ class ArraySubset extends Constraint
         foreach ($array as &$value) {
             if (\is_array($value)) {
                 $this->deepSort($value);
-            } elseif (!\is_string($value) || empty($value)) {
+            } elseif (\is_scalar($value) && !\is_string($value) || empty($value)) {
                 // In order to ensure consistent sorting results in data sets
                 // that have a mix of strings and integers we need to perform
                 // string comparisons on all scalar values. Typically this is

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -149,6 +149,13 @@ class ArraySubset extends Constraint
         foreach ($array as &$value) {
             if (\is_array($value)) {
                 $this->deepSort($value);
+            } elseif (!\is_string($value) || empty($value)) {
+                // In order to ensure consistent sorting results in data sets
+                // that have a mix of strings and integers we need to perform
+                // string comparisons on all scalar values. Typically this is
+                // done by passing the SORT_STRING flag to a sorting function
+                // but this doesn't work on multidimensional arrays.
+                $value = (string) (int) $value;
             }
         }
 
@@ -184,7 +191,7 @@ class ArraySubset extends Constraint
             // haystack and check if they match the ones in the subset.
             foreach ($array as $array_value) {
                 if (\is_array($array_value)) {
-                    foreach ($subset as $key => $subset_value) {
+                    foreach (\array_diff_key($subset, $intersect) as $key => $subset_value) {
                         if (\is_array($subset_value)) {
                             $recursed = $this->arrayIntersectRecursive($array_value, $subset_value);
 
@@ -196,7 +203,7 @@ class ArraySubset extends Constraint
                         }
                     }
                 } else {
-                    foreach ($subset as $key => $subset_value) {
+                    foreach (\array_diff_key($subset, $intersect) as $key => $subset_value) {
                         if (!\is_array($subset_value) && $this->compare($subset_value, $array_value)) {
                             $intersect[$key] = $array_value;
 
@@ -207,6 +214,7 @@ class ArraySubset extends Constraint
             }
         }
 
-        return $intersect;
+        // Only return the result if it fully matches the subset.
+        return \count($subset) == \count($intersect) ? $intersect : [];
     }
 }

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -149,7 +149,7 @@ class ArraySubset extends Constraint
         foreach ($array as &$value) {
             if (\is_array($value)) {
                 $this->deepSort($value);
-            } elseif (\is_scalar($value) && !\is_string($value) || empty($value)) {
+            } elseif ((\is_scalar($value) && !\is_string($value)) || empty($value)) {
                 // In order to ensure consistent sorting results in data sets
                 // that have a mix of strings and integers we need to perform
                 // string comparisons on all scalar values. Typically this is

--- a/tests/Framework/Constraint/ArraySubsetTest.php
+++ b/tests/Framework/Constraint/ArraySubsetTest.php
@@ -314,7 +314,7 @@ class ArraySubsetTest extends ConstraintTestCase
                 'expected' => true,
                 'subset'   => new \ArrayObject([
                     [[3, 4], '2'],
-                    '10',
+                    [[3, 4], '2'],
                     '10',
                 ]),
                 'other'    => [
@@ -324,7 +324,11 @@ class ArraySubsetTest extends ConstraintTestCase
                         'ab' => [5, 4, 3],
                         'ac' => 10,
                     ],
-                    'b' => '10',
+                    'b' => [
+                        'ba' => [3, 4, 5],
+                        'bb' => 10,
+                        'bc' => '2',
+                    ],
                 ],
                 'strict'   => true,
             ],

--- a/tests/Framework/Constraint/ArraySubsetTest.php
+++ b/tests/Framework/Constraint/ArraySubsetTest.php
@@ -332,6 +332,26 @@ class ArraySubsetTest extends ConstraintTestCase
                 ],
                 'strict'   => true,
             ],
+            'regression test for issue 3240' => [
+                'expected' => true,
+                'subset'   => [
+                    [
+                        'name'     => 'amount',
+                        'required' => true,
+                    ],
+                ],
+                'other' => [
+                    [
+                        'name'     => 'amount',
+                        'required' => true,
+                    ],
+                    [
+                        'name'     => 'accountNumber',
+                        'required' => true,
+                    ],
+                ],
+                'strict' => true,
+            ],
         ];
     }
 

--- a/tests/Framework/Constraint/ArraySubsetTest.php
+++ b/tests/Framework/Constraint/ArraySubsetTest.php
@@ -156,6 +156,178 @@ class ArraySubsetTest extends ConstraintTestCase
                 ],
                 'strict'   => true
             ],
+            'loose indexed array subset with duplicates and array other' => [
+                'expected' => true,
+                'subset'   => [0, 0],
+                'other'    => ['', '0'],
+                'strict'   => false,
+            ],
+            'strict indexed array subset with duplicates and array other' => [
+                'expected' => false,
+                'subset'   => [0, 0],
+                'other'    => ['', '0'],
+                'strict'   => true,
+            ],
+            'loose indexed array subset with duplicates and ArrayObject other' => [
+                'expected' => true,
+                'subset'   => [0, 0],
+                'other'    => new \ArrayObject(['', '0']),
+                'strict'   => false,
+            ],
+            'strict indexed ArrayObject subset with duplicates and array other' => [
+                'expected' => false,
+                'subset'   => new \ArrayObject([0, 0]),
+                'other'    => [0],
+                'strict'   => true,
+            ],
+            'loose unordered indexed array subset with duplicates and array other (positive)' => [
+                'expected' => true,
+                'subset'   => [0, '1', 1],
+                'other'    => ['1', '2', '0', '1'],
+                'strict'   => false,
+            ],
+            'loose unordered indexed array subset with duplicates and array other (negative)' => [
+                'expected' => false,
+                'subset'   => [0, '1', 1],
+                'other'    => ['1', '2', '0'],
+                'strict'   => false,
+            ],
+            'strict unordered indexed array subset with duplicates and array other' => [
+                'expected' => false,
+                'subset'   => [0, '1', 1],
+                'other'    => ['1', '2', '0', '1'],
+                'strict'   => true,
+            ],
+            'loose unordered indexed array subset with duplicates and ArrayObject other' => [
+                'expected' => true,
+                'subset'   => [0, '1', 1],
+                'other'    => new \ArrayObject(['1', '2', '0', '1']),
+                'strict'   => false,
+            ],
+            'strict unordered indexed ArrayObject subset with duplicates and array other' => [
+                'expected' => false,
+                'subset'   => new \ArrayObject([0, '1', '1']),
+                'other'    => ['1', '2', 0],
+                'strict'   => true,
+            ],
+            'loose unordered multidimensional indexed array subset with duplicates and array other (positive)' => [
+                'expected' => true,
+                'subset'   => [
+                    ['a', 0, 0],
+                    ['a', false, 0],
+                    ['a', 1, 0],
+                ],
+                'other'    => [
+                    0   => ['a', '0', '0'],
+                    'b' => ['a', '1', '0'],
+                    'c' => ['a', '0', '0'],
+                    3   => ['a', '1', '0'],
+                ],
+                'strict'   => false,
+            ],
+            'loose unordered multidimensional indexed array subset with duplicates and array other (negative)' => [
+                'expected' => false,
+                'subset'   => [
+                    ['a', 0, 0],
+                    ['a', 0, 0],
+                    ['a', 1, 0],
+                ],
+                'other'    => [
+                    0   => ['a', '0', '0'],
+                    'b' => ['a', '1', '0'],
+                    3   => ['a', '1', '0'],
+                ],
+                'strict'   => false,
+            ],
+            'strict unordered multidimensional indexed array subset with duplicates and array other (positive)' => [
+                'expected' => true,
+                'subset'   => [
+                    [[3, 4], '2'],
+                    '10',
+                    '10',
+                ],
+                'other'    => [
+                    0   => '10',
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
+                'strict'   => true,
+            ],
+            'strict unordered multidimensional indexed array subset with duplicates and array other (negative, missing value)' => [
+                'expected' => false,
+                'subset'   => [
+                    [[3, 4], 2],
+                    '10',
+                    '10',
+                ],
+                'other'    => [
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
+                'strict'   => true,
+            ],
+            'strict unordered multidimensional indexed array subset with duplicates and array other (negative, wrong type)' => [
+                'expected' => false,
+                'subset'   => [
+                    [[3, 4], 2],
+                    '10',
+                    '10',
+                ],
+                'other'    => [
+                    0   => 10,
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
+                'strict'   => true,
+            ],
+            'loose unordered multidimensional indexed array subset with duplicates and ArrayObject other' => [
+                'expected' => true,
+                'subset'   => [
+                    [[3, 4], 2],
+                    '10',
+                    '10',
+                ],
+                'other'    => new \ArrayObject([
+                    0   => 10,
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ]),
+                'strict'   => false,
+            ],
+            'strict unordered multidimensional indexed ArrayObject subset with duplicates and array other' => [
+                'expected' => true,
+                'subset'   => new \ArrayObject([
+                    [[3, 4], '2'],
+                    '10',
+                    '10',
+                ]),
+                'other'    => [
+                    0   => '10',
+                    'a' => [
+                        'aa' => '2',
+                        'ab' => [5, 4, 3],
+                        'ac' => 10,
+                    ],
+                    'b' => '10',
+                ],
+                'strict'   => true,
+            ],
         ];
     }
 


### PR DESCRIPTION
In #3161 support was added for checking indexed arrays in `ArraySubset`. The edge case of checking subsets that contain multiple identical values was left out of the scope of that PR. This means that in the current implementation the following example will generate a false positive:

* Array: `[0, 1, 2, 3]`
* Subset: `[0, 1, 1, 2]`
* Expected result: `FALSE` since the value `1` is only present once in the array, but twice in the subset.
* Actual result: `TRUE`

This PR adds support for this edge case, so that it will become possible to check subsets with duplicate values.