### PR TITLE
Emit error when mocked method isn't really mocked #3127

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -752,12 +752,6 @@ class Generator
         $mockedMethods = '';
         $configurable  = [];
 
-        foreach ($methods as $methodName) {
-            if ($methodName !== '__construct' && $methodName !== '__clone') {
-                $configurable[] = \strtolower($methodName);
-            }
-        }
-
         if (isset($class)) {
             // https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
             if ($isInterface && $class->implementsInterface(Traversable::class) &&
@@ -777,6 +771,7 @@ class Generator
                             $cloneArguments,
                             $callOriginalMethods
                         );
+                        $configurable[] = \strtolower($methodName);
                     }
                 } catch (ReflectionException $e) {
                     $mockedMethods .= $this->generateMockedMethodDefinition(
@@ -784,6 +779,7 @@ class Generator
                         $methodName,
                         $cloneArguments
                     );
+                    $configurable[] = \strtolower($methodName);
                 }
             }
         } elseif ($isMultipleInterfaces) {
@@ -794,6 +790,7 @@ class Generator
                         $cloneArguments,
                         $callOriginalMethods
                     );
+                    $configurable[] = \strtolower($methodName);
                 }
             }
         } else {
@@ -803,6 +800,7 @@ class Generator
                     $methodName,
                     $cloneArguments
                 );
+                $configurable[] = \strtolower($methodName);
             }
         }
 

--- a/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\MockObject\Stub\MatcherCollection;
 use PHPUnit\Framework\TestCase;
 
 class InvocationMockerTest extends TestCase
@@ -70,5 +71,19 @@ class InvocationMockerTest extends TestCase
         $this->assertSame('foo', $mock->foo());
         $value = 'bar';
         $this->assertSame('bar', $mock->foo());
+    }
+
+    public function testWillFailWhenTryingToPerformExpectationUnconfigurableMethod()
+    {
+        /** @var MatcherCollection|\PHPUnit\Framework\MockObject\MockObject $matcherCollection */
+        $matcherCollection = $this->createMock(MatcherCollection::class);
+        $invocationMocker  = new \PHPUnit\Framework\MockObject\Builder\InvocationMocker(
+            $matcherCollection,
+            $this->any(),
+            []
+        );
+
+        $this->expectException(RuntimeException::class);
+        $invocationMocker->method('someMethod');
     }
 }

--- a/tests/unit/Framework/MockObject/Generator/class_with_finakl_method.phpt
+++ b/tests/unit/Framework/MockObject/Generator/class_with_finakl_method.phpt
@@ -1,0 +1,84 @@
+--TEST--
+\PHPUnit\Framework\MockObject\Generator::generate('ClassWithFinalMethod', [], 'MockFoo', true, true)
+--FILE--
+<?php
+class ClassWithFinalMethod
+{
+    final public function finalMethod()
+    {
+    }
+}
+
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+$generator = new \PHPUnit\Framework\MockObject\Generator;
+
+$mock = $generator->generate(
+    'ClassWithFinalMethod',
+    [],
+    'MockFoo',
+    true,
+    true
+);
+
+print $mock['code'];
+?>
+--EXPECT--
+class MockFoo extends ClassWithFinalMethod implements PHPUnit\Framework\MockObject\MockObject
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+    private $__phpunit_configurable = [];
+    private $__phpunit_returnValueGeneration = true;
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function expects(\PHPUnit\Framework\MockObject\Matcher\Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any     = new \PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+        $expects = $this->expects($any);
+
+        return call_user_func_array([$expects, 'method'], func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+        $this->__phpunit_returnValueGeneration = $returnValueGeneration;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker($this->__phpunit_configurable, $this->__phpunit_returnValueGeneration);
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify($unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}


### PR DESCRIPTION
* Only mark mocked methods as configurable
* Test that you can only expect on configurable methods