### PR TITLE
Add --default-time-limit

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -258,6 +258,7 @@
         <xs:attribute name="beStrictAboutTestsThatDoNotTestAnything" type="xs:boolean" default="true"/>
         <xs:attribute name="beStrictAboutTodoAnnotatedTests" type="xs:boolean" default="false"/>
         <xs:attribute name="beStrictAboutCoversAnnotation" type="xs:boolean" default="false"/>
+        <xs:attribute name="defaultTimeLimit" type="xs:integer" default="1"/>
         <xs:attribute name="enforceTimeLimit" type="xs:boolean" default="false"/>
         <xs:attribute name="ignoreDeprecatedCodeUnitsFromCodeCoverage" type="xs:boolean" default="false"/>
         <xs:attribute name="timeoutForSmallTests" type="xs:integer" default="1"/>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -258,7 +258,7 @@
         <xs:attribute name="beStrictAboutTestsThatDoNotTestAnything" type="xs:boolean" default="true"/>
         <xs:attribute name="beStrictAboutTodoAnnotatedTests" type="xs:boolean" default="false"/>
         <xs:attribute name="beStrictAboutCoversAnnotation" type="xs:boolean" default="false"/>
-        <xs:attribute name="defaultTimeLimit" type="xs:integer" default="1"/>
+        <xs:attribute name="defaultTimeLimit" type="xs:integer" default="0"/>
         <xs:attribute name="enforceTimeLimit" type="xs:boolean" default="false"/>
         <xs:attribute name="ignoreDeprecatedCodeUnitsFromCodeCoverage" type="xs:boolean" default="false"/>
         <xs:attribute name="timeoutForSmallTests" type="xs:integer" default="1"/>

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -1106,14 +1106,6 @@ class TestResult implements Countable
     /**
      * Returns the set timeout for large tests.
      */
-    public function getDefaultTimeoutTests(): int
-    {
-        return $this->defaultTimeLimit;
-    }
-
-    /**
-     * Returns the set timeout for large tests.
-     */
     public function getTimeoutForLargeTests(): int
     {
         return $this->timeoutForLargeTests;

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -645,7 +645,8 @@ class TestResult implements Countable
         try {
             if (!$test instanceof WarningTestCase &&
                 $this->enforceTimeLimit &&
-                ($this->defaultTimeLimit || $test->getSize() != \PHPUnit\Util\Test::UNKNOWN)) {
+                ($this->defaultTimeLimit || $test->getSize() != \PHPUnit\Util\Test::UNKNOWN) &&
+                \extension_loaded('pcntl') && \class_exists(Invoker::class)) {
                 switch ($test->getSize()) {
                     case \PHPUnit\Util\Test::SMALL:
                         $_timeout = $this->timeoutForSmallTests;

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -142,7 +142,7 @@ class TestResult implements Countable
     /**
      * @var int
      */
-    protected $defaultTimeLimit = 1;
+    protected $defaultTimeLimit = 0;
 
     /**
      * @var bool
@@ -644,8 +644,8 @@ class TestResult implements Countable
 
         try {
             if (!$test instanceof WarningTestCase &&
-                $test->getSize() != \PHPUnit\Util\Test::UNKNOWN &&
                 $this->enforceTimeLimit &&
+                ($this->defaultTimeLimit || $test->getSize() != \PHPUnit\Util\Test::UNKNOWN) &&
                 \extension_loaded('pcntl') && \class_exists(Invoker::class)) {
                 switch ($test->getSize()) {
                     case \PHPUnit\Util\Test::SMALL:
@@ -660,6 +660,11 @@ class TestResult implements Countable
 
                     case \PHPUnit\Util\Test::LARGE:
                         $_timeout = $this->timeoutForLargeTests;
+
+                        break;
+
+                    case \PHPUnit\Util\Test::UNKNOWN:
+                        $_timeout = $this->defaultTimeLimit;
 
                         break;
                 }

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -140,6 +140,11 @@ class TestResult implements Countable
     protected $beStrictAboutResourceUsageDuringSmallTests = false;
 
     /**
+     * @var int
+     */
+    protected $defaultTimeLimit = 1;
+
+    /**
      * @var bool
      */
     protected $enforceTimeLimit = false;
@@ -1062,6 +1067,14 @@ class TestResult implements Countable
     }
 
     /**
+     * Sets the default timeout for tests
+     */
+    public function setDefaultTimeLimit(int $timeout): void
+    {
+        $this->defaultTimeLimit = $timeout;
+    }
+
+    /**
      * Sets the timeout for small tests.
      */
     public function setTimeoutForSmallTests(int $timeout): void
@@ -1083,6 +1096,14 @@ class TestResult implements Countable
     public function setTimeoutForLargeTests(int $timeout): void
     {
         $this->timeoutForLargeTests = $timeout;
+    }
+
+    /**
+     * Returns the set timeout for large tests.
+     */
+    public function getDefaultTimeoutTests(): int
+    {
+        return $this->defaultTimeLimit;
     }
 
     /**

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -142,7 +142,7 @@ class TestResult implements Countable
     /**
      * @var int
      */
-    protected $defaultTimeLimit = 0;
+    private $defaultTimeLimit = 0;
 
     /**
      * @var bool

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -645,8 +645,7 @@ class TestResult implements Countable
         try {
             if (!$test instanceof WarningTestCase &&
                 $this->enforceTimeLimit &&
-                ($this->defaultTimeLimit || $test->getSize() != \PHPUnit\Util\Test::UNKNOWN) &&
-                \extension_loaded('pcntl') && \class_exists(Invoker::class)) {
+                ($this->defaultTimeLimit || $test->getSize() != \PHPUnit\Util\Test::UNKNOWN)) {
                 switch ($test->getSize()) {
                     case \PHPUnit\Util\Test::SMALL:
                         $_timeout = $this->timeoutForSmallTests;

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1126,7 +1126,7 @@ Test Execution Options:
   --disallow-test-output      Be strict about output during tests
   --disallow-resource-usage   Be strict about resource usage during small tests
   --enforce-time-limit        Enforce time limit based on test size
-  --default-time-limit=<sec>  Maximum running time in seconds for unsized tests
+  --default-time-limit=<sec>  Timeout in seconds for tests without @small, @medium or @large
   --disallow-todo-tests       Disallow @todo-annotated tests
 
   --process-isolation         Run each test in a separate PHP process

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1126,6 +1126,7 @@ Test Execution Options:
   --disallow-test-output      Be strict about output during tests
   --disallow-resource-usage   Be strict about resource usage during small tests
   --enforce-time-limit        Enforce time limit based on test size
+  --default-time-limit=<sec>  Maximum running time in seconds for unsized tests
   --disallow-todo-tests       Disallow @todo-annotated tests
 
   --process-isolation         Run each test in a separate PHP process

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -84,6 +84,7 @@ class Command
         'disallow-test-output'      => null,
         'disallow-resource-usage'   => null,
         'disallow-todo-tests'       => null,
+        'default-time-limit='       => null,
         'enforce-time-limit'        => null,
         'exclude-group='            => null,
         'filter='                   => null,
@@ -689,6 +690,11 @@ class Command
 
                 case '--disallow-resource-usage':
                     $this->arguments['beStrictAboutResourceUsageDuringSmallTests'] = true;
+
+                    break;
+
+                case '--default-time-limit':
+                    $this->arguments['defaultTimeLimit'] = (int) $option[1];
 
                     break;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -1184,7 +1184,7 @@ class TestRunner extends BaseTestRunner
         $arguments['crap4jThreshold']                                 = $arguments['crap4jThreshold'] ?? 30;
         $arguments['disallowTestOutput']                              = $arguments['disallowTestOutput'] ?? false;
         $arguments['disallowTodoAnnotatedTests']                      = $arguments['disallowTodoAnnotatedTests'] ?? false;
-        $arguments['defaultTimeLimit']                                = $arguments['defaultTimeLimit'] ?? 1;
+        $arguments['defaultTimeLimit']                                = $arguments['defaultTimeLimit'] ?? 0;
         $arguments['enforceTimeLimit']                                = $arguments['enforceTimeLimit'] ?? false;
         $arguments['excludeGroups']                                   = $arguments['excludeGroups'] ?? [];
         $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? false;

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -580,6 +580,7 @@ class TestRunner extends BaseTestRunner
         $result->beStrictAboutTodoAnnotatedTests($arguments['disallowTodoAnnotatedTests']);
         $result->beStrictAboutResourceUsageDuringSmallTests($arguments['beStrictAboutResourceUsageDuringSmallTests']);
         $result->enforceTimeLimit($arguments['enforceTimeLimit']);
+        $result->setDefaultTimeLimit($arguments['defaultTimeLimit']);
         $result->setTimeoutForSmallTests($arguments['timeoutForSmallTests']);
         $result->setTimeoutForMediumTests($arguments['timeoutForMediumTests']);
         $result->setTimeoutForLargeTests($arguments['timeoutForLargeTests']);
@@ -942,6 +943,10 @@ class TestRunner extends BaseTestRunner
                 $arguments['disallowTestOutput'] = $phpunitConfiguration['disallowTestOutput'];
             }
 
+            if (isset($phpunitConfiguration['defaultTimeLimit']) && !isset($arguments['defaultTimeLimit'])) {
+                $arguments['defaultTimeLimit'] = $phpunitConfiguration['defaultTimeLimit'];
+            }
+
             if (isset($phpunitConfiguration['enforceTimeLimit']) && !isset($arguments['enforceTimeLimit'])) {
                 $arguments['enforceTimeLimit'] = $phpunitConfiguration['enforceTimeLimit'];
             }
@@ -1179,6 +1184,7 @@ class TestRunner extends BaseTestRunner
         $arguments['crap4jThreshold']                                 = $arguments['crap4jThreshold'] ?? 30;
         $arguments['disallowTestOutput']                              = $arguments['disallowTestOutput'] ?? false;
         $arguments['disallowTodoAnnotatedTests']                      = $arguments['disallowTodoAnnotatedTests'] ?? false;
+        $arguments['defaultTimeLimit']                                = $arguments['defaultTimeLimit'] ?? 1;
         $arguments['enforceTimeLimit']                                = $arguments['enforceTimeLimit'] ?? false;
         $arguments['excludeGroups']                                   = $arguments['excludeGroups'] ?? [];
         $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? false;

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -54,6 +54,7 @@ use SebastianBergmann\CodeCoverage\Report\Text as TextReport;
 use SebastianBergmann\CodeCoverage\Report\Xml\Facade as XmlReport;
 use SebastianBergmann\Comparator\Comparator;
 use SebastianBergmann\Environment\Runtime;
+use SebastianBergmann\Invoker\Invoker;
 
 /**
  * A TestRunner for the Command Line Interface (CLI)
@@ -579,6 +580,16 @@ class TestRunner extends BaseTestRunner
         $result->beStrictAboutOutputDuringTests($arguments['disallowTestOutput']);
         $result->beStrictAboutTodoAnnotatedTests($arguments['disallowTodoAnnotatedTests']);
         $result->beStrictAboutResourceUsageDuringSmallTests($arguments['beStrictAboutResourceUsageDuringSmallTests']);
+
+        if ($arguments['enforceTimeLimit'] === true) {
+            if (!\class_exists(Invoker::class)) {
+                $this->writeMessage('Error', 'Package phpunit/php-invoker is required for enforcing time limits');
+            }
+
+            if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
+                $this->writeMessage('Error', 'PHP extension pcntl is required for enforcing time limits');
+            }
+        }
         $result->enforceTimeLimit($arguments['enforceTimeLimit']);
         $result->setDefaultTimeLimit($arguments['defaultTimeLimit']);
         $result->setTimeoutForSmallTests($arguments['timeoutForSmallTests']);

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -59,7 +59,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
  *          beStrictAboutResourceUsageDuringSmallTests="false"
  *          beStrictAboutTestsThatDoNotTestAnything="false"
  *          beStrictAboutTodoAnnotatedTests="false"
- *          defaultTimeLimit="1"
+ *          defaultTimeLimit="0"
  *          enforceTimeLimit="false"
  *          ignoreDeprecatedCodeUnitsFromCodeCoverage="false"
  *          timeoutForSmallTests="1"

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -59,6 +59,7 @@ use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
  *          beStrictAboutResourceUsageDuringSmallTests="false"
  *          beStrictAboutTestsThatDoNotTestAnything="false"
  *          beStrictAboutTodoAnnotatedTests="false"
+ *          defaultTimeLimit="1"
  *          enforceTimeLimit="false"
  *          ignoreDeprecatedCodeUnitsFromCodeCoverage="false"
  *          timeoutForSmallTests="1"
@@ -852,6 +853,13 @@ final class Configuration
             $result['strictCoverage'] = $this->getBoolean(
                 (string) $root->getAttribute('beStrictAboutCoversAnnotation'),
                 false
+            );
+        }
+
+        if ($root->hasAttribute('defaultTimeLimit')) {
+            $result['defaultTimeLimit'] = $this->getInteger(
+                (string) $root->getAttribute('defaultTimeLimit'),
+                1
             );
         }
 

--- a/tests/Regression/GitHub/2085/Issue2085Test.php
+++ b/tests/Regression/GitHub/2085/Issue2085Test.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class Issue2085Test extends TestCase
+{
+    public function testShouldAbortSlowTestByEnforcingTimeLimit(): void
+    {
+        $this->assertTrue(true);
+        \sleep(2);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Regression/GitHub/2085/Issue2085Test.php
+++ b/tests/Regression/GitHub/2085/Issue2085Test.php
@@ -14,7 +14,7 @@ class Issue2085Test extends TestCase
     public function testShouldAbortSlowTestByEnforcingTimeLimit(): void
     {
         $this->assertTrue(true);
-        \sleep(2);
+        \sleep(1.2);
         $this->assertTrue(true);
     }
 }

--- a/tests/Regression/GitHub/2085/configuration_enforce_time_limit_options.xml
+++ b/tests/Regression/GitHub/2085/configuration_enforce_time_limit_options.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit enforceTimeLimit="true" defaultTimeLimit="1" />

--- a/tests/Regression/GitHub/2085/enforce-time-limit-options-via-config-without-invoker.phpt
+++ b/tests/Regression/GitHub/2085/enforce-time-limit-options-via-config-without-invoker.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test XML config enforceTimeLimit, defaultTimeLimit without php-invoker, with pcntl
+--SKIPIF--
+<?php
+if (\class_exists(Invoker::class)) {
+    print "Skip: package phpunit/php-invoker is installed" . PHP_EOL;
+}
+
+if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
+    print "Skip: extension pcntl is required for enforcing time limits" . PHP_EOL;
+}
+--DESCRIPTION--
+https://github.com/sebastianbergmann/phpunit/issues/2085
+--FILE--
+<?php
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = __DIR__ . '/configuration_enforce_time_limit_options.xml';
+$_SERVER['argv'][3] = __DIR__ . '/Issue2085Test.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+Error:         Package phpunit/php-invoker is required for enforcing time limits
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 2 assertions)

--- a/tests/Regression/GitHub/2085/issue-2085-test-missing-invoker.phpt
+++ b/tests/Regression/GitHub/2085/issue-2085-test-missing-invoker.phpt
@@ -1,11 +1,11 @@
 --TEST--
-Test CLI flags --enforce-time-limit --default-time-limit
+Test CLI flags --enforce-time-limit --default-time-limit when missing php-invoker, has pcntl
 --DESCRIPTION--
 https://github.com/sebastianbergmann/phpunit/issues/2085
 --SKIPIF--
 <?php
-if (!\class_exists(Invoker::class)) {
-    print "Skip: package phpunit/php-invoker is required for enforcing time limits" . PHP_EOL;
+if (\class_exists(Invoker::class)) {
+    print "Skip: package phpunit/php-invoker is installed" . PHP_EOL;
 }
 
 if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
@@ -15,7 +15,7 @@ if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--enforce-time-limit';
-$_SERVER['argv'][3] = '--default-time-limit=1';
+$_SERVER['argv'][3] = '--default-time-limit=10';
 $_SERVER['argv'][4] = __DIR__ . '/Issue2085Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
@@ -23,14 +23,10 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-R                                                                   1 / 1 (100%)
+
+Error:         Package phpunit/php-invoker is required for enforcing time limits
+.                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %s
 
-There was 1 risky test:
-
-1) Issue2085Test::testShouldAbortSlowTestByEnforcingTimeLimit
-Execution aborted after 1 second
-
-OK, but incomplete, skipped, or risky tests!
-Tests: 1, Assertions: 1, Risky: 1.
+OK (1 test, 2 assertions)

--- a/tests/Regression/GitHub/2085/issue-2085-test-without-invoker.phpt
+++ b/tests/Regression/GitHub/2085/issue-2085-test-without-invoker.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test CLI flags --enforce-time-limit --default-time-limit when missing php-invoker, has pcntl
+Test CLI flags --enforce-time-limit --default-time-limit without php-invoker, with pcntl
 --DESCRIPTION--
 https://github.com/sebastianbergmann/phpunit/issues/2085
 --SKIPIF--

--- a/tests/Regression/GitHub/2085/issue-2085-test.phpt
+++ b/tests/Regression/GitHub/2085/issue-2085-test.phpt
@@ -2,8 +2,12 @@
 https://github.com/sebastianbergmann/phpunit/issues/2085
 --SKIPIF--
 <?php
-if (false || !\class_exists(Invoker::class)) {
-    print "Package phpunit/php-invoker is required for enforcing time limits");
+if (!\class_exists(Invoker::class)) {
+    print "Skip: package phpunit/php-invoker is required for enforcing time limits" . PHP_EOL;
+}
+
+if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
+    print "Skip: extension pcntl is required for enforcing time limits" . PHP_EOL;
 }
 --FILE--
 <?php

--- a/tests/Regression/GitHub/2085/issue-2085-test.phpt
+++ b/tests/Regression/GitHub/2085/issue-2085-test.phpt
@@ -1,0 +1,30 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/2085
+--SKIPIF--
+<?php
+if (false || !\class_exists(Invoker::class)) {
+    print "Package phpunit/php-invoker is required for enforcing time limits");
+}
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--enforce-time-limit';
+$_SERVER['argv'][3] = '--default-time-limit=1';
+$_SERVER['argv'][4] = __DIR__ . '/Issue2085Test.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+R                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) Issue2085Test::testShouldAbortSlowTestByEnforcingTimeLimit
+Execution aborted after 1 second
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 1, Risky: 1.

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -25,6 +25,7 @@
          beStrictAboutTestsThatDoNotTestAnything="false"
          beStrictAboutTodoAnnotatedTests="false"
          beStrictAboutCoversAnnotation="false"
+         defaultTimeLimit="123"
          enforceTimeLimit="false"
          ignoreDeprecatedCodeUnitsFromCodeCoverage="false"
          timeoutForSmallTests="1"

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -26,6 +26,7 @@
          beStrictAboutTestsThatDoNotTestAnything="false"
          beStrictAboutTodoAnnotatedTests="false"
          beStrictAboutCoversAnnotation="false"
+         defaultTimeLimit="123"
          enforceTimeLimit="false"
          ignoreDeprecatedCodeUnitsFromCodeCoverage="false"
          timeoutForSmallTests="1"

--- a/tests/end-to-end/help.phpt
+++ b/tests/end-to-end/help.phpt
@@ -56,7 +56,7 @@ Test Execution Options:
   --disallow-test-output      Be strict about output during tests
   --disallow-resource-usage   Be strict about resource usage during small tests
   --enforce-time-limit        Enforce time limit based on test size
-  --default-time-limit=<sec>  Maximum running time in seconds for unsized tests
+  --default-time-limit=<sec>  Timeout in seconds for tests without @small, @medium or @large
   --disallow-todo-tests       Disallow @todo-annotated tests
 
   --process-isolation         Run each test in a separate PHP process

--- a/tests/end-to-end/help.phpt
+++ b/tests/end-to-end/help.phpt
@@ -56,6 +56,7 @@ Test Execution Options:
   --disallow-test-output      Be strict about output during tests
   --disallow-resource-usage   Be strict about resource usage during small tests
   --enforce-time-limit        Enforce time limit based on test size
+  --default-time-limit=<sec>  Maximum running time in seconds for unsized tests
   --disallow-todo-tests       Disallow @todo-annotated tests
 
   --process-isolation         Run each test in a separate PHP process

--- a/tests/end-to-end/help2.phpt
+++ b/tests/end-to-end/help2.phpt
@@ -57,7 +57,7 @@ Test Execution Options:
   --disallow-test-output      Be strict about output during tests
   --disallow-resource-usage   Be strict about resource usage during small tests
   --enforce-time-limit        Enforce time limit based on test size
-  --default-time-limit=<sec>  Maximum running time in seconds for unsized tests
+  --default-time-limit=<sec>  Timeout in seconds for tests without @small, @medium or @large
   --disallow-todo-tests       Disallow @todo-annotated tests
 
   --process-isolation         Run each test in a separate PHP process

--- a/tests/end-to-end/help2.phpt
+++ b/tests/end-to-end/help2.phpt
@@ -57,6 +57,7 @@ Test Execution Options:
   --disallow-test-output      Be strict about output during tests
   --disallow-resource-usage   Be strict about resource usage during small tests
   --enforce-time-limit        Enforce time limit based on test size
+  --default-time-limit=<sec>  Maximum running time in seconds for unsized tests
   --disallow-todo-tests       Disallow @todo-annotated tests
 
   --process-isolation         Run each test in a separate PHP process

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -471,6 +471,7 @@ class ConfigurationTest extends TestCase
                 'reportUselessTests'                         => false,
                 'strictCoverage'                             => false,
                 'disallowTestOutput'                         => false,
+                'defaultTimeLimit'                           => 123,
                 'enforceTimeLimit'                           => false,
                 'extensionsDirectory'                        => '/tmp',
                 'printerClass'                               => 'PHPUnit\TextUI\ResultPrinter',

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -155,6 +155,22 @@ class ConfigurationTest extends TestCase
         @\unlink($tmpFilename);
     }
 
+    public function testShouldParseXmlConfigurationToEnforceTimeLimitAndDefaultTimeout(): void
+    {
+        $tmpFilename = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'phpunit.' . \uniqid() . '.xml';
+        $xml         = "<phpunit enforceTimeLimit='true' defaultTimeLimit='432'></phpunit>" . \PHP_EOL;
+        \file_put_contents($tmpFilename, $xml);
+
+        $configurationInstance = Configuration::getInstance($tmpFilename);
+        $this->assertFalse($configurationInstance->hasValidationErrors(), 'option causes validation error');
+
+        $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
+        $this->assertSame(true, $configurationValues['enforceTimeLimit']);
+        $this->assertSame(432, $configurationValues['defaultTimeLimit']);
+
+        @\unlink($tmpFilename);
+    }
+
     public function testFilterConfigurationIsReadCorrectly(): void
     {
         $this->assertEquals(

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -155,22 +155,6 @@ class ConfigurationTest extends TestCase
         @\unlink($tmpFilename);
     }
 
-    public function testShouldParseXmlConfigurationToEnforceTimeLimitAndDefaultTimeout(): void
-    {
-        $tmpFilename = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'phpunit.' . \uniqid() . '.xml';
-        $xml         = "<phpunit enforceTimeLimit='true' defaultTimeLimit='432'></phpunit>" . \PHP_EOL;
-        \file_put_contents($tmpFilename, $xml);
-
-        $configurationInstance = Configuration::getInstance($tmpFilename);
-        $this->assertFalse($configurationInstance->hasValidationErrors(), 'option causes validation error');
-
-        $configurationValues   = $configurationInstance->getPHPUnitConfiguration();
-        $this->assertSame(true, $configurationValues['enforceTimeLimit']);
-        $this->assertSame(432, $configurationValues['defaultTimeLimit']);
-
-        @\unlink($tmpFilename);
-    }
-
     public function testFilterConfigurationIsReadCorrectly(): void
     {
         $this->assertEquals(


### PR DESCRIPTION
Implementation for #2085 

This is a convenience feature for people managing large(r) and potentially slow legacy test collections. Classic example: tests for database integration that have huge `@dataprovider` sets or when using PHPUnit to test webservices/APIs.

Note: I tried running around with my laptop, however I did not manage to validate the timer at relativistic speeds.

