### PR TITLE
Fix: Remove unused field $maxDepth from IsEqual constraint

### DIFF
--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -35,11 +35,6 @@ class IsEqual extends Constraint
     private $delta;
 
     /**
-     * @var int
-     */
-    private $maxDepth;
-
-    /**
      * @var bool
      */
     private $canonicalize;
@@ -55,7 +50,6 @@ class IsEqual extends Constraint
 
         $this->value        = $value;
         $this->delta        = $delta;
-        $this->maxDepth     = $maxDepth;
         $this->canonicalize = $canonicalize;
         $this->ignoreCase   = $ignoreCase;
     }


### PR DESCRIPTION
This PR

* [x] removes an unused field `$maxDepth` from the `IsEqual` constraint

Related #3180.

💁‍♂️ `$maxDepth` still needs to be removed from a lot of other places, which partially constitute BC issues. Happy to work on it, if there are no objections!