### PR TITLE
Make testdox print more useful dataSet messages

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -84,7 +84,7 @@ final class NamePrettifier
         }
 
         if ($test->usesDataProvider() && !$annotationWithPlaceholders) {
-            $result .= ' data set "' . $test->dataDescription() . '"';
+            $result .= $test->getDataSetAsString();
         }
 
         return $result;


### PR DESCRIPTION
reused `getDataSetAsString` method to make this


Issue:

![image](https://user-images.githubusercontent.com/39970/44598272-a24e4300-a78f-11e8-81ba-a584571f4016.png)

Solution:
![image](https://user-images.githubusercontent.com/39970/44598388-1a1c6d80-a790-11e8-8cf0-79b385359445.png)


