### PR TITLE
Extract code generation for classes

### DIFF
--- a/src/Framework/MockObject/MockType.php
+++ b/src/Framework/MockObject/MockType.php
@@ -1,0 +1,175 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use Text_Template;
+
+final class MockType
+{
+    /**
+     * @var Text_Template[]
+     */
+    private static $templates = [];
+
+    /**
+     * @var OriginalType
+     */
+    private $originalType;
+
+    /**
+     * @var TypeName
+     */
+    private $className;
+
+    /**
+     * @var MockMethodSet
+     */
+    private $methods;
+
+    /**
+     * @var bool
+     */
+    private $callAutoload;
+
+    /**
+     * @var string[]
+     */
+    private $interfaces;
+
+    /**
+     * @var bool
+     */
+    private $callOriginalClone;
+
+    public function __construct(OriginalType $originalType, TypeName $className, array $interfaces, MockMethodSet $methods, bool $callAutoload, bool $callOriginalClone)
+    {
+        $this->originalType      = $originalType;
+        $this->className         = $className;
+        $this->methods           = $methods;
+        $this->interfaces        = $interfaces;
+        $this->callAutoload      = $callAutoload;
+        $this->callOriginalClone = $callOriginalClone;
+    }
+
+    public function generateCode(): string
+    {
+        $classTemplate = $this->getTemplate('mocked_class.tpl');
+
+        $method = '';
+
+        if (!$this->methods->hasMethod('method') && !$this->originalType->hasMethod('method')) {
+            $methodTemplate = $this->getTemplate('mocked_class_method.tpl');
+            $method         = $methodTemplate->render();
+        }
+
+        $mockedMethodCode = '';
+        $configurable     = [];
+
+        /** @var MockMethod $mockMethod */
+        foreach ($this->methods->asArray() as $mockMethod) {
+            $mockedMethodCode .= $mockMethod->generateCode();
+            $configurable[] = \strtolower($mockMethod->getName());
+        }
+
+        $classTemplate->setVar(
+            [
+                'prologue'          => $this->originalType->getCodePrologue(),
+                'epilogue'          => $this->originalType->getCodeEpilogue(),
+                'class_declaration' => $this->generateMockClassDeclaration(),
+                'clone'             => $this->generateCodeClone(),
+                'mock_class_name'   => $this->getClassName()->getQualifiedName(),
+                'mocked_methods'    => $mockedMethodCode,
+                'method'            => $method,
+                'configurable'      => '[' . \implode(
+                        ', ',
+                        \array_map(
+                            function ($m) {
+                                return '\'' . $m . '\'';
+                            },
+                            $configurable
+                        )
+                    ) . ']',
+            ]
+        );
+
+        return $classTemplate->render();
+    }
+
+    public function getClassName(): TypeName
+    {
+        return $this->className;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function getTemplate(string $template): Text_Template
+    {
+        $filename = __DIR__ . \DIRECTORY_SEPARATOR . 'Generator' . \DIRECTORY_SEPARATOR . $template;
+
+        if (!isset(self::$templates[$filename])) {
+            self::$templates[$filename] = new Text_Template($filename);
+        }
+
+        return self::$templates[$filename];
+    }
+
+    private function generateMockClassDeclaration(): string
+    {
+        $additionalInterfaces   = $this->interfaces;
+        $additionalInterfaces[] = MockObject::class;
+
+        $originalTypeName = $this->originalType->getName();
+
+        if ($this->originalType->isInterface()) {
+            if (!\in_array($originalTypeName->getSimpleName(), $additionalInterfaces)) {
+                $additionalInterfaces[] = $originalTypeName->getQualifiedName();
+            }
+
+            return \sprintf(
+                'class %s implements %s',
+                $this->className->getSimpleName(),
+                \implode(', ', $additionalInterfaces)
+            );
+        }
+
+        return \sprintf(
+                'class %s extends %s implements %s',
+                $this->className->getSimpleName(),
+                $originalTypeName->getQualifiedName(),
+                \implode(', ', $additionalInterfaces)
+            );
+    }
+
+    private function generateCodeClone(): string
+    {
+        $cloneTemplate = null;
+
+        if ($this->originalType->hasMethod('__clone')) {
+            $cloneMethod = $this->originalType->getMethod('__clone');
+
+            if (!$cloneMethod->isFinal()) {
+                if ($this->callOriginalClone && !$this->originalType->isInterface()) {
+                    $cloneTemplate = $this->getTemplate('unmocked_clone.tpl');
+                } else {
+                    $cloneTemplate = $this->getTemplate('mocked_clone.tpl');
+                }
+            }
+        } else {
+            $cloneTemplate = $this->getTemplate('mocked_clone.tpl');
+        }
+
+        if (\is_object($cloneTemplate)) {
+            return $cloneTemplate->render();
+        }
+
+        return '';
+    }
+}

--- a/src/Framework/MockObject/OriginalType.php
+++ b/src/Framework/MockObject/OriginalType.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+interface OriginalType
+{
+    public function getCodePrologue(): string;
+
+    public function getCodeEpilogue(): string;
+
+    public function hasMethod(string $name): bool;
+
+    /**
+     * @throws \OutOfBoundsException if method does not exist
+     */
+    public function getMethod(string $name): \ReflectionMethod;
+
+    public function isInterface(): bool;
+
+    public function getName(): TypeName;
+
+    public function getMethods(): array;
+
+    public function isFinal(): bool;
+
+    public function implementsInterface(string $interface): bool;
+}

--- a/src/Framework/MockObject/OriginalTypeGenerated.php
+++ b/src/Framework/MockObject/OriginalTypeGenerated.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+final class OriginalTypeGenerated implements OriginalType
+{
+    /**
+     * @var TypeName
+     */
+    private $originalType;
+
+    public function __construct(TypeName $originalType)
+    {
+        $this->originalType = $originalType;
+    }
+
+    public function getCodePrologue(): string
+    {
+        $prologue = 'class ' . $this->originalType->getSimpleName() . "\n{\n}\n\n";
+
+        if ($this->originalType->isNamespaced()) {
+            $prologue = 'namespace ' . $this->originalType->getNamespaceName() .
+                " {\n\n" . $prologue . "}\n\n" .
+                "namespace {\n\n";
+        }
+
+        return $prologue;
+    }
+
+    public function getCodeEpilogue(): string
+    {
+        if ($this->originalType->isNamespaced()) {
+            return "\n\n}";
+        }
+
+        return '';
+    }
+
+    public function hasMethod(string $name): bool
+    {
+        return false;
+    }
+
+    /**
+     * @throws \OutOfBoundsException if method does not exist
+     */
+    public function getMethod(string $name): \ReflectionMethod
+    {
+        throw new \OutOfBoundsException('Generated types have no methods.');
+    }
+
+    public function getMethods(): array
+    {
+        return [];
+    }
+
+    public function isInterface(): bool
+    {
+        return false;
+    }
+
+    public function getName(): TypeName
+    {
+        return $this->originalType;
+    }
+
+    public function isFinal(): bool
+    {
+        return false;
+    }
+
+    public function implementsInterface(string $interface): bool
+    {
+        return false;
+    }
+}

--- a/src/Framework/MockObject/OriginalTypeReflection.php
+++ b/src/Framework/MockObject/OriginalTypeReflection.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+final class OriginalTypeReflection implements OriginalType
+{
+    /**
+     * @var \ReflectionClass
+     */
+    private $class;
+
+    public function __construct(\ReflectionClass $class)
+    {
+        $this->class = $class;
+    }
+
+    public function getCodePrologue(): string
+    {
+        return '';
+    }
+
+    public function getCodeEpilogue(): string
+    {
+        return '';
+    }
+
+    public function hasMethod(string $name): bool
+    {
+        return $this->class->hasMethod($name);
+    }
+
+    /**
+     * @throws \OutOfBoundsException if method does not exist
+     */
+    public function getMethod(string $name): \ReflectionMethod
+    {
+        try {
+            return $this->class->getMethod($name);
+        } catch (\ReflectionException $e) {
+            throw new \OutOfBoundsException($e->getMessage(), 0, $e);
+        }
+    }
+
+    public function getMethods(): array
+    {
+        return $this->class->getMethods();
+    }
+
+    public function isInterface(): bool
+    {
+        return $this->class->isInterface();
+    }
+
+    public function getName(): TypeName
+    {
+        return new TypeName($this->class->getNamespaceName(), $this->class->getShortName());
+    }
+
+    public function isFinal(): bool
+    {
+        return $this->class->isFinal();
+    }
+
+    public function implementsInterface(string $interface): bool
+    {
+        return $this->class->implementsInterface($interface);
+    }
+}

--- a/src/Framework/MockObject/TypeName.php
+++ b/src/Framework/MockObject/TypeName.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+final class TypeName
+{
+    /**
+     * @var string
+     */
+    private $namespaceName;
+
+    /**
+     * @var string
+     */
+    private $simpleName;
+
+    public static function fromQualifiedName(string $fullClassName): self
+    {
+        if ($fullClassName[0] === '\\') {
+            $fullClassName = \substr($fullClassName, 1);
+        }
+
+        $classNameParts = \explode('\\', $fullClassName);
+
+        $simpleName    = \array_pop($classNameParts);
+        $namespaceName = \implode('\\', $classNameParts);
+
+        return new self($namespaceName, $simpleName);
+    }
+
+    public static function fromReflection(\ReflectionClass $type): self
+    {
+        return new self(
+            $type->getNamespaceName(),
+            $type->getShortName()
+        );
+    }
+
+    public function __construct(string $namespaceName, string $simpleName)
+    {
+        $this->namespaceName  = $namespaceName;
+        $this->simpleName     = $simpleName;
+    }
+
+    public function getNamespaceName(): string
+    {
+        return $this->namespaceName;
+    }
+
+    public function getSimpleName(): string
+    {
+        return $this->simpleName;
+    }
+
+    public function getQualifiedName(): string
+    {
+        if (null === $this->namespaceName || '' === $this->namespaceName) {
+            return $this->simpleName;
+        }
+
+        return $this->namespaceName . '\\' . $this->simpleName;
+    }
+
+    public function isNamespaced(): bool
+    {
+        return $this->namespaceName !== '';
+    }
+}

--- a/tests/unit/Framework/MockObject/MockMethodTest.php
+++ b/tests/unit/Framework/MockObject/MockMethodTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 /*
  * This file is part of PHPUnit.
  *
@@ -14,10 +13,10 @@ use PHPUnit\Framework\TestCase;
 
 class MockMethodTest extends TestCase
 {
-    public function testGetNameReturnsMethodName()
+    public function testGetNameReturnsMethodName(): void
     {
         $method = new MockMethod(
-            'ClassName',
+            new TypeName('', 'ClassName'),
             'methodName',
             false,
             '',
@@ -33,10 +32,10 @@ class MockMethodTest extends TestCase
         $this->assertEquals('methodName', $method->getName());
     }
 
-    public function testFailWhenReturnTypeIsParentButThereIsNoParentClass()
+    public function testFailWhenReturnTypeIsParentButThereIsNoParentClass(): void
     {
         $method = new MockMethod(
-            \stdClass::class,
+            new TypeName('', \stdClass::class),
             'methodName',
             false,
             '',

--- a/tests/unit/Framework/MockObject/OriginalTypeGeneratedTest.php
+++ b/tests/unit/Framework/MockObject/OriginalTypeGeneratedTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use PHPUnit\Framework\TestCase;
+
+class OriginalTypeGeneratedTest extends TestCase
+{
+    public function testPrologueContainsNoUndefinedNamespace(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Foo')
+        );
+
+        $this->assertEquals(
+            "class Foo\n{\n}\n\n",
+            $originalType->getCodePrologue()
+        );
+    }
+
+    public function testEpilogueIsEmptyForUndefinedNamespace(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Foo')
+        );
+
+        $this->assertEquals(
+            '',
+            $originalType->getCodeEpilogue()
+        );
+    }
+
+    public function testPrologueContainsDefinedNamespace(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+
+        $this->assertEquals(
+            "namespace Bar {\n\nclass Foo\n{\n}\n\n}\n\nnamespace {\n\n",
+            $originalType->getCodePrologue()
+        );
+    }
+
+    public function testEpilogueClosesDefinedNamespace(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+
+        $this->assertEquals(
+            "\n\n}",
+            $originalType->getCodeEpilogue()
+        );
+    }
+
+    public function testHasNoToStringMethod(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+        $this->assertFalse($originalType->hasMethod('__toString'));
+    }
+
+    public function testFailsToGetMethod(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+        $this->expectException(\OutOfBoundsException::class);
+        $originalType->getMethod('__toString');
+    }
+
+    public function testHasNoMethods(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+        $this->assertEquals([], $originalType->getMethods());
+    }
+
+    public function testIsNoInterface(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+        $this->assertFalse($originalType->isInterface());
+    }
+
+    public function testIsNotFinal(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+        $this->assertFalse($originalType->isFinal());
+    }
+
+    public function testPreservesName(): void
+    {
+        $typeName     = TypeName::fromQualifiedName('Bar\\Foo');
+        $originalType = new OriginalTypeGenerated($typeName);
+        $this->assertSame($typeName, $originalType->getName());
+    }
+
+    public function testDoesNotImplementInterface(): void
+    {
+        $originalType = new OriginalTypeGenerated(
+            TypeName::fromQualifiedName('Bar\\Foo')
+        );
+        $this->assertFalse($originalType->implementsInterface(\Traversable::class));
+    }
+}

--- a/tests/unit/Framework/MockObject/OriginalTypeReflectionTest.php
+++ b/tests/unit/Framework/MockObject/OriginalTypeReflectionTest.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use PHPUnit\Framework\TestCase;
+
+class OriginalTypeReflectionTest extends TestCase
+{
+    public function testPrologueIsEmpty(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\stdClass::class)
+        );
+        $this->assertEquals('', $originalType->getCodePrologue());
+    }
+
+    public function testEpilogueIsEmpty(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\stdClass::class)
+        );
+        $this->assertEquals('', $originalType->getCodeEpilogue());
+    }
+
+    public function testHasMethodOfClass(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\IteratorAggregate::class)
+        );
+        $this->assertTrue($originalType->hasMethod('getIterator'));
+    }
+
+    public function testDoesNotHaveMethodNotDefinedInClass(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\IteratorAggregate::class)
+        );
+        $this->assertFalse($originalType->hasMethod('__toString'));
+    }
+
+    public function testGetMethodDefinedInClass(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\IteratorAggregate::class)
+        );
+        $method = $originalType->getMethod('getIterator');
+        $this->assertEquals('getIterator', $method->getName());
+        $this->assertEquals(\IteratorAggregate::class, $method->getDeclaringClass()->getName());
+    }
+
+    public function testFailToGetMethodNotDefinedInClass(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\IteratorAggregate::class)
+        );
+        $this->expectException(\OutOfBoundsException::class);
+        $originalType->getMethod('foo');
+    }
+
+    public function testGetAllMethods(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\IteratorAggregate::class)
+        );
+        $methods = $originalType->getMethods();
+        $this->assertCount(1, $methods);
+        /** @var \ReflectionMethod $method */
+        $method = $methods[0];
+        $this->assertEquals('getIterator', $method->getName());
+        $this->assertEquals(\IteratorAggregate::class, $method->getDeclaringClass()->getName());
+    }
+
+    public function testInterfaceIsInterface(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\IteratorAggregate::class)
+        );
+        $this->assertTrue($originalType->isInterface());
+    }
+
+    public function testClassIsNoInterface(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\stdClass::class)
+        );
+        $this->assertFalse($originalType->isInterface());
+    }
+
+    public function testFinalClassIsFinal(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(OriginalTypeReflection::class)
+        );
+        $this->assertTrue($originalType->isFinal());
+    }
+
+    public function testUnFinalClassIsNotFinal(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\stdClass::class)
+        );
+        $this->assertFalse($originalType->isFinal());
+    }
+
+    public function testDetectImplementedInterface(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(OriginalTypeReflection::class)
+        );
+        $this->assertTrue($originalType->implementsInterface(OriginalType::class));
+    }
+
+    public function testDetectUnImplementedInterface(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(OriginalTypeReflection::class)
+        );
+        $this->assertFalse($originalType->implementsInterface(\IteratorAggregate::class));
+    }
+
+    public function testPreservesName(): void
+    {
+        $originalType = new OriginalTypeReflection(
+            new \ReflectionClass(\stdClass::class)
+        );
+        $this->assertEquals(
+            TypeName::fromQualifiedName(\stdClass::class),
+            $originalType->getName()
+        );
+    }
+}

--- a/tests/unit/Framework/MockObject/TypeNameTest.php
+++ b/tests/unit/Framework/MockObject/TypeNameTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use PHPUnit\Framework\TestCase;
+
+class TypeNameTest extends TestCase
+{
+    public function testFromReflection(): void
+    {
+        $class    = new \ReflectionClass(TypeName::class);
+        $typeName = TypeName::fromReflection($class);
+
+        $this->assertTrue($typeName->isNamespaced());
+        $this->assertEquals('PHPUnit\\Framework\\MockObject', $typeName->getNamespaceName());
+        $this->assertEquals(TypeName::class, $typeName->getQualifiedName());
+        $this->assertEquals('TypeName', $typeName->getSimpleName());
+    }
+
+    public function testFromQualifiedName(): void
+    {
+        $typeName = TypeName::fromQualifiedName('PHPUnit\\Framework\\MockObject\\TypeName');
+
+        $this->assertTrue($typeName->isNamespaced());
+        $this->assertEquals('PHPUnit\\Framework\\MockObject', $typeName->getNamespaceName());
+        $this->assertEquals('PHPUnit\\Framework\\MockObject\\TypeName', $typeName->getQualifiedName());
+        $this->assertEquals('TypeName', $typeName->getSimpleName());
+    }
+
+    public function testFromQualifiedNameWithLeadingSeparator(): void
+    {
+        $typeName = TypeName::fromQualifiedName('\\Foo\\Bar');
+
+        $this->assertTrue($typeName->isNamespaced());
+        $this->assertEquals('Foo', $typeName->getNamespaceName());
+        $this->assertEquals('Foo\\Bar', $typeName->getQualifiedName());
+        $this->assertEquals('Bar', $typeName->getSimpleName());
+    }
+
+    public function testFromQualifiedNameWithoutNamespace(): void
+    {
+        $typeName = TypeName::fromQualifiedName('Bar');
+
+        $this->assertFalse($typeName->isNamespaced());
+        $this->assertEquals('', $typeName->getNamespaceName());
+        $this->assertEquals('Bar', $typeName->getQualifiedName());
+        $this->assertEquals('Bar', $typeName->getSimpleName());
+    }
+}


### PR DESCRIPTION
* Moved some code that is responsible for the code generation of mock classes to new classes.
* Introduced a value object (TypeName) for the names of classes and interfaces to clearly differentiate between qualified and unqualified class names.
* Use morphism instead of conditions for the different handling of generated and existing original methods.