### PR TITLE
Fix: Actually resolve dependencies

### DIFF
--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -139,7 +139,7 @@ class TestSuiteSorterTest extends TestCase
             // Activating dependency resolution should have no effect under normal circumstances
             'resolve default' => [
                 TestSuiteSorter::ORDER_DEFAULT,
-                self::IGNORE_DEPENDENCIES,
+                self::RESOLVE_DEPENDENCIES,
                 ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive']],
 
             // Reversing without checks should give a simple reverse order


### PR DESCRIPTION
This PR

* [x] uses the appropriate constant in the `TestSuiteSorterTest` to trigger resolving test dependencies