### PR TITLE
Fix TestSuite sorting glitch

### DIFF
--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -275,6 +275,10 @@ final class TestSuiteSorter
      */
     private function getNormalizedTestName($test): string
     {
+        if ($test instanceof TestSuite && !($test instanceof DataProviderTestSuite)) {
+            return $test->getName();
+        }
+
         if ($test instanceof PhptTestCase) {
             return $test->getName();
         }

--- a/tests/end-to-end/regression/GitHub/3396/issue-3396-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3396/issue-3396-test.phpt
@@ -2,40 +2,54 @@
 https://github.com/sebastianbergmann/phpunit/issues/3396
 --FILE--
 <?php
+$tmpResultCache = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/../../../../_files/DataproviderExecutionOrderTest_result_cache.txt'));
+
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--order-by=defects';
-$_SERVER['argv'][3] = '--testdox';
-$_SERVER['argv'][4] = \dirname(\dirname(\dirname(__DIR__))) . '/../_files/DataproviderExecutionOrderTest.php';
+$_SERVER['argv'][3] = '--debug';
+$_SERVER['argv'][4] = '--cache-result';
+$_SERVER['argv'][5] = '--cache-result-file=' . $tmpResultCache;
+$_SERVER['argv'][6] = \dirname(\dirname(\dirname(__DIR__))) . '/../_files/DataproviderExecutionOrderTest.php';
 
 require __DIR__ . '/../../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();
+
+unlink($tmpResultCache);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-DataproviderExecutionOrder
- ✔ First test that always works
- ✔ Add numbers with a dataprovider with data set "1+2=3"
- ✔ Add numbers with a dataprovider with data set "2+1=3"
- ✘ Add numbers with a dataprovider with data set "1+1=3"
-   │
-   │ Failed asserting that 2 is identical to 3.
-   │%w
-   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:24
-   │%w
+Test 'DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "1+1=3" (1, 1, 3)' started
+Test 'DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "1+1=3" (1, 1, 3)' ended
+Test 'DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "1+2=3" (1, 2, 3)' started
+Test 'DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "1+2=3" (1, 2, 3)' ended
+Test 'DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "2+1=3" (2, 1, 3)' started
+Test 'DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "2+1=3" (2, 1, 3)' ended
+Test 'DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "1+1=3" (1, 1, 3)' started
+Test 'DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "1+1=3" (1, 1, 3)' ended
+Test 'DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "1+2=3" (1, 2, 3)' started
+Test 'DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "1+2=3" (1, 2, 3)' ended
+Test 'DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "2+1=3" (2, 1, 3)' started
+Test 'DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "2+1=3" (2, 1, 3)' ended
+Test 'DataproviderExecutionOrderTest::testFirstTestThatAlwaysWorks' started
+Test 'DataproviderExecutionOrderTest::testFirstTestThatAlwaysWorks' ended
+Test 'DataproviderExecutionOrderTest::testTestInTheMiddleThatAlwaysWorks' started
+Test 'DataproviderExecutionOrderTest::testTestInTheMiddleThatAlwaysWorks' ended
 
- ✔ Test in the middle that always works
- ✔ Add more numbers with a dataprovider with data set "1+2=3"
- ✔ Add more numbers with a dataprovider with data set "2+1=3"
- ✘ Add more numbers with a dataprovider with data set "1+1=3"
-   │
-   │ Failed asserting that 2 is identical to 3.
-   │%w
-   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:37
-   │%w
-%A
+
 Time: %s, Memory: %s
 
-Summary of non-successful tests:
-%A
+There were 2 failures:
+
+1) DataproviderExecutionOrderTest::testAddNumbersWithADataprovider with data set "1+1=3" (1, 1, 3)
+Failed asserting that 2 is identical to 3.
+
+%s%etests%e_files%eDataproviderExecutionOrderTest.php:%d
+
+2) DataproviderExecutionOrderTest::testAddMoreNumbersWithADataprovider with data set "1+1=3" (1, 1, 3)
+Failed asserting that 2 is identical to 3.
+
+%s%etests%e_files%eDataproviderExecutionOrderTest.php:%d
+
 FAILURES!
 Tests: 8, Assertions: 8, Failures: 2.


### PR DESCRIPTION
Repaired two bugs that crept in while working on the dataprovider sorting fixes. Didn't cause any failing tests, but nested `TestSuites` were not seen by the sorter. Also found the correct regression test for #3396 in a git stash. 🤐 
