### PR TITLE
Incorrect TestDox output for data provider with indexed array

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -85,7 +85,7 @@ final class NamePrettifier
         }
 
         if ($test->usesDataProvider() && !$annotationWithPlaceholders) {
-            $result .= ' data set "' . $test->dataDescription() . '"';
+            $result .= $test->getDataSetAsString(false);
         }
 
         return $result;

--- a/tests/_files/DataProviderTestDoxTest.php
+++ b/tests/_files/DataProviderTestDoxTest.php
@@ -29,6 +29,14 @@ class DataProviderTestDoxTest extends TestCase
     }
 
     /**
+     * @dataProvider providerWithIndexedArray
+     */
+    public function testWithProviderWithIndexedArrayWith($value): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
      * @dataProvider placeHolderprovider
      * @testdox ... $value ...
      */
@@ -42,6 +50,14 @@ class DataProviderTestDoxTest extends TestCase
         return [
             'one' => [1],
             'two' => [2],
+        ];
+    }
+
+    public function providerWithIndexedArray()
+    {
+        return [
+            ['first'],
+            ['second'],
         ];
     }
 

--- a/tests/_files/DataProviderTestDoxTest.php
+++ b/tests/_files/DataProviderTestDoxTest.php
@@ -13,7 +13,7 @@ class DataProviderTestDoxTest extends TestCase
 {
     /**
      * @dataProvider provider
-     * @testdox Does something with
+     * @testdox Does something
      */
     public function testOne(): void
     {
@@ -23,7 +23,7 @@ class DataProviderTestDoxTest extends TestCase
     /**
      * @dataProvider provider
      */
-    public function testDoesSomethingElseWith(): void
+    public function testDoesSomethingElse(): void
     {
         $this->assertTrue(true);
     }
@@ -31,7 +31,7 @@ class DataProviderTestDoxTest extends TestCase
     /**
      * @dataProvider providerWithIndexedArray
      */
-    public function testWithProviderWithIndexedArrayWith($value): void
+    public function testWithProviderWithIndexedArray($value): void
     {
         $this->assertTrue(true);
     }

--- a/tests/end-to-end/dataprovider-testdox.phpt
+++ b/tests/end-to-end/dataprovider-testdox.phpt
@@ -17,6 +17,8 @@ DataProviderTestDox
  ✔ Does something with data set "two"
  ✔ Does something else with data set "one"
  ✔ Does something else with data set "two"
+ ✔ With provider with indexed array with data set #0
+ ✔ With provider with indexed array with data set #1
  ✔ ... true ...
  ✔ ... 1 ...
  ✔ ... 1.0 ...
@@ -29,4 +31,4 @@ DataProviderTestDox
 
 Time: %s, Memory: %s
 
-OK (13 tests, 13 assertions)
+OK (15 tests, 15 assertions)


### PR DESCRIPTION
Extending test case would produce the failure:
```diff
--- Expected
+++ Actual
@@ @@
  ✔ Does something with data set "two"
  ✔ Does something else with data set "one"
  ✔ Does something else with data set "two"
- ✔ With provider with indexed array with data set #0
- ✔ With provider with indexed array with data set #1
+ ✔ With provider with indexed array with data set ""
+ ✔ With provider with indexed array with data set ""
  ✔ ... true ...
  ✔ ... 1 ...
  ✔ ... 1.0 ...
```