### PR TITLE
Fix IsEqual string quotes

### DIFF
--- a/src/Framework/Constraint/IsEqual.php
+++ b/src/Framework/Constraint/IsEqual.php
@@ -157,7 +157,7 @@ class IsEqual extends Constraint
             }
 
             return \sprintf(
-                'is equal to "%s"',
+                "is equal to '%s'",
                 $this->value
             );
         }


### PR DESCRIPTION
Double quotes don't match var_export, so when comparing two empty strings, phpunit generated confusing message `Failed asserting that '' is not equal to "".`