### PR TITLE
Safeguard JUnit logger against non-standard TestCase

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -313,7 +313,12 @@ class JUnit extends Printer implements TestListener
      */
     public function endTest(Test $test, float $time): void
     {
-        $numAssertions = $test->getNumAssertions();
+        if (\method_exists($test, 'getNumAssertions')) {
+            $numAssertions = $test->getNumAssertions();
+        } else {
+            $numAssertions = 0;
+        }
+
         $this->testSuiteAssertions[$this->testSuiteLevel] += $numAssertions;
 
         $this->currentTestCase->setAttribute(
@@ -333,10 +338,16 @@ class JUnit extends Printer implements TestListener
         $this->testSuiteTests[$this->testSuiteLevel]++;
         $this->testSuiteTimes[$this->testSuiteLevel] += $time;
 
-        if ($test->hasOutput()) {
+        if (\method_exists($test, 'hasOutput') && \method_exists($test, 'getActualOutput')) {
+            $testOutput = $test->hasOutput() ? $test->getActualOutput() : '';
+        } else {
+            $testOutput = '';
+        }
+
+        if (!empty($testOutput)) {
             $systemOut = $this->document->createElement(
                 'system-out',
-                Xml::prepareString($test->getActualOutput())
+                Xml::prepareString($testOutput)
             );
 
             $this->currentTestCase->appendChild($systemOut);

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -313,10 +313,10 @@ class JUnit extends Printer implements TestListener
      */
     public function endTest(Test $test, float $time): void
     {
+        $numAssertions = 0;
+
         if (\method_exists($test, 'getNumAssertions')) {
             $numAssertions = $test->getNumAssertions();
-        } else {
-            $numAssertions = 0;
         }
 
         $this->testSuiteAssertions[$this->testSuiteLevel] += $numAssertions;
@@ -338,10 +338,10 @@ class JUnit extends Printer implements TestListener
         $this->testSuiteTests[$this->testSuiteLevel]++;
         $this->testSuiteTimes[$this->testSuiteLevel] += $time;
 
+        $testOutput = '';
+
         if (\method_exists($test, 'hasOutput') && \method_exists($test, 'getActualOutput')) {
             $testOutput = $test->hasOutput() ? $test->getActualOutput() : '';
-        } else {
-            $testOutput = '';
         }
 
         if (!empty($testOutput)) {


### PR DESCRIPTION
Not all project-specific implementations of `TestCase` implement support for information methods like e.g. `TestCase::getNumAssertions()` or `TestCase::hasOutput()` Rather than causing a scary fatal in the JUnit logger, we quietly skip these elements in the log.

ping @Naktibalda 🎁 

### Note
I do realize this is a quickfix, however I would rather have this than have existing test collections fail unexpectedly when run with the JUnit logger. The projects that have spent time on implementing their own `TestCase` are usually large and complex. I feel it to be much nicer to add some protection on the PHPUnit side as a courtesy for now (7.x) and focus on creating an easy-to-use the [TestHook system](https://github.com/sebastianbergmann/phpunit/issues/3390) in version 8.x.