### PR TITLE
Fix bug when replacing placeholders in testdox using an associative array

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -158,11 +158,15 @@ final class NamePrettifier
     {
         $reflector          = new \ReflectionMethod(\get_class($test), $test->getName(false));
         $providedData       = [];
-        $providedDataValues = $test->getProvidedData();
+        $providedDataValues = \array_values($test->getProvidedData());
         $i                  = 0;
 
         foreach ($reflector->getParameters() as $parameter) {
-            $value = $providedDataValues[$i++];
+            if (!\array_key_exists($i, $providedDataValues) && $parameter->isDefaultValueAvailable()) {
+                $providedDataValues[$i] = $parameter->getDefaultValue();
+            }
+
+            $value = $providedDataValues[$i++] ?? null;
 
             if (\is_object($value)) {
                 $reflector = new \ReflectionObject($value);

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -57,4 +57,58 @@ class NamePrettifierTest extends TestCase
         $this->assertEquals('Sets redirect header on 301', $this->namePrettifier->prettifyTestMethod('testSetsRedirectHeaderOn301'));
         $this->assertEquals('Sets redirect header on 302', $this->namePrettifier->prettifyTestMethod('testSetsRedirectHeaderOn302'));
     }
+
+    public function testPhpDoxIgnoreDataKeys(): void
+    {
+        $test = new class extends TestCase {
+            public function __construct()
+            {
+                parent::__construct('testAddition', [
+                    'augend' => 1,
+                    'addend' => 2,
+                    'result' => 3,
+                ]);
+            }
+
+            public function testAddition(int $augend, int $addend, int $result): void
+            {
+            }
+
+            public function getAnnotations(): array
+            {
+                return [
+                    'method' => [
+                        'testdox' => ['$augend + $addend = $result'],
+                    ],
+                ];
+            }
+        };
+
+        $this->assertEquals('1 + 2 = 3', $this->namePrettifier->prettifyTestCase($test));
+    }
+
+    public function testPhpDoxUsesDefaultValue(): void
+    {
+        $test = new class extends TestCase {
+            public function __construct()
+            {
+                parent::__construct('testAddition', []);
+            }
+
+            public function testAddition(int $augend = 1, int $addend = 2, int $result = 3): void
+            {
+            }
+
+            public function getAnnotations(): array
+            {
+                return [
+                    'method' => [
+                        'testdox' => ['$augend + $addend = $result'],
+                    ],
+                ];
+            }
+        };
+
+        $this->assertEquals('1 + 2 = 3', $this->namePrettifier->prettifyTestCase($test));
+    }
 }


### PR DESCRIPTION
At Croct we usually assign keys to data provider arguments to improve code readability:
```php
private function dataProvider() : array
{
    return [
        '1 + 2 = 3' => [
            'augend' => 1,
            'addend' => 2,
            'result' => 3
        ]
    ];
}
```
It works fine in all cases except when the `@testdox` has placeholders. In this case you will get an error:
```
Undefined offset: 0
```
There is also a bug when omitting optional parameters in data providers:
```php
private function dataProvider() : array
{
    return [
        [1]
    ];
}

/**
 * @testdox Message regarding $optional
 */
public function testFoo(int $value, bool $optional = true) : void
{
}
```
Warning:
```
Undefined offset: 1
```
This PR includes the fixes and tests for both scenarios.