### PR TITLE
Buffered TestDox printer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
+         cacheResult="true"
          verbose="true">
     <testsuites>
         <testsuite name="unit">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         cacheResult="true"
          verbose="true">
     <testsuites>
         <testsuite name="unit">

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -167,7 +167,7 @@ final class TestSuiteSorter
         $max = 0;
 
         foreach ($suite->tests() as $test) {
-            $testname = $this->getNormalizedTestName($test);
+            $testname = TestResultCache::getTestSorterUID($test);
 
             if (!isset($this->defectSortOrder[$testname])) {
                 $this->defectSortOrder[$testname]        = self::DEFECT_SORT_WEIGHT[$this->cache->getState($testname)];
@@ -233,8 +233,8 @@ final class TestSuiteSorter
      */
     private function cmpDefectPriorityAndTime(Test $a, Test $b): int
     {
-        $priorityA = $this->defectSortOrder[$this->getNormalizedTestName($a)] ?? 0;
-        $priorityB = $this->defectSortOrder[$this->getNormalizedTestName($b)] ?? 0;
+        $priorityA = $this->defectSortOrder[TestResultCache::getTestSorterUID($a)] ?? 0;
+        $priorityB = $this->defectSortOrder[TestResultCache::getTestSorterUID($b)] ?? 0;
 
         if ($priorityB <=> $priorityA) {
             // Sort defect weight descending
@@ -254,7 +254,7 @@ final class TestSuiteSorter
      */
     private function cmpDuration(Test $a, Test $b): int
     {
-        return $this->cache->getTime($this->getNormalizedTestName($a)) <=> $this->cache->getTime($this->getNormalizedTestName($b));
+        return $this->cache->getTime(TestResultCache::getTestSorterUID($a)) <=> $this->cache->getTime(TestResultCache::getTestSorterUID($b));
     }
 
     /**
@@ -280,7 +280,7 @@ final class TestSuiteSorter
         do {
             $todoNames = \array_map(
                 function ($test) {
-                    return $this->getNormalizedTestName($test);
+                    return TestResultCache::getTestSorterUID($test);
                 },
                 $tests
             );
@@ -294,28 +294,6 @@ final class TestSuiteSorter
         } while (!empty($tests) && ($i < \count($tests)));
 
         return \array_merge($newTestOrder, $tests);
-    }
-
-    /**
-     * @param DataProviderTestSuite|TestCase $test
-     *
-     * @return string Full test name as "TestSuiteClassName::testMethodName"
-     */
-    private function getNormalizedTestName($test): string
-    {
-        if ($test instanceof TestSuite && !($test instanceof DataProviderTestSuite)) {
-            return $test->getName();
-        }
-
-        if ($test instanceof PhptTestCase) {
-            return $test->getName();
-        }
-
-        if (\strpos($test->getName(), '::') !== false) {
-            return $test->getName(true);
-        }
-
-        return \get_class($test) . '::' . $test->getName(true);
     }
 
     /**
@@ -348,7 +326,7 @@ final class TestSuiteSorter
         if ($suite instanceof TestSuite) {
             foreach ($suite->tests() as $test) {
                 if (!($test instanceof TestSuite)) {
-                    $tests[] = $this->getNormalizedTestName($test);
+                    $tests[] = TestResultCache::getTestSorterUID($test);
                 } else {
                     $tests = \array_merge($tests, $this->calculateTestExecutionOrder($test));
                 }

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -349,11 +349,9 @@ final class TestSuiteSorter
             foreach ($suite->tests() as $test) {
                 if (!($test instanceof TestSuite)) {
                     $tests[] = $this->getNormalizedTestName($test);
+                } else {
+                    $tests = \array_merge($tests, $this->calculateTestExecutionOrder($test));
                 }
-            }
-
-            foreach ($suite as $_suite) {
-                $tests = \array_merge($tests, $this->calculateTestExecutionOrder($_suite));
             }
         }
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -39,6 +39,7 @@ use PHPUnit\Util\Configuration;
 use PHPUnit\Util\Log\JUnit;
 use PHPUnit\Util\Log\TeamCity;
 use PHPUnit\Util\Printer;
+use PHPUnit\Util\TestDox\CliTestDoxPrinter;
 use PHPUnit\Util\TestDox\HtmlResultPrinter;
 use PHPUnit\Util\TestDox\TextResultPrinter;
 use PHPUnit\Util\TestDox\XmlResultPrinter;
@@ -203,6 +204,7 @@ class TestRunner extends BaseTestRunner
             $sorter = new TestSuiteSorter($cache);
 
             $sorter->reorderTestsInSuite($suite, $arguments['executionOrder'], $arguments['resolveDependencies'], $arguments['executionOrderDefects']);
+            $originalExecutionOrder = $sorter->getOriginalExecutionOrder();
 
             unset($sorter);
         }
@@ -309,6 +311,11 @@ class TestRunner extends BaseTestRunner
                     $arguments['columns'],
                     $arguments['reverseList']
                 );
+
+                if (isset($originalExecutionOrder) && ($this->printer instanceof CliTestDoxPrinter)) {
+                    /* @var CliTestDoxPrinter */
+                    $this->printer->setOriginalExecutionOrder($originalExecutionOrder);
+                }
             }
         }
 

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Runner\PhptTestCase;
-use PHPUnit\Runner\TestResultCache;
+use PHPUnit\Runner\TestSuiteSorter;
 use PHPUnit\TextUI\ResultPrinter;
 use SebastianBergmann\Timer\Timer;
 
@@ -241,7 +241,7 @@ class CliTestDoxPrinter extends ResultPrinter
     {
         $this->outputBuffer[$this->testIndex] = [
             'className'  => $this->className,
-            'testName'   => TestResultCache::getTestSorterUID($test),
+            'testName'   => TestSuiteSorter::getTestSorterUID($test),
             'testMethod' => $this->testMethod,
             'message'    => $msg,
             'failed'     => $this->lastTestFailed,

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -212,7 +212,7 @@ class CliTestDoxPrinter extends ResultPrinter
             $this->write($msg);
             $this->testFlushCount++;
 
-            while (isset($this->outputBuffer[$this->originalExecutionOrder[$this->testFlushCount]])) {
+            while ($this->testFlushCount < $this->testCount && isset($this->outputBuffer[$this->originalExecutionOrder[$this->testFlushCount]])) {
 //                $this->write("** flushing {$this->originalExecutionOrder[$this->testFlushCount]}\n");
                 foreach($this->outputBuffer[$this->originalExecutionOrder[$this->testFlushCount++]] as $line) {
                     $this->write($line);

--- a/src/Util/TestResultCache.php
+++ b/src/Util/TestResultCache.php
@@ -10,7 +10,6 @@
 namespace PHPUnit\Runner;
 
 use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestCase;
 
 class TestResultCache implements \Serializable, TestResultCacheInterface
 {
@@ -63,25 +62,6 @@ class TestResultCache implements \Serializable, TestResultCacheInterface
      * @var array<string, float>
      */
     private $times = [];
-
-    public static function getTestSorterUID(Test $test): string
-    {
-        if ($test instanceof PhptTestCase) {
-            return $test->getName();
-        }
-
-        if ($test instanceof TestCase) {
-            $testName = $test->getName(true);
-
-            if (\strpos($testName, '::') === false) {
-                $testName = \get_class($test) . '::' . $testName;
-            }
-
-            return $testName;
-        }
-
-        return $test->getName();
-    }
 
     public function __construct($filename = null)
     {

--- a/src/Util/TestResultCache.php
+++ b/src/Util/TestResultCache.php
@@ -64,6 +64,25 @@ class TestResultCache implements \Serializable, TestResultCacheInterface
      */
     private $times = [];
 
+    public static function getTestSorterUID(Test $test): string
+    {
+        if ($test instanceof PhptTestCase) {
+            return $test->getName();
+        }
+
+        if ($test instanceof TestCase) {
+            $testName = $test->getName(true);
+
+            if (\strpos($testName, '::') === false) {
+                $testName = \get_class($test) . '::' . $testName;
+            }
+
+            return $testName;
+        }
+
+        return $test->getName();
+    }
+
     public function __construct($filename = null)
     {
         $this->cacheFilename = $filename ?? $_ENV['PHPUNIT_RESULT_CACHE'] ?? self::DEFAULT_RESULT_CACHE_FILENAME;
@@ -192,23 +211,5 @@ class TestResultCache implements \Serializable, TestResultCacheInterface
     private function createDirectory(string $directory): bool
     {
         return !(!\is_dir($directory) && !@\mkdir($directory, 0777, true) && !\is_dir($directory));
-    }
-
-    public static function getTestSorterUID(Test $test): string
-    {
-        if ($test instanceof PhptTestCase) {
-            return $test->getName();
-        }
-
-        if ($test instanceof TestCase) {
-            $testName = $test->getName(true);
-
-            if (\strpos($testName, '::') === false) {
-                $testName = \get_class($test) . '::' . $testName;
-            }
-            return $testName;
-        }
-
-        return $test->getName();
     }
 }

--- a/src/Util/TestResultCache.php
+++ b/src/Util/TestResultCache.php
@@ -9,6 +9,9 @@
  */
 namespace PHPUnit\Runner;
 
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+
 class TestResultCache implements \Serializable, TestResultCacheInterface
 {
     /**
@@ -189,5 +192,23 @@ class TestResultCache implements \Serializable, TestResultCacheInterface
     private function createDirectory(string $directory): bool
     {
         return !(!\is_dir($directory) && !@\mkdir($directory, 0777, true) && !\is_dir($directory));
+    }
+
+    public static function getTestSorterUID(Test $test): string
+    {
+        if ($test instanceof PhptTestCase) {
+            return $test->getName();
+        }
+
+        if ($test instanceof TestCase) {
+            $testName = $test->getName(true);
+
+            if (\strpos($testName, '::') === false) {
+                $testName = \get_class($test) . '::' . $testName;
+            }
+            return $testName;
+        }
+
+        return $test->getName();
     }
 }

--- a/tests/end-to-end/regression/GitHub/3380/issue-3380-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3380/issue-3380-test.phpt
@@ -39,10 +39,25 @@ DataproviderExecutionOrder
    │%w
    │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:37
    │%w
-%A
+
 Time: %s, Memory: %s
 
 Summary of non-successful tests:
+
+DataproviderExecutionOrder
+ ✘ Add numbers with a dataprovider with data set "1+1=3"
+   │
+   │ Failed asserting that 2 is identical to 3.
+   │
 %A
+   │
+
+ ✘ Add more numbers with a dataprovider with data set "1+1=3"
+   │
+   │ Failed asserting that 2 is identical to 3.
+   │
+%A
+   │
+
 FAILURES!
 Tests: 8, Assertions: 8, Failures: 2.

--- a/tests/end-to-end/regression/GitHub/3380/issue-3380-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3380/issue-3380-test.phpt
@@ -27,7 +27,7 @@ DataproviderExecutionOrder
    │
    │ Failed asserting that 2 is identical to 3.
    │%w
-   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:24
+   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:%d
    │%w
 
  ✔ Test in the middle that always works
@@ -37,7 +37,7 @@ DataproviderExecutionOrder
    │
    │ Failed asserting that 2 is identical to 3.
    │%w
-   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:37
+   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:%d
    │%w
 
 Time: %s, Memory: %s
@@ -48,16 +48,16 @@ DataproviderExecutionOrder
  ✘ Add numbers with a dataprovider with data set "1+1=3"
    │
    │ Failed asserting that 2 is identical to 3.
-   │
-%A
-   │
+   │%w
+   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:%d
+   │%w
 
  ✘ Add more numbers with a dataprovider with data set "1+1=3"
    │
    │ Failed asserting that 2 is identical to 3.
-   │
-%A
-   │
+   │%w
+   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:%d
+   │%w
 
 FAILURES!
 Tests: 8, Assertions: 8, Failures: 2.

--- a/tests/end-to-end/regression/GitHub/3380/issue-3380-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3380/issue-3380-test.phpt
@@ -1,0 +1,48 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/3380
+--FILE--
+<?php
+$tmpResultCache = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/../../../../_files/DataproviderExecutionOrderTest_result_cache.txt'));
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--order-by=defects';
+$_SERVER['argv'][3] = '--testdox';
+$_SERVER['argv'][4] = '--cache-result';
+$_SERVER['argv'][5] = '--cache-result-file=' . $tmpResultCache;
+$_SERVER['argv'][6] = \dirname(\dirname(\dirname(__DIR__))) . '/../_files/DataproviderExecutionOrderTest.php';
+
+require __DIR__ . '/../../../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+
+unlink($tmpResultCache);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+DataproviderExecutionOrder
+ ✔ First test that always works
+ ✔ Add numbers with a dataprovider with data set "1+2=3"
+ ✔ Add numbers with a dataprovider with data set "2+1=3"
+ ✘ Add numbers with a dataprovider with data set "1+1=3"
+   │
+   │ Failed asserting that 2 is identical to 3.
+   │%w
+   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:24
+   │%w
+
+ ✔ Test in the middle that always works
+ ✔ Add more numbers with a dataprovider with data set "1+2=3"
+ ✔ Add more numbers with a dataprovider with data set "2+1=3"
+ ✘ Add more numbers with a dataprovider with data set "1+1=3"
+   │
+   │ Failed asserting that 2 is identical to 3.
+   │%w
+   │ %s%etests%e_files%eDataproviderExecutionOrderTest.php:37
+   │%w
+%A
+Time: %s, Memory: %s
+
+Summary of non-successful tests:
+%A
+FAILURES!
+Tests: 8, Assertions: 8, Failures: 2.

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -24,6 +24,14 @@ class TestSuiteSorterTest extends TestCase
 
     private const RESOLVE_DEPENDENCIES = true;
 
+    private const MULTIDEPENDENCYTEST_EXECUTION_ORDER = [
+        \MultiDependencyTest::class . '::testOne',
+        \MultiDependencyTest::class . '::testTwo',
+        \MultiDependencyTest::class . '::testThree',
+        \MultiDependencyTest::class . '::testFour',
+        \MultiDependencyTest::class . '::testFive',
+    ];
+
     public function testThrowsExceptionWhenUsingInvalidOrderOption(): void
     {
         $suite = new TestSuite;
@@ -54,17 +62,17 @@ class TestSuiteSorterTest extends TestCase
         $sorter = new TestSuiteSorter;
         $suite  = new TestSuite;
 
-        $this->assertSame([], $suite->tests());
-
         $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, $orderDefects);
 
-        $this->assertSame([], $suite->tests());
+        $this->assertEmpty($suite->tests());
+        $this->assertEmpty($sorter->getOriginalExecutionOrder());
+        $this->assertEmpty($sorter->getExecutionOrder());
     }
 
     /**
      * @dataProvider commonSorterOptionsProvider
      */
-    public function testBasicExecutionOrderOptions(int $order, bool $resolveDependencies, array $expected): void
+    public function testBasicExecutionOrderOptions(int $order, bool $resolveDependencies, array $expectedOrder): void
     {
         $suite = new TestSuite;
         $suite->addTestSuite(\MultiDependencyTest::class);
@@ -72,7 +80,8 @@ class TestSuiteSorterTest extends TestCase
 
         $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, TestSuiteSorter::ORDER_DEFAULT);
 
-        $this->assertSame($expected, $this->getTestExecutionOrder($suite));
+        $this->assertSame(self::MULTIDEPENDENCYTEST_EXECUTION_ORDER, $sorter->getOriginalExecutionOrder());
+        $this->assertSame($expectedOrder, $sorter->getExecutionOrder());
     }
 
     public function testCanSetRandomizationWithASeed(): void
@@ -84,7 +93,15 @@ class TestSuiteSorterTest extends TestCase
         \mt_srand(54321);
         $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_RANDOMIZED, false, TestSuiteSorter::ORDER_DEFAULT);
 
-        $this->assertSame(['testTwo', 'testFour', 'testFive', 'testThree', 'testOne'], $this->getTestExecutionOrder($suite));
+        $expectedOrder = [
+            \MultiDependencyTest::class . '::testTwo',
+            \MultiDependencyTest::class . '::testFour',
+            \MultiDependencyTest::class . '::testFive',
+            \MultiDependencyTest::class . '::testThree',
+            \MultiDependencyTest::class . '::testOne',
+        ];
+
+        $this->assertSame($expectedOrder, $sorter->getExecutionOrder());
     }
 
     public function testCanSetRandomizationWithASeedAndResolveDependencies(): void
@@ -96,7 +113,15 @@ class TestSuiteSorterTest extends TestCase
         \mt_srand(54321);
         $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_RANDOMIZED, true, TestSuiteSorter::ORDER_DEFAULT);
 
-        $this->assertSame(['testTwo', 'testFive', 'testOne', 'testThree', 'testFour'], $this->getTestExecutionOrder($suite));
+        $expectedOrder = [
+            \MultiDependencyTest::class . '::testTwo',
+            \MultiDependencyTest::class . '::testFive',
+            \MultiDependencyTest::class . '::testOne',
+            \MultiDependencyTest::class . '::testThree',
+            \MultiDependencyTest::class . '::testFour',
+        ];
+
+        $this->assertSame($expectedOrder, $sorter->getExecutionOrder());
     }
 
     /**
@@ -117,7 +142,7 @@ class TestSuiteSorterTest extends TestCase
             TestSuiteSorter::ORDER_DEFAULT
         );
 
-        $this->assertSame($expected, $this->getTestExecutionOrder($suite));
+        $this->assertSame($expected, $sorter->getExecutionOrder());
     }
 
     public function orderDurationWithoutCacheProvider(): array
@@ -126,21 +151,21 @@ class TestSuiteSorterTest extends TestCase
             'dependency-ignore' => [
                 self::IGNORE_DEPENDENCIES,
                 [
-                    'testOne',
-                    'testTwo',
-                    'testThree',
-                    'testFour',
-                    'testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
                 ],
             ],
             'dependency-resolve' => [
                 self::RESOLVE_DEPENDENCIES,
                 [
-                    'testOne',
-                    'testTwo',
-                    'testThree',
-                    'testFour',
-                    'testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
                 ],
             ],
         ];
@@ -170,7 +195,7 @@ class TestSuiteSorterTest extends TestCase
             TestSuiteSorter::ORDER_DEFAULT
         );
 
-        $this->assertSame($expected, $this->getTestExecutionOrder($suite));
+        $this->assertSame($expected, $sorter->getExecutionOrder());
     }
 
     public function orderDurationWithCacheProvider(): array
@@ -186,11 +211,11 @@ class TestSuiteSorterTest extends TestCase
                     'testFive'  => 1,
                 ],
                 [
-                    'testOne',
-                    'testTwo',
-                    'testThree',
-                    'testFour',
-                    'testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
                 ],
             ],
             'duration-same-dependency-resolve' => [
@@ -203,11 +228,11 @@ class TestSuiteSorterTest extends TestCase
                     'testFive'  => 1,
                 ],
                 [
-                    'testOne',
-                    'testTwo',
-                    'testThree',
-                    'testFour',
-                    'testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
                 ],
             ],
             'duration-different-dependency-ignore' => [
@@ -220,11 +245,11 @@ class TestSuiteSorterTest extends TestCase
                     'testFive'  => 2,
                 ],
                 [
-                    'testFour',
-                    'testFive',
-                    'testTwo',
-                    'testThree',
-                    'testOne',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testOne',
                 ],
             ],
             'duration-different-dependency-resolve' => [
@@ -237,11 +262,11 @@ class TestSuiteSorterTest extends TestCase
                     'testFive'  => 2,
                 ],
                 [
-                    'testFive',
-                    'testTwo',
-                    'testOne',
-                    'testThree',
-                    'testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
                 ],
             ],
         ];
@@ -265,7 +290,7 @@ class TestSuiteSorterTest extends TestCase
         $sorter  = new TestSuiteSorter($cache);
         $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, TestSuiteSorter::ORDER_DEFECTS_FIRST);
 
-        $this->assertSame($expected, $this->getTestExecutionOrder($suite));
+        $this->assertSame($expected, $sorter->getExecutionOrder());
     }
 
     /**
@@ -282,28 +307,52 @@ class TestSuiteSorterTest extends TestCase
             'default' => [
                 TestSuiteSorter::ORDER_DEFAULT,
                 self::IGNORE_DEPENDENCIES,
-                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive'],
+                [
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                ],
             ],
 
             // Activating dependency resolution should have no effect under normal circumstances
             'resolve default' => [
                 TestSuiteSorter::ORDER_DEFAULT,
                 self::RESOLVE_DEPENDENCIES,
-                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive'],
+                [
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                ],
             ],
 
             // Reversing without checks should give a simple reverse order
             'reverse' => [
                 TestSuiteSorter::ORDER_REVERSED,
                 self::IGNORE_DEPENDENCIES,
-                ['testFive', 'testFour', 'testThree', 'testTwo', 'testOne'],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testOne',
+                ],
             ],
 
             // Reversing with resolution still allows testFive to move to front, testTwo before testOne
             'resolve reverse' => [
                 TestSuiteSorter::ORDER_REVERSED,
                 self::RESOLVE_DEPENDENCIES,
-                ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour'],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                ],
             ],
         ];
     }
@@ -330,7 +379,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                 ],
-                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive'], ],
+                [
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                ],
+            ],
 
             // Running with an empty cache should not spook the TestSuiteSorter
             'default, empty result cache' => [
@@ -339,7 +395,14 @@ class TestSuiteSorterTest extends TestCase
                 [
                     // empty result cache
                 ],
-                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive'], ],
+                [
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                ],
+            ],
 
             // testFive is independent and can be moved to the front
             'default, testFive skipped' => [
@@ -352,7 +415,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
                 ],
-                ['testFive', 'testOne', 'testTwo', 'testThree', 'testFour'], ],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                ],
+            ],
 
             // Defects in testFive and testTwo, but the faster testFive should be run first
             'default, testTwo testFive skipped' => [
@@ -365,7 +435,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 0],
                 ],
-                ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour'], ],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                ],
+            ],
 
             // Skipping testThree will move it to the front when ignoring dependencies
             'default, testThree skipped' => [
@@ -378,7 +455,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                 ],
-                ['testThree', 'testOne', 'testTwo', 'testFour', 'testFive'], ],
+                [
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                ],
+            ],
 
             // Skipping testThree will move it to the front but behind its dependencies
             'default resolve, testThree skipped' => [
@@ -391,7 +475,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                 ],
-                ['testOne', 'testTwo', 'testThree', 'testFour', 'testFive'], ],
+                [
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testFive',
+                ],
+            ],
 
             // Skipping testThree will move it to the front and keep the others reversed
             'reverse, testThree skipped' => [
@@ -404,7 +495,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                 ],
-                ['testThree', 'testFive', 'testFour', 'testTwo', 'testOne'], ],
+                [
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testFour',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testOne',
+                ],
+            ],
 
             // Demonstrate a limit of the dependency resolver: after sorting defects to the front,
             // the resolver will mark testFive done before testThree because of dependencies
@@ -418,7 +516,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
                 ],
-                ['testFive', 'testOne', 'testTwo', 'testThree', 'testFour'], ],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                ],
+            ],
 
             // Torture test
             // - incomplete TestResultCache
@@ -433,7 +538,14 @@ class TestSuiteSorterTest extends TestCase
                     'testTwo'   => ['state' => BaseTestRunner::STATUS_PASSED, 'time' => 1],
                     'testThree' => ['state' => BaseTestRunner::STATUS_SKIPPED, 'time' => 1],
                 ],
-                ['testFive', 'testTwo', 'testOne', 'testThree', 'testFour'], ],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                ],
+            ],
 
             // Make sure the dependency resolver is not confused by failing tests.
             // Scenario: Four has a @depends on Three and fails. Result: Three is still run first
@@ -448,7 +560,14 @@ class TestSuiteSorterTest extends TestCase
                     'testFour'  => ['state' => BaseTestRunner::STATUS_FAILURE, 'time' => 1],
                     'testFive'  => ['state' => BaseTestRunner::STATUS_FAILURE, 'time' => 1],
                 ],
-                ['testFive', 'testOne', 'testTwo', 'testThree', 'testFour'], ],
+                [
+                    \MultiDependencyTest::class . '::testFive',
+                    \MultiDependencyTest::class . '::testOne',
+                    \MultiDependencyTest::class . '::testTwo',
+                    \MultiDependencyTest::class . '::testThree',
+                    \MultiDependencyTest::class . '::testFour',
+                ],
+            ],
         ];
     }
 
@@ -485,12 +604,5 @@ class TestSuiteSorterTest extends TestCase
         }
 
         return $data;
-    }
-
-    private function getTestExecutionOrder(TestSuite $suite): array
-    {
-        return \array_map(function ($test) {
-            return $test->getName();
-        }, $suite->tests()[0]->tests());
     }
 }


### PR DESCRIPTION
This addition provides a working solution to #3380. For Nikolaus you wanted:

> The TestDox result printer(s) should be changed to buffer test results in order to ensure the right order and then emit all output after the last test was run.

Refactoring the TextDox printer turned out be a bit of work. To clean up the internal `TestResult` magic I ended up rewriting large parts. Still some minor cleaning up to do, but it's good enough for daily use. 

### Changes
- `TestSuiteSorter` now calculates and stores the original execution order before a run
- naming scheme logic for test reordering consolidated in `TestSuiteSorter::getTestSorterUID`
- main runner passes this original order into a `CliTestDoxPrinter` extension when required
- prints unbuffered when original execution order is not provided
- when buffering the printer will flush test results in the original order as soon as it can
- new PHPT end-to-end test keeps an eye on functionality
- unit test fixes to match test naming scheme

### How to test
Edit `phpunit.xml` and switch to `verbose=false`. Then run the test suite in both buffered and unbuffered TestDox mode:
```
./phpunit --testdox | tee /tmp/new.unbuffered
./phpunit --testdox --order-by=defects,depends | tee /tmp/new.buffered
diff /tmp/new.unbuffered /tmp/new.buffered
```

### Notes
- output diff: when buffering the names of some tests have a bit of extra detail
- could clean up unbuffered message formatting and writing; rather do that after the test Hooks are done