### PR TITLE
Fix conflicting placeholder replacement and argument exporting inconsistencies in @testdox

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -160,9 +160,7 @@ final class NamePrettifier
         $providedDataValues = \array_values($test->getProvidedData());
         $i                  = 0;
 
-        $parameters = $reflector->getParameters();
-
-        foreach ($parameters as $parameter) {
+        foreach ($reflector->getParameters() as $parameter) {
             if (!\array_key_exists($i, $providedDataValues) && $parameter->isDefaultValueAvailable()) {
                 $providedDataValues[$i] = $parameter->getDefaultValue();
             }

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -63,7 +63,7 @@ final class NamePrettifier
         $annotations                = $test->getAnnotations();
         $annotationWithPlaceholders = false;
 
-        $callback = static function (string $variable) : string {
+        $callback = static function (string $variable): string {
             return \sprintf('/%s(?=\b)/', \preg_quote($variable, '/'));
         };
 

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -118,13 +118,13 @@ class NamePrettifierTest extends TestCase
             public function __construct()
             {
                 parent::__construct('testExport', [
-                    'int' => 1234,
-                    'strInt' => '1234',
-                    'float' => 2.123,
+                    'int'      => 1234,
+                    'strInt'   => '1234',
+                    'float'    => 2.123,
                     'strFloat' => '2.123',
-                    'string' => 'foo',
-                    'bool' => true,
-                    'null' => null,
+                    'string'   => 'foo',
+                    'bool'     => true,
+                    'null'     => null,
                 ]);
             }
 

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -111,4 +111,62 @@ class NamePrettifierTest extends TestCase
 
         $this->assertEquals('1 + 2 = 3', $this->namePrettifier->prettifyTestCase($test));
     }
+
+    public function testPhpDoxArgumentExporting(): void
+    {
+        $test = new class extends TestCase {
+            public function __construct()
+            {
+                parent::__construct('testExport', [
+                    'int' => 1234,
+                    'strInt' => '1234',
+                    'float' => 2.123,
+                    'strFloat' => '2.123',
+                    'string' => 'foo',
+                    'bool' => true,
+                    'null' => null,
+                ]);
+            }
+
+            public function testExport($int, $strInt, $float, $strFloat, $string, $bool, $null): void
+            {
+            }
+
+            public function getAnnotations(): array
+            {
+                return [
+                    'method' => [
+                        'testdox' => ['$int, $strInt, $float, $strFloat, $string, $bool, $null'],
+                    ],
+                ];
+            }
+        };
+
+        $this->assertEquals('1234, 1234, 2.123, 2.123, foo, true, NULL', $this->namePrettifier->prettifyTestCase($test));
+    }
+
+    public function testPhpDoxReplacesLongerVariablesFirst(): void
+    {
+        $test = new class extends TestCase {
+            public function __construct()
+            {
+                parent::__construct('testFoo', []);
+            }
+
+            public function testFoo(int $a = 1, int $ab = 2, int $abc = 3): void
+            {
+            }
+
+            public function getAnnotations(): array
+            {
+                return [
+                    'method' => [
+                        'testdox' => ['$a, "$a", $a$ab, $abc, $abcd, $ab'],
+                    ],
+                ];
+            }
+        };
+
+        $this->assertEquals('1, "1", 12, 3, $abcd, 2', $this->namePrettifier->prettifyTestCase($test));
+    }
 }


### PR DESCRIPTION
This PR fixes a bug when two variables share the same prefix resulting in a badly formatted testdox:

```php
/**
 * @testdox Message regarding $foo and $fooBar
 * @dataProvider fooProvider
 */
public function testFoo(string $foo, string $fooBar) : void
{
}
````
Outputs:
```
Message regarding fooValue and fooValueBar
```
It also fixes inconsistencies on how arguments are rendered. Currently, a string `foo` rendered unquoted, while a numeric string `124` is enclosed in quotes. The same occurs for float values. The fix addresses these issues by using the exporter logic to handle boolean, integer and float values only. The reasoning is that if one wants to use quotes, it is preferable to put it in the `@testdox`.  