### PR TITLE
fix(templates): define the named constant "PHPUNIT_COMPOSER_INSTALL" before requiring the autoload file

### DIFF
--- a/src/Util/PHP/Template/PhptTestCase.tpl.dist
+++ b/src/Util/PHP/Template/PhptTestCase.tpl.dist
@@ -10,8 +10,8 @@ ob_start();
 $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'][] = '{job}';
 
 if ($composerAutoload) {
-    require_once $composerAutoload;
     define('PHPUNIT_COMPOSER_INSTALL', $composerAutoload);
+    require_once $composerAutoload;
 } else if ($phar) {
     require $phar;
 }

--- a/src/Util/PHP/Template/TestCaseClass.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseClass.tpl.dist
@@ -18,8 +18,8 @@ $phar             = {phar};
 ob_start();
 
 if ($composerAutoload) {
-    require_once $composerAutoload;
     define('PHPUNIT_COMPOSER_INSTALL', $composerAutoload);
+    require_once $composerAutoload;
 } else if ($phar) {
     require $phar;
 }

--- a/src/Util/PHP/Template/TestCaseMethod.tpl.dist
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl.dist
@@ -19,8 +19,8 @@ $phar             = {phar};
 ob_start();
 
 if ($composerAutoload) {
-    require_once $composerAutoload;
     define('PHPUNIT_COMPOSER_INSTALL', $composerAutoload);
+    require_once $composerAutoload;
 } else if ($phar) {
     require $phar;
 }


### PR DESCRIPTION
The goal : be consistent with what is done in the phpunit executable itself (constant definition and then requiring the composer autoload file).

My use case : In a particular setup, I need to check if phpunit is running in an autoloaded file. However, it is impossible when the tests are ran in separate processes because this particular constant is defined after requiring the composer autoload file.