### PR TITLE
Make --filter case insensitive - issue #3181

### DIFF
--- a/ChangeLog-6.5.md
+++ b/ChangeLog-6.5.md
@@ -5,6 +5,7 @@ All notable changes of the PHPUnit 6.5 release series are documented in this fil
 ## [6.5.13] - 2018-MM-DD
 
 * Fixed [#3254](https://github.com/sebastianbergmann/phpunit/issues/3254): TextUI test runner cannot run a `Test` instance that is not a `TestSuite`
+* Fixed [#3181](https://github.com/sebastianbergmann/phpunit/issues/3181): Make --filter case insensitive
 
 ## [6.5.12] - 2018-08-22
 

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -79,7 +79,7 @@ class NameFilterIterator extends RecursiveFilterIterator
 
             // Escape delimiters in regular expression. Do NOT use preg_quote,
             // to keep magic characters.
-            $filter = \sprintf('/%s/', \str_replace(
+            $filter = \sprintf('/%s/i', \str_replace(
                 '/',
                 '\\/',
                 $filter

--- a/tests/unit/Runner/Filter/NameFilterIteratorTest.php
+++ b/tests/unit/Runner/Filter/NameFilterIteratorTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use PHPUnit\Framework\TestCase;
+
+class NameFilterIteratorTest extends TestCase
+{
+    public function testCaseSensitiveMatch()
+    {
+        $iterator = $this->getTestSuiteItteratorMock();
+        $filter   = new NameFilterIterator($iterator, 'Success');
+        $this->assertTrue((bool) $filter->accept());
+    }
+
+    public function testCaseInsensitiveMatch()
+    {
+        $iterator = $this->getTestSuiteItteratorMock();
+        $filter   = new NameFilterIterator($iterator, 'success');
+        $this->assertTrue((bool) $filter->accept());
+    }
+
+    /**
+     * @return \PHPUnit\Framework\TestSuiteIterator
+     */
+    private function getTestSuiteItteratorMock()
+    {
+        $success   = new \Success();
+        $iterator = $this->createMock(\PHPUnit\Framework\TestSuiteIterator::class);
+        $iterator->expects($this->once())->method('current')->willReturn($success);
+
+        return $iterator;
+    }
+}


### PR DESCRIPTION
In order to make named filters case insensitive the `i` modifier gets added to the resulting regex.

Unit test for both cases (sensitive and insensitive) where added as well.