### PR TITLE
Fix fatal syntax error "unexpected '-', expecting '{'"

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1640,7 +1640,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     protected function getMockFromWsdl($wsdlFile, $originalClassName = '', $mockClassName = '', array $methods = [], $callOriginalConstructor = true, array $options = [])
     {
         if ($originalClassName === '') {
-            $originalClassName = \pathinfo(\basename(\parse_url($wsdlFile)['path']), PATHINFO_FILENAME);
+            $fileName = \pathinfo(\basename(\parse_url($wsdlFile)['path']), PATHINFO_FILENAME);
+            $originalClassName = preg_replace('/[^a-zA-Z0-9_]/', '', $fileName);
         }
 
         if (!\class_exists($originalClassName)) {


### PR DESCRIPTION
caused by special chars in wsdl file name.

**This is the fix, you can find the tests here**: https://github.com/sebastianbergmann/phpunit-mock-objects/pull/424
Im sorry but the fix might be best placed here while the tests for it are in another project :(