### PR TITLE
Add tests for missing options and arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "sebastian/version": "^2.0.1"
     },
     "require-dev": {
-        "ext-PDO": "*"
+        "ext-PDO": "*",
+        "mikey179/vfsStream": "~1.0"
     },
     "conflict": {
         "phpunit/phpunit-mock-objects": "*"

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -197,8 +197,7 @@ class Command
             return $this->handleListTestsXml($suite, $this->arguments['listTestsXml'], $exit);
         }
 
-        unset($this->arguments['test'], $this->arguments['testFile']
-        );
+        unset($this->arguments['test'], $this->arguments['testFile']);
 
         try {
             $result = $runner->doRun($suite, $this->arguments, $exit);

--- a/tests/TextUI/_files/AlwaysPass.php
+++ b/tests/TextUI/_files/AlwaysPass.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+final class AlwaysPass extends TestCase
+{
+    public function testTrue()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/TextUI/_files/Column.php
+++ b/tests/TextUI/_files/Column.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Column extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider provideColumnCount
+     */
+    public function testShouldAlwaysPass()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function provideColumnCount()
+    {
+        $data = [];
+
+        for ($i = 0; $i < 20; $i++) {
+            $data[] = [];
+        }
+
+        return $data;
+    }
+}

--- a/tests/TextUI/_files/CoverStub.php
+++ b/tests/TextUI/_files/CoverStub.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+final class CoverStub
+{
+    public static function notCoveredWithUse()
+    {
+        return true;
+    }
+}

--- a/tests/TextUI/_files/Coverage.php
+++ b/tests/TextUI/_files/Coverage.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+require_once __DIR__ . '/CoverStub.php';
+
+/**
+ * @covers CoverStub
+ */
+class Coverage extends PHPUnit\Framework\TestCase
+{
+    public function test_it_should_always_return_true()
+    {
+        $this->assertTrue(CoverStub::notCoveredWithUse());
+    }
+}

--- a/tests/TextUI/_files/FailOn.php
+++ b/tests/TextUI/_files/FailOn.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+final class FailOn extends PHPUnit\Framework\TestCase
+{
+    public function testRisky()
+    {
+        // Always risky, no assertion
+    }
+
+    public function testWarning()
+    {
+        \trigger_error('warning', \E_USER_WARNING);
+    }
+}

--- a/tests/TextUI/_files/IncludePath.php
+++ b/tests/TextUI/_files/IncludePath.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class IncludePath extends \PHPUnit\Framework\TestCase
+{
+    public function testShouldSetIncludePath()
+    {
+        $this->assertContains('tests/TextUI', \ini_get('include_path'));
+    }
+}

--- a/tests/TextUI/_files/Output.php
+++ b/tests/TextUI/_files/Output.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+final class Output extends TestCase
+{
+    public function testProduceOutput()
+    {
+        print 'Outputed string';
+        $this->assertTrue(true);
+    }
+}

--- a/tests/TextUI/_files/StopOn.php
+++ b/tests/TextUI/_files/StopOn.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+final class StopOn extends PHPUnit\Framework\TestCase
+{
+    public function testShouldFail()
+    {
+        $this->fail('Always fail');
+    }
+
+    public function testShouldBeRisky()
+    {
+        // Always risky, no assertion
+    }
+
+    public function testShouldBeIncomplete()
+    {
+        $this->markTestIncomplete('Always incomplete');
+    }
+
+    public function testShouldBeSkipped()
+    {
+        $this->markTestSkipped('Always skip');
+    }
+
+    public function testShouldBeWarning()
+    {
+        \trigger_error('Should error', \E_USER_WARNING);
+    }
+
+    public function testShouldBeError()
+    {
+        \trigger_error('Should error', \E_USER_NOTICE);
+    }
+
+    public function testNeverExecutedInFailRiskyIncompleteSkippedError()
+    {
+        // should be the last test for --stop-on-* flags to exclude
+        $this->fail('--stop-on-* should not execute this test');
+    }
+}

--- a/tests/TextUI/_files/coverage.xml
+++ b/tests/TextUI/_files/coverage.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<phpunit colors="false">
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./Coverage.php</directory>
+        </whitelist>
+    </filter>
+</phpunit>
+

--- a/tests/TextUI/_files/logging.xml
+++ b/tests/TextUI/_files/logging.xml
@@ -1,0 +1,8 @@
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.3/phpunit.xsd"
+    backupGlobals="false"
+>
+    <logging>
+        <log type="coverage-html" target="/tmp/coverage" />
+    </logging>
+</phpunit>

--- a/tests/TextUI/atleast-version.phpt
+++ b/tests/TextUI/atleast-version.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Support --atleast-version long option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--atleast-version';
+$_SERVER['argv'][] = '999';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--

--- a/tests/TextUI/check-version.phpt
+++ b/tests/TextUI/check-version.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Support --check-version option.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--check-version';
+
+require __DIR__ . '/../bootstrap.php';
+define('__PHPUNIT_PHAR__', '');
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+You are using the latest version of PHPUnit.

--- a/tests/TextUI/column-int.phpt
+++ b/tests/TextUI/column-int.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Support --columns={int} option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/Column.php';
+$_SERVER['argv'][] = '--columns=25';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.......... 10 / 20 ( 50%)
+.......... 20 / 20 (100%)
+
+
+Time: %s, Memory: %s
+
+OK (20 tests, 20 assertions)

--- a/tests/TextUI/column-max.phpt
+++ b/tests/TextUI/column-max.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Support --columns=max option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/Column.php';
+$_SERVER['argv'][] = '--columns=max';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+....................                                              20 / 20 (100%)
+
+Time: %s, Memory: %s
+
+OK (20 tests, 20 assertions)

--- a/tests/TextUI/coverage-clover.phpt
+++ b/tests/TextUI/coverage-clover.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Support --coverage-clover option.
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+$root = \org\bovigo\vfs\vfsStream::setup('coverage');
+$coveragePath = \org\bovigo\vfs\vfsStream::path('coverage');
+$configPath = __DIR__ . '/_files/coverage.xml';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '-c';
+$_SERVER['argv'][] = $configPath;
+$_SERVER['argv'][] = '--coverage-clover';
+$_SERVER['argv'][] = $coveragePath;
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+Generating code coverage report in Clover XML format ... done

--- a/tests/TextUI/coverage-crap4j.phpt
+++ b/tests/TextUI/coverage-crap4j.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Support --coverage-crap4j option.
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+$root = \org\bovigo\vfs\vfsStream::setup('coverage');
+$coveragePath = \org\bovigo\vfs\vfsStream::path('coverage');
+$configPath = __DIR__ . '/_files/coverage.xml';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '-c';
+$_SERVER['argv'][] = $configPath;
+$_SERVER['argv'][] = '--coverage-crap4j';
+$_SERVER['argv'][] = $coveragePath;
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+Generating Crap4J report XML file ... done

--- a/tests/TextUI/coverage-html.phpt
+++ b/tests/TextUI/coverage-html.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Support --coverage-html option.
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+$root = \org\bovigo\vfs\vfsStream::setup('coverage');
+$coveragePath = $root->url();
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/coverage.xml';
+$_SERVER['argv'][] = '--coverage-html';
+$_SERVER['argv'][] = $coveragePath;
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+Generating code coverage report in HTML format ... done

--- a/tests/TextUI/coverage-php.phpt
+++ b/tests/TextUI/coverage-php.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Support --coverage-php option.
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+$root = \org\bovigo\vfs\vfsStream::setup('root');
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '-c';
+$_SERVER['argv'][] = __DIR__ . '/_files/coverage.xml';
+$_SERVER['argv'][] = '--coverage-php';
+$_SERVER['argv'][] = $root->url() . '/coverage';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+Generating code coverage report in PHP format ... done

--- a/tests/TextUI/coverage-text.phpt
+++ b/tests/TextUI/coverage-text.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Support --coverage-text with specified file
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+\org\bovigo\vfs\vfsStream::enableDotfiles();
+$root = \org\bovigo\vfs\vfsStream::setup('root');
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/coverage.xml';
+$_SERVER['argv'][] = '--coverage-text';
+$_SERVER['argv'][] = $root->path() . '/coverage.txt';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %sMB
+
+OK (1 test, 1 assertion)
+
+
+Code Coverage Report:%s
+  %s
+%s
+ Summary:%s
+  Classes:  0.00% (0/1)
+  Methods:  0.00% (0/1)
+  Lines:    0.00% (0/2)

--- a/tests/TextUI/coverage-xml.phpt
+++ b/tests/TextUI/coverage-xml.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Support --coverage-xml option.
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+$root = \org\bovigo\vfs\vfsStream::setup('coverage');
+$configPath = __DIR__ . '/_files/coverage.xml';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = $configPath;
+$_SERVER['argv'][] = '--coverage-xml';
+$_SERVER['argv'][] = $root->url() . '/coverage.xml';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+Generating code coverage report in PHPUnit XML format ... done

--- a/tests/TextUI/disallow-test-output.phpt
+++ b/tests/TextUI/disallow-test-output.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Support --disallow-test-output with specified file
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--disallow-test-output';
+$_SERVER['argv'][] = __DIR__ . '/_files/Output.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+R                                                                   1 / 1 (100%)Outputed string
+
+Time: %s ms, Memory: %sMB
+
+There was 1 risky test:
+
+1) Output::testProduceOutput
+This test printed output: Outputed string
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 1, Risky: 1.

--- a/tests/TextUI/dont-report-useless-tests.phpt
+++ b/tests/TextUI/dont-report-useless-tests.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Support --dont-report-useless-tests option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'Risky';
+$_SERVER['argv'][] = '--dont-report-useless-tests';
+$_SERVER['argv'][] = __DIR__ . '/_files/FailOn.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 0 assertions)

--- a/tests/TextUI/enforce-time-limit.phpt
+++ b/tests/TextUI/enforce-time-limit.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Support --enforce-time-limit with specified file
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--enforce-time-limit';
+$_SERVER['argv'][] = __DIR__ . '/_files/AlwaysPass.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %sMB
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/fail-on-risky.phpt
+++ b/tests/TextUI/fail-on-risky.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Support --fail-on-risky.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'Risky';
+$_SERVER['argv'][] = '--fail-on-risky';
+$_SERVER['argv'][] = __DIR__ . '/_files/FailOn.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+R                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) FailOn::testRisky
+This test did not perform any assertions
+
+%s/FailOn.php:%s
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 0, Risky: 1.

--- a/tests/TextUI/fail-on-warning.phpt
+++ b/tests/TextUI/fail-on-warning.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Support --fail-on-warning.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'Warning';
+$_SERVER['argv'][] = '--fail-on-warning';
+$_SERVER['argv'][] = __DIR__ . '/_files/FailOn.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) FailOn::testWarning
+warning
+
+%s/FailOn.php:%s
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/TextUI/include-path.phpt
+++ b/tests/TextUI/include-path.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Support --include-path option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--include-path';
+$_SERVER['argv'][] = __DIR__;
+$_SERVER['argv'][] = __DIR__ . '/_files/IncludePath.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/loader.phpt
+++ b/tests/TextUI/loader.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Support --loader option.
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+$root = \org\bovigo\vfs\vfsStream::setup('root');
+
+class StubLoader implements \PHPUnit\Runner\TestSuiteLoader
+{
+    public function load(string $suiteClassName, string $suiteClassFile = ''): ReflectionClass
+    {
+        throw new \PHPUnit\Framework\AssertionFailedError('Method ' . __METHOD__ . ' not implemented yet.');
+    }
+
+    public function reload(ReflectionClass $aClass): ReflectionClass
+    {
+        throw new \PHPUnit\Framework\AssertionFailedError('Method ' . __METHOD__ . ' not implemented yet.');
+    }
+}
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--loader';
+$_SERVER['argv'][] = StubLoader::class;
+$_SERVER['argv'][] = __DIR__ . '/_files/AlwaysPass.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+Method StubLoader::load not implemented yet.

--- a/tests/TextUI/no-coverage.phpt
+++ b/tests/TextUI/no-coverage.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Support --no-coverage with specified file
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/coverage.xml';
+$_SERVER['argv'][] = '--no-coverage';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %sMB
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/no-logging.phpt
+++ b/tests/TextUI/no-logging.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Support --no-logging with specified file
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/logging.xml';
+$_SERVER['argv'][] = '--no-logging';
+$_SERVER['argv'][] = __DIR__ . '/_files/AlwaysPass.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %sMB
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/printer.phpt
+++ b/tests/TextUI/printer.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Support --printer option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+$_SERVER['argv'][] = '--printer=TestPrinter';
+
+
+use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\Framework\TestResult;
+
+class TestPrinter extends ResultPrinter
+{
+    public function printResult(TestResult $result): void
+    {
+        $this->write('test');
+        parent::printResult($result);
+    }
+}
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)test
+
+Time: %s ms, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/stderr.phpt
+++ b/tests/TextUI/stderr.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Support --stderr long option.
+--FILE--
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--stderr';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/TextUI/stop-on-failure.phpt
+++ b/tests/TextUI/stop-on-failure.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Support --stop-on-failure long option.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'Fail';
+$_SERVER['argv'][] = '--stop-on-failure';
+$_SERVER['argv'][] = __DIR__ . '/_files/StopOn.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+F
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) StopOn::testShouldFail
+Always fail
+
+%s/StopOn.php:%s
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.
+

--- a/tests/TextUI/stop-on-risky.phpt
+++ b/tests/TextUI/stop-on-risky.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Support --stop-on-risky long option.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'Risky';
+$_SERVER['argv'][] = '--stop-on-risky';
+$_SERVER['argv'][] = __DIR__ . '/_files/StopOn.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+R
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) StopOn::testShouldBeRisky
+This test did not perform any assertions
+
+%s/StopOn.php:%s
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 0, Risky: 1.

--- a/tests/TextUI/stop-on-skipped.phpt
+++ b/tests/TextUI/stop-on-skipped.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Support --stop-on-skipped long option.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'Skipped';
+$_SERVER['argv'][] = '--stop-on-skipped';
+$_SERVER['argv'][] = __DIR__ . '/_files/StopOn.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+S
+
+Time: %s, Memory: %s
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 0, Skipped: 1.
+

--- a/tests/TextUI/strict-coverage.phpt
+++ b/tests/TextUI/strict-coverage.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Support --strict-coverage-text with specified file
+--FILE--
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+\org\bovigo\vfs\vfsStream::enableDotfiles();
+$root = \org\bovigo\vfs\vfsStream::setup('root');
+
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/coverage.xml';
+$_SERVER['argv'][] = '--coverage-text';
+$_SERVER['argv'][] = $root->path() . '/coverage.txt';
+$_SERVER['argv'][] = '--strict-coverage';
+$_SERVER['argv'][] = __DIR__ . '/_files/Coverage.php';
+
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+R                                                                   1 / 1 (100%)
+
+Time: %s ms, Memory: %sMB
+
+There was 1 risky test:
+
+1) Coverage::test_it_should_always_return_true
+This test executed code that is not listed as code to be covered or used:
+- Coverage::test_it_should_always_return_true
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 1, Risky: 1.
+
+
+Code Coverage Report:%s
+%s
+%s
+ Summary: %s
+  Classes:  0.00% (0/1)
+  Methods:  0.00% (0/1)
+  Lines:    0.00% (0/2)
+

--- a/tests/TextUI/version.phpt
+++ b/tests/TextUI/version.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Support --version long option.
+--FILE--
+<?php
+$_SERVER['argv'][] = ''; // present to start index at 0
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--version';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.


### PR DESCRIPTION
This PR adds coverage to all uncovered options of the `Command` class.

This is to make sure that no options are missed when changing the runner (ie. if we change to `symfony/console`, or #3213).

This is a migration of the tests found in #1868
