### PR TITLE
Fix % escaping (all cases) for StringMatchesFormat 

### DIFF
--- a/src/Framework/Constraint/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/StringMatchesFormatDescription.php
@@ -75,37 +75,23 @@ class StringMatchesFormatDescription extends RegularExpression
 
     private function createPatternFromFormat(string $string): string
     {
-        $string = \preg_replace(
+        $string = \strtr(
+            \preg_quote($string, '/'),
             [
-                '/(?<!%)%e/',
-                '/(?<!%)%s/',
-                '/(?<!%)%S/',
-                '/(?<!%)%a/',
-                '/(?<!%)%A/',
-                '/(?<!%)%w/',
-                '/(?<!%)%i/',
-                '/(?<!%)%d/',
-                '/(?<!%)%x/',
-                '/(?<!%)%f/',
-                '/(?<!%)%c/'
-            ],
-            [
-                \str_replace('\\', '\\\\', '\\' . \DIRECTORY_SEPARATOR),
-                '[^\r\n]+',
-                '[^\r\n]*',
-                '.+',
-                '.*',
-                '\s*',
-                '[+-]?\d+',
-                '\d+',
-                '[0-9a-fA-F]+',
-                '[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?',
-                '.'
-            ],
-            \preg_quote($string, '/')
+                '%%' => '%',
+                '%e' => '\\' . \DIRECTORY_SEPARATOR,
+                '%s' => '[^\r\n]+',
+                '%S' => '[^\r\n]*',
+                '%a' => '.+',
+                '%A' => '.*',
+                '%w' => '\s*',
+                '%i' => '[+-]?\d+',
+                '%d' => '\d+',
+                '%x' => '[0-9a-fA-F]+',
+                '%f' => '[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?',
+                '%c' => '.'
+            ]
         );
-
-        $string = \str_replace('%%', '%', $string);
 
         return '/^' . $string . '$/s';
     }

--- a/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -13,13 +13,13 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 class StringMatchesFormatDescriptionTest extends ConstraintTestCase
 {
-    public function testConstraintStringMatchesCharacter(): void
+    public function testConstraintStringMatchesDirectorySeparator(): void
     {
-        $constraint = new StringMatchesFormatDescription('*%c*');
+        $constraint = new StringMatchesFormatDescription('*%e*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
-        $this->assertTrue($constraint->evaluate('***', '', true));
-        $this->assertEquals('matches PCRE pattern "/^\*.\*$/s"', $constraint->toString());
+        $this->assertTrue($constraint->evaluate('*' . \DIRECTORY_SEPARATOR . '*', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\*\\' . \DIRECTORY_SEPARATOR . '\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
 
@@ -30,6 +30,46 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertFalse($constraint->evaluate('**', '', true));
         $this->assertTrue($constraint->evaluate('***', '', true));
         $this->assertEquals('matches PCRE pattern "/^\*[^\r\n]+\*$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesOptionalString(): void
+    {
+        $constraint = new StringMatchesFormatDescription('*%S*');
+
+        $this->assertFalse($constraint->evaluate('*', '', true));
+        $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\*[^\r\n]*\*$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesAnything(): void
+    {
+        $constraint = new StringMatchesFormatDescription('*%a*');
+
+        $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\*.+\*$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesOptionalAnything(): void
+    {
+        $constraint = new StringMatchesFormatDescription('*%A*');
+
+        $this->assertFalse($constraint->evaluate('*', '', true));
+        $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\*.*\*$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesWhitespace(): void
+    {
+        $constraint = new StringMatchesFormatDescription('*%w*');
+
+        $this->assertFalse($constraint->evaluate('*', '', true));
+        $this->assertTrue($constraint->evaluate('* *', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\*\s*\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
 
@@ -70,6 +110,16 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertFalse($constraint->evaluate('**', '', true));
         $this->assertTrue($constraint->evaluate('*1.0*', '', true));
         $this->assertEquals('matches PCRE pattern "/^\*[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?\*$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesCharacter(): void
+    {
+        $constraint = new StringMatchesFormatDescription('*%c*');
+
+        $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\*.\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
 

--- a/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -203,6 +203,16 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
+    public function testConstraintStringMatchesEscapedPercentThenPlaceholder(): void
+    {
+        $constraint = new StringMatchesFormatDescription('%%%e,%%%s,%%%S,%%%a,%%%A,%%%w,%%%i,%%%d,%%%x,%%%f,%%%c');
+
+        $this->assertFalse($constraint->evaluate('%%e,%%s,%%S,%%a,%%A,%%w,%%i,%%d,%%x,%%f,%%c', '', true));
+        $this->assertTrue($constraint->evaluate('%' . \DIRECTORY_SEPARATOR . ',%*,%*,%*,%*,% ,%0,%0,%0f0f0f,%1.0,%*', '', true));
+        $this->assertEquals('matches PCRE pattern "/^%\\' . \DIRECTORY_SEPARATOR . ',%[^\r\n]+,%[^\r\n]*,%.+,%.*,%\s*,%[+-]?\d+,%\d+,%[0-9a-fA-F]+,%[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?,%.$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
     public function testConstraintStringMatchesSlash(): void
     {
         $constraint = new StringMatchesFormatDescription('/');

--- a/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -193,6 +193,16 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
+    public function testConstraintStringMatchesEscapedPercent(): void
+    {
+        $constraint = new StringMatchesFormatDescription('%%,%%e,%%s,%%S,%%a,%%A,%%w,%%i,%%d,%%x,%%f,%%c,%%Z,%%%%,%%');
+
+        $this->assertFalse($constraint->evaluate('%%,%' . \DIRECTORY_SEPARATOR . ',%*,%*,%*,%*,% ,%0,%0,%0f0f0f,%1.0,%*,%%Z,%%%%,%%', '', true));
+        $this->assertTrue($constraint->evaluate('%,%e,%s,%S,%a,%A,%w,%i,%d,%x,%f,%c,%Z,%%,%', '', true));
+        $this->assertEquals('matches PCRE pattern "/^%,%e,%s,%S,%a,%A,%w,%i,%d,%x,%f,%c,%Z,%%,%$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
     public function testConstraintStringMatchesSlash(): void
     {
         $constraint = new StringMatchesFormatDescription('/');

--- a/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -18,7 +18,10 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%e*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate('*a*', '', true));
+
         $this->assertTrue($constraint->evaluate('*' . \DIRECTORY_SEPARATOR . '*', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*\\' . \DIRECTORY_SEPARATOR . '\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -28,7 +31,11 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%s*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate("*\n*", '', true));
+
         $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertTrue($constraint->evaluate('*foo 123 bar*', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*[^\r\n]+\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -38,7 +45,12 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%S*');
 
         $this->assertFalse($constraint->evaluate('*', '', true));
+        $this->assertFalse($constraint->evaluate("*\n*", '', true));
+
         $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertTrue($constraint->evaluate('*foo 123 bar*', '', true));
+        $this->assertTrue($constraint->evaluate('**', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*[^\r\n]*\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -48,7 +60,11 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%a*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+
         $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertTrue($constraint->evaluate('*foo 123 bar*', '', true));
+        $this->assertTrue($constraint->evaluate("*\n*", '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*.+\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -58,7 +74,12 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%A*');
 
         $this->assertFalse($constraint->evaluate('*', '', true));
+
         $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertTrue($constraint->evaluate('*foo 123 bar*', '', true));
+        $this->assertTrue($constraint->evaluate("*\n*", '', true));
+        $this->assertTrue($constraint->evaluate('**', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*.*\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -68,7 +89,12 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%w*');
 
         $this->assertFalse($constraint->evaluate('*', '', true));
+        $this->assertFalse($constraint->evaluate('*a*', '', true));
+
         $this->assertTrue($constraint->evaluate('* *', '', true));
+        $this->assertTrue($constraint->evaluate("*\t\n*", '', true));
+        $this->assertTrue($constraint->evaluate('**', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*\s*\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -78,7 +104,14 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%i*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate('*a*', '', true));
+        $this->assertFalse($constraint->evaluate('*1.0*', '', true));
+
         $this->assertTrue($constraint->evaluate('*0*', '', true));
+        $this->assertTrue($constraint->evaluate('*12*', '', true));
+        $this->assertTrue($constraint->evaluate('*-1*', '', true));
+        $this->assertTrue($constraint->evaluate('*+2*', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*[+-]?\d+\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -88,7 +121,14 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%d*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate('*a*', '', true));
+        $this->assertFalse($constraint->evaluate('*1.0*', '', true));
+        $this->assertFalse($constraint->evaluate('*-1*', '', true));
+        $this->assertFalse($constraint->evaluate('*+2*', '', true));
+
         $this->assertTrue($constraint->evaluate('*0*', '', true));
+        $this->assertTrue($constraint->evaluate('*12*', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*\d+\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -98,7 +138,17 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%x*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate('***', '', true));
+        $this->assertFalse($constraint->evaluate('*g*', '', true));
+        $this->assertFalse($constraint->evaluate('*1.0*', '', true));
+        $this->assertFalse($constraint->evaluate('*-1*', '', true));
+        $this->assertFalse($constraint->evaluate('*+2*', '', true));
+
         $this->assertTrue($constraint->evaluate('*0f0f0f*', '', true));
+        $this->assertTrue($constraint->evaluate('*0*', '', true));
+        $this->assertTrue($constraint->evaluate('*12*', '', true));
+        $this->assertTrue($constraint->evaluate('*a*', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*[0-9a-fA-F]+\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -108,7 +158,18 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%f*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate('***', '', true));
+        $this->assertFalse($constraint->evaluate('*a*', '', true));
+
         $this->assertTrue($constraint->evaluate('*1.0*', '', true));
+        $this->assertTrue($constraint->evaluate('*0*', '', true));
+        $this->assertTrue($constraint->evaluate('*12*', '', true));
+        $this->assertTrue($constraint->evaluate('*.1*', '', true));
+        $this->assertTrue($constraint->evaluate('*1.*', '', true));
+        $this->assertTrue($constraint->evaluate('*2e3*', '', true));
+        $this->assertTrue($constraint->evaluate('*-2.34e-56*', '', true));
+        $this->assertTrue($constraint->evaluate('*+2.34e+56*', '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?\*$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
@@ -118,8 +179,47 @@ class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $constraint = new StringMatchesFormatDescription('*%c*');
 
         $this->assertFalse($constraint->evaluate('**', '', true));
+        $this->assertFalse($constraint->evaluate('*ab*', '', true));
+
         $this->assertTrue($constraint->evaluate('***', '', true));
+        $this->assertTrue($constraint->evaluate('*a*', '', true));
+        $this->assertTrue($constraint->evaluate('*g*', '', true));
+        $this->assertTrue($constraint->evaluate('*0*', '', true));
+        $this->assertTrue($constraint->evaluate('*2*', '', true));
+        $this->assertTrue($constraint->evaluate('* *', '', true));
+        $this->assertTrue($constraint->evaluate("*\n*", '', true));
+
         $this->assertEquals('matches PCRE pattern "/^\*.\*$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesSlash(): void
+    {
+        $constraint = new StringMatchesFormatDescription('/');
+
+        $this->assertFalse($constraint->evaluate('\\/', '', true));
+        $this->assertTrue($constraint->evaluate('/', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\\/$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesBackslash(): void
+    {
+        $constraint = new StringMatchesFormatDescription('\\');
+
+        $this->assertFalse($constraint->evaluate('\\\\', '', true));
+        $this->assertTrue($constraint->evaluate('\\', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\\\\$/s"', $constraint->toString());
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testConstraintStringMatchesBackslashSlash(): void
+    {
+        $constraint = new StringMatchesFormatDescription('\\/');
+
+        $this->assertFalse($constraint->evaluate('/', '', true));
+        $this->assertTrue($constraint->evaluate('\\/', '', true));
+        $this->assertEquals('matches PCRE pattern "/^\\\\\\/$/s"', $constraint->toString());
         $this->assertCount(1, $constraint);
     }
 


### PR DESCRIPTION
PHPUnit version 7.3.2
PHP version 7.1.20

```php
$this->assertStringMatchesFormat('%d', '1'); // passes
$this->assertStringMatchesFormat('%%d', '%d'); // passes (thanks to #2914)
$this->assertStringMatchesFormat('%%%d', '%1'); // still FAILS (currently expects '%%d')
```

It seems appropriate to use [`strtr`](http://php.net/strtr) rather than `str_replace`/`preg_replace`.

Fixes the fix of #2914 for #2907