### PR TITLE
Fix fatal syntax error "unexpected '-', expecting '{'"

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1447,7 +1447,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     protected function getMockFromWsdl($wsdlFile, $originalClassName = '', $mockClassName = '', array $methods = [], $callOriginalConstructor = true, array $options = []): MockObject
     {
         if ($originalClassName === '') {
-            $originalClassName = \pathinfo(\basename(\parse_url($wsdlFile)['path']), \PATHINFO_FILENAME);
+            $fileName          = \pathinfo(\basename(\parse_url($wsdlFile)['path']), \PATHINFO_FILENAME);
+            $originalClassName = \preg_replace('/[^a-zA-Z0-9_]/', '', $fileName);
         }
 
         if (!\class_exists($originalClassName)) {

--- a/tests/Framework/MockObject/MockObjectTest.php
+++ b/tests/Framework/MockObject/MockObjectTest.php
@@ -942,6 +942,18 @@ class MockObjectTest extends TestCase
     }
 
     /**
+     * @see      https://github.com/sebastianbergmann/phpunit/issues/2573
+     * @ticket   2573
+     * @requires extension soap
+     */
+    public function testCreateMockOfWsdlFileWithSpecialChars()
+    {
+        $mock = $this->getMockFromWsdl(__DIR__ . '/_fixture/Go ogle-Sea.rch.wsdl');
+
+        $this->assertStringStartsWith('Mock_GoogleSearch_', \get_class($mock));
+    }
+
+    /**
      * @see    https://github.com/sebastianbergmann/phpunit-mock-objects/issues/156
      * @ticket 156
      */

--- a/tests/_files/Go ogle-Sea.rch.wsdl
+++ b/tests/_files/Go ogle-Sea.rch.wsdl
@@ -1,0 +1,198 @@
+<?xml version="1.0"?>
+
+<!-- WSDL description of the Google Web APIs.
+     The Google Web APIs are in beta release. All interfaces are subject to
+     change as we refine and extend our APIs. Please see the terms of use
+     for more information. -->
+
+<!-- Revision 2002-08-16 -->
+
+<definitions name="GoogleSearch"
+             targetNamespace="urn:GoogleSearch"
+             xmlns:typens="urn:GoogleSearch"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+             xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+
+  <!-- Types for search - result elements, directory categories -->
+
+  <types>
+    <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+                targetNamespace="urn:GoogleSearch">
+
+      <xsd:complexType name="GoogleSearchResult">
+        <xsd:all>
+          <xsd:element name="documentFiltering"           type="xsd:boolean"/>
+          <xsd:element name="searchComments"              type="xsd:string"/>
+          <xsd:element name="estimatedTotalResultsCount"  type="xsd:int"/>
+          <xsd:element name="estimateIsExact"             type="xsd:boolean"/>
+          <xsd:element name="resultElements"              type="typens:ResultElementArray"/>
+          <xsd:element name="searchQuery"                 type="xsd:string"/>
+          <xsd:element name="startIndex"                  type="xsd:int"/>
+          <xsd:element name="endIndex"                    type="xsd:int"/>
+          <xsd:element name="searchTips"                  type="xsd:string"/>
+          <xsd:element name="directoryCategories"         type="typens:DirectoryCategoryArray"/>
+          <xsd:element name="searchTime"                  type="xsd:double"/>
+        </xsd:all>
+      </xsd:complexType>
+
+      <xsd:complexType name="ResultElement">
+        <xsd:all>
+          <xsd:element name="summary" type="xsd:string"/>
+          <xsd:element name="URL" type="xsd:string"/>
+          <xsd:element name="snippet" type="xsd:string"/>
+          <xsd:element name="title" type="xsd:string"/>
+          <xsd:element name="cachedSize" type="xsd:string"/>
+          <xsd:element name="relatedInformationPresent" type="xsd:boolean"/>
+          <xsd:element name="hostName" type="xsd:string"/>
+          <xsd:element name="directoryCategory" type="typens:DirectoryCategory"/>
+          <xsd:element name="directoryTitle" type="xsd:string"/>
+        </xsd:all>
+      </xsd:complexType>
+
+      <xsd:complexType name="ResultElementArray">
+        <xsd:complexContent>
+          <xsd:restriction base="soapenc:Array">
+             <xsd:attribute ref="soapenc:arrayType" wsdl:arrayType="typens:ResultElement[]"/>
+          </xsd:restriction>
+        </xsd:complexContent>
+      </xsd:complexType>
+
+      <xsd:complexType name="DirectoryCategoryArray">
+        <xsd:complexContent>
+          <xsd:restriction base="soapenc:Array">
+             <xsd:attribute ref="soapenc:arrayType" wsdl:arrayType="typens:DirectoryCategory[]"/>
+          </xsd:restriction>
+        </xsd:complexContent>
+      </xsd:complexType>
+
+      <xsd:complexType name="DirectoryCategory">
+        <xsd:all>
+          <xsd:element name="fullViewableName" type="xsd:string"/>
+          <xsd:element name="specialEncoding" type="xsd:string"/>
+        </xsd:all>
+      </xsd:complexType>
+
+    </xsd:schema>
+  </types>
+
+  <!-- Messages for Google Web APIs - cached page, search, spelling. -->
+
+  <message name="doGetCachedPage">
+    <part name="key"            type="xsd:string"/>
+    <part name="url"            type="xsd:string"/>
+  </message>
+
+  <message name="doGetCachedPageResponse">
+    <part name="return"         type="xsd:base64Binary"/>
+  </message>
+
+  <message name="doSpellingSuggestion">
+    <part name="key"            type="xsd:string"/>
+    <part name="phrase"         type="xsd:string"/>
+  </message>
+
+  <message name="doSpellingSuggestionResponse">
+    <part name="return"         type="xsd:string"/>
+  </message>
+
+  <!-- note, ie and oe are ignored by server; all traffic is UTF-8. -->
+
+  <message name="doGoogleSearch">
+    <part name="key"            type="xsd:string"/>
+    <part name="q"              type="xsd:string"/>
+    <part name="start"          type="xsd:int"/>
+    <part name="maxResults"     type="xsd:int"/>
+    <part name="filter"         type="xsd:boolean"/>
+    <part name="restrict"       type="xsd:string"/>
+    <part name="safeSearch"     type="xsd:boolean"/>
+    <part name="lr"             type="xsd:string"/>
+    <part name="ie"             type="xsd:string"/>
+    <part name="oe"             type="xsd:string"/>
+  </message>
+
+  <message name="doGoogleSearchResponse">
+    <part name="return"         type="typens:GoogleSearchResult"/>
+  </message>
+
+  <!-- Port for Google Web APIs, "GoogleSearch" -->
+
+  <portType name="GoogleSearchPort">
+
+    <operation name="doGetCachedPage">
+      <input message="typens:doGetCachedPage"/>
+      <output message="typens:doGetCachedPageResponse"/>
+    </operation>
+
+    <operation name="doSpellingSuggestion">
+      <input message="typens:doSpellingSuggestion"/>
+      <output message="typens:doSpellingSuggestionResponse"/>
+    </operation>
+
+    <operation name="doGoogleSearch">
+      <input message="typens:doGoogleSearch"/>
+      <output message="typens:doGoogleSearchResponse"/>
+    </operation>
+
+  </portType>
+
+
+  <!-- Binding for Google Web APIs - RPC, SOAP over HTTP -->
+
+  <binding name="GoogleSearchBinding" type="typens:GoogleSearchPort">
+    <soap:binding style="rpc"
+                  transport="http://schemas.xmlsoap.org/soap/http"/>
+
+    <operation name="doGetCachedPage">
+      <soap:operation soapAction="urn:GoogleSearchAction"/>
+      <input>
+        <soap:body use="encoded"
+                   namespace="urn:GoogleSearch"
+                   encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </input>
+      <output>
+        <soap:body use="encoded"
+                   namespace="urn:GoogleSearch"
+                   encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </output>
+    </operation>
+
+    <operation name="doSpellingSuggestion">
+      <soap:operation soapAction="urn:GoogleSearchAction"/>
+      <input>
+        <soap:body use="encoded"
+                   namespace="urn:GoogleSearch"
+                   encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </input>
+      <output>
+        <soap:body use="encoded"
+                   namespace="urn:GoogleSearch"
+                   encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </output>
+    </operation>
+
+    <operation name="doGoogleSearch">
+      <soap:operation soapAction="urn:GoogleSearchAction"/>
+      <input>
+        <soap:body use="encoded"
+                   namespace="urn:GoogleSearch"
+                   encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </input>
+      <output>
+        <soap:body use="encoded"
+                   namespace="urn:GoogleSearch"
+                   encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+      </output>
+    </operation>
+  </binding>
+
+  <!-- Endpoint for Google Web APIs -->
+  <service name="GoogleSearchService">
+    <port name="GoogleSearchPort" binding="typens:GoogleSearchBinding">
+      <soap:address location="http://api.google.com/search/beta2"/>
+    </port>
+  </service>
+
+</definitions>


### PR DESCRIPTION
 caused by special chars in wsdl filename

This might also fix https://github.com/sebastianbergmann/phpunit-mock-objects/issues/357 and fix https://github.com/sebastianbergmann/phpunit/issues/2573

Stumbled over that bug yesterday. Remote file could be load via http (`http://example.org/soap.wsdl`) but saved as local file with name (`/home/user/my-dir/acme-soap.wsdl`) lead to that error.