### PR TITLE
Do not create cache file by default #3237

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -223,7 +223,7 @@
         <xs:attribute name="backupGlobals" type="xs:boolean" default="false"/>
         <xs:attribute name="backupStaticAttributes" type="xs:boolean" default="false"/>
         <xs:attribute name="bootstrap" type="xs:anyURI"/>
-        <xs:attribute name="cacheResult" type="xs:boolean"/>
+        <xs:attribute name="cacheResult" type="xs:boolean" default="false"/>
         <xs:attribute name="cacheResultFile" type="xs:anyURI"/>
         <xs:attribute name="cacheTokens" type="xs:boolean"/>
         <xs:attribute name="colors" type="xs:boolean" default="false"/>

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -1157,7 +1157,7 @@ class TestRunner extends BaseTestRunner
         $arguments['backupStaticAttributes']                          = $arguments['backupStaticAttributes'] ?? null;
         $arguments['beStrictAboutChangesToGlobalState']               = $arguments['beStrictAboutChangesToGlobalState'] ?? null;
         $arguments['beStrictAboutResourceUsageDuringSmallTests']      = $arguments['beStrictAboutResourceUsageDuringSmallTests'] ?? false;
-        $arguments['cacheResult']                                     = $arguments['cacheResult'] ?? true;
+        $arguments['cacheResult']                                     = $arguments['cacheResult'] ?? false;
         $arguments['cacheTokens']                                     = $arguments['cacheTokens'] ?? false;
         $arguments['colors']                                          = $arguments['colors'] ?? ResultPrinter::COLOR_DEFAULT;
         $arguments['columns']                                         = $arguments['columns'] ?? 80;

--- a/tests/TextUI/defects-first-order-via-cli.phpt
+++ b/tests/TextUI/defects-first-order-via-cli.phpt
@@ -8,9 +8,10 @@ file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/../_files/Multi
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
 $_SERVER['argv'][3] = '--order-by=defects';
-$_SERVER['argv'][4] = '--cache-result-file=' . $tmpResultCache;
-$_SERVER['argv'][5] = 'MultiDependencyTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][4] = '--cache-result';
+$_SERVER['argv'][5] = '--cache-result-file=' . $tmpResultCache;
+$_SERVER['argv'][6] = 'MultiDependencyTest';
+$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();


### PR DESCRIPTION
The documentation read this feature is disabled by default it was enabled anyway.

Disable it by default to maintain backwards compatibility and allow tests to run on read only filesystem.

ref: #3237