### PR TITLE
[WIP] Test with system memory allocator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ matrix:
 
 env:
   matrix:
-    - DEPENDENCIES="high"
-    - DEPENDENCIES="low"
+    - DEPENDENCIES="high" USE_ZEND_ALLOC=1
+    - DEPENDENCIES="high" USE_ZEND_ALLOC=0
+    - DEPENDENCIES="low" USE_ZEND_ALLOC=1
   global:
     - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest"
 


### PR DESCRIPTION
`USE_ZEND_ALLOC=0` in the environment will stop the memory manager from functioning, all allocations fall back on the default system allocators which can be useful for debugging leaks, and should only be used for this purpose.