### PR TITLE
Fix: Reduce scope of assertion

### DIFF
--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -451,8 +451,8 @@ class ConfigurationTest extends TestCase
         );
 
         $this->assertEquals(
-            $expectedConfiguration->getTestSuiteConfiguration(),
-            $actualConfiguration->getTestSuiteConfiguration()
+            $expectedConfiguration->getTestSuiteConfiguration()->tests(),
+            $actualConfiguration->getTestSuiteConfiguration()->tests()
         );
     }
 


### PR DESCRIPTION
This PR

* [x] reduces the scope of an assertion when testing `Configuration`
