### PR TITLE
Fix: Add void return type declarations

### DIFF
--- a/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
@@ -73,7 +73,7 @@ class InvocationMockerTest extends TestCase
         $this->assertSame('bar', $mock->foo());
     }
 
-    public function testWillFailWhenTryingToPerformExpectationUnconfigurableMethod()
+    public function testWillFailWhenTryingToPerformExpectationUnconfigurableMethod(): void
     {
         /** @var MatcherCollection|\PHPUnit\Framework\MockObject\MockObject $matcherCollection */
         $matcherCollection = $this->createMock(MatcherCollection::class);

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -945,7 +945,7 @@ class MockObjectTest extends TestCase
      * @ticket   2573
      * @requires extension soap
      */
-    public function testCreateMockOfWsdlFileWithSpecialChars()
+    public function testCreateMockOfWsdlFileWithSpecialChars(): void
     {
         $mock = $this->getMockFromWsdl(__DIR__ . '/_fixture/Go ogle-Sea.rch.wsdl');
 

--- a/tests/unit/Framework/TestResultTest.php
+++ b/tests/unit/Framework/TestResultTest.php
@@ -34,7 +34,7 @@ class TestResultTest extends TestCase
         );
     }
 
-    public function testAddErrorOfTypeIncompleteTest()
+    public function testAddErrorOfTypeIncompleteTest(): void
     {
         $time      = 17;
         $throwable = new IncompleteTestError();
@@ -75,7 +75,7 @@ class TestResultTest extends TestCase
     /**
      * @dataProvider canSkipCoverageProvider
      */
-    public function testCanSkipCoverage($testCase, $expectedCanSkip)
+    public function testCanSkipCoverage($testCase, $expectedCanSkip): void
     {
         require_once TEST_FILES_PATH . $testCase . '.php';
 

--- a/tests/unit/Runner/Filter/NameFilterIteratorTest.php
+++ b/tests/unit/Runner/Filter/NameFilterIteratorTest.php
@@ -14,12 +14,12 @@ use PHPUnit\Framework\TestSuite;
 
 class NameFilterIteratorTest extends TestCase
 {
-    public function testCaseSensitiveMatch()
+    public function testCaseSensitiveMatch(): void
     {
         $this->assertTrue($this->createFilter('BankAccountTest')->accept());
     }
 
-    public function testCaseInsensitiveMatch()
+    public function testCaseInsensitiveMatch(): void
     {
         $this->assertTrue($this->createFilter('bankaccounttest')->accept());
     }

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -24,7 +24,7 @@ class TestSuiteSorterTest extends TestCase
 
     private const RESOLVE_DEPENDENCIES = true;
 
-    public function testThrowsExceptionWhenUsingInvalidOrderOption()
+    public function testThrowsExceptionWhenUsingInvalidOrderOption(): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -35,7 +35,7 @@ class TestSuiteSorterTest extends TestCase
         $sorter->reorderTestsInSuite($suite, -1, false, TestSuiteSorter::ORDER_DEFAULT);
     }
 
-    public function testThrowsExceptionWhenUsingInvalidOrderDefectsOption()
+    public function testThrowsExceptionWhenUsingInvalidOrderDefectsOption(): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -49,7 +49,7 @@ class TestSuiteSorterTest extends TestCase
     /**
      * @dataProvider suiteSorterOptionPermutationsProvider
      */
-    public function testShouldNotAffectEmptyTestSuite(int $order, bool $resolveDependencies, int $orderDefects)
+    public function testShouldNotAffectEmptyTestSuite(int $order, bool $resolveDependencies, int $orderDefects): void
     {
         $sorter = new TestSuiteSorter;
         $suite  = new TestSuite;
@@ -64,7 +64,7 @@ class TestSuiteSorterTest extends TestCase
     /**
      * @dataProvider commonSorterOptionsProvider
      */
-    public function testBasicExecutionOrderOptions(int $order, bool $resolveDependencies, array $expected)
+    public function testBasicExecutionOrderOptions(int $order, bool $resolveDependencies, array $expected): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -75,7 +75,7 @@ class TestSuiteSorterTest extends TestCase
         $this->assertSame($expected, $this->getTestExecutionOrder($suite));
     }
 
-    public function testCanSetRandomizationWithASeed()
+    public function testCanSetRandomizationWithASeed(): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -87,7 +87,7 @@ class TestSuiteSorterTest extends TestCase
         $this->assertSame(['testTwo', 'testFour', 'testFive', 'testThree', 'testOne'], $this->getTestExecutionOrder($suite));
     }
 
-    public function testCanSetRandomizationWithASeedAndResolveDependencies()
+    public function testCanSetRandomizationWithASeedAndResolveDependencies(): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -102,7 +102,7 @@ class TestSuiteSorterTest extends TestCase
     /**
      * @dataProvider defectsSorterOptionsProvider
      */
-    public function testSuiteSorterDefectsOptions(int $order, bool $resolveDependencies, array $runState, array $expected)
+    public function testSuiteSorterDefectsOptions(int $order, bool $resolveDependencies, array $runState, array $expected): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -303,7 +303,7 @@ class TestSuiteSorterTest extends TestCase
     /**
      * @see https://github.com/lstrojny/phpunit-clever-and-smart/issues/38
      */
-    public function testCanHandleSuiteWithEmptyTestCase()
+    public function testCanHandleSuiteWithEmptyTestCase(): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\EmptyTestCaseTest::class);

--- a/tests/unit/TextUI/TestRunnerTest.php
+++ b/tests/unit/TextUI/TestRunnerTest.php
@@ -13,14 +13,14 @@ use PHPUnit\Framework\TestCase;
 
 class TestRunnerTest extends TestCase
 {
-    public function testTestIsRunnable()
+    public function testTestIsRunnable(): void
     {
         $runner = new TestRunner();
         $runner->setPrinter($this->getResultPrinterMock());
         $runner->doRun(new \Success(), ['filter' => 'foo'], false);
     }
 
-    public function testSuiteIsRunnable()
+    public function testSuiteIsRunnable(): void
     {
         $runner = new TestRunner();
         $runner->setPrinter($this->getResultPrinterMock());

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -18,7 +18,7 @@ class XDebugFilterScriptGeneratorTest extends TestCase
      *
      * @dataProvider scriptGeneratorTestDataProvider
      */
-    public function testReturnsExpectedScript(array $filterConfiguration, array $resolvedWhitelist)
+    public function testReturnsExpectedScript(array $filterConfiguration, array $resolvedWhitelist): void
     {
         $writer = new XDebugFilterScriptGenerator();
         $actual = $writer->generate($filterConfiguration, $resolvedWhitelist);


### PR DESCRIPTION
This PR

* [x] adds `void` return type declarations to test methods

💁‍♂️ I ran

```
$ php-cs-fixer fix --rules=void_return
$ git add tests/unit
```