### PR TITLE
Simplify the implementation of #3272

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -544,10 +544,7 @@ class TestRunner extends BaseTestRunner
 
             if (isset($arguments['xdebugFilterFile'], $filterConfiguration)) {
                 $filterScriptGenerator = new XDebugFilterScriptGenerator();
-                $script                = $filterScriptGenerator->generate(
-                    $filterConfiguration['whitelist'],
-                    $this->codeCoverageFilter->getWhitelist()
-                );
+                $script                = $filterScriptGenerator->generate($filterConfiguration['whitelist']);
                 \file_put_contents($arguments['xdebugFilterFile'], $script);
 
                 $this->write("\n");

--- a/src/Util/XDebugFilterScriptGenerator.php
+++ b/src/Util/XDebugFilterScriptGenerator.php
@@ -11,9 +11,9 @@ namespace PHPUnit\Util;
 
 class XDebugFilterScriptGenerator
 {
-    public function generate(array $filterData, array $whitelistedFiles): string
+    public function generate(array $filterData): string
     {
-        $items = $this->getItems($filterData, $whitelistedFiles);
+        $items = $this->getWhitelistItems($filterData);
 
         $files = \array_map(function ($item) {
             return \sprintf("        '%s'", $item);
@@ -37,16 +37,7 @@ $files
 EOF;
     }
 
-    private function getItems(array $filterData, array $whitelistedFiles): array
-    {
-        if ($this->canUseRawFilterData($filterData)) {
-            return $this->getItemsFromRawFilterData($filterData);
-        }
-
-        return $whitelistedFiles;
-    }
-
-    private function getItemsFromRawFilterData(array $filterData): array
+    private function getWhitelistItems(array $filterData): array
     {
         $files = [];
 
@@ -63,20 +54,5 @@ EOF;
         }
 
         return $files;
-    }
-
-    private function canUseRawFilterData(array $filterData): bool
-    {
-        if (\count($filterData['exclude']['directory']) > 0 || \count($filterData['exclude']['file'])) {
-            return false;
-        }
-
-        foreach ($filterData['include']['directory'] as $directory) {
-            if (($directory['suffix'] !== '' && $directory['suffix'] !== '.php') || $directory['prefix'] !== '') {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/tests/_files/configuration_whitelist.xml
+++ b/tests/_files/configuration_whitelist.xml
@@ -5,6 +5,9 @@
   <filter>
     <whitelist>
       <file>AbstractTest.php</file>
+      <exclude>
+        <file>Foo.php</file>
+      </exclude>
     </whitelist>
   </filter>
 

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -15,61 +15,32 @@ class XDebugFilterScriptGeneratorTest extends TestCase
 {
     /**
      * @covers \PHPUnit\Util\XDebugFilterScriptGenerator::generate
-     *
-     * @dataProvider scriptGeneratorTestDataProvider
      */
-    public function testReturnsExpectedScript(array $filterConfiguration, array $resolvedWhitelist): void
+    public function testReturnsExpectedScript(): void
     {
-        $writer = new XDebugFilterScriptGenerator();
-        $actual = $writer->generate($filterConfiguration, $resolvedWhitelist);
-
-        $this->assertStringEqualsFile(__DIR__ . '/_files/expectedXDebugFilterScript.txt', $actual);
-    }
-
-    public function scriptGeneratorTestDataProvider(): array
-    {
-        return [
-            [
-                [
-                    'include' => [
-                        'directory' => [
-                            [
-                                'path'   => 'src/somePath',
-                                'suffix' => '.php',
-                                'prefix' => '',
-                            ],
-                        ],
-                        'file' => [
-                            'src/foo.php',
-                            'src/bar.php',
-                        ],
-                    ],
-                    'exclude' => [
-                        'directory' => [],
-                        'file'      => [],
+        $filterConfiguration = [
+            'include' => [
+                'directory' => [
+                    [
+                        'path'   => 'src/somePath',
+                        'suffix' => '.php',
+                        'prefix' => '',
                     ],
                 ],
-                [],
-                __DIR__ . '/_files/expectedXDebugFilterScript.php',
-            ],
-            [
-                [
-                    'include' => [
-                        'directory' => ['src/'],
-                        'file'      => ['src/foo.php'],
-                    ],
-                    'exclude' => [
-                        'directory' => [],
-                        'file'      => ['src/baz.php'],
-                    ],
-                ],
-                [
-                    'src/somePath',
+                'file' => [
                     'src/foo.php',
                     'src/bar.php',
                 ],
-                __DIR__ . '/_files/expectedXDebugFilterScript.php',
+            ],
+            'exclude' => [
+                'directory' => [],
+                'file'      => [],
             ],
         ];
+
+        $writer = new XDebugFilterScriptGenerator();
+        $actual = $writer->generate($filterConfiguration);
+
+        $this->assertStringEqualsFile(__DIR__ . '/_files/expectedXDebugFilterScript.txt', $actual);
     }
 }


### PR DESCRIPTION
XDebugFilterScriptGenerator now completely ignores the <exclude>
part of the filter configuration and always creates the script
based on the whitelist only. Letting PHPUnit filter out the
excluded paths proved to be much faster than providing a long
list of individual files to xdebug_set_filter().