### PR TITLE
Don't escape slashes in prettified JSON

### DIFF
--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -28,7 +28,7 @@ final class Json
             );
         }
 
-        return \json_encode($decodedJson, \JSON_PRETTY_PRINT);
+        return \json_encode($decodedJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES);
     }
 
     /*

--- a/tests/Util/JsonTest.php
+++ b/tests/Util/JsonTest.php
@@ -60,6 +60,7 @@ class JsonTest extends TestCase
     {
         return [
             ['{"name":"John","age": "5"}', "{\n    \"name\": \"John\",\n    \"age\": \"5\"\n}"],
+            ['{"url":"https://www.example.com/"}', "{\n    \"url\": \"https://www.example.com/\"\n}"],
         ];
     }
 


### PR DESCRIPTION
* Slashes are not needed in JSON
* In particular JSON objects with lots of URL are easier on the eye