### PR TITLE
Adding assertArrayStructure

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -14,6 +14,7 @@ use Countable;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
+use PHPUnit\Framework\Constraint\ArrayStructure;
 use PHPUnit\Framework\Constraint\ArraySubset;
 use PHPUnit\Framework\Constraint\Attribute;
 use PHPUnit\Framework\Constraint\Callback;
@@ -132,6 +133,33 @@ abstract class Assert
         static::assertThat($array, $constraint, $message);
     }
 
+    /**
+     * Checks that an array conforms to a given structure.
+     *
+     * @param $expectedStructure
+     * @param $array
+     */
+    public static function assertArrayStructure($expectedStructure, $array, bool $strict = false, string $message = ''): void
+    {
+        if (!(\is_array($expectedStructure))) {
+            throw InvalidArgumentHelper::factory(
+                1,
+                'array'
+            );
+        }
+
+        if (!(\is_array($array))) {
+            throw InvalidArgumentHelper::factory(
+                2,
+                'array'
+            );
+        }
+
+        $constraint = new ArrayStructure($expectedStructure, $strict);
+
+        static::assertThat($array, $constraint, $message);
+    }
+    
     /**
      * Asserts that an array does not have a specified key.
      *

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -159,7 +159,7 @@ abstract class Assert
 
         static::assertThat($array, $constraint, $message);
     }
-    
+
     /**
      * Asserts that an array does not have a specified key.
      *

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -91,12 +91,10 @@ function assertArraySubset($subset, $array, bool $strict = false, string $messag
 
 /**
  * Checks that an array conforms to a given structure.
- * 
+ *
  * @param $expectedStructure
  * @param $array
- * @param bool $strict
- * @param string $message
- * 
+ *
  * @throws InvalidArgumentHelper
  */
 function assertArrayStructure($expectedStructure, $array, bool $strict = false, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -90,6 +90,21 @@ function assertArraySubset($subset, $array, bool $strict = false, string $messag
 }
 
 /**
+ * Checks that an array conforms to a given structure.
+ * 
+ * @param $expectedStructure
+ * @param $array
+ * @param bool $strict
+ * @param string $message
+ * 
+ * @throws InvalidArgumentHelper
+ */
+function assertArrayStructure($expectedStructure, $array, bool $strict = false, string $message = ''): void
+{
+    Assert::assertArrayStructure(...\func_get_args());
+}
+
+/**
  * Asserts that an array does not have a specified key.
  *
  * @param int|string        $key

--- a/src/Framework/Constraint/ArrayStructure.php
+++ b/src/Framework/Constraint/ArrayStructure.php
@@ -120,7 +120,7 @@ class ArrayStructure extends Constraint
         }
 
         if ($strict && \count($expected) != \count($actual)) {
-            return 'Both arrays do not have the same length.';
+            return "Array has more elements than present in the given structure.\nStrict mode is ENABLED.";
         }
 
         return '';

--- a/src/Framework/Constraint/ArrayStructure.php
+++ b/src/Framework/Constraint/ArrayStructure.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+/**
+ * Class ArrayStructure
+ */
+class ArrayStructure extends Constraint
+{
+    /**
+     * @var array
+     */
+    private $expectedStructure;
+
+    /**
+     * @var bool
+     */
+    private $strict;
+
+    /**
+     * @var string
+     */
+    private $additionalFailureDescription = '';
+
+    /**
+     * @param $expectedStructure
+     * @param $strict
+     */
+    public function __construct($expectedStructure, $strict)
+    {
+        parent::__construct();
+
+        $this->strict            = $strict;
+        $this->expectedStructure = $expectedStructure;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function toString(): string
+    {
+        return 'matches the given structure.';
+    }
+
+    protected function matches($other): bool
+    {
+        if (\is_array($other)) {
+            $result = $this->checkArrayStructureRecursive($this->expectedStructure, $other, '', $this->strict);
+
+            if (!($result)) {
+                return true;
+            }
+            $this->additionalFailureDescription = $result;
+        }
+
+        return false;
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        return $this->additionalFailureDescription;
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function failureDescription($other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+
+    /**
+     * Recursively checks the structure of the given array against the structure provided in $expectedStructure
+     */
+    private function checkArrayStructureRecursive(
+        array $expected,
+        array $actual,
+        string $path,
+        bool $strict = false
+    ): string {
+        foreach ($expected as $key => $value) {
+            if (\is_array($value)) {
+                if (!\array_key_exists($key, $actual)) {
+                    return $path . $key . ' not available.';
+                }
+
+                if (!\is_array($actual[$key])) {
+                    return $path . $key . ' is not an array.';
+                }
+                $nextLevelResult = self::checkArrayStructureRecursive($expected[$key], $actual[$key], $path . $key . ' => ');
+
+                if (!empty($nextLevelResult)) {
+                    return $nextLevelResult;
+                }
+            } else {
+                if (!\array_key_exists($value, $actual)) {
+                    return $path . $value . ' not available.';
+                }
+
+                if (empty($actual[$value]) && \gettype($actual[$value]) != 'boolean') {
+                    return $path . $value . ' is empty.';
+                }
+            }
+        }
+
+        if ($strict && \count($expected) != \count($actual)) {
+            return 'Both arrays do not have the same length.';
+        }
+
+        return '';
+    }
+}

--- a/tests/Framework/AssertTest.php
+++ b/tests/Framework/AssertTest.php
@@ -126,6 +126,52 @@ class AssertTest extends TestCase
         $this->assertContains('', 'test');
     }
 
+    public function testAssertArrayStructureThrowsExceptionForInvalidFirstArgument(): void
+    {
+        $this->expectException(Exception::class);
+        $this->assertArrayStructure('string', []);
+    }
+
+    public function testAssertArrayStructureThrowsExceptionForInvalidSecondArgument(): void
+    {
+        $this->expectException(Exception::class);
+        $this->assertArrayStructure([], 'string');
+    }
+
+    public function testAssertArrayStructureFailsBecauseOfMissingElementInActual(): void
+    {
+        $expected = [
+            'a',
+            'b',
+            'c',
+        ];
+
+        $actual = [
+            'a' => 'aval',
+            'b' => 'bval',
+        ];
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertArrayStructure($expected, $actual);
+    }
+
+    public function testAssertArrayStructureFailsBecauseOfMissingElementInExpectedWhileStrictModeIsOn(): void
+    {
+        $expected = [
+            'a',
+            'b',
+        ];
+
+        $actual = [
+            'a' => 'aval',
+            'b' => 'bval',
+            'c' => 'cval',
+        ];
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertArrayStructure($expected, $actual, true);
+    }
+
     public function testAssertArrayHasKeyThrowsExceptionForInvalidFirstArgument(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Framework/Constraint/ArrayStructureTest.php
+++ b/tests/Framework/Constraint/ArrayStructureTest.php
@@ -72,7 +72,8 @@ EOF
             $this->assertEquals(
                 <<<EOF
 Failed asserting that an array matches the given structure..
-Both arrays do not have the same length.
+Array has more elements than present in the given structure.
+Strict mode is ENABLED.
 
 EOF
                 ,

--- a/tests/Framework/Constraint/ArrayStructureTest.php
+++ b/tests/Framework/Constraint/ArrayStructureTest.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestFailure;
+
+class ArrayStructureTest extends ConstraintTestCase
+{
+    public function testConstraintArrayStructureWithKeysMissingFromActual(): void
+    {
+        $constraint = new ArrayStructure([
+            'a' => ['b', 'c'],
+            'd',
+            'e',
+        ], false);
+
+        $actual = [];
+        $this->assertFalse($constraint->evaluate($actual, '', true));
+        $this->assertEquals('matches the given structure.', $constraint->toString());
+        $this->assertCount(1, $constraint);
+
+        try {
+            $constraint->evaluate($actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that an array matches the given structure..
+a not available.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testConstraintArrayStructureWithActualHavingExtraElementsWhenStrictIsTrue(): void
+    {
+        $constraint = new ArrayStructure([
+            'a',
+            'b',
+            'c' => ['d', 'e'],
+        ], true);
+        $actual     = [
+            'a' => 'aval',
+            'b' => 'bval',
+            'c' => [
+                'd' => 'dval',
+                'e' => ['f' => 'fval'],
+            ],
+            'f' => 'fval'
+        ];
+        $this->assertFalse($constraint->evaluate($actual, '', true));
+        $this->assertEquals('matches the given structure.', $constraint->toString());
+        $this->assertCount(1, $constraint);
+
+        try {
+            $constraint->evaluate($actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that an array matches the given structure..
+Both arrays do not have the same length.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testConstraintArrayStructureWhenAnElementShouldBeArrayButIsNot(): void
+    {
+        $constraint = new ArrayStructure([
+            'a' => ['b', 'c'],
+            'd',
+            'e',
+        ], false);
+
+        $actual = [
+            'a' => 'aval',
+            'd' => 'dval',
+            'e' => 'eval',
+        ];
+        $this->assertFalse($constraint->evaluate($actual, '', true));
+        $this->assertEquals('matches the given structure.', $constraint->toString());
+        $this->assertCount(1, $constraint);
+
+        try {
+            $constraint->evaluate($actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                <<<EOF
+Failed asserting that an array matches the given structure..
+a is not an array.
+
+EOF
+                ,
+                TestFailure::exceptionToString($e)
+            );
+
+            return;
+        }
+
+        $this->fail();
+    }
+}


### PR DESCRIPTION
This assertion makes sure that an array conforms to a given structure.

`$strict` parameters makes the assertion fail if there are one or more elements that are present in `$array` but not present in `$expectedStructure`  

Examples: 



```php
        
        $expected = [
            'a',
            'b',
            'c' => ['d', 'e'],
        ];

        $actual = [
            'a' => 'aval',
            'b' => 'bval',
            'c' => ['d' => 'dval', 'e' => 'eval'],
            'f',
        ];

        $this->assertArrayStructure($expected, $actual); //should pass
        $this->assertArrayStructure($expected, $actual, true); //should NOT pass

```



```php
        
        $expected = [
            'a',
            'b',
            'c'
        ];

        $actual = [
            'a' => 'aval',
            'b' => 'bval',
        ];

        $this->assertArrayStructure($expected, $actual); //should NOT pass

```
