### PR TITLE
Introduce TestRunAwareTestListener

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -364,15 +364,33 @@ class TestResult implements Countable
         $this->time += $time;
     }
 
+    public function startTestRun(TestSuite $suite): void
+    {
+        $this->topTestSuite = $suite;
+
+        foreach ($this->listeners as $listener) {
+            if ($listener instanceof TestRunAwareTestListener) {
+                $listener->startTestRun($this->topTestSuite);
+            }
+        }
+    }
+
+    public function endTestRun(): void
+    {
+        $this->flushListeners();
+
+        foreach ($this->listeners as $listener) {
+            if ($listener instanceof TestRunAwareTestListener) {
+                $listener->endTestRun($this->topTestSuite, $this);
+            }
+        }
+    }
+
     /**
      * Informs the result that a test suite will be started.
      */
     public function startTestSuite(TestSuite $suite): void
     {
-        if ($this->topTestSuite === null) {
-            $this->topTestSuite = $suite;
-        }
-
         foreach ($this->listeners as $listener) {
             $listener->startTestSuite($suite);
         }

--- a/src/Framework/TestRunAwareTestListener.php
+++ b/src/Framework/TestRunAwareTestListener.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+/**
+ * A Listener for test progress.
+ */
+interface TestRunAwareTestListener extends TestListener
+{
+    /**
+     * A test run started.
+     */
+    public function startTestRun(TestSuite $suite): void;
+
+    /**
+     * A test run ended.
+     */
+    public function endTestRun(TestSuite $suite, TestResult $result): void;
+}

--- a/src/Runner/Hook/TestListenerAdapter.php
+++ b/src/Runner/Hook/TestListenerAdapter.php
@@ -11,12 +11,13 @@ namespace PHPUnit\Runner;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestRunAwareTestListener;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Util\Test as TestUtil;
 
-final class TestListenerAdapter implements TestListener
+final class TestListenerAdapter implements TestRunAwareTestListener
 {
     /**
      * @var TestHook[]
@@ -129,5 +130,29 @@ final class TestListenerAdapter implements TestListener
 
     public function endTestSuite(TestSuite $suite): void
     {
+    }
+
+    /**
+     * A test run started.
+     */
+    public function startTestRun(TestSuite $suite): void
+    {
+        foreach ($this->hooks as $hook) {
+            if ($hook instanceof BeforeFirstTestHook) {
+                $hook->executeBeforeFirstTest();
+            }
+        }
+    }
+
+    /**
+     * A test run ended.
+     */
+    public function endTestRun(TestSuite $suite, TestResult $result): void
+    {
+        foreach ($this->hooks as $hook) {
+            if ($hook instanceof AfterLastTestHook) {
+                $hook->executeAfterLastTest();
+            }
+        }
     }
 }

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -14,8 +14,8 @@ use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestFailure;
-use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestRunAwareTestListener;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Runner\PhptTestCase;
@@ -27,7 +27,7 @@ use SebastianBergmann\Timer\Timer;
 /**
  * Prints the result of a TextUI TestRunner run.
  */
-class ResultPrinter extends Printer implements TestListener
+class ResultPrinter extends Printer implements TestRunAwareTestListener
 {
     public const EVENT_TEST_START      = 0;
 
@@ -249,15 +249,28 @@ class ResultPrinter extends Printer implements TestListener
     }
 
     /**
+     * A test run started.
+     */
+    public function startTestRun(TestSuite $suite): void
+    {
+        $this->numTests      = \count($suite);
+        $this->numTestsWidth = \strlen((string) $this->numTests);
+        $this->maxColumn     = $this->numberOfColumns - \strlen('  /  (XXX%)') - (2 * $this->numTestsWidth);
+    }
+
+    /**
+     * A test run ended.
+     */
+    public function endTestRun(TestSuite $suite, TestResult $result): void
+    {
+        $this->printResult($result);
+    }
+
+    /**
      * A testsuite started.
      */
     public function startTestSuite(TestSuite $suite): void
     {
-        if ($this->numTests == -1) {
-            $this->numTests      = \count($suite);
-            $this->numTestsWidth = \strlen((string) $this->numTests);
-            $this->maxColumn     = $this->numberOfColumns - \strlen('  /  (XXX%)') - (2 * $this->numTestsWidth);
-        }
     }
 
     /**

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -220,7 +220,7 @@ class TestRunner extends BaseTestRunner
         $listenerNeeded = false;
 
         foreach ($this->extensions as $extension) {
-            if ($extension instanceof TestHook) {
+            if ($extension instanceof TestHook || $extension instanceof BeforeFirstTestHook || $extension instanceof AfterLastTestHook) {
                 $listener->add($extension);
 
                 $listenerNeeded = true;
@@ -602,26 +602,13 @@ class TestRunner extends BaseTestRunner
         if ($suite instanceof TestSuite) {
             $this->processSuiteFilters($suite, $arguments);
             $suite->setRunTestInSeparateProcess($arguments['processIsolation']);
-        }
-
-        foreach ($this->extensions as $extension) {
-            if ($extension instanceof BeforeFirstTestHook) {
-                $extension->executeBeforeFirstTest();
-            }
+            $result->startTestRun($suite);
         }
 
         $suite->run($result);
 
-        foreach ($this->extensions as $extension) {
-            if ($extension instanceof AfterLastTestHook) {
-                $extension->executeAfterLastTest();
-            }
-        }
-
-        $result->flushListeners();
-
-        if ($this->printer instanceof ResultPrinter) {
-            $this->printer->printResult($result);
+        if ($suite instanceof TestSuite) {
+            $result->endTestRun();
         }
 
         if (isset($codeCoverage)) {

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -30,11 +30,6 @@ use SebastianBergmann\Comparator\ComparisonFailure;
 class TeamCity extends ResultPrinter
 {
     /**
-     * @var bool
-     */
-    private $isSummaryTestCountPrinted = false;
-
-    /**
      * @var string
      */
     private $startedTestName;
@@ -201,6 +196,23 @@ class TeamCity extends ResultPrinter
     }
 
     /**
+     * A test run started.
+     */
+    public function startTestRun(TestSuite $suite): void
+    {
+        if (\stripos(\ini_get('disable_functions'), 'getmypid') === false) {
+            $this->flowId = \getmypid();
+        } else {
+            $this->flowId = false;
+        }
+
+        $this->printEvent(
+            'testCount',
+            ['count' => \count($suite)]
+        );
+    }
+
+    /**
      * A testsuite started.
      *
      * @throws \ReflectionException
@@ -211,15 +223,6 @@ class TeamCity extends ResultPrinter
             $this->flowId = \getmypid();
         } else {
             $this->flowId = false;
-        }
-
-        if (!$this->isSummaryTestCountPrinted) {
-            $this->isSummaryTestCountPrinted = true;
-
-            $this->printEvent(
-                'testCount',
-                ['count' => \count($suite)]
-            );
         }
 
         $suiteName = $suite->getName();

--- a/tests/end-to-end/log-teamcity.phpt
+++ b/tests/end-to-end/log-teamcity.phpt
@@ -36,3 +36,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Time: %s, Memory: %s
 
 OK (3 tests, 3 assertions)
+
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)


### PR DESCRIPTION
Adds startTestRun and endTestRun hooks to TestListener so implementing
classes don't have to check whether a startTestSuite call is the first
one, plus it allows implementers to do something after the very last
test, which is usefull for implementers that want to buffer data and
only output once everything is done.