### PR TITLE
Removing unnecessary blocks of conditional code

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -60,7 +60,6 @@ use PHPUnit\Util\Xml;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionObject;
-use ReflectionProperty;
 use Traversable;
 
 /**
@@ -2352,9 +2351,11 @@ abstract class Assert
 
         try {
             $reflector = new ReflectionObject($object);
+
             do {
                 try {
                     $attribute = $reflector->getProperty($attributeName);
+
                     if (!$attribute || $attribute->isPublic()) {
                         return $object->$attributeName;
                     }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1144,52 +1144,47 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
         try {
             $testResult = $this->{$this->name}(...\array_values($testArguments));
-        } catch (Throwable $t) {
-            $exception = $t;
-        }
-
-        if (isset($exception)) {
-            if ($this->checkExceptionExpectations($exception)) {
-                if ($this->expectedException !== null) {
-                    $this->assertThat(
-                        $exception,
-                        new ExceptionConstraint(
-                            $this->expectedException
-                        )
-                    );
-                }
-
-                if ($this->expectedExceptionMessage !== null) {
-                    $this->assertThat(
-                        $exception,
-                        new ExceptionMessage(
-                            $this->expectedExceptionMessage
-                        )
-                    );
-                }
-
-                if ($this->expectedExceptionMessageRegExp !== null) {
-                    $this->assertThat(
-                        $exception,
-                        new ExceptionMessageRegularExpression(
-                            $this->expectedExceptionMessageRegExp
-                        )
-                    );
-                }
-
-                if ($this->expectedExceptionCode !== null) {
-                    $this->assertThat(
-                        $exception,
-                        new ExceptionCode(
-                            $this->expectedExceptionCode
-                        )
-                    );
-                }
-
-                return;
+        } catch (Throwable $exception) {
+            if (!$this->checkExceptionExpectations($exception)) {
+                throw $exception;
+            }
+            if ($this->expectedException !== null) {
+                $this->assertThat(
+                    $exception,
+                    new ExceptionConstraint(
+                        $this->expectedException
+                    )
+                );
             }
 
-            throw $exception;
+            if ($this->expectedExceptionMessage !== null) {
+                $this->assertThat(
+                    $exception,
+                    new ExceptionMessage(
+                        $this->expectedExceptionMessage
+                    )
+                );
+            }
+
+            if ($this->expectedExceptionMessageRegExp !== null) {
+                $this->assertThat(
+                    $exception,
+                    new ExceptionMessageRegularExpression(
+                        $this->expectedExceptionMessageRegExp
+                    )
+                );
+            }
+
+            if ($this->expectedExceptionCode !== null) {
+                $this->assertThat(
+                    $exception,
+                    new ExceptionCode(
+                        $this->expectedExceptionCode
+                    )
+                );
+            }
+
+            return;
         }
 
         if ($this->expectedException !== null) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1148,6 +1148,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             if (!$this->checkExceptionExpectations($exception)) {
                 throw $exception;
             }
+
             if ($this->expectedException !== null) {
                 $this->assertThat(
                     $exception,

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -182,13 +182,7 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                     }
 
                     $data = self::skipTest($className, $name, $message);
-                } catch (Throwable $_t) {
-                    $t = $_t;
-                } catch (Exception $_t) {
-                    $t = $_t;
-                }
-
-                if (isset($t)) {
+                } catch (Throwable $t) {
                     $message = \sprintf(
                         'The data provider specified for %s::%s is invalid.',
                         $className,


### PR DESCRIPTION
I removed a few blocks of code, that seem to be leftovers from older versions without current need for the additional block and condition.
This does hopefully help making the code more readable.