### PR TITLE
Enable dependency resolution by default + AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ environment:
   COMPOSER_ROOT_VERSION: '7.0-dev'
 
   matrix:
-    - PHP_VERSION: '7.1.11'
-      XDEBUG_VERSION: '2.5.5-7.1'
+    - PHP_VERSION: '7.2.12'
+      XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: '--prefer-lowest'
-    - PHP_VERSION: '7.1.11'
-      XDEBUG_VERSION: '2.5.5-7.1'
+    - PHP_VERSION: '7.2.12'
+      XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: ''
 
 matrix:
@@ -31,8 +31,8 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC14-x86.zip https://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-Win32-VC14-x86.zip
-  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC14-x86.zip -y >nul
+  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC15-x86.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86.zip
+  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC15-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
   - IF NOT EXIST php-installed.txt echo max_execution_time=1200 >> php.ini
@@ -48,8 +48,8 @@ install:
   - IF NOT EXIST php-installed.txt echo assert.exception=On >> php.ini
   - IF NOT EXIST php-installed.txt curl -fsS -o composer.phar https://getcomposer.org/composer.phar
   - IF NOT EXIST php-installed.txt echo @php %%~dp0composer.phar %%* > composer.bat
-  - IF NOT EXIST php-installed.txt curl -fsS -o c:\php\%PHP_VERSION%\ext\php_xdebug-%XDEBUG_VERSION%-vc14.dll https://xdebug.org/files/php_xdebug-%XDEBUG_VERSION%-vc14.dll
-  - IF NOT EXIST php-installed.txt echo zend_extension=php_xdebug-%XDEBUG_VERSION%-vc14.dll >> php.ini
+  - IF NOT EXIST php-installed.txt curl -fsS -o c:\php\%PHP_VERSION%\ext\php_xdebug-%XDEBUG_VERSION%-vc15.dll https://xdebug.org/files/php_xdebug-%XDEBUG_VERSION%-vc15.dll
+  - IF NOT EXIST php-installed.txt echo zend_extension=php_xdebug-%XDEBUG_VERSION%-vc15.dll >> php.ini
   - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
   - cd c:\phpunit
   - composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable %DEPENDENCIES%

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         cacheResult="true"
          executionOrder="depends"
          verbose="true">
     <testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
+         cacheResult="true"
+         executionOrder="depends"
          verbose="true">
     <testsuites>
         <testsuite name="unit">

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -184,6 +184,11 @@
             <xs:enumeration value="depends,random"/>
             <xs:enumeration value="depends,reverse"/>
             <xs:enumeration value="depends,duration"/>
+            <xs:enumeration value="no-depends"/>
+            <xs:enumeration value="no-depends,defects"/>
+            <xs:enumeration value="no-depends,random"/>
+            <xs:enumeration value="no-depends,reverse"/>
+            <xs:enumeration value="no-depends,duration"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="fileFilterType">

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -94,6 +94,7 @@ class Command
         'globals-backup'            => null,
         'group='                    => null,
         'help'                      => null,
+        'resolve-dependencies'      => null,
         'ignore-dependencies'       => null,
         'include-path='             => null,
         'list-groups'               => null,

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -94,7 +94,6 @@ class Command
         'globals-backup'            => null,
         'group='                    => null,
         'help'                      => null,
-        'resolve-dependencies'      => null,
         'ignore-dependencies'       => null,
         'include-path='             => null,
         'list-groups'               => null,
@@ -745,7 +744,7 @@ class Command
                     break;
 
                 case '--ignore-dependencies':
-                    $this->arguments['resolveDependencies'] = false;
+                    $this->handleOrderByOption('no-depends');
 
                     break;
 
@@ -1163,8 +1162,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --resolve-dependencies      Resolve dependencies between tests
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends|no-depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file
@@ -1370,6 +1368,11 @@ EOT;
 
                 case 'depends':
                     $this->arguments['resolveDependencies'] = true;
+
+                    break;
+
+                case 'no-depends':
+                    $this->arguments['resolveDependencies'] = false;
 
                     break;
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1348,7 +1348,7 @@ EOT;
                 case 'default':
                     $this->arguments['executionOrder']        = TestSuiteSorter::ORDER_DEFAULT;
                     $this->arguments['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFAULT;
-                    $this->arguments['resolveDependencies']   = false;
+                    $this->arguments['resolveDependencies']   = true;
 
                     break;
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1163,7 +1163,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends|no-depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|no-depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -1240,7 +1240,7 @@ class TestRunner extends BaseTestRunner
         $arguments['reportUselessTests']                              = $arguments['reportUselessTests'] ?? true;
         $arguments['reverseList']                                     = $arguments['reverseList'] ?? false;
         $arguments['executionOrder']                                  = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
-        $arguments['resolveDependencies']                             = $arguments['resolveDependencies'] ?? false;
+        $arguments['resolveDependencies']                             = $arguments['resolveDependencies'] ?? true;
         $arguments['stopOnError']                                     = $arguments['stopOnError'] ?? false;
         $arguments['stopOnFailure']                                   = $arguments['stopOnFailure'] ?? false;
         $arguments['stopOnIncomplete']                                = $arguments['stopOnIncomplete'] ?? false;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -965,6 +965,10 @@ final class Configuration
                         $result['resolveDependencies'] = true;
 
                         break;
+                    case 'no-depends':
+                        $result['resolveDependencies'] = false;
+
+                        break;
                 }
             }
         }

--- a/tests/_files/configuration_execution_order_options.xml
+++ b/tests/_files/configuration_execution_order_options.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit executionOrder="reverse"
-         resolveDependencies="true"
+<phpunit executionOrder="no-depends,reverse"
          cacheResultFile="MultiDependencyTest_result_cache.txt">
 
     <php>

--- a/tests/end-to-end/cache-result.phpt
+++ b/tests/end-to-end/cache-result.phpt
@@ -5,7 +5,7 @@ phpunit --order-by=no-depends,reverse --cache-result --cache-result-file MultiDe
 $target = tempnam(sys_get_temp_dir(), __FILE__);
 
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--ignore-dependencies'   // keep coverage for legacy CLI option
+$_SERVER['argv'][2] = '--ignore-dependencies';   // keep coverage for legacy CLI option
 $_SERVER['argv'][3] = '--order-by=reverse';
 $_SERVER['argv'][4] = '--cache-result';
 $_SERVER['argv'][5] = '--cache-result-file=' . $target;

--- a/tests/end-to-end/cache-result.phpt
+++ b/tests/end-to-end/cache-result.phpt
@@ -1,11 +1,11 @@
 --TEST--
-phpunit --reverse-order --cache-result --cache-result-file MultiDependencyTest ./tests/_files/MultiDependencyTest.php
+phpunit --order-by=no-depends,reverse --cache-result --cache-result-file MultiDependencyTest ./tests/_files/MultiDependencyTest.php
 --FILE--
 <?php
 $target = tempnam(sys_get_temp_dir(), __FILE__);
 
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--reverse-order';
+$_SERVER['argv'][2] = '--order-by=no-depends,reverse';
 $_SERVER['argv'][3] = '--cache-result';
 $_SERVER['argv'][4] = '--cache-result-file=' . $target;
 $_SERVER['argv'][5] = 'MultiDependencyTest';

--- a/tests/end-to-end/cache-result.phpt
+++ b/tests/end-to-end/cache-result.phpt
@@ -5,11 +5,12 @@ phpunit --order-by=no-depends,reverse --cache-result --cache-result-file MultiDe
 $target = tempnam(sys_get_temp_dir(), __FILE__);
 
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--order-by=no-depends,reverse';
-$_SERVER['argv'][3] = '--cache-result';
-$_SERVER['argv'][4] = '--cache-result-file=' . $target;
-$_SERVER['argv'][5] = 'MultiDependencyTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][2] = '--ignore-dependencies'   // keep coverage for legacy CLI option
+$_SERVER['argv'][3] = '--order-by=reverse';
+$_SERVER['argv'][4] = '--cache-result';
+$_SERVER['argv'][5] = '--cache-result-file=' . $target;
+$_SERVER['argv'][6] = 'MultiDependencyTest';
+$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main(false);

--- a/tests/end-to-end/execution-order-options-via-config.phpt
+++ b/tests/end-to-end/execution-order-options-via-config.phpt
@@ -15,16 +15,17 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Test 'MultiDependencyTest::testFive' started
 Test 'MultiDependencyTest::testFive' ended
+Test 'MultiDependencyTest::testFour' started
+Test 'MultiDependencyTest::testFour' ended
+Test 'MultiDependencyTest::testThree' started
+Test 'MultiDependencyTest::testThree' ended
 Test 'MultiDependencyTest::testTwo' started
 Test 'MultiDependencyTest::testTwo' ended
 Test 'MultiDependencyTest::testOne' started
 Test 'MultiDependencyTest::testOne' ended
-Test 'MultiDependencyTest::testThree' started
-Test 'MultiDependencyTest::testThree' ended
-Test 'MultiDependencyTest::testFour' started
-Test 'MultiDependencyTest::testFour' ended
 
 
 Time: %s, Memory: %s
 
-OK (5 tests, 6 assertions)
+OK, but incomplete, skipped, or risky tests!
+Tests: 5, Assertions: 3, Skipped: 2.

--- a/tests/end-to-end/help.phpt
+++ b/tests/end-to-end/help.phpt
@@ -87,8 +87,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --resolve-dependencies      Resolve dependencies between tests
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends|no-depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/help.phpt
+++ b/tests/end-to-end/help.phpt
@@ -87,7 +87,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends|no-depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|no-depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/help2.phpt
+++ b/tests/end-to-end/help2.phpt
@@ -88,8 +88,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --resolve-dependencies      Resolve dependencies between tests
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends|no-depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/help2.phpt
+++ b/tests/end-to-end/help2.phpt
@@ -88,7 +88,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|depends|no-depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|no-depends
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/regression/GitHub/3093/issue-3093-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3093/issue-3093-test.phpt
@@ -3,9 +3,8 @@ https://github.com/sebastianbergmann/phpunit/issues/3093
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--reverse-order';
-$_SERVER['argv'][3] = '--resolve-dependencies';
-$_SERVER['argv'][4] = __DIR__ . '/Issue3093Test.php';
+$_SERVER['argv'][2] = '--order-by=reverse';
+$_SERVER['argv'][3] = __DIR__ . '/Issue3093Test.php';
 
 require __DIR__ . '/../../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/3107/issue-3107-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3107/issue-3107-test.phpt
@@ -5,7 +5,7 @@ https://github.com/sebastianbergmann/phpunit/issues/3107
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--testdox';
-$_SERVER['argv'][4] = '--order-by=default';
+$_SERVER['argv'][4] = '--order-by=no-depends';
 $_SERVER['argv'][5] = __DIR__ . '/Issue3107Test.php';
 
 require __DIR__ . '/../../../../bootstrap.php';

--- a/tests/end-to-end/regression/GitHub/3107/issue-3107-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3107/issue-3107-test.phpt
@@ -5,7 +5,8 @@ https://github.com/sebastianbergmann/phpunit/issues/3107
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--testdox';
-$_SERVER['argv'][4] = __DIR__ . '/Issue3107Test.php';
+$_SERVER['argv'][4] = '--order-by=default';
+$_SERVER['argv'][5] = __DIR__ . '/Issue3107Test.php';
 
 require __DIR__ . '/../../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/test-order-randomized-seed-with-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-randomized-seed-with-dependency-resolution.phpt
@@ -1,15 +1,14 @@
 --TEST--
-phpunit --random-order --random-order-seed=54321 --resolve-dependencies ../_files/MultiDependencyTest.php
+phpunit --order-by=depends,random --random-order-seed=54321 ../_files/MultiDependencyTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
 $_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--random-order';
+$_SERVER['argv'][4] = '--order-by=depends,random';
 $_SERVER['argv'][5] = '--random-order-seed=54321';
-$_SERVER['argv'][6] = '--resolve-dependencies';
-$_SERVER['argv'][7] = 'MultiDependencyTest';
-$_SERVER['argv'][8] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][6] = 'MultiDependencyTest';
+$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/test-order-randomized-with-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-randomized-with-dependency-resolution.phpt
@@ -4,9 +4,10 @@ phpunit --order-by=depends,random ../_files/MultiDependencyTest.php
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--verbose';
-$_SERVER['argv'][3] = '--order-by=depends,random';
-$_SERVER['argv'][4] = 'MultiDependencyTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][3] = '--resolve-dependencies';     // keep coverage for legacy CLI option
+$_SERVER['argv'][4] = '--order-by=depends,random';
+$_SERVER['argv'][5] = 'MultiDependencyTest';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/test-order-randomized-with-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-randomized-with-dependency-resolution.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --order-by=random --resolve-dependencies ../_files/MultiDependencyTest.php
+phpunit --order-by=depends,random ../_files/MultiDependencyTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--verbose';
-$_SERVER['argv'][3] = '--order-by=random';
-$_SERVER['argv'][4] = '--resolve-dependencies';
-$_SERVER['argv'][5] = 'MultiDependencyTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][3] = '--order-by=depends,random';
+$_SERVER['argv'][4] = 'MultiDependencyTest';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/test-order-reversed-with-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-reversed-with-dependency-resolution.phpt
@@ -5,10 +5,9 @@ phpunit --verbose --order-by=reverse ../_files/DependencySuccessTest.php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
 $_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--order-by=reverse';
-$_SERVER['argv'][5] = '--resolve-dependencies';
-$_SERVER['argv'][6] = 'MultiDependencyTest';
-$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][4] = '--order-by=depends,reverse';
+$_SERVER['argv'][5] = 'MultiDependencyTest';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/test-order-reversed-without-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-reversed-without-dependency-resolution.phpt
@@ -1,14 +1,13 @@
 --TEST--
-phpunit --reverse-order --ignore-dependencies ../_files/MultiDependencyTest.php
+phpunit --order-by=no-depends,reverse ../_files/MultiDependencyTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
 $_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--reverse-order';
-$_SERVER['argv'][5] = '--ignore-dependencies';
-$_SERVER['argv'][6] = 'MultiDependencyTest';
-$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][4] = '--order-by=no-depends,reverse';
+$_SERVER['argv'][5] = 'MultiDependencyTest';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();


### PR DESCRIPTION
Implements #3133 

- updated PHP and Xdebug version for AppVeyor Windows CI build
- switch dependency resolver on by default in configuration handlers
- remove `--resolve-dependencies` and `--ignore-dependencies` from help messages, but keep them functional. It would be user unfriendly to have legacy tests fail when upgrading to 8.x.
- added `--order-by=no-depends` flag to give user full on/off control over dependency resolver
- add `no-depends` as an option to XML-configuration
- update tests to use `--order-by` flags, keep minimal coverage for legacy options