### PR TITLE
Fixed TypeHinting for JUnit::setWriteDocument

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -367,9 +367,11 @@ class JUnit extends Printer implements TestListener
      * @param bool $flag Enables or disables the writing of the document.
      *                   default: `true`
      */
-    public function setWriteDocument(bool $flag): void
+    public function setWriteDocument($flag): void
     {
-        $this->writeDocument = $flag;
+        if (\is_bool($flag)) {
+            $this->writeDocument = $flag;
+        }
     }
 
     /**

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -363,7 +363,7 @@ class JUnit extends Printer implements TestListener
      *
      * This is a "hack" needed for the integration of
      * PHPUnit with Phing.
-     * 
+     *
      * @param bool $flag Enables or disables the writing of the document.
      *                   default: `true`
      */

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -363,12 +363,12 @@ class JUnit extends Printer implements TestListener
      *
      * This is a "hack" needed for the integration of
      * PHPUnit with Phing.
+     * 
+     * @param bool $flag
      */
-    public function setWriteDocument($flag): ?string
+    public function setWriteDocument(bool $flag): void
     {
-        if (\is_bool($flag)) {
-            $this->writeDocument = $flag;
-        }
+        $this->writeDocument = $flag;
     }
 
     /**

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -364,7 +364,8 @@ class JUnit extends Printer implements TestListener
      * This is a "hack" needed for the integration of
      * PHPUnit with Phing.
      * 
-     * @param bool $flag
+     * @param bool $flag Enables or disables the writing of the document.
+     *                   default: `true`
      */
     public function setWriteDocument(bool $flag): void
     {


### PR DESCRIPTION
By invoking `JUnit::setWriteDocument` the result is:
```
Return value of PHPUnit\Util\Log\JUnit::setWriteDocument() must be of the type string or null, none returned
```
