### PR TITLE
Load autoload.php from parent folder

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -27,7 +27,7 @@ if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');
 }
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
 


### PR DESCRIPTION
I tried running phpunit and got this:
```
$ vendor/bin/phpunit
You need to set up the project dependencies using Composer:

    composer install

You can learn all about Composer on https://getcomposer.org/.
```

Turns out that the search for autoload.php is not correct when `phpunit` is inside `vendor/bin`.

The `autoload.php` file is in `vendor/autoload.php`. That's why it should search for `../autoload.php` first (when `phpunit` is inside `vendor/bin`)