### PR TITLE
[4.8] The `expectExceptionObject()` method for the backwards compatibility

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -453,6 +453,19 @@ abstract class PHPUnit_Framework_TestCase extends PHPUnit_Framework_Assert imple
     }
 
     /**
+     * Sets up an expectation for an exception to be raised by the code under test.
+     * Information for expected exception class, expected exception message, and
+     * expected exception code are retrieved from a given Exception object.
+     *
+     * @param \Exception $exception
+     * @return void
+     */
+    public function expectExceptionObject(\Exception $exception)
+    {
+        $this->setExpectedException(get_class($exception), $exception->getMessage(), $exception->getCode());
+    }
+
+    /**
      * @param mixed  $exceptionName
      * @param string $exceptionMessage
      * @param int    $exceptionCode


### PR DESCRIPTION
With this and also similar PR to the [5.7], it would be possible to use `expectExceptionObject()` on the latest PHPUnit 4 and PHPUnit 5 versions.