### PR TITLE
fix inefficient loop in getHookMethods and save up to 4% in cachegrind files

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -715,26 +715,30 @@ final class Test
                         continue;
                     }
 
-                    if (self::isBeforeClassMethod($method)) {
-                        \array_unshift(
-                            self::$hookMethods[$className]['beforeClass'],
-                            $method->getName()
-                        );
-                    }
+                    if ($methodComment = $method->getDocComment()) {
+                        if ($method->isStatic()) {
+                            if (\strpos($methodComment, '@beforeClass') !== false) {
+                                \array_unshift(
+                                    self::$hookMethods[$className]['beforeClass'],
+                                    $method->getName()
+                                );
+                            }
 
-                    if (self::isBeforeMethod($method)) {
-                        \array_unshift(
-                            self::$hookMethods[$className]['before'],
-                            $method->getName()
-                        );
-                    }
+                            if (\strpos($methodComment, '@afterClass') !== false) {
+                                self::$hookMethods[$className]['afterClass'][] = $method->getName();
+                            }
+                        }
 
-                    if (self::isAfterMethod($method)) {
-                        self::$hookMethods[$className]['after'][] = $method->getName();
-                    }
+                        if (\preg_match('/@before\b/', $methodComment) > 0) {
+                            \array_unshift(
+                                self::$hookMethods[$className]['before'],
+                                $method->getName()
+                            );
+                        }
 
-                    if (self::isAfterClassMethod($method)) {
-                        self::$hookMethods[$className]['afterClass'][] = $method->getName();
+                        if (\preg_match('/@after\b/', $methodComment) > 0) {
+                            self::$hookMethods[$className]['after'][] = $method->getName();
+                        }
                     }
                 }
             } catch (ReflectionException $e) {
@@ -1083,26 +1087,6 @@ final class Test
         }
 
         return $result;
-    }
-
-    private static function isBeforeClassMethod(ReflectionMethod $method): bool
-    {
-        return $method->isStatic() && \strpos($method->getDocComment(), '@beforeClass') !== false;
-    }
-
-    private static function isBeforeMethod(ReflectionMethod $method): bool
-    {
-        return \preg_match('/@before\b/', $method->getDocComment()) > 0;
-    }
-
-    private static function isAfterClassMethod(ReflectionMethod $method): bool
-    {
-        return $method->isStatic() && \strpos($method->getDocComment(), '@afterClass') !== false;
-    }
-
-    private static function isAfterMethod(ReflectionMethod $method): bool
-    {
-        return \preg_match('/@after\b/', $method->getDocComment()) > 0;
     }
 
     /**


### PR DESCRIPTION
this commit is the result of finding a significant bottleneck in cachegrind files and performance gain up to 4% (measured in a project)
    
It fixes an inefficient loop in getHookMethods in which unnecessary logic can be executed when method docblock are not defined. It also minimizes calls to the same methods.

Also, the code is verbose enough to understand without the need for extra private methods.