### PR TITLE
Avoid mkdir() race condition

### DIFF
--- a/src/Util/Printer.php
+++ b/src/Util/Printer.php
@@ -54,7 +54,9 @@ class Printer
                     $this->out = \fsockopen($out[0], $out[1]);
                 } else {
                     if (\strpos($out, 'php://') === false && !\is_dir(\dirname($out))) {
-                        \mkdir(\dirname($out), 0777, true);
+                        if (!@\mkdir(\dirname($out), 0777, true) && !\is_dir(\dirname($out))) {
+                            throw new Exception('Failed to create directory '.\dirname($out));
+                        }
                     }
 
                     $this->out = \fopen($out, 'wt');


### PR DESCRIPTION
Rather unconfirmed, but I _think_ https://github.com/elifesciences/journal/pull/1039 was caused by a `is_dir()`/`mkdir()` race condition (we're using [Fastest](https://github.com/liuggio/fastest)).