### PR TITLE
Fix assertCount and the Count class

### DIFF
--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -89,15 +89,20 @@ class Count extends Constraint
             $traversable = $traversable->getIterator();
         }
 
-        if ($traversable instanceof Generator) {
+        if ($traversable instanceof Iterator) {
+            if ($this->iteratorIsRewindable($traversable)) {
+                return $this->getCountOfRewindableIterator($traversable);
+            }
+
             return $this->getCountOfNonRewindableIterator($traversable);
         }
 
-        if ($traversable instanceof Iterator) {
-            return $this->getCountOfRewindableIterator($traversable);
-        }
-
         return \iterator_count($traversable);
+    }
+
+    private function iteratorIsRewindable(Iterator $iterator): bool
+    {
+        return !($iterator instanceof Generator) && !($iterator instanceof \NoRewindIterator);
     }
 
     /**

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -62,22 +62,25 @@ class Count extends Constraint
         }
 
         if ($other instanceof Traversable) {
-            while ($other instanceof IteratorAggregate) {
-                $other = $other->getIterator();
-            }
-
-            $iterator = $other;
-
-            if ($iterator instanceof Generator) {
-                return $this->getCountOfGenerator($iterator);
-            }
-
-            if (!$iterator instanceof Iterator) {
-                return \iterator_count($iterator);
-            }
-
-            return $this->getCountOfRewindableIterator($iterator);
+            return $this->getCountOfTraversable($other);
         }
+    }
+
+    private function getCountOfTraversable(Traversable $traversable): int
+    {
+        while ($traversable instanceof IteratorAggregate) {
+            $traversable = $traversable->getIterator();
+        }
+
+        if ($traversable instanceof Generator) {
+            return $this->getCountOfGenerator($traversable);
+        }
+
+        if ($traversable instanceof Iterator) {
+            return $this->getCountOfRewindableIterator($traversable);
+        }
+
+        return \iterator_count($traversable);
     }
 
     /**

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -31,7 +31,7 @@ class Count extends Constraint
     {
         parent::__construct();
 
-        $this->expectedCount = $expected;
+        $this->expectedCount     = $expected;
         $this->traversableCounts = new \SplObjectStorage();
     }
 
@@ -66,23 +66,6 @@ class Count extends Constraint
         }
     }
 
-    private function getCountOfTraversable(Traversable $traversable): int
-    {
-        while ($traversable instanceof IteratorAggregate) {
-            $traversable = $traversable->getIterator();
-        }
-
-        if ($traversable instanceof Generator) {
-            return $this->getCountOfGenerator($traversable);
-        }
-
-        if ($traversable instanceof Iterator) {
-            return $this->getCountOfRewindableIterator($traversable);
-        }
-
-        return \iterator_count($traversable);
-    }
-
     /**
      * Returns the total number of iterations from a generator.
      * This will fully exhaust the generator.
@@ -98,6 +81,40 @@ class Count extends Constraint
         }
 
         return $this->traversableCounts[$generator];
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     */
+    protected function failureDescription($other): string
+    {
+        return \sprintf(
+            'actual size %d matches expected size %d',
+            $this->getCountOf($other),
+            $this->expectedCount
+        );
+    }
+
+    private function getCountOfTraversable(Traversable $traversable): int
+    {
+        while ($traversable instanceof IteratorAggregate) {
+            $traversable = $traversable->getIterator();
+        }
+
+        if ($traversable instanceof Generator) {
+            return $this->getCountOfGenerator($traversable);
+        }
+
+        if ($traversable instanceof Iterator) {
+            return $this->getCountOfRewindableIterator($traversable);
+        }
+
+        return \iterator_count($traversable);
     }
 
     private function getCountOfRewindableIterator(Iterator $iterator): int
@@ -116,22 +133,5 @@ class Count extends Constraint
         }
 
         return $count;
-    }
-
-    /**
-     * Returns the description of the failure.
-     *
-     * The beginning of failure messages is "Failed asserting that" in most
-     * cases. This method should return the second part of that sentence.
-     *
-     * @param mixed $other evaluated value or object
-     */
-    protected function failureDescription($other): string
-    {
-        return \sprintf(
-            'actual size %d matches expected size %d',
-            $this->getCountOf($other),
-            $this->expectedCount
-        );
     }
 }

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -22,7 +22,7 @@ class Count extends Constraint
     private $expectedCount;
 
     /**
-     * @var \SplObjectStorage
+     * @var \SplObjectStorage|null
      */
     private $traversableCounts;
 
@@ -31,7 +31,6 @@ class Count extends Constraint
         parent::__construct();
 
         $this->expectedCount     = $expected;
-        $this->traversableCounts = new \SplObjectStorage();
     }
 
     public function toString(): string

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -66,40 +66,6 @@ class Count extends Constraint
         }
     }
 
-    /**
-     * Returns the total number of iterations from a generator.
-     * This will fully exhaust the generator.
-     */
-    protected function getCountOfGenerator(Generator $generator): int
-    {
-        if (!$this->traversableCounts->contains($generator)) {
-            for ($countOfGenerator = 0; $generator->valid(); $generator->next()) {
-                ++$countOfGenerator;
-            }
-
-            $this->traversableCounts->attach($generator, $countOfGenerator);
-        }
-
-        return $this->traversableCounts[$generator];
-    }
-
-    /**
-     * Returns the description of the failure.
-     *
-     * The beginning of failure messages is "Failed asserting that" in most
-     * cases. This method should return the second part of that sentence.
-     *
-     * @param mixed $other evaluated value or object
-     */
-    protected function failureDescription($other): string
-    {
-        return \sprintf(
-            'actual size %d matches expected size %d',
-            $this->getCountOf($other),
-            $this->expectedCount
-        );
-    }
-
     private function getCountOfTraversable(Traversable $traversable): int
     {
         while ($traversable instanceof IteratorAggregate) {
@@ -115,6 +81,23 @@ class Count extends Constraint
         }
 
         return \iterator_count($traversable);
+    }
+
+    /**
+     * Returns the total number of iterations from a generator.
+     * This will fully exhaust the generator.
+     */
+    protected function getCountOfGenerator(Generator $generator): int
+    {
+        if (!$this->traversableCounts->contains($generator)) {
+            for ($countOfGenerator = 0; $generator->valid(); $generator->next()) {
+                ++$countOfGenerator;
+            }
+
+            $this->traversableCounts->attach($generator, $countOfGenerator);
+        }
+
+        return $this->traversableCounts[$generator];
     }
 
     private function getCountOfRewindableIterator(Iterator $iterator): int
@@ -133,5 +116,22 @@ class Count extends Constraint
         }
 
         return $count;
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     */
+    protected function failureDescription($other): string
+    {
+        return \sprintf(
+            'actual size %d matches expected size %d',
+            $this->getCountOf($other),
+            $this->expectedCount
+        );
     }
 }

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -22,7 +22,7 @@ class Count extends Constraint
     private $expectedCount;
 
     /**
-     * @var \SplObjectStorage|null
+     * @var null|\SplObjectStorage
      */
     private $traversableCounts;
 
@@ -117,17 +117,6 @@ class Count extends Constraint
         return $count;
     }
 
-    private function iteratorIsRewindable(Iterator $iterator): bool
-    {
-        try {
-            $iterator->rewind();
-        } catch (\Exception $e) {
-            return false;
-        }
-
-        return !($iterator instanceof \NoRewindIterator);
-    }
-
     /**
      * Returns the total number of iterations from a iterator.
      * This will fully exhaust the iterator.
@@ -139,6 +128,17 @@ class Count extends Constraint
         }
 
         return $countOfGenerator;
+    }
+
+    private function iteratorIsRewindable(Iterator $iterator): bool
+    {
+        try {
+            $iterator->rewind();
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return !($iterator instanceof \NoRewindIterator);
     }
 
     private function rewindIterator(Iterator $iterator, $key): void

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -22,6 +22,11 @@ class Count extends Constraint
      */
     private $expectedCount;
 
+    /**
+     * @var null|int
+     */
+    private $countOfGenerator;
+
     public function __construct(int $expected)
     {
         parent::__construct();
@@ -93,11 +98,13 @@ class Count extends Constraint
      */
     protected function getCountOfGenerator(Generator $generator): int
     {
-        for ($count = 0; $generator->valid(); $generator->next()) {
-            ++$count;
+        if ($this->countOfGenerator === null) {
+            for ($this->countOfGenerator = 0; $generator->valid(); $generator->next()) {
+                ++$this->countOfGenerator;
+            }
         }
 
-        return $count;
+        return $this->countOfGenerator;
     }
 
     /**

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -66,6 +66,40 @@ class Count extends Constraint
         }
     }
 
+    /**
+     * Returns the total number of iterations from a iterator.
+     * This will fully exhaust the generator.
+     */
+    protected function getCountOfNonRewindableIterator(Iterator $iterator): int
+    {
+        if (!$this->iteratorCounts->contains($iterator)) {
+            for ($countOfGenerator = 0; $iterator->valid(); $iterator->next()) {
+                ++$countOfGenerator;
+            }
+
+            $this->iteratorCounts->attach($iterator, $countOfGenerator);
+        }
+
+        return $this->iteratorCounts[$iterator];
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     */
+    protected function failureDescription($other): string
+    {
+        return \sprintf(
+            'actual size %d matches expected size %d',
+            $this->getCountOf($other),
+            $this->expectedCount
+        );
+    }
+
     private function getCountOfTraversable(Traversable $traversable): int
     {
         while ($traversable instanceof IteratorAggregate) {
@@ -81,23 +115,6 @@ class Count extends Constraint
         }
 
         return \iterator_count($traversable);
-    }
-
-    /**
-     * Returns the total number of iterations from a iterator.
-     * This will fully exhaust the generator.
-     */
-    protected function getCountOfNonRewindableIterator(Iterator $iterator): int
-    {
-        if (!$this->iteratorCounts->contains($iterator)) {
-            for ( $countOfGenerator = 0; $iterator->valid(); $iterator->next()) {
-                ++$countOfGenerator;
-            }
-
-            $this->iteratorCounts->attach($iterator, $countOfGenerator);
-        }
-
-        return $this->iteratorCounts[$iterator];
     }
 
     private function getCountOfRewindableIterator(Iterator $iterator): int
@@ -116,22 +133,5 @@ class Count extends Constraint
         }
 
         return $count;
-    }
-
-    /**
-     * Returns the description of the failure.
-     *
-     * The beginning of failure messages is "Failed asserting that" in most
-     * cases. This method should return the second part of that sentence.
-     *
-     * @param mixed $other evaluated value or object
-     */
-    protected function failureDescription($other): string
-    {
-        return \sprintf(
-            'actual size %d matches expected size %d',
-            $this->getCountOf($other),
-            $this->expectedCount
-        );
     }
 }

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -115,7 +115,7 @@ class Count extends Constraint
     {
         $key          = $iterator->key();
         $isRewindable = $this->attemptIteratorRewind($iterator);
-        $count        = $this->getCountOfIterator($iterator);
+        $count        = $this->getRemainingCountOfIterator($iterator);
 
         if ($isRewindable) {
             $this->moveIteratorToPosition($iterator, $key);
@@ -125,10 +125,9 @@ class Count extends Constraint
     }
 
     /**
-     * Returns the total number of iterations from a iterator.
      * This will fully exhaust the iterator.
      */
-    private function getCountOfIterator(Iterator $iterator): int
+    private function getRemainingCountOfIterator(Iterator $iterator): int
     {
         for ($count = 0; $iterator->valid(); $iterator->next()) {
             ++$count;

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -67,23 +67,6 @@ class Count extends Constraint
     }
 
     /**
-     * Returns the total number of iterations from a iterator.
-     * This will fully exhaust the generator.
-     */
-    protected function getCountOfNonRewindableIterator(Iterator $iterator): int
-    {
-        if (!$this->iteratorCounts->contains($iterator)) {
-            for ($countOfGenerator = 0; $iterator->valid(); $iterator->next()) {
-                ++$countOfGenerator;
-            }
-
-            $this->iteratorCounts->attach($iterator, $countOfGenerator);
-        }
-
-        return $this->iteratorCounts[$iterator];
-    }
-
-    /**
      * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
@@ -115,6 +98,23 @@ class Count extends Constraint
         }
 
         return \iterator_count($traversable);
+    }
+
+    /**
+     * Returns the total number of iterations from a iterator.
+     * This will fully exhaust the generator.
+     */
+    private function getCountOfNonRewindableIterator(Iterator $iterator): int
+    {
+        if (!$this->iteratorCounts->contains($iterator)) {
+            for ($countOfGenerator = 0; $iterator->valid(); $iterator->next()) {
+                ++$countOfGenerator;
+            }
+
+            $this->iteratorCounts->attach($iterator, $countOfGenerator);
+        }
+
+        return $this->iteratorCounts[$iterator];
     }
 
     private function getCountOfRewindableIterator(Iterator $iterator): int

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -95,11 +95,20 @@ class Count extends Constraint
             return $this->traversableCounts[$traversable];
         }
 
+        $count = $this->countNonIteratorAggregateTraversable($traversable);
+
+        $this->traversableCounts->attach($traversable, $count);
+
+        return $count;
+    }
+
+    private function countNonIteratorAggregateTraversable(Traversable $traversable): int
+    {
         if ($traversable instanceof Iterator) {
             return $this->countIteratorWithoutChangingPositionIfPossible($traversable);
         }
 
-        return $this->getCountOfTraversableThatIsNotIteratorOrIteratorAggregate($traversable);
+        return \iterator_count($traversable);
     }
 
     private function countIteratorWithoutChangingPositionIfPossible(Iterator $iterator): int
@@ -110,8 +119,6 @@ class Count extends Constraint
 
         if ($isRewindable) {
             $this->moveIteratorToPosition($iterator, $key);
-        } else {
-            $this->traversableCounts->attach($iterator, $count);
         }
 
         return $count;
@@ -147,19 +154,12 @@ class Count extends Constraint
 
     private function moveIteratorToPosition(Iterator $iterator, $key): void
     {
-        $iterator->rewind();
+        if ($key !== null) {
+            $iterator->rewind();
 
-        while ($iterator->valid() && $key !== $iterator->key()) {
-            $iterator->next();
+            while ($iterator->valid() && $key !== $iterator->key()) {
+                $iterator->next();
+            }
         }
-    }
-
-    private function getCountOfTraversableThatIsNotIteratorOrIteratorAggregate(Traversable $traversable): int
-    {
-        $count = \iterator_count($traversable);
-
-        $this->traversableCounts->attach($traversable, $count);
-
-        return $count;
     }
 }

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -31,8 +31,8 @@ class Count extends Constraint
     {
         parent::__construct();
 
-        $this->expectedCount     = $expected;
-        $this->iteratorCounts    = new \SplObjectStorage();
+        $this->expectedCount  = $expected;
+        $this->iteratorCounts = new \SplObjectStorage();
     }
 
     public function toString(): string

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -104,7 +104,7 @@ class Count extends Constraint
                 ++$countOfGenerator;
             }
 
-			$this->traversableCounts->attach($generator, $countOfGenerator);
+            $this->traversableCounts->attach($generator, $countOfGenerator);
         }
 
         return $this->traversableCounts[$generator];

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -23,15 +23,16 @@ class Count extends Constraint
     private $expectedCount;
 
     /**
-     * @var null|int
+     * @var \SplObjectStorage
      */
-    private $countOfGenerator;
+    private $traversableCounts;
 
     public function __construct(int $expected)
     {
         parent::__construct();
 
         $this->expectedCount = $expected;
+        $this->traversableCounts = new \SplObjectStorage();
     }
 
     public function toString(): string
@@ -98,13 +99,15 @@ class Count extends Constraint
      */
     protected function getCountOfGenerator(Generator $generator): int
     {
-        if ($this->countOfGenerator === null) {
-            for ($this->countOfGenerator = 0; $generator->valid(); $generator->next()) {
-                ++$this->countOfGenerator;
+        if (!$this->traversableCounts->contains($generator)) {
+            for ($countOfGenerator = 0; $generator->valid(); $generator->next()) {
+                ++$countOfGenerator;
             }
+
+			$this->traversableCounts->attach($generator, $countOfGenerator);
         }
 
-        return $this->countOfGenerator;
+        return $this->traversableCounts[$generator];
     }
 
     /**

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -123,11 +123,11 @@ class Count extends Constraint
      */
     private function getCountOfIterator(Iterator $iterator): int
     {
-        for ($countOfGenerator = 0; $iterator->valid(); $iterator->next()) {
-            ++$countOfGenerator;
+        for ($count = 0; $iterator->valid(); $iterator->next()) {
+            ++$count;
         }
 
-        return $countOfGenerator;
+        return $count;
     }
 
     private function iteratorIsRewindable(Iterator $iterator): bool

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -76,20 +76,7 @@ class Count extends Constraint
                 return \iterator_count($iterator);
             }
 
-            $key   = $iterator->key();
-            $count = \iterator_count($iterator);
-
-            // Manually rewind $iterator to previous key, since iterator_count
-            // moves pointer.
-            if ($key !== null) {
-                $iterator->rewind();
-
-                while ($iterator->valid() && $key !== $iterator->key()) {
-                    $iterator->next();
-                }
-            }
-
-            return $count;
+            return $this->getCountOfRewindableIterator($iterator);
         }
     }
 
@@ -108,6 +95,24 @@ class Count extends Constraint
         }
 
         return $this->traversableCounts[$generator];
+    }
+
+    private function getCountOfRewindableIterator(Iterator $iterator): int
+    {
+        $key   = $iterator->key();
+        $count = \iterator_count($iterator);
+
+        // Manually rewind $iterator to previous key, since iterator_count
+        // moves pointer.
+        if ($key !== null) {
+            $iterator->rewind();
+
+            while ($iterator->valid() && $key !== $iterator->key()) {
+                $iterator->next();
+            }
+        }
+
+        return $count;
     }
 
     /**

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -25,14 +25,14 @@ class Count extends Constraint
     /**
      * @var \SplObjectStorage
      */
-    private $traversableCounts;
+    private $iteratorCounts;
 
     public function __construct(int $expected)
     {
         parent::__construct();
 
         $this->expectedCount     = $expected;
-        $this->traversableCounts = new \SplObjectStorage();
+        $this->iteratorCounts    = new \SplObjectStorage();
     }
 
     public function toString(): string
@@ -73,7 +73,7 @@ class Count extends Constraint
         }
 
         if ($traversable instanceof Generator) {
-            return $this->getCountOfGenerator($traversable);
+            return $this->getCountOfNonRewindableIterator($traversable);
         }
 
         if ($traversable instanceof Iterator) {
@@ -84,20 +84,20 @@ class Count extends Constraint
     }
 
     /**
-     * Returns the total number of iterations from a generator.
+     * Returns the total number of iterations from a iterator.
      * This will fully exhaust the generator.
      */
-    protected function getCountOfGenerator(Generator $generator): int
+    protected function getCountOfNonRewindableIterator(Iterator $iterator): int
     {
-        if (!$this->traversableCounts->contains($generator)) {
-            for ($countOfGenerator = 0; $generator->valid(); $generator->next()) {
+        if (!$this->iteratorCounts->contains($iterator)) {
+            for ( $countOfGenerator = 0; $iterator->valid(); $iterator->next()) {
                 ++$countOfGenerator;
             }
 
-            $this->traversableCounts->attach($generator, $countOfGenerator);
+            $this->iteratorCounts->attach($iterator, $countOfGenerator);
         }
 
-        return $this->traversableCounts[$generator];
+        return $this->iteratorCounts[$iterator];
     }
 
     private function getCountOfRewindableIterator(Iterator $iterator): int

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -30,7 +30,7 @@ class Count extends Constraint
     {
         parent::__construct();
 
-        $this->expectedCount     = $expected;
+        $this->expectedCount = $expected;
     }
 
     public function toString(): string

--- a/tests/_files/FailingGeneratorCountTest.php
+++ b/tests/_files/FailingGeneratorCountTest.php
@@ -11,7 +11,7 @@ namespace Test;
 
 use PHPUnit\Framework\TestCase;
 
-class GeneratorTest extends TestCase
+class FailingGeneratorCountTest extends TestCase
 {
     public function testGenerator()
     {

--- a/tests/_files/GeneratorTest.php
+++ b/tests/_files/GeneratorTest.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Test;
+
+use PHPUnit\Framework\TestCase;
+
+class GeneratorTest extends TestCase
+{
+    public function testGenerator()
+    {
+        $generator = static function () {
+            yield 1;
+
+            yield 2;
+
+            yield 3;
+        };
+
+        static::assertCount(4, $generator());
+    }
+}

--- a/tests/end-to-end/generator-failing-assert-count.phpt
+++ b/tests/end-to-end/generator-failing-assert-count.phpt
@@ -1,0 +1,26 @@
+--TEST--
+phpunit BankAccountTest ../../_files/GeneratorTest.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/GeneratorTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+F                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) Test\GeneratorTest::testGenerator
+Failed asserting that actual size 3 matches expected size 4.
+
+%sGeneratorTest.php:%i
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/end-to-end/generator-failing-assert-count.phpt
+++ b/tests/end-to-end/generator-failing-assert-count.phpt
@@ -1,9 +1,9 @@
 --TEST--
-phpunit BankAccountTest ../../_files/GeneratorTest.php
+phpunit BankAccountTest ../../_files/FailingGeneratorCountTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/GeneratorTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/FailingGeneratorCountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
@@ -17,10 +17,10 @@ Time: %s, Memory: %s
 
 There was 1 failure:
 
-1) Test\GeneratorTest::testGenerator
+1) Test\FailingGeneratorCountTest::testGenerator
 Failed asserting that actual size 3 matches expected size 4.
 
-%sGeneratorTest.php:%i
+%sFailingGeneratorCountTest.php:%i
 
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -145,17 +145,27 @@ class CountTest extends ConstraintTestCase
 
 	public function testCountingNonRewindableIteratorWithDifferentCount(): void
 	{
-		$countConstraint = new Count(2);
-		$iterator = new \NoRewindIterator(new \ArrayIterator([1, 2, 3]));
-
-		$this->assertFalse($countConstraint->evaluate($iterator, '', true));
+		$this->assertCountFails(
+			new Count(2),
+			new \NoRewindIterator(new \ArrayIterator([1, 2, 3]))
+		);
 	}
 
 	public function testCountingNonRewindableIteratorWithSameCount(): void
 	{
-		$countConstraint = new Count(2);
-		$iterator = new \NoRewindIterator(new \ArrayIterator([1, 2]));
+		$this->assertCountSucceeds(
+			new Count(2),
+			new \NoRewindIterator(new \ArrayIterator([1, 2]))
+		);
+	}
 
-		$this->assertTrue($countConstraint->evaluate($iterator, '', true));
+	public function assertCountFails(Count $count, iterable $iterable): void
+	{
+		$this->assertFalse($count->evaluate($iterable, '', true));
+	}
+
+	public function assertCountSucceeds(Count $count, iterable $iterable): void
+	{
+		$this->assertTrue($count->evaluate($iterable, '', true));
 	}
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -9,6 +9,9 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestFailure;
+
 class CountTest extends ConstraintTestCase
 {
     public function testCount(): void
@@ -176,5 +179,29 @@ class CountTest extends ConstraintTestCase
 
         $this->assertCountFails($count, $generatorWithThreeElements);
         $this->assertCountSucceeds($count, $generatorWithTwoElements);
+    }
+
+    public function testFailureMessageIsCorrectForGenerators()
+    {
+        $this->assertEvaluateFailsWithMessage(
+            new Count(1),
+            (new \TestGeneratorMaker())->create(['a', 'b']),
+            'actual size 2 matches expected size 1'
+        );
+    }
+
+    private function assertEvaluateFailsWithMessage(Count $count, iterable $iterable, string $message)
+    {
+        try {
+            $count->evaluate($iterable);
+        } catch (ExpectationFailedException $e) {
+            $this->assertContains(
+                $message,
+                TestFailure::exceptionToString($e)
+            );
+            return;
+        }
+
+        $this->assertFalse(true, 'An exception should have been thrown');
     }
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -181,7 +181,7 @@ class CountTest extends ConstraintTestCase
         $this->assertCountSucceeds($count, $generatorWithTwoElements);
     }
 
-    public function testFailureMessageIsCorrectForGenerators()
+    public function testFailureMessageIsCorrectForGenerators(): void
     {
         $this->assertEvaluateFailsWithMessage(
             new Count(1),
@@ -190,7 +190,7 @@ class CountTest extends ConstraintTestCase
         );
     }
 
-    public function testFailureMessageIsCorrectForNonRewindableIterators()
+    public function testFailureMessageIsCorrectForNonRewindableIterators(): void
     {
         $this->assertEvaluateFailsWithMessage(
             new Count(1),
@@ -199,7 +199,16 @@ class CountTest extends ConstraintTestCase
         );
     }
 
-    private function assertEvaluateFailsWithMessage(Count $count, iterable $iterable, string $message)
+    public function testFailureMessageIsCorrectForTraversablesThatAreNotIteratorsOrIteratorAggregates(): void
+    {
+        $this->assertEvaluateFailsWithMessage(
+            new Count(1),
+            $this->newPdoStatementWithThreeValues(),
+            'actual size 3 matches expected size 1'
+        );
+    }
+
+    private function assertEvaluateFailsWithMessage(Count $count, iterable $iterable, string $message): void
     {
         try {
             $count->evaluate($iterable);
@@ -213,5 +222,18 @@ class CountTest extends ConstraintTestCase
         }
 
         $this->fail('An exception should have been thrown');
+    }
+
+    private function newPdoStatementWithThreeValues(): \Traversable
+    {
+        if (!\class_exists('\PDO')) {
+            $this->markTestSkipped('derp');
+        }
+
+        $conn = new \PDO('sqlite::memory:');
+        $conn->exec('CREATE TABLE foo (id INT NOT NULL PRIMARY KEY)');
+        $conn->exec('INSERT INTO foo VALUES (1), (2), (3)');
+
+        return $conn->query('SELECT * FROM foo');
     }
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -199,6 +199,7 @@ class CountTest extends ConstraintTestCase
                 $message,
                 TestFailure::exceptionToString($e)
             );
+
             return;
         }
 

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -168,4 +168,16 @@ class CountTest extends ConstraintTestCase
 	{
 		$this->assertTrue($count->evaluate($iterable, '', true));
 	}
+
+	public function testCountingDifferentGeneratorsSequentiallyWorks(): void
+	{
+		$count = new Count(2);
+
+		$generatorMaker = new \TestGeneratorMaker();
+		$generatorWithThreeElements = $generatorMaker->create(['a', 'b', 'c']);
+		$generatorWithTwoElements = $generatorMaker->create(['a', 'b']);
+
+		$this->assertCountFails($count, $generatorWithThreeElements);
+		$this->assertCountSucceeds($count, $generatorWithTwoElements);
+	}
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -118,7 +118,7 @@ class CountTest extends ConstraintTestCase
         $this->assertNull($generator->current());
     }
 
-    public function testCountsExhaustedIteratorsAsZero(): void
+    public function testCountsExhaustedGeneratorsAsZero(): void
     {
         $countConstraint = new Count(0);
         $generator       = (new \TestGeneratorMaker())->create([1]);

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -142,4 +142,20 @@ class CountTest extends ConstraintTestCase
         $this->assertNotInstanceOf(\IteratorAggregate::class, $datePeriod);
         $this->assertTrue($countConstraint->evaluate($datePeriod, '', true));
     }
+
+	public function testCountingNonRewindableIteratorWithDifferentCount(): void
+	{
+		$countConstraint = new Count(2);
+		$iterator = new \NoRewindIterator(new \ArrayIterator([1, 2, 3]));
+
+		$this->assertFalse($countConstraint->evaluate($iterator, '', true));
+	}
+
+	public function testCountingNonRewindableIteratorWithSameCount(): void
+	{
+		$countConstraint = new Count(2);
+		$iterator = new \NoRewindIterator(new \ArrayIterator([1, 2]));
+
+		$this->assertTrue($countConstraint->evaluate($iterator, '', true));
+	}
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -99,7 +99,7 @@ class CountTest extends ConstraintTestCase
     public function testDoesNotRewindGeneratorAtStartingPosition(): void
     {
         $countConstraint = new Count(3);
-        $generator = (new \TestGeneratorMaker())->create([1, 2, 3]);
+        $generator       = (new \TestGeneratorMaker())->create([1, 2, 3]);
 
         $this->assertCountSucceeds($countConstraint, $generator);
         $this->assertNull($generator->current());
@@ -108,7 +108,7 @@ class CountTest extends ConstraintTestCase
     public function testOnlyCountRemainingGeneratorElements(): void
     {
         $countConstraint = new Count(2);
-        $generator = (new \TestGeneratorMaker())->create([1, 2, 3]);
+        $generator       = (new \TestGeneratorMaker())->create([1, 2, 3]);
         $generator->next();
 
         $this->assertCountSucceeds($countConstraint, $generator);
@@ -118,7 +118,7 @@ class CountTest extends ConstraintTestCase
     public function testCountsExhaustedIteratorsAsZero(): void
     {
         $countConstraint = new Count(0);
-        $generator = (new \TestGeneratorMaker())->create([1]);
+        $generator       = (new \TestGeneratorMaker())->create([1]);
         $generator->next();
 
         $this->assertCountSucceeds($countConstraint, $generator);
@@ -170,9 +170,9 @@ class CountTest extends ConstraintTestCase
     {
         $count = new Count(2);
 
-        $generatorMaker = new \TestGeneratorMaker();
+        $generatorMaker             = new \TestGeneratorMaker();
         $generatorWithThreeElements = $generatorMaker->create(['a', 'b', 'c']);
-        $generatorWithTwoElements = $generatorMaker->create(['a', 'b']);
+        $generatorWithTwoElements   = $generatorMaker->create(['a', 'b']);
 
         $this->assertCountFails($count, $generatorWithThreeElements);
         $this->assertCountSucceeds($count, $generatorWithTwoElements);

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -212,6 +212,6 @@ class CountTest extends ConstraintTestCase
             return;
         }
 
-        $this->assertFalse(true, 'An exception should have been thrown');
+        $this->fail('An exception should have been thrown');
     }
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -128,6 +128,17 @@ class CountTest extends ConstraintTestCase
         $this->assertNull($generator->current());
     }
 
+    public function testFullyCountsIteratorsNotAtTheirStartingPosition(): void
+    {
+        $iterator = new \TestIterator([1, 2, 3]);
+        $iterator->next();
+
+        $this->assertCountSucceeds(
+            new Count(3),
+            $iterator
+        );
+    }
+
     public function testCountTraversable(): void
     {
         $countConstraint = new Count(5);

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -226,8 +226,8 @@ class CountTest extends ConstraintTestCase
 
     private function newPdoStatementWithThreeValues(): \Traversable
     {
-        if (!\class_exists('\PDO')) {
-            $this->markTestSkipped('derp');
+        if (!\extension_loaded('pdo') || !\in_array('sqlite', \PDO::getAvailableDrivers())) {
+            $this->markTestSkipped('PDO_SQLITE is required');
         }
 
         $conn = new \PDO('sqlite::memory:');

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -190,6 +190,15 @@ class CountTest extends ConstraintTestCase
         );
     }
 
+    public function testFailureMessageIsCorrectForNonRewindableIterators()
+    {
+        $this->assertEvaluateFailsWithMessage(
+            new Count(1),
+            new \NoRewindIterator(new \ArrayIterator([1, 2, 3])),
+            'actual size 3 matches expected size 1'
+        );
+    }
+
     private function assertEvaluateFailsWithMessage(Count $count, iterable $iterable, string $message)
     {
         try {


### PR DESCRIPTION
This is ready for review. Ping @sebastianbergmann 

Fixes #3302, builds upon and replaces https://github.com/sebastianbergmann/phpunit/pull/3304

Behavior changes with master:
* Error messages for non-rewindable Iterators are now shown correctly
* The `Count` class can now evaluate the same non-rewindable Iterator more than once
* Non-rewindable Iterators that are not Generators will no longer be rewound by `Count`, which for some Iterators causes an error

I took care to not change any other behavior. Though beware that the protected method `getCountOfGenerator` has been refactored away.

Tests added for the changed behavior and some clean up of existing tests, including adding assertions for existing behavior that was not tested yet.