### PR TITLE
Enhancement: Configure visibility_required fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -177,7 +177,13 @@ return PhpCsFixer\Config::create()
             'trailing_comma_in_multiline_array' => true,
             'trim_array_spaces' => true,
             'unary_operator_spaces' => true,
-            'visibility_required' => true,
+            'visibility_required' => [
+                'elements' => [
+                    'const',
+                    'method',
+                    'property',
+                ],
+            ],
             //'void_return' => true,
             'whitespace_after_comma_in_array' => true,
         ]

--- a/tests/_files/DataProviderIssue2833/SecondTest.php
+++ b/tests/_files/DataProviderIssue2833/SecondTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class SecondTest extends TestCase
 {
-    const DUMMY = 'dummy';
+    public const DUMMY = 'dummy';
 
     public function testSecond(): void
     {

--- a/tests/_files/ExceptionNamespaceTest.php
+++ b/tests/_files/ExceptionNamespaceTest.php
@@ -16,14 +16,14 @@ class ExceptionNamespaceTest extends \PHPUnit\Framework\TestCase
      *
      * @var string
      */
-    const ERROR_MESSAGE = 'Exception namespace message';
+    public const ERROR_MESSAGE = 'Exception namespace message';
 
     /**
      * Exception code
      *
      * @var int
      */
-    const ERROR_CODE = 200;
+    public const ERROR_CODE = 200;
 
     /**
      * @expectedException Class

--- a/tests/_files/ExceptionTest.php
+++ b/tests/_files/ExceptionTest.php
@@ -16,21 +16,21 @@ class ExceptionTest extends TestCase
      *
      * @var string
      */
-    const ERROR_MESSAGE = 'Exception message';
+    public const ERROR_MESSAGE = 'Exception message';
 
     /**
      * Exception message
      *
      * @var string
      */
-    const ERROR_MESSAGE_REGEX = '#regex#';
+    public const ERROR_MESSAGE_REGEX = '#regex#';
 
     /**
      * Exception code
      *
      * @var int
      */
-    const ERROR_CODE = 500;
+    public const ERROR_CODE = 500;
 
     /**
      * @expectedException FooBarBaz

--- a/tests/end-to-end/regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
+++ b/tests/end-to-end/regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
@@ -13,11 +13,11 @@
  */
 class SeparateClassRunMethodInNewProcessTest extends PHPUnit\Framework\TestCase
 {
-    const PROCESS_ID_FILE_PATH = __DIR__ . '/parent_process_id.txt';
+    public const PROCESS_ID_FILE_PATH = __DIR__ . '/parent_process_id.txt';
 
-    const INITIAL_MASTER_PID   = 0;
+    public const INITIAL_MASTER_PID   = 0;
 
-    const INITIAL_PID1         = 1;
+    public const INITIAL_PID1         = 1;
 
     public static $masterPid = self::INITIAL_MASTER_PID;
 

--- a/tests/end-to-end/regression/GitHub/2725/BeforeAfterClassPidTest.php
+++ b/tests/end-to-end/regression/GitHub/2725/BeforeAfterClassPidTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BeforeAfterClassPidTest extends TestCase
 {
-    const PID_VARIABLE = 'current_pid';
+    public const PID_VARIABLE = 'current_pid';
 
     /**
      * @beforeClass


### PR DESCRIPTION
This PR

* [x] configures the `visibility_required` fixer to also require visibility for `const`
* [x] runs `php-cs-fixer`

Follows https://github.com/sebastianbergmann/php-file-iterator/pull/56.