### PR TITLE
Enhancement: Enable blank_line_after_opening_tag fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,6 +22,7 @@ return PhpCsFixer\Config::create()
                 ],
             ],
             'blank_line_after_namespace' => true,
+            'blank_line_after_opening_tag' => true,
             'blank_line_before_statement' => [
                 'statements' => [
                     'break',

--- a/src/Runner/Hook/AfterIncompleteTestHook.php
+++ b/src/Runner/Hook/AfterIncompleteTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterLastTestHook.php
+++ b/src/Runner/Hook/AfterLastTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterRiskyTestHook.php
+++ b/src/Runner/Hook/AfterRiskyTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterSkippedTestHook.php
+++ b/src/Runner/Hook/AfterSkippedTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterSuccessfulTestHook.php
+++ b/src/Runner/Hook/AfterSuccessfulTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterTestErrorHook.php
+++ b/src/Runner/Hook/AfterTestErrorHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterTestFailureHook.php
+++ b/src/Runner/Hook/AfterTestFailureHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/AfterTestWarningHook.php
+++ b/src/Runner/Hook/AfterTestWarningHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/BeforeFirstTestHook.php
+++ b/src/Runner/Hook/BeforeFirstTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/BeforeTestHook.php
+++ b/src/Runner/Hook/BeforeTestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/Hook.php
+++ b/src/Runner/Hook/Hook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/TestHook.php
+++ b/src/Runner/Hook/TestHook.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Hook/TestListenerAdapter.php
+++ b/src/Runner/Hook/TestListenerAdapter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Runner/Version.php
+++ b/src/Runner/Version.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Util/TextTestListRenderer.php
+++ b/src/Util/TextTestListRenderer.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/src/Util/XmlTestListRenderer.php
+++ b/src/Util/XmlTestListRenderer.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/tests/_files/3194.php
+++ b/tests/_files/3194.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/tests/_files/RouterTest.php
+++ b/tests/_files/RouterTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/tests/end-to-end/_files/HookTest.php
+++ b/tests/end-to-end/_files/HookTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *

--- a/tests/end-to-end/regression/GitHub/3156/Issue3156Test.php
+++ b/tests/end-to-end/regression/GitHub/3156/Issue3156Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /*
  * This file is part of PHPUnit.

--- a/tests/unit/Framework/Constraint/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/IsInstanceOfTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *


### PR DESCRIPTION
This PR

* [x] enables the `blank_line_after_opening_tag` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.0.0#usage:

>**blank_line_after_opening_tag** `[@Symfony]`
>
>Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.