### PR TITLE
Fix PHPT coverage from phpdbg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
 
 script:
   - ./phpunit --coverage-clover=coverage.xml
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini; true
   - phpdbg -qrr ./phpunit --coverage-text
   - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
   - xmllint --noout --schema phpunit.xsd phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ before_script:
 
 script:
   - ./phpunit --coverage-clover=coverage.xml
-  - phpenv config-rm xdebug.ini; true
-  - phpdbg -qrr ./phpunit --coverage-text
   - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
   - xmllint --noout --schema phpunit.xsd phpunit.xml
   - xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 
 script:
   - ./phpunit --coverage-clover=coverage.xml
+  - phpdbg -qrr ./phpunit --coverage-text
   - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
   - xmllint --noout --schema phpunit.xsd phpunit.xml
   - xmllint --noout --schema phpunit.xsd tests/_files/configuration.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 
 script:
   - ./phpunit --coverage-clover=coverage.xml
+  - phpenv config-rm xdebug.ini
   - phpdbg -qrr ./phpunit --coverage-text
   - ./phpunit --configuration ./build/travis-ci-fail.xml > /dev/null; if [ $? -eq 0 ]; then echo "SHOULD FAIL"; false; else echo "fail checked"; fi;
   - xmllint --noout --schema phpunit.xsd phpunit.xml

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -150,7 +150,7 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         if ($result->getCollectCodeCoverageInformation()) {
-            $this->renderForCoverage($settings);
+            $this->renderForCoverage($code);
         }
 
         Timer::start();
@@ -488,7 +488,7 @@ class PhptTestCase implements Test, SelfDescribing
         ];
     }
 
-    private function renderForCoverage(array &$settings): void
+    private function renderForCoverage(string &$job): void
     {
         $files = $this->getCoverageFiles();
 
@@ -520,23 +520,22 @@ class PhptTestCase implements Test, SelfDescribing
                 'phar'             => $phar,
                 'globals'          => $globals,
                 'job'              => $files['job'],
-                'coverageFile'     => $files['coverage'],
-                'autoPrependFile'  => \var_export(
-                    !empty($settings['auto_prepend_file']) ? $settings['auto_prepend_file'] : false,
-                    true
-                )
+                'coverageFile'     => $files['coverage']
             ]
         );
 
-        \file_put_contents($files['job'], $template->render());
-
-        $settings['auto_prepend_file'] = $files['job'];
+        \file_put_contents($files['job'], $job);
+        $job = $template->render();
     }
 
     private function cleanupForCoverage(): array
     {
         $files    = $this->getCoverageFiles();
         $coverage = @\unserialize(\file_get_contents($files['coverage']));
+
+        if ($coverage === false) {
+            $coverage = [];
+        }
 
         foreach ($files as $file) {
             @\unlink($file);

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -479,7 +479,7 @@ class PhptTestCase implements Test, SelfDescribing
 
     private function getCoverageFiles(): array
     {
-        $baseDir          = \dirname($this->filename) . \DIRECTORY_SEPARATOR;
+        $baseDir          = \dirname(\realpath($this->filename)) . \DIRECTORY_SEPARATOR;
         $basename         = \basename($this->filename, 'phpt');
 
         return [

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -54,6 +54,7 @@ final class Filter
 
         foreach ($eTrace as $frame) {
             if (isset($frame['file']) && \is_file($frame['file']) &&
+                (empty($GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST']) || !\in_array($frame['file'], $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'])) &&
                 !$blacklist->isBlacklisted($frame['file']) &&
                 ($prefix === false || \strpos($frame['file'], $prefix) !== 0) &&
                 $frame['file'] !== $script) {

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -180,24 +180,21 @@ abstract class AbstractPhpProcess
         $command .= $this->settingsToParameters($settings);
 
         if (\PHP_SAPI === 'phpdbg') {
-            $command .= ' -qrr ';
+            $command .= ' -qrr';
 
-            if ($file) {
-                $command .= '-e ' . \escapeshellarg($file);
-            } else {
-                $command .= \escapeshellarg(__DIR__ . '/eval-stdin.php');
-            }
-        } else {
-            if ($file) {
-                $command .= ' -f ' . \escapeshellarg($file);
-            }
-
-            if ($this->args) {
-                $command .= ' --';
+            if (!$file) {
+                $command .= 's=';
             }
         }
 
+        if ($file) {
+            $command .= ' ' . \escapeshellarg($file);
+        }
+
         if ($this->args) {
+            if (!$file) {
+                $command .= ' --';
+            }
             $command .= ' ' . $this->args;
         }
 

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -187,12 +187,18 @@ abstract class AbstractPhpProcess
             } else {
                 $command .= \escapeshellarg(__DIR__ . '/eval-stdin.php');
             }
-        } elseif ($file) {
-            $command .= ' -f ' . \escapeshellarg($file);
+        } else {
+            if ($file) {
+                $command .= ' -f ' . \escapeshellarg($file);
+            }
+
+            if ($this->args) {
+                $command .= ' --';
+            }
         }
 
         if ($this->args) {
-            $command .= ' -- ' . $this->args;
+            $command .= ' ' . $this->args;
         }
 
         if ($this->stderrRedirection === true) {

--- a/src/Util/PHP/Template/PhptTestCase.tpl.dist
+++ b/src/Util/PHP/Template/PhptTestCase.tpl.dist
@@ -3,7 +3,6 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 $composerAutoload = {composerAutoload};
 $phar             = {phar};
-$autoPrependFile  = {autoPrependFile};
 
 ob_start();
 
@@ -28,7 +27,7 @@ if (class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
     $coverage->start(__FILE__);
 }
 
-register_shutdown_function(function() use ($coverage, $autoPrependFile) {
+register_shutdown_function(function() use ($coverage) {
     $output = null;
     if ($coverage) {
         $output = $coverage->stop();
@@ -38,9 +37,4 @@ register_shutdown_function(function() use ($coverage, $autoPrependFile) {
 
 ob_end_clean();
 
-if ($autoPrependFile) {
-    require $autoPrependFile;
-    $includes = get_included_files();
-    $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'][] = array_pop($includes);
-    unset($includes);
-}
+require '{job}';

--- a/src/Util/PHP/Template/TestCaseClass.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseClass.tpl.dist
@@ -58,6 +58,7 @@ function __phpunit_run_isolated_test()
         $output = $test->getActualOutput();
     }
 
+    ini_set('xdebug.scream', 0);
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
     if ($stdout = stream_get_contents(STDOUT)) {
         $output = $stdout . $output;

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -60,6 +60,7 @@ function __phpunit_run_isolated_test()
         $output = $test->getActualOutput();
     }
 
+    ini_set('xdebug.scream', '0');
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
     if ($stdout = stream_get_contents(STDOUT)) {
         $output = $stdout . $output;

--- a/tests/Regression/GitHub/1348.phpt
+++ b/tests/Regression/GitHub/1348.phpt
@@ -2,7 +2,7 @@
 https://github.com/sebastianbergmann/phpunit/issues/1348
 --SKIPIF--
 <?php
-if (defined('HHVM_VERSION')) {
+if (defined('HHVM_VERSION') || defined('PHPDBG_VERSION')) {
     print 'skip: PHP runtime required';
 }
 ?>

--- a/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-php73.phpt
+++ b/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-php73.phpt
@@ -28,12 +28,10 @@ Time: %s, Memory: %s
 There were 2 errors:
 
 1) Issue2591_SeparateFunctionNoPreserveTest::testChangedGlobalString
-PHPUnit\Framework\Exception: %sUncaught Error: Class 'PHPUnit\Framework\TestCase' not found in %s/SeparateFunctionNoPreserveTest.php:%d%S
-Stack trace:
+PHPUnit\Framework\Exception: %sUncaught Error%sin %s
 %a
 2) Issue2591_SeparateFunctionNoPreserveTest::testGlobalString
-PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Error: Class 'PHPUnit\Framework\TestCase' not found in %s:%d
-Stack trace:
+PHPUnit\Framework\Exception: %sUncaught Error%sin %s
 %a
 ERRORS!
 Tests: 2, Assertions: 0, Errors: 2.

--- a/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-php73.phpt
+++ b/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-php73.phpt
@@ -28,20 +28,12 @@ Time: %s, Memory: %s
 There were 2 errors:
 
 1) Issue2591_SeparateFunctionNoPreserveTest::testChangedGlobalString
-PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Error: Class 'PHPUnit\Framework\TestCase' not found in %s/SeparateFunctionNoPreserveTest.php:%d
+PHPUnit\Framework\Exception: %sUncaught Error: Class 'PHPUnit\Framework\TestCase' not found in %s/SeparateFunctionNoPreserveTest.php:%d%S
 Stack trace:
-#0 Standard input code(31): require_once()
-#1 Standard input code(110): __phpunit_run_isolated_test()
-#2 {main}
-  thrown in %s on line %d
-
+%a
 2) Issue2591_SeparateFunctionNoPreserveTest::testGlobalString
 PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught Error: Class 'PHPUnit\Framework\TestCase' not found in %s:%d
 Stack trace:
-#0 Standard input code(31): require_once()
-#1 Standard input code(110): __phpunit_run_isolated_test()
-#2 {main}
-  thrown in %s on line %d
-
+%a
 ERRORS!
 Tests: 2, Assertions: 0, Errors: 2.

--- a/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-xdebug.phpt
+++ b/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap-xdebug.phpt
@@ -26,14 +26,12 @@ Time: %s, Memory: %s
 There were 2 errors:
 
 1) Issue2591_SeparateFunctionNoPreserveTest::testChangedGlobalString
-PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
-PHP Stack trace:
+PHPUnit\Framework\Exception:%sPHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
+%SPHP Stack trace:%S
 %a
-
 2) Issue2591_SeparateFunctionNoPreserveTest::testGlobalString
-PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
-PHP Stack trace:
+PHPUnit\Framework\Exception:%sPHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
+%SPHP Stack trace:%S
 %a
-
 ERRORS!
 Tests: 2, Assertions: 0, Errors: 2.

--- a/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap.phpt
+++ b/tests/Regression/GitHub/2591-separate-function-no-preserve-no-bootstrap.phpt
@@ -28,10 +28,10 @@ Time: %s, Memory: %s
 There were 2 errors:
 
 1) Issue2591_SeparateFunctionNoPreserveTest::testChangedGlobalString
-PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
-
+PHPUnit\Framework\Exception:%sPHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
+%A
 2) Issue2591_SeparateFunctionNoPreserveTest::testGlobalString
-PHPUnit\Framework\Exception: PHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
-
+PHPUnit\Framework\Exception:%sPHP Fatal error:  Class 'PHPUnit\Framework\TestCase' not found %s
+%A
 ERRORS!
 Tests: 2, Assertions: 0, Errors: 2.

--- a/tests/Regression/GitHub/873.phpt
+++ b/tests/Regression/GitHub/873.phpt
@@ -16,7 +16,6 @@ require __DIR__ . '/../../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-%A
-%SException: PHPUnit suppresses exceptions thrown outside of test case function in %s:%i
+%AException: PHPUnit suppresses exceptions thrown outside of test case function in %s:%i
 Stack trace:
 %a

--- a/tests/Regression/GitHub/873.phpt
+++ b/tests/Regression/GitHub/873.phpt
@@ -16,7 +16,7 @@ require __DIR__ . '/../../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-
-Fatal error: Uncaught Exception: PHPUnit suppresses exceptions thrown outside of test case function in %s:%i
+%A
+%SException: PHPUnit suppresses exceptions thrown outside of test case function in %s:%i
 Stack trace:
 %a

--- a/tests/TextUI/code-coverage-phpt.phpt
+++ b/tests/TextUI/code-coverage-phpt.phpt
@@ -34,10 +34,10 @@ Code Coverage Report:%w
 %w
  Summary:%w
   Classes: 100.00% (2/2)%w
-  Methods: 100.00% (6/6)%w
-  Lines:   100.00% (12/12)
+  Methods: 100.00% (%d/%d)%w
+  Lines:   100.00% (%d/%d)
 
 CoveredClass
-  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  7/  7)
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)
 CoveredParentClass
-  Methods: 100.00% ( 3/ 3)   Lines: 100.00% (  5/  5)
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)

--- a/tests/TextUI/fatal-isolation.phpt
+++ b/tests/TextUI/fatal-isolation.phpt
@@ -19,7 +19,6 @@ Time: %s, Memory: %s
 There was 1 error:
 
 1) FatalTest::testFatalError
-%s
-
+%a
 ERRORS!
 Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/Util/PHP/AbstractPhpProcessTest.php
+++ b/tests/Util/PHP/AbstractPhpProcessTest.php
@@ -83,8 +83,7 @@ class AbstractPhpProcessTest extends TestCase
 
     public function testShouldHaveFileToCreateCommand(): void
     {
-        $argumentEscapingCharacter = \DIRECTORY_SEPARATOR === '\\' ? '"' : '\'';
-        $expectedCommandFormat     = \sprintf('%%s -%%c %1$sfile.php%1$s', $argumentEscapingCharacter);
+        $expectedCommandFormat     = '%s %cfile.php%c';
         $actualCommand             = $this->phpProcess->getCommand([], 'file.php');
 
         $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);

--- a/tests/Util/PHP/AbstractPhpProcessTest.php
+++ b/tests/Util/PHP/AbstractPhpProcessTest.php
@@ -55,7 +55,7 @@ class AbstractPhpProcessTest extends TestCase
             'display_errors=1',
         ];
 
-        $expectedCommandFormat  = '%s -d %callow_url_fopen=1%c -d %cauto_append_file=%c -d %cdisplay_errors=1%c';
+        $expectedCommandFormat  = '%s -d %callow_url_fopen=1%c -d %cauto_append_file=%c -d %cdisplay_errors=1%c%S';
         $actualCommand          = $this->phpProcess->getCommand($settings);
 
         $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);
@@ -75,7 +75,7 @@ class AbstractPhpProcessTest extends TestCase
     {
         $this->phpProcess->setArgs('foo=bar');
 
-        $expectedCommandFormat  = '%s -- foo=bar';
+        $expectedCommandFormat  = '%s foo=bar';
         $actualCommand          = $this->phpProcess->getCommand([]);
 
         $this->assertStringMatchesFormat($expectedCommandFormat, $actualCommand);


### PR DESCRIPTION
Fixes #3111.
Stop using auto_append_file as it doesn't work with the phpdbg sapi.
Instead, the job's code is written to a temp file and the coverage instrumentation code takes over the code.