### PR TITLE
Add AfterTestHook for extensions

### DIFF
--- a/src/Runner/Hook/AfterTestHook.php
+++ b/src/Runner/Hook/AfterTestHook.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+interface AfterTestHook extends Hook
+{
+    /**
+     * This hook will fire after any test, regardless of the result.
+     *
+     * For more fine grained control, have a look at the other hooks
+     * that extend PHPUnit\Runner\Hook.
+     */
+    public function executeAfterTest(string $test, float $time): void;
+}

--- a/src/Runner/Hook/TestListenerAdapter.php
+++ b/src/Runner/Hook/TestListenerAdapter.php
@@ -112,13 +112,17 @@ final class TestListenerAdapter implements TestListener
 
     public function endTest(Test $test, float $time): void
     {
-        if ($this->lastTestWasNotSuccessful === true) {
-            return;
+        if ($this->lastTestWasNotSuccessful !== true) {
+            foreach ($this->hooks as $hook) {
+                if ($hook instanceof AfterSuccessfulTestHook) {
+                    $hook->executeAfterSuccessfulTest(TestUtil::describeAsString($test), $time);
+                }
+            }
         }
 
         foreach ($this->hooks as $hook) {
-            if ($hook instanceof AfterSuccessfulTestHook) {
-                $hook->executeAfterSuccessfulTest(TestUtil::describeAsString($test), $time);
+            if ($hook instanceof AfterTestHook) {
+                $hook->executeAfterTest(TestUtil::describeAsString($test), $time);
             }
         }
     }

--- a/tests/end-to-end/_files/Extension.php
+++ b/tests/end-to-end/_files/Extension.php
@@ -16,11 +16,12 @@ use PHPUnit\Runner\AfterSkippedTestHook;
 use PHPUnit\Runner\AfterSuccessfulTestHook;
 use PHPUnit\Runner\AfterTestErrorHook;
 use PHPUnit\Runner\AfterTestFailureHook;
+use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\AfterTestWarningHook;
 use PHPUnit\Runner\BeforeFirstTestHook;
 use PHPUnit\Runner\BeforeTestHook;
 
-final class Extension implements BeforeFirstTestHook, BeforeTestHook, AfterSuccessfulTestHook, AfterSkippedTestHook, AfterRiskyTestHook, AfterIncompleteTestHook, AfterTestErrorHook, AfterTestWarningHook, AfterTestFailureHook, AfterLastTestHook
+final class Extension implements BeforeFirstTestHook, BeforeTestHook, AfterTestHook, AfterSuccessfulTestHook, AfterSkippedTestHook, AfterRiskyTestHook, AfterIncompleteTestHook, AfterTestErrorHook, AfterTestWarningHook, AfterTestFailureHook, AfterLastTestHook
 {
     private $amountOfInjectedArguments = 0;
 
@@ -41,6 +42,11 @@ final class Extension implements BeforeFirstTestHook, BeforeTestHook, AfterSucce
     }
 
     public function executeBeforeTest(string $test): void
+    {
+        print __METHOD__ . ': ' . $test . \PHP_EOL;
+    }
+
+    public function executeAfterTest(string $test, float $time): void
     {
         print __METHOD__ . ': ' . $test . \PHP_EOL;
     }

--- a/tests/end-to-end/hooks.phpt
+++ b/tests/end-to-end/hooks.phpt
@@ -16,16 +16,23 @@ PHPUnit\Test\Extension::tellAmountOfInjectedArguments: %d
 PHPUnit\Test\Extension::executeBeforeFirstTest
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testSuccess
 PHPUnit\Test\Extension::executeAfterSuccessfulTest: PHPUnit\Test\HookTest::testSuccess
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testSuccess
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testFailure
 PHPUnit\Test\Extension::executeAfterTestFailure: PHPUnit\Test\HookTest::testFailure: Failed asserting that false is true.
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testFailure
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testError
 PHPUnit\Test\Extension::executeAfterTestError: PHPUnit\Test\HookTest::testError: message
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testError
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testIncomplete
 PHPUnit\Test\Extension::executeAfterIncompleteTest: PHPUnit\Test\HookTest::testIncomplete: message
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testIncomplete
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testRisky
 PHPUnit\Test\Extension::executeAfterRiskyTest: PHPUnit\Test\HookTest::testRisky: message
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testRisky
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testSkipped
 PHPUnit\Test\Extension::executeAfterSkippedTest: PHPUnit\Test\HookTest::testSkipped: message
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testSkipped
 PHPUnit\Test\Extension::executeBeforeTest: PHPUnit\Test\HookTest::testWarning
 PHPUnit\Test\Extension::executeAfterTestWarning: PHPUnit\Test\HookTest::testWarning: message
+PHPUnit\Test\Extension::executeAfterTest: PHPUnit\Test\HookTest::testWarning
 PHPUnit\Test\Extension::executeAfterLastTest


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/3391

So extensions have hook for some common functionality that should
happen after every test, regardless of the result.