### PR TITLE
Make ExceptionMessage constraint strict, expectedException can handle only expected class, not message nor code - for 7.4 line

### DIFF
--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -40,11 +40,7 @@ class ExceptionMessage extends Constraint
      */
     protected function matches($other): bool
     {
-        if ($this->expectedMessage === '') {
-            return $other->getMessage() === '';
-        }
-
-        return \strpos($other->getMessage(), $this->expectedMessage) !== false;
+        return $other->getMessage() === $this->expectedMessage;
     }
 
     /**

--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -29,7 +29,7 @@ class ExceptionMessage extends Constraint
             return 'exception message is empty';
         }
 
-        return 'exception message contains ';
+        return 'exception message equals ';
     }
 
     /**
@@ -61,7 +61,7 @@ class ExceptionMessage extends Constraint
         }
 
         return \sprintf(
-            "exception message '%s' contains '%s'",
+            "exception message '%s' equals '%s'",
             $other->getMessage(),
             $this->expectedMessage
         );

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -62,7 +62,7 @@ final class Test
     /**
      * @var string
      */
-    private const REGEX_EXPECTED_EXCEPTION = '(@expectedException\s+([:.\w\\\\x7f-\xff]+)(?:[\t ]+(\S*))?(?:[\t ]+(\S*))?\s*$)m';
+    private const REGEX_EXPECTED_EXCEPTION = '(@expectedException\s+([:.\w\\\\x7f-\xff]+)\s*$)m';
 
     /**
      * @var string
@@ -361,9 +361,7 @@ final class Test
             $message       = '';
             $messageRegExp = '';
 
-            if (isset($matches[2])) {
-                $message = \trim($matches[2]);
-            } elseif (isset($annotations['method']['expectedExceptionMessage'])) {
+            if (isset($annotations['method']['expectedExceptionMessage'])) {
                 $message = self::parseAnnotationContent(
                     $annotations['method']['expectedExceptionMessage'][0]
                 );
@@ -375,9 +373,7 @@ final class Test
                 );
             }
 
-            if (isset($matches[3])) {
-                $code = $matches[3];
-            } elseif (isset($annotations['method']['expectedExceptionCode'])) {
+            if (isset($annotations['method']['expectedExceptionCode'])) {
                 $code = self::parseAnnotationContent(
                     $annotations['method']['expectedExceptionCode'][0]
                 );

--- a/tests/_files/ExceptionTest.php
+++ b/tests/_files/ExceptionTest.php
@@ -61,13 +61,6 @@ class ExceptionTest extends TestCase
     }
 
     /**
-     * @expectedException Class Message 1234
-     */
-    public function testFive(): void
-    {
-    }
-
-    /**
      * @expectedException Class
      * @expectedExceptionMessage Message
      * @expectedExceptionCode 1234

--- a/tests/unit/Framework/Constraint/ExceptionMessageRegExpTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionMessageRegExpTest.php
@@ -45,7 +45,8 @@ class ExceptionMessageRegExpTest extends TestCase
     }
 
     /**
-     * @expectedException \Exception variadic
+     * @expectedException \Exception
+     * @expectedExceptionMessage A variadic exception message
      * @expectedExceptionMessageRegExp /^A variadic \w+ message/
      */
     public function testSimultaneousLiteralAndRegExpExceptionMessage(): void

--- a/tests/unit/Framework/Constraint/ExceptionMessageTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionMessageTest.php
@@ -21,31 +21,4 @@ class ExceptionMessageTest extends TestCase
     {
         throw new \Exception('A literal exception message');
     }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage A partial
-     */
-    public function testPartialMessageBegin(): void
-    {
-        throw new \Exception('A partial exception message');
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage partial exception
-     */
-    public function testPartialMessageMiddle(): void
-    {
-        throw new \Exception('A partial exception message');
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage exception message
-     */
-    public function testPartialMessageEnd(): void
-    {
-        throw new \Exception('A partial exception message');
-    }
 }

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -54,7 +54,7 @@ class GeneratorTest extends TestCase
     public function testGetMockGeneratorFails(): void
     {
         $this->expectException(\PHPUnit\Framework\MockObject\RuntimeException::class);
-        $this->expectExceptionMessage('duplicates: "foo, bar, foo" (duplicate: "foo")');
+        $this->expectExceptionMessageRegExp('/duplicates: "foo, bar, foo" \(duplicate: "foo"\)/');
 
         $this->generator->getMock(stdClass::class, ['foo', 'bar', 'foo']);
     }

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -261,7 +261,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->failureCount());
         $this->assertCount(1, $result);
         $this->assertEquals(
-            "Failed asserting that exception message 'A runtime error occurred' contains 'A logic error occurred'.",
+            "Failed asserting that exception message 'A runtime error occurred' equals 'A logic error occurred'.",
             $test->getStatusMessage()
         );
     }

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -44,11 +44,6 @@ class TestTest extends TestCase
 
         $this->assertArraySubset(
             ['class' => 'Class', 'code' => 1234, 'message' => 'Message'],
-            Test::getExpectedException(\ExceptionTest::class, 'testFive')
-        );
-
-        $this->assertArraySubset(
-            ['class' => 'Class', 'code' => 1234, 'message' => 'Message'],
             Test::getExpectedException(\ExceptionTest::class, 'testSix')
         );
 


### PR DESCRIPTION
#3326 for 7.4 line

as requested by @sebastianbergmann in https://github.com/sebastianbergmann/phpunit/pull/3326#issuecomment-428072577