### PR TITLE
Enhancement: Allow to order tests by time (duration)

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -176,12 +176,14 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="default"/>
             <xs:enumeration value="defects"/>
+            <xs:enumeration value="duration"/>
             <xs:enumeration value="depends"/>
             <xs:enumeration value="depends,defects"/>
             <xs:enumeration value="random"/>
             <xs:enumeration value="reverse"/>
             <xs:enumeration value="depends,random"/>
             <xs:enumeration value="depends,reverse"/>
+            <xs:enumeration value="depends,duration"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="fileFilterType">


### PR DESCRIPTION
This PR

* [x] allows to order tests by time (duration)

Fixes #3284.

💁‍♂️ Hope I'm not stepping on anyone's toes. Not sure, maybe I should add more test cases, what do you think, @epdenouden?