### PR TITLE
Convert errors independent of the error_reporting setting

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -606,8 +606,7 @@ class TestResult implements Countable
 
         if ($this->convertErrorsToExceptions) {
             $oldErrorHandler = \set_error_handler(
-                [ErrorHandler::class, 'handleError'],
-                \E_ALL | \E_STRICT
+                [ErrorHandler::class, 'handleError']
             );
 
             if ($oldErrorHandler === null) {

--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -31,7 +31,7 @@ final class ErrorHandler
 
     public static function handleError(int $errorNumber, string $errorString, string $errorFile, int $errorLine): bool
     {
-        if (!($errorNumber & \error_reporting())) {
+        if (\error_reporting() === 0) {
             return false;
         }
 


### PR DESCRIPTION
According to [the documentation](https://phpunit.readthedocs.io/en/7.1/configuration.html), all PHP errors get converted by default:

    convertErrorsToExceptions="true"
    convertNoticesToExceptions="true"
    convertWarningsToExceptions="true"

However, when reading [Testing PHP Errors](https://phpunit.readthedocs.io/en/7.1/writing-tests-for-phpunit.html#testing-php-errors) it becomes clear that it also depends on the `error_reporting` setting.

I find this unexpected behaviour and also rather undesired. The `error_reporting` setting is configured system-wide and may not be in control of the programmer.

If the [default configuration](https://github.com/php/php-src/blob/master/php.ini-production) (`error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT`) is used, you will miss static calls to non-static functions. This is what happend to me today.

Even worse, consider a system where the system administrator set `error_reporting = E_ALL & ~E_NOTICE`.
Now you run PHPUnit on this system, also setting `convertNoticesToExceptions="true"`, and you will miss undefined index errors. And not just those, there are [others](https://github.com/php/php-src/search?q=zend_error+E_NOTICE), too.

To truly let PHPUnit handle error conversion as configured, it comes down to calling PHPUnit like `phpunit -d error_reporting=32767` every time.
By the way, `phpunit -d error_reporting=E_ALL` does not work: Since it is not parsed, it ends up as being 0. So you either *hope* that `error_reporting` is configured sanely, you remember the fancy number, or you calculate it every time (I mean, just to be sure you got the digits right... Maybe try -1. Maybe not. :sweat_smile:)

Either way, this feels all very hackish!

This PR ignores `error_reporting` and hands over control back to the programmer.

It does not even need adjustments to the test suite...