### PR TITLE
Simplification and removing PHP5-Leftovers

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -398,35 +398,38 @@ class Generator
             \sort($type);
         }
 
-        if ($mockClassName === '') {
-            $key = \md5(
-                \is_array($type) ? \implode('_', $type) : $type .
-                \serialize($methods) .
-                \serialize($callOriginalClone) .
-                \serialize($cloneArguments) .
-                \serialize($callOriginalMethods)
+        if ($mockClassName !== '') {
+            return $this->generateMock(
+                $type,
+                $methods,
+                $mockClassName,
+                $callOriginalClone,
+                $callAutoload,
+                $cloneArguments,
+                $callOriginalMethods
             );
-
-            if (isset(self::$cache[$key])) {
-                return self::$cache[$key];
-            }
         }
-
-        $mock = $this->generateMock(
-            $type,
-            $methods,
-            $mockClassName,
-            $callOriginalClone,
-            $callAutoload,
-            $cloneArguments,
-            $callOriginalMethods
+        $key = \md5(
+            \is_array($type) ? \implode('_', $type) : $type .
+            \serialize($methods) .
+            \serialize($callOriginalClone) .
+            \serialize($cloneArguments) .
+            \serialize($callOriginalMethods)
         );
 
-        if (isset($key)) {
-            self::$cache[$key] = $mock;
+        if (!isset(self::$cache[$key])) {
+            self::$cache[$key] = $this->generateMock(
+                $type,
+                $methods,
+                $mockClassName,
+                $callOriginalClone,
+                $callAutoload,
+                $cloneArguments,
+                $callOriginalMethods
+            );
         }
 
-        return $mock;
+        return self::$cache[$key];
     }
 
     /**
@@ -485,13 +488,13 @@ class Generator
             }
         }
 
-        $optionsBuffer = 'array(';
+        $optionsBuffer = '[';
 
         foreach ($options as $key => $value) {
             $optionsBuffer .= $key . ' => ' . $value;
         }
 
-        $optionsBuffer .= ')';
+        $optionsBuffer .= ']';
 
         $classTemplate = $this->getTemplate('wsdl_class.tpl');
         $namespace     = '';

--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -88,9 +88,7 @@ class ConsecutiveParameters extends StatelessInvocation
      */
     private function verifyInvocation(BaseInvocation $invocation, $callIndex): void
     {
-        if (isset($this->parameterGroups[$callIndex])) {
-            $parameters = $this->parameterGroups[$callIndex];
-        } else {
+        if (!isset($this->parameterGroups[$callIndex])) {
             // no parameter assertion for this call index
             return;
         }
@@ -100,6 +98,8 @@ class ConsecutiveParameters extends StatelessInvocation
                 'Mocked method does not exist.'
             );
         }
+
+        $parameters = $this->parameterGroups[$callIndex];
 
         if (\count($invocation->getParameters()) < \count($parameters)) {
             throw new ExpectationFailedException(

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -894,17 +894,13 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 }
             }
         } catch (Throwable $_e) {
-            if (!isset($e)) {
-                $e = $_e;
-            }
+            $e = $e ?? $_e;
         }
 
         try {
             $this->stopOutputBuffering();
         } catch (RiskyTestError $_e) {
-            if (!isset($e)) {
-                $e = $_e;
-            }
+            $e = $e ?? $_e;
         }
 
         if (isset($_e)) {

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -269,22 +269,18 @@ class PhptTestCase implements Test, SelfDescribing
         foreach ($assertions as $sectionName => $sectionAssertion) {
             if (isset($sections[$sectionName])) {
                 $sectionContent = \preg_replace('/\r\n/', "\n", \trim($sections[$sectionName]));
-                $assertion      = $sectionAssertion;
                 $expected       = $sectionName === 'EXPECTREGEX' ? "/{$sectionContent}/" : $sectionContent;
 
-                break;
+                if ($expected === null) {
+                    throw new Exception('No PHPT expectation found');
+                }
+                Assert::$sectionAssertion($expected, $actual);
+
+                return;
             }
         }
 
-        if (!isset($assertion)) {
-            throw new Exception('No PHPT assertion found');
-        }
-
-        if (!isset($expected)) {
-            throw new Exception('No PHPT expectation found');
-        }
-
-        Assert::$assertion($expected, $actual);
+        throw new Exception('No PHPT assertion found');
     }
 
     /**

--- a/src/Runner/ResultCacheExtension.php
+++ b/src/Runner/ResultCacheExtension.php
@@ -96,11 +96,7 @@ final class ResultCacheExtension implements AfterSuccessfulTestHook, AfterSkippe
         $matches = [];
 
         if (\preg_match('/^(?:\S+::)?(?<name>\S+)(?:(?<data> with data set (?:#\d+|"[^"]+"))\s\()?/', $test, $matches)) {
-            $test = $matches['name'];
-
-            if (isset($matches['data'])) {
-                $test .= $matches['data'];
-            }
+            $test = $matches['name'] . ($matches['data'] ?? '');
         }
 
         return $test;

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -188,9 +188,7 @@ class TestRunner extends BaseTestRunner
         }
 
         if ($arguments['executionOrder'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['executionOrderDefects'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['resolveDependencies']) {
-            if (!isset($cache)) {
-                $cache = new NullTestResultCache;
-            }
+            $cache = $cache ?? new NullTestResultCache;
 
             $cache->load();
 

--- a/src/Util/PHP/Template/TestCaseClass.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseClass.tpl.dist
@@ -69,12 +69,12 @@ function __phpunit_run_isolated_test()
     }
 
     print serialize(
-      array(
+      [
         'testResult'    => $test->getResult(),
         'numAssertions' => $test->getNumAssertions(),
         'result'        => $result,
         'output'        => $output
-      )
+      ]
     );
 }
 

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -71,12 +71,12 @@ function __phpunit_run_isolated_test()
     }
 
     print serialize(
-      array(
+      [
         'testResult'    => $test->getResult(),
         'numAssertions' => $test->getNumAssertions(),
         'result'        => $result,
         'output'        => $output
-      )
+      ]
     );
 }
 


### PR DESCRIPTION
Changes
- removing isset where ?? is sufficient
- uniting blocks that do no longer need to be separated
- replacing the last few array() with []