### PR TITLE
Don't ignore coverage of methods without assertions

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -754,6 +754,7 @@ class TestResult implements Countable
         }
 
         if ($this->beStrictAboutTestsThatDoNotTestAnything &&
+            $test->doesNotPerformAssertions() === false &&
             $test->getNumAssertions() == 0) {
             $risky = true;
         }

--- a/tests/_files/CoverageDoesNotPerformAssertionsTest.php
+++ b/tests/_files/CoverageDoesNotPerformAssertionsTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class CoverageDoesNotPerformAssertionsTest extends TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     *
+     * @covers CoveredClass
+     * @covers CoveredParentClass
+     */
+    public function testSomething(): void
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/end-to-end/code-coverage-works-with-no-assertions.phpt
+++ b/tests/end-to-end/code-coverage-works-with-no-assertions.phpt
@@ -1,0 +1,43 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout ../../_files/CoverageDoesNotPerformAssertionsTest.php --whitelist ../../_files/CoveredClass.php
+--SKIPIF--
+<?php
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+?>
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--bootstrap';
+$_SERVER['argv'][3] = __DIR__ . '/../bootstrap.php';
+$_SERVER['argv'][4] = '--colors=never';
+$_SERVER['argv'][5] = '--coverage-text=php://stdout';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/CoverageDoesNotPerformAssertionsTest.php';
+$_SERVER['argv'][7] = '--whitelist';
+$_SERVER['argv'][8] = __DIR__ . '/../_files/CoveredClass.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 0 assertions)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (2/2)%w
+  Methods: 100.00% (%d/%d)%w
+  Lines:   100.00% (%d/%d)
+
+CoveredClass
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)
+CoveredParentClass
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)


### PR DESCRIPTION
PHPUnit was not adding the coverage of tests with `@doesNotPerformAssertions` or `$this->expectNotToPerformAssertions();` to the report, leading to wrong coverage results.