### PR TITLE
Support @...Order annotations to set order of @before, @beforeClass, …

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -829,7 +829,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
             if ($this->inIsolation) {
                 foreach ($hookMethods['beforeClass'] as $method) {
-                    $this->$method();
+                    $methodName = $method['name'];
+                    $this->$methodName();
                 }
             }
 
@@ -837,7 +838,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->setDoesNotPerformAssertionsFromAnnotation();
 
             foreach ($hookMethods['before'] as $method) {
-                $this->$method();
+                $methodName = $method['name'];
+                $this->$methodName();
             }
 
             $this->assertPreConditions();
@@ -884,12 +886,14 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         try {
             if ($hasMetRequirements) {
                 foreach ($hookMethods['after'] as $method) {
-                    $this->$method();
+                    $methodName = $method['name'];
+                    $this->$methodName();
                 }
 
                 if ($this->inIsolation) {
                     foreach ($hookMethods['afterClass'] as $method) {
-                        $this->$method();
+                        $methodName = $method['name'];
+                        $this->$methodName();
                     }
                 }
             }

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -693,6 +693,8 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             $this->setUp();
 
             foreach ($hookMethods['beforeClass'] as $beforeClassMethod) {
+                $beforeClassMethod = $beforeClassMethod['name'];
+
                 if ($this->testCase === true &&
                     \class_exists($this->name, false) &&
                     \method_exists($this->name, $beforeClassMethod)) {
@@ -751,6 +753,8 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
         }
 
         foreach ($hookMethods['afterClass'] as $afterClassMethod) {
+            $afterClassMethod = $afterClassMethod['name'];
+
             if ($this->testCase === true && \class_exists($this->name, false) && \method_exists($this->name, $afterClassMethod)) {
                 \call_user_func([$this->name, $afterClassMethod]);
             }


### PR DESCRIPTION
Support @...Order annotations to set order of @before, @beforeClass, @after and @afterClass

This adds support for annotations that help prioritize execution of hook methods. If this sounds reasonable, I can add update for documentation.

Basically, we're using @before/after etc. to initialize kernel, databases, kafka and other services in tests. However sometimes dependencies require other dependencies (eg. our Database-injecting trait requires kernel trait to be injected before).

This helps to sort those hooks between each other when for example `@beforeClassOrder 10` is added.

`@before` with `@beforeClassOrder 10` is executed sooner than `@before` with `@beforeClassOrder 11` and `@before` with no _order_ annotation.