### PR TITLE
Make ExceptionMessage constraint strict, expectedException can handle only expected class, not message nor code

### DIFF
--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -59,7 +59,7 @@ class ExceptionMessage extends Constraint
         }
 
         return \sprintf(
-            "exception message '%s' contains '%s'",
+            "exception message '%s' equals '%s'",
             $other->getMessage(),
             $this->expectedMessage
         );
@@ -74,6 +74,6 @@ class ExceptionMessage extends Constraint
             return 'exception message is empty';
         }
 
-        return 'exception message contains ';
+        return 'exception message equals ';
     }
 }

--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -36,11 +36,7 @@ class ExceptionMessage extends Constraint
      */
     protected function matches($other)
     {
-        if ($this->expectedMessage === '') {
-            return $other->getMessage() === '';
-        }
-
-        return \strpos($other->getMessage(), $this->expectedMessage) !== false;
+        return $other->getMessage() === $this->expectedMessage;
     }
 
     /**

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -33,7 +33,7 @@ class Test
 {
     const REGEX_DATA_PROVIDER               = '/@dataProvider\s+([a-zA-Z0-9._:-\\\\x7f-\xff]+)/';
     const REGEX_TEST_WITH                   = '/@testWith\s+/';
-    const REGEX_EXPECTED_EXCEPTION          = '(@expectedException\s+([:.\w\\\\x7f-\xff]+)(?:[\t ]+(\S*))?(?:[\t ]+(\S*))?\s*$)m';
+    const REGEX_EXPECTED_EXCEPTION          = '(@expectedException\s+([:.\w\\\\x7f-\xff]+)\s*$)m';
     const REGEX_REQUIRES_VERSION            = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m';
     const REGEX_REQUIRES_VERSION_CONSTRAINT = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<constraint>[\d\t -.|~^]+)[ \t]*\r?$/m';
     const REGEX_REQUIRES_OS                 = '/@requires\s+(?P<name>OS(?:FAMILY)?)\s+(?P<value>.+?)[ \t]*\r?$/m';
@@ -374,9 +374,7 @@ class Test
             $message       = '';
             $messageRegExp = '';
 
-            if (isset($matches[2])) {
-                $message = \trim($matches[2]);
-            } elseif (isset($annotations['method']['expectedExceptionMessage'])) {
+            if (isset($annotations['method']['expectedExceptionMessage'])) {
                 $message = self::parseAnnotationContent(
                     $annotations['method']['expectedExceptionMessage'][0]
                 );
@@ -388,9 +386,7 @@ class Test
                 );
             }
 
-            if (isset($matches[3])) {
-                $code = $matches[3];
-            } elseif (isset($annotations['method']['expectedExceptionCode'])) {
+            if (isset($annotations['method']['expectedExceptionCode'])) {
                 $code = self::parseAnnotationContent(
                     $annotations['method']['expectedExceptionCode'][0]
                 );

--- a/tests/_files/ExceptionTest.php
+++ b/tests/_files/ExceptionTest.php
@@ -53,13 +53,6 @@ class ExceptionTest extends TestCase
     }
 
     /**
-     * @expectedException Class Message 1234
-     */
-    public function testFive()
-    {
-    }
-
-    /**
      * @expectedException Class
      * @expectedExceptionMessage Message
      * @expectedExceptionCode 1234

--- a/tests/unit/Framework/Constraint/ExceptionMessageRegExpTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionMessageRegExpTest.php
@@ -46,7 +46,8 @@ class ExceptionMessageRegExpTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception variadic
+     * @expectedException \Exception
+     * @expectedExceptionMessage A variadic exception message
      * @expectedExceptionMessageRegExp /^A variadic \w+ message/
      */
     public function testSimultaneousLiteralAndRegExpExceptionMessage()

--- a/tests/unit/Framework/Constraint/ExceptionMessageTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionMessageTest.php
@@ -22,31 +22,4 @@ class ExceptionMessageTest extends TestCase
     {
         throw new \Exception('A literal exception message');
     }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage A partial
-     */
-    public function testPartialMessageBegin()
-    {
-        throw new \Exception('A partial exception message');
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage partial exception
-     */
-    public function testPartialMessageMiddle()
-    {
-        throw new \Exception('A partial exception message');
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage exception message
-     */
-    public function testPartialMessageEnd()
-    {
-        throw new \Exception('A partial exception message');
-    }
 }

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -254,7 +254,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->failureCount());
         $this->assertCount(1, $result);
         $this->assertEquals(
-            "Failed asserting that exception message 'A runtime error occurred' contains 'A logic error occurred'.",
+            "Failed asserting that exception message 'A runtime error occurred' equals 'A logic error occurred'.",
             $test->getStatusMessage()
         );
     }

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -45,11 +45,6 @@ class TestTest extends TestCase
 
         $this->assertArraySubset(
             ['class' => 'Class', 'code' => 1234, 'message' => 'Message'],
-            Test::getExpectedException(\ExceptionTest::class, 'testFive')
-        );
-
-        $this->assertArraySubset(
-            ['class' => 'Class', 'code' => 1234, 'message' => 'Message'],
             Test::getExpectedException(\ExceptionTest::class, 'testSix')
         );
 


### PR DESCRIPTION
Closes #3325

Commit logs are meaningful.

As  described in ticket, this change may be consider a little bigger than it appears on first look.
Eg, changing `strpos` to `===` in constraint makes (by purpose) partial message not working anymore, and `@expectedException \ClassOfException Message Code` annotation, well, make no sense anymore - as `Message` can be exactly one, single word - and without partial exception, it's pointless...

