### PR TITLE
change stdout to stderr in dump-xdebug-filter.phpt

### DIFF
--- a/tests/end-to-end/dump-xdebug-filter.phpt
+++ b/tests/end-to-end/dump-xdebug-filter.phpt
@@ -10,7 +10,7 @@ if (!extension_loaded('xdebug')) {
 $_SERVER['argv'][1] = '-c';
 $_SERVER['argv'][2] = __DIR__ . '/../_files/configuration_whitelist.xml';
 $_SERVER['argv'][3] = '--dump-xdebug-filter';
-$_SERVER['argv'][4] = 'php://stdout';
+$_SERVER['argv'][4] = 'php://stderr';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
@@ -28,3 +28,5 @@ if (!\function_exists('xdebug_set_filter')) {
         %s
     ]
 );
+
+Wrote Xdebug filter script to php://stderr


### PR DESCRIPTION
When letting the test use `php://stdout` as output for the generated Xdebug filter script, the message that is written to the output by PHPUnit is missing on Linux and macOS, but not on Windows, leading to failing builds. Using `php://stderr` instead works around that issue. 