### PR TITLE
Print duration of the tests events in the TeamCity logger

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -76,6 +76,7 @@ class TeamCity extends ResultPrinter
                 'name'    => $test->getName(),
                 'message' => self::getMessage($e),
                 'details' => self::getDetails($e),
+                'duration' => self::toMilliseconds($time),
             ]
         );
     }
@@ -94,7 +95,8 @@ class TeamCity extends ResultPrinter
             [
                 'name'    => $test->getName(),
                 'message' => self::getMessage($e),
-                'details' => self::getDetails($e)
+                'details' => self::getDetails($e),
+                'duration' => self::toMilliseconds($time),
             ]
         );
     }
@@ -112,6 +114,7 @@ class TeamCity extends ResultPrinter
             'name'    => $test->getName(),
             'message' => self::getMessage($e),
             'details' => self::getDetails($e),
+            'duration' => self::toMilliseconds($time),
         ];
 
         if ($e instanceof ExpectationFailedException) {
@@ -150,7 +153,7 @@ class TeamCity extends ResultPrinter
      */
     public function addIncompleteTest(Test $test, \Exception $e, $time)
     {
-        $this->printIgnoredTest($test->getName(), $e);
+        $this->printIgnoredTest($test->getName(), $e, $time);
     }
 
     /**
@@ -177,14 +180,14 @@ class TeamCity extends ResultPrinter
         $testName = $test->getName();
         if ($this->startedTestName != $testName) {
             $this->startTest($test);
-            $this->printIgnoredTest($testName, $e);
+            $this->printIgnoredTest($testName, $e, $time);
             $this->endTest($test, $time);
         } else {
-            $this->printIgnoredTest($testName, $e);
+            $this->printIgnoredTest($testName, $e, $time);
         }
     }
 
-    public function printIgnoredTest($testName, \Exception $e)
+    public function printIgnoredTest($testName, \Exception $e, $time)
     {
         $this->printEvent(
             'testIgnored',
@@ -192,6 +195,7 @@ class TeamCity extends ResultPrinter
                 'name'    => $testName,
                 'message' => self::getMessage($e),
                 'details' => self::getDetails($e),
+                'duration' => self::toMilliseconds($time),
             ]
         );
     }
@@ -302,7 +306,7 @@ class TeamCity extends ResultPrinter
             'testFinished',
             [
                 'name'     => $test->getName(),
-                'duration' => (int) (\round($time, 2) * 1000)
+                'duration' => self::toMilliseconds($time),
             ]
         );
     }
@@ -419,5 +423,14 @@ class TeamCity extends ResultPrinter
         $reflectionClass = new ReflectionClass($className);
 
         return $reflectionClass->getFileName();
+    }
+
+    /**
+     * @param float $time microseconds
+     * @return int
+     */
+    private static function toMilliseconds($time)
+    {
+        return \round($time * 1000);
     }
 }

--- a/tests/TextUI/teamcity-inner-exceptions.phpt
+++ b/tests/TextUI/teamcity-inner-exceptions.phpt
@@ -19,13 +19,13 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ##teamcity[testStarted name='testPrintingChildException' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest::testPrintingChildException' flowId='%d']
 
-##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n' details=' %s%eExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n |n %s%eExceptionStackTest.php:10|n ' flowId='%d']
+##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n' details=' %s%eExceptionStackTest.php:14|n |n Caused by|n message|n Failed asserting that two arrays are equal.|n --- Expected|n +++ Actual|n @@ @@|n  Array (|n -    0 => 1|n +    0 => 2|n |n %s%eExceptionStackTest.php:10|n ' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testPrintingChildException' duration='%d' flowId='%d']
 
 ##teamcity[testStarted name='testNestedExceptions' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\ExceptionStackTest::testNestedExceptions' flowId='%d']
 
-##teamcity[testFailed name='testNestedExceptions' message='Exception : One' details=' %s%etests%e_files%eExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s%etests%e_files%eExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s%etests%e_files%eExceptionStackTest.php:20|n ' flowId='%d']
+##teamcity[testFailed name='testNestedExceptions' message='Exception : One' details=' %s%etests%e_files%eExceptionStackTest.php:22|n |n Caused by|n InvalidArgumentException: Two|n |n %s%etests%e_files%eExceptionStackTest.php:21|n |n Caused by|n Exception: Three|n |n %s%etests%e_files%eExceptionStackTest.php:20|n ' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testNestedExceptions' duration='%d' flowId='%d']
 


### PR DESCRIPTION
6.5 PR version of #3251 