### PR TITLE
Prevent callbacks from being calls multiple times in withConsecutive()

### DIFF
--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -72,13 +72,6 @@ class ConsecutiveParameters extends StatelessInvocation
         return false;
     }
 
-    public function verify(): void
-    {
-        foreach ($this->invocations as $callIndex => $invocation) {
-            $this->verifyInvocation($invocation, $callIndex);
-        }
-    }
-
     /**
      * Verify a single invocation
      *

--- a/tests/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -65,4 +65,39 @@ class ConsecutiveParametersTest extends TestCase
 
         $mock->foo('invalid');
     }
+
+    public function testCallbackConstraintOnlyEvaluatedOnce()
+    {
+        $mock  = $this->getMockBuilder(Foo::class)->setMethods(['bar'])->getMock();
+
+        $callCount = ['call_1' => 0, 'call_2' => 0];
+
+        $mock->expects($this->exactly(2))->method('bar')
+            ->withConsecutive(
+                [
+                    $this->callback(function ($argument) use (&$callCount) {
+                        $this->assertEquals('call_1', $argument);
+
+                        $callCount['call_1']++;
+                        $this->assertEquals(1, $callCount['call_1']);
+
+                        return true;
+                    })
+                ],
+                [
+                    $this->callback(function ($argument) use (&$callCount) {
+                        $this->assertEquals('call_2', $argument);
+
+                        $callCount['call_2']++;
+                        $this->assertEquals(1, $callCount['call_2']);
+
+                        return true;
+                    })
+                ]);
+
+        $mock->bar('call_1');
+        $mock->bar('call_2');
+
+        $this->assertEquals(['call_1' => 1, 'call_2' => 1], $callCount);
+    }
 }

--- a/tests/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -93,7 +93,8 @@ class ConsecutiveParametersTest extends TestCase
 
                         return true;
                     })
-                ]);
+                ]
+            );
 
         $mock->bar('call_1');
         $mock->bar('call_2');


### PR DESCRIPTION
This removes verify() from PHPUnit_Framework_MockObject_Matcher_ConsecutiveParameters to prevent multiple calls of callbacks (should fix sebastianbergmann/phpunit-mock-objects#400).

The verify() seemed to be unnecessary and called the callbacks of all preceding invocations, which could lead to errors if parameters changed.