### PR TITLE
Additions for #3272

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -549,6 +549,9 @@ class TestRunner extends BaseTestRunner
                 );
                 \file_put_contents($arguments['xdebugFilterFile'], $script);
 
+                $this->write("\n");
+                $this->write(\sprintf('Wrote Xdebug filter script to %s ' . \PHP_EOL, $arguments['xdebugFilterFile']));
+
                 exit(self::SUCCESS_EXIT);
             }
 

--- a/src/Util/XDebugFilterScriptGenerator.php
+++ b/src/Util/XDebugFilterScriptGenerator.php
@@ -21,14 +21,14 @@ class XDebugFilterScriptGenerator
         $files = \implode(",\n", $files);
 
         return <<<EOF
-<?php
+<?php declare(strict_types=1);
 if (!\\function_exists('xdebug_set_filter')) {
     return;
 }
 
-xdebug_set_filter(
-    XDEBUG_FILTER_CODE_COVERAGE,
-    XDEBUG_PATH_WHITELIST,
+\\xdebug_set_filter(
+    \\XDEBUG_FILTER_CODE_COVERAGE,
+    \\XDEBUG_PATH_WHITELIST,
     [
 $files
     ]

--- a/tests/end-to-end/dump-xdebug-filter.phpt
+++ b/tests/end-to-end/dump-xdebug-filter.phpt
@@ -16,14 +16,14 @@ require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
-<?php
+<?php declare(strict_types=1);
 if (!\function_exists('xdebug_set_filter')) {
     return;
 }
 
-xdebug_set_filter(
-    XDEBUG_FILTER_CODE_COVERAGE,
-    XDEBUG_PATH_WHITELIST,
+\xdebug_set_filter(
+    \XDEBUG_FILTER_CODE_COVERAGE,
+    \XDEBUG_PATH_WHITELIST,
     [
         %s
     ]

--- a/tests/unit/Util/_files/expectedXDebugFilterScript.txt
+++ b/tests/unit/Util/_files/expectedXDebugFilterScript.txt
@@ -1,11 +1,11 @@
-<?php
+<?php declare(strict_types=1);
 if (!\function_exists('xdebug_set_filter')) {
     return;
 }
 
-xdebug_set_filter(
-    XDEBUG_FILTER_CODE_COVERAGE,
-    XDEBUG_PATH_WHITELIST,
+\xdebug_set_filter(
+    \XDEBUG_FILTER_CODE_COVERAGE,
+    \XDEBUG_PATH_WHITELIST,
     [
         'src/somePath',
         'src/foo.php',


### PR DESCRIPTION
Changes:
- Running PHPUnit with `--dump-xdebug-filter` will now write a message to the output
- The generated Xdebug script file now complies with the coding guidelines