### PR TITLE
Add Exception callable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -156,6 +156,13 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
      * @var int|string
      */
     private $expectedExceptionCode = null;
+    
+    /**
+     * The callable that tests the expected Exception.
+     *
+     * @var callable
+     */
+    private $expectedExceptionCallable = null;
 
     /**
      * The name of the test case.
@@ -621,6 +628,26 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
         }
 
         $this->expectedExceptionMessageRegExp = $messageRegExp;
+    }
+
+    /**
+     * The callable method will be called with the Exception as parameter
+     *
+     * @param callable $callable
+     *
+     * @throws PHPUnit_Framework_Exception
+     */
+    public function expectExceptionCustom(callable $callable)
+    {
+        if (!$this->expectedException) {
+            $this->expectedException = \Exception::class;
+        }
+
+        if (!is_callable($callable)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(1, 'callable');
+        }
+
+        $this->expectedExceptionCallable = $callable;
     }
 
     /**
@@ -1120,6 +1147,10 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
                     );
                 }
 
+                if ($this->expectedExceptionCallable !== null) {
+                    call_user_func_array($this->expectedExceptionCallable, [$e]);
+                }
+                
                 return;
             } else {
                 throw $e;


### PR DESCRIPTION
I've added the option to configure a callable for exceptions. The goal is to test custom Exception properties, like [ErrorException::getSeverity](http://php.net/manual/en/errorexception.getseverity.php).

A test could look like this:
```$this->expectException(\ErrorException::class);
$this->expectExceptionMessage($errstr);
$this->expectExceptionCustom(function (\ErrorException $ex) use ($errno) {
    $this->assertEquals($errno, $ex->getSeverity());
});
```