### PR TITLE
Fix: Remove unused local variables

### DIFF
--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -436,7 +436,6 @@ class MockObjectTest extends TestCase
     public function testGetMockWithFixedClassNameCanProduceTheSameMockTwice(): void
     {
         $mock = $this->getMockBuilder(stdClass::class)->setMockClassName('FixedName')->getMock();
-        $mock = $this->getMockBuilder(stdClass::class)->setMockClassName('FixedName')->getMock();
         $this->assertInstanceOf(stdClass::class, $mock);
     }
 

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -116,8 +116,6 @@ class ConfigurationTest extends TestCase
 
     public function configurationRootOptionsProvider(): array
     {
-        $tmpFilePath = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR;
-
         return [
             'executionOrder default'                                        => ['executionOrder', 'default', TestSuiteSorter::ORDER_DEFAULT],
             'executionOrder random'                                         => ['executionOrder', 'random', TestSuiteSorter::ORDER_RANDOMIZED],


### PR DESCRIPTION
This PR

* [x] removes unused local variables