### PR TITLE
Fix ignored test with duplicate key in dataprovider

### DIFF
--- a/src/Framework/InvalidDataProviderException.php
+++ b/src/Framework/InvalidDataProviderException.php
@@ -1,0 +1,14 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+class InvalidDataProviderException extends Exception
+{
+}

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\CodeCoverageException;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\InvalidCoversTargetException;
+use PHPUnit\Framework\InvalidDataProviderException;
 use PHPUnit\Framework\SelfDescribing;
 use PHPUnit\Framework\SkippedTestError;
 use PHPUnit\Framework\TestCase;
@@ -881,6 +882,14 @@ final class Test
                     foreach ($origData as $key => $value) {
                         if (\is_int($key)) {
                             $data[] = $value;
+                        } elseif (\array_key_exists($key, $data)) {
+                            throw new InvalidDataProviderException(
+                                \sprintf(
+                                    'The key "%s" as already been defined in the dataprovider "%s".',
+                                    $key,
+                                    $match
+                                )
+                            );
                         } else {
                             $data[$key] = $value;
                         }

--- a/tests/_files/DuplicateKeyDataProviderTest.php
+++ b/tests/_files/DuplicateKeyDataProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class DuplicateKeyDataProviderTest extends TestCase
+{
+    public static function dataProvider()
+    {
+        yield 'foo' => ['foo'];
+
+        yield 'foo' => ['bar'];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function test($arg): void
+    {
+    }
+}

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Util;
 use PharIo\Version\VersionConstraint;
 use PHPUnit\Framework\CodeCoverageException;
 use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\InvalidDataProviderException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
 
@@ -560,6 +561,14 @@ class TestTest extends TestCase
             ['H'],
             ['I'],
         ], $dataSets);
+    }
+
+    public function testWithDuplicateKeyDataProviders(): void
+    {
+        $this->expectException(InvalidDataProviderException::class);
+        $this->expectExceptionMessage('The key "foo" as already been defined in the dataprovider "dataProvider".');
+
+        Test::getProvidedData(\DuplicateKeyDataProviderTest::class, 'test');
     }
 
     public function testTestWithEmptyAnnotation(): void


### PR DESCRIPTION
With generators dataProvider may have duplicate keys.

```php
    public static function dataProvider()
    {
        yield 'foo' => ['foo'];
        yield 'foo' => ['bar'];
    }
```

This PR throws an exception when the dataprovider contains duplicate keys.