### PR TITLE
Add missing xs:choice 

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -18,12 +18,14 @@
     </xs:complexType>
     <xs:complexType name="filterType">
         <xs:sequence>
-            <xs:group ref="pathGroup"/>
-            <xs:element name="exclude" maxOccurs="unbounded" minOccurs="0">
-                <xs:complexType>
-                    <xs:group ref="pathGroup"/>
-                </xs:complexType>
-            </xs:element>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+                <xs:group ref="pathGroup"/>
+                <xs:element name="exclude">
+                    <xs:complexType>
+                        <xs:group ref="pathGroup"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="whiteListType">
@@ -153,8 +155,10 @@
     </xs:complexType>
     <xs:group name="pathGroup">
         <xs:sequence>
-            <xs:element name="directory" type="directoryFilterType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="file" type="fileFilterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="directory" type="directoryFilterType"/>
+                <xs:element name="file" type="fileFilterType"/>
+            </xs:choice>
         </xs:sequence>
     </xs:group>
     <xs:complexType name="directoryFilterType">


### PR DESCRIPTION
Some xs:sequence nodes of the xsd need xs:choice to make the sort order become irrelevant as PHPUnit doesn't care and the config is perfectly valid either way.

Fixes #3248 
