### PR TITLE
Fix JUnit missing PHPT results 

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -223,6 +223,11 @@ class PhptTestCase implements Test, SelfDescribing
         return $this->output;
     }
 
+    public function hasOutput(): bool
+    {
+        return !empty($this->output);
+    }
+
     /**
      * Parse --INI-- section key value pairs and return as array.
      *
@@ -581,10 +586,5 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         return $settings;
-    }
-
-    public function hasOutput(): bool
-    {
-        return !empty($this->output);
     }
 }

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -63,6 +63,11 @@ class PhptTestCase implements Test, SelfDescribing
     private $phpUtil;
 
     /**
+     * @var string
+     */
+    private $output = '';
+
+    /**
      * Constructs a test case with the given filename.
      *
      * @throws Exception
@@ -155,8 +160,9 @@ class PhptTestCase implements Test, SelfDescribing
 
         Timer::start();
 
-        $jobResult = $this->phpUtil->runJob($code, $this->stringifyIni($settings));
-        $time      = Timer::stop();
+        $jobResult    = $this->phpUtil->runJob($code, $this->stringifyIni($settings));
+        $time         = Timer::stop();
+        $this->output = $jobResult['stdout'] ?? '';
 
         if ($result->getCollectCodeCoverageInformation() && ($coverage = $this->cleanupForCoverage())) {
             $result->getCodeCoverage()->append($coverage, $this, true, [], [], true);
@@ -200,6 +206,21 @@ class PhptTestCase implements Test, SelfDescribing
     public function toString(): string
     {
         return $this->filename;
+    }
+
+    public function usesDataProvider(): bool
+    {
+        return false;
+    }
+
+    public function getNumAssertions(): int
+    {
+        return 1;
+    }
+
+    public function getActualOutput(): string
+    {
+        return $this->output;
     }
 
     /**
@@ -475,8 +496,8 @@ class PhptTestCase implements Test, SelfDescribing
 
     private function getCoverageFiles(): array
     {
-        $baseDir          = \dirname(\realpath($this->filename)) . \DIRECTORY_SEPARATOR;
-        $basename         = \basename($this->filename, 'phpt');
+        $baseDir  = \dirname(\realpath($this->filename)) . \DIRECTORY_SEPARATOR;
+        $basename = \basename($this->filename, 'phpt');
 
         return [
             'coverage' => $baseDir . $basename . 'coverage',
@@ -507,7 +528,10 @@ class PhptTestCase implements Test, SelfDescribing
         $globals = '';
 
         if (!empty($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
-            $globals = '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = ' . \var_export($GLOBALS['__PHPUNIT_BOOTSTRAP'], true) . ";\n";
+            $globals = '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = ' . \var_export(
+                $GLOBALS['__PHPUNIT_BOOTSTRAP'],
+                    true
+            ) . ";\n";
         }
 
         $template->setVar(
@@ -557,5 +581,10 @@ class PhptTestCase implements Test, SelfDescribing
         }
 
         return $settings;
+    }
+
+    public function hasOutput(): bool
+    {
+        return !empty($this->output);
     }
 }

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -291,10 +291,6 @@ class JUnit extends Printer implements TestListener
      */
     public function startTest(Test $test): void
     {
-        if (!$test instanceof TestCase) {
-            return;
-        }
-
         $testCase = $this->document->createElement('testcase');
         $testCase->setAttribute('name', $test->getName());
 
@@ -318,10 +314,6 @@ class JUnit extends Printer implements TestListener
      */
     public function endTest(Test $test, float $time): void
     {
-        if (!$test instanceof TestCase) {
-            return;
-        }
-
         $numAssertions = $test->getNumAssertions();
         $this->testSuiteAssertions[$this->testSuiteLevel] += $numAssertions;
 

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\SelfDescribing;
 use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestFailure;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;

--- a/tests/end-to-end/log-junit-phpt.phpt
+++ b/tests/end-to-end/log-junit-phpt.phpt
@@ -1,0 +1,28 @@
+--TEST--
+phpunit --log-junit php://stdout ../end-to-end/phpt-stderr.phpt
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--log-junit';
+$_SERVER['argv'][3] = 'php://stdout';
+$_SERVER['argv'][4] = __DIR__ . '/../end-to-end/phpt-stderr.phpt';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="%s">
+    <testcase name="%send-to-end%ephpt-stderr.phpt" assertions="1" time="%s">
+      <system-out>PHPUnit must look at STDERR when running PHPT tests.</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>
+
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/log-junit-phpt.phpt
+++ b/tests/end-to-end/log-junit-phpt.phpt
@@ -5,7 +5,7 @@ phpunit --log-junit php://stdout ../end-to-end/phpt-stderr.phpt
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--log-junit';
 $_SERVER['argv'][3] = 'php://stdout';
-$_SERVER['argv'][4] = __DIR__ . '/../end-to-end/phpt-stderr.phpt';
+$_SERVER['argv'][4] = \realpath(__DIR__ . '/../end-to-end/phpt-stderr.phpt');
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/log-teamcity-phpt.phpt
+++ b/tests/end-to-end/log-teamcity-phpt.phpt
@@ -5,7 +5,7 @@ phpunit --log-teamcity php://stdout ../end-to-end/phpt-stderr.phpt
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--log-teamcity';
 $_SERVER['argv'][3] = 'php://stdout';
-$_SERVER['argv'][4] = __DIR__ . '/../end-to-end/phpt-stderr.phpt';
+$_SERVER['argv'][4] = \realpath(__DIR__ . '/../end-to-end/phpt-stderr.phpt');
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/log-teamcity-phpt.phpt
+++ b/tests/end-to-end/log-teamcity-phpt.phpt
@@ -1,0 +1,25 @@
+--TEST--
+phpunit --log-teamcity php://stdout ../end-to-end/phpt-stderr.phpt
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--log-teamcity';
+$_SERVER['argv'][3] = 'php://stdout';
+$_SERVER['argv'][4] = __DIR__ . '/../end-to-end/phpt-stderr.phpt';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+##teamcity[testCount count='1' flowId='%d']
+
+##teamcity[testStarted name='%send-to-end%ephpt-stderr.phpt' flowId='%d']
+.                                                                   1 / 1 (100%)
+##teamcity[testFinished name='%send-to-end%ephpt-stderr.phpt' duration='%d' flowId='%d']
+
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -84,11 +84,13 @@ EOF;
         $this->testCase   = null;
     }
 
-    public function testAlwaysReportsNumberOfAssertionsIsOne(): void {
+    public function testAlwaysReportsNumberOfAssertionsIsOne(): void
+    {
         $this->assertSame(1, $this->testCase->getNumAssertions());
     }
 
-    public function testAlwaysReportsItDoesNotUseADataprovider(): void {
+    public function testAlwaysReportsItDoesNotUseADataprovider(): void
+    {
         $this->assertSame(false, $this->testCase->usesDataProvider());
     }
 

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -84,6 +84,14 @@ EOF;
         $this->testCase   = null;
     }
 
+    public function testAlwaysReportsNumberOfAssertionsIsOne(): void {
+        $this->assertSame(1, $this->testCase->getNumAssertions());
+    }
+
+    public function testAlwaysReportsItDoesNotUseADataprovider(): void {
+        $this->assertSame(false, $this->testCase->usesDataProvider());
+    }
+
     public function testShouldRunFileSectionAsTest(): void
     {
         $this->setPhpContent($this->ensureCorrectEndOfLine(self::EXPECT_CONTENT));


### PR DESCRIPTION
Fixes #3436 

![image](https://user-images.githubusercontent.com/26651359/49524588-56da2380-f8ac-11e8-8908-3afe9a62b0b8.png)

Fixed JUnit logger by implementing more methods from `TestCase` in `PhptTestCase`.

Changes:
- JUnit logger no longer checks for strict `instanceof TestCase`
- `PhptTestCase` always returns number of run assertions of 1
- `PhptTestCase` now correctly replies it doesn't use a dataprovider
- `PhptTestCase` now returns the `STDOUT` of a test for `<system-out>` element
- add tests for PHPT results being included in TeamCity and JUnit logs

Thanks to @Naktibalda for noticing the bug.