### PR TITLE
@Depends file will be run if not ran yet + Full namespace bug when using @depends [FEATURE&BUG-FIX]

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -56,6 +56,7 @@ use Throwable;
 abstract class TestCase extends Assert implements Test, SelfDescribing
 {
     private const LOCALE_CATEGORIES = [\LC_ALL, \LC_COLLATE, \LC_CTYPE, \LC_MONETARY, \LC_NUMERIC, \LC_TIME];
+
     private const DEPENDENCY_PREFIX = 'Dependency_';
 
     /** @var TestResult \PHPUnit\Framework\TestResult */
@@ -387,8 +388,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
             $this->setName($name);
         }
 
-        if (!isset(self::$DEPENDENCY_TASK_RESULTS))
-        {
+        if (!isset(self::$DEPENDENCY_TASK_RESULTS)) {
             self::$DEPENDENCY_TASK_RESULTS = new TestResult;
         }
 
@@ -1805,11 +1805,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                         && $className !== \explode('::', $dependency, 2)[0]
                     ) {
                         $dependencyClass = \explode('::', $dependency, 2)[0];
-                        $dependencyKey = self::DEPENDENCY_PREFIX . \ucfirst($dependencyClass);
-                        $oldErrorsCount = self::$DEPENDENCY_TASK_RESULTS->errorCount();
+                        $dependencyKey   = self::DEPENDENCY_PREFIX . \ucfirst($dependencyClass);
+                        $oldErrorsCount  = self::$DEPENDENCY_TASK_RESULTS->errorCount();
                         (new TestSuite($dependencyClass, $dependencyKey))->run(self::$DEPENDENCY_TASK_RESULTS);
-                        if ($oldErrorsCount < self::$DEPENDENCY_TASK_RESULTS->errorCount())
-                        {
+
+                        if ($oldErrorsCount < self::$DEPENDENCY_TASK_RESULTS->errorCount()) {
                             $this->setSkippedDependsOn($dependency);
 
                             return false;

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1787,10 +1787,19 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                     }
                 }
 
-                if (isset($passed[$dependency])) {
-                    if ($passed[$dependency]['size'] != \PHPUnit\Util\Test::UNKNOWN &&
+                $dependencyName = false;
+                if (isset($passed[$dependency]))
+                {
+                    $dependencyName = $dependency;
+                } else if (isset($passed[$dependency.$this->getDataSetAsString(false)]))
+                {
+                    $dependencyName = $dependency.$this->getDataSetAsString(false);
+                }
+
+                if ($dependencyName) {
+                    if ($passed[$dependencyName]['size'] != \PHPUnit\Util\Test::UNKNOWN &&
                         $this->getSize() != \PHPUnit\Util\Test::UNKNOWN &&
-                        $passed[$dependency]['size'] > $this->getSize()) {
+                        $passed[$dependencyName]['size'] > $this->getSize()) {
                         $this->result->addError(
                             $this,
                             new SkippedTestError(
@@ -1806,11 +1815,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                         $deepCopy = new DeepCopy;
                         $deepCopy->skipUncloneable(false);
 
-                        $this->dependencyInput[$dependency] = $deepCopy->copy($passed[$dependency]['result']);
+                        $this->dependencyInput[$dependency] = $deepCopy->copy($passed[$dependencyName]['result']);
                     } elseif ($shallowClone) {
-                        $this->dependencyInput[$dependency] = clone $passed[$dependency]['result'];
+                        $this->dependencyInput[$dependency] = clone $passed[$dependencyName]['result'];
                     } else {
-                        $this->dependencyInput[$dependency] = $passed[$dependency]['result'];
+                        $this->dependencyInput[$dependency] = $passed[$dependencyName]['result'];
                     }
                 } else {
                     $this->dependencyInput[$dependency] = null;

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1709,15 +1709,15 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
     private function processPassed(array $passedKeys): array
     {
-        foreach (\array_keys($passedKeys) as $i => $iValue) {
-            $pos = \strpos($iValue, ' with data set');
+        foreach (\array_keys($passedKeys) as $key) {
+            $pos = \strpos($key, ' with data set');
 
             if ($pos !== false) {
-                $passedKeys[$i] = \substr($iValue, 0, $pos);
+                $newPassedKeys[] = \substr($key, 0, $pos);
             }
         }
 
-        return \array_flip(\array_unique($passedKeys));
+        return \array_merge(\array_flip(\array_unique($newPassedKeys ?? [])), $passedKeys);
     }
 
     private function processSkipped(array $skipped): array

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1788,12 +1788,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 }
 
                 $dependencyName = false;
-                if (isset($passed[$dependency]))
-                {
+
+                if (isset($passed[$dependency])) {
                     $dependencyName = $dependency;
-                } else if (isset($passed[$dependency.$this->getDataSetAsString(false)]))
-                {
-                    $dependencyName = $dependency.$this->getDataSetAsString(false);
+                } elseif (isset($passed[$dependency . $this->getDataSetAsString(false)])) {
+                    $dependencyName = $dependency . $this->getDataSetAsString(false);
                 }
 
                 if ($dependencyName) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1861,7 +1861,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
                 if (isset($passed[$dependency . $this->getDataSetAsString(false)])) {
                     $dependencyName = $dependency . $this->getDataSetAsString(false);
-                } else if (isset($passed[$dependency])) {
+                } elseif (isset($passed[$dependency])) {
                     $dependencyName = $dependency;
                 }
 

--- a/tests/_files/PR3349.php
+++ b/tests/_files/PR3349.php
@@ -114,8 +114,8 @@ final class Tests extends TestCase
     }
 
     /**
-     * @return array
      * @group PR3349_Group9
+     *
      * @see \Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency
      * @see \Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString
      * @testWith    ["45348fed-cc85-4bdf-9c6b-3d132c951bd2", "45348fed-cc85-4bdf-9c6b-3d132c951bd2-TEST"]
@@ -126,6 +126,7 @@ final class Tests extends TestCase
     public function testSameClassDependencyUsingDataSet_Dependency(string $foo, string $bar): array
     {
         $this->addToAssertionCount(1);
+
         return [$foo => $bar];
     }
 
@@ -135,7 +136,7 @@ final class Tests extends TestCase
      */
     public function testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency(array $array): void
     {
-        $this->assertEquals(\reset($array), \key($array).'-TEST');
+        $this->assertEquals(\reset($array), \key($array) . '-TEST');
     }
 
     /**
@@ -148,7 +149,7 @@ final class Tests extends TestCase
      */
     public function testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency(string $expect, array $array): void
     {
-        $this->assertEquals($expect, \key($array).'-TEST');
+        $this->assertEquals($expect, \key($array) . '-TEST');
     }
 
     /**
@@ -166,7 +167,7 @@ final class Tests extends TestCase
      */
     public function testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency(array $array): void
     {
-        $this->assertEquals(\reset($array), \key($array).'-TEST');
+        $this->assertEquals(\reset($array), \key($array) . '-TEST');
     }
 
     /**
@@ -188,7 +189,7 @@ final class Tests extends TestCase
      */
     public function testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency(string $expect, array $array): void
     {
-        $this->assertEquals($expect, \key($array).'-TEST');
+        $this->assertEquals($expect, \key($array) . '-TEST');
     }
 }
 
@@ -228,8 +229,8 @@ final class Test_Dependencies extends TestCase
     }
 
     /**
-     * @return array
      * @group PR3349_Group10
+     *
      *      * @see \Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency
      * @see \Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString
      * @testWith    ["45348fed-cc85-4bdf-9c6b-3d132c951bd3", "45348fed-cc85-4bdf-9c6b-3d132c951bd3-TEST"]
@@ -240,6 +241,7 @@ final class Test_Dependencies extends TestCase
     public function testExternalClassDependencyUsingDataSet_Dependency(string $foo, string $bar): array
     {
         $this->addToAssertionCount(1);
+
         return [$foo => $bar];
     }
 }

--- a/tests/_files/PR3349.php
+++ b/tests/_files/PR3349.php
@@ -192,7 +192,7 @@ final class Test_ChainOne extends TestCase
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain
      * @group PR3349_Group8
-     * @depends \Test\PR3349\Test_ChainTwo::testExternalClassDependencyChainFunctionTwo
+     * @depends \Test\PR3349\Test_ChainTwo::testExternalClassDependencyChainFunctionTwoFailure
      */
     public function testExternalClassDependencyChainFunctionOneWithFailureInChain(int $int): int
     {

--- a/tests/_files/PR3349.php
+++ b/tests/_files/PR3349.php
@@ -1,4 +1,7 @@
 <?php
+/** @noinspection ThrowRawExceptionInspection */
+/** @noinspection PhpUnusedParameterInspection */
+/** @noinspection PhpDocSignatureInspection */
 
 declare(strict_types=1);
 /*
@@ -109,6 +112,84 @@ final class Tests extends TestCase
     {
         $this->assertEquals(100, $int);
     }
+
+    /**
+     * @return array
+     * @group PR3349_Group9
+     * @see \Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency
+     * @see \Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString
+     * @testWith    ["45348fed-cc85-4bdf-9c6b-3d132c951bd2", "45348fed-cc85-4bdf-9c6b-3d132c951bd2-TEST"]
+     *              ["bf62e6b7-1518-4a5b-9dbb-d803b52acf0a", "bf62e6b7-1518-4a5b-9dbb-d803b52acf0a-TEST"]
+     *              ["f1b7df75-d148-458a-9bce-278e6d9b2766", "f1b7df75-d148-458a-9bce-278e6d9b2766-TEST"]
+     *              ["c514d010-1cfc-49c4-9fc0-032fc6f5c6a0", "c514d010-1cfc-49c4-9fc0-032fc6f5c6a0-TEST"]
+     */
+    public function testSameClassDependencyUsingDataSet_Dependency(string $foo, string $bar): array
+    {
+        $this->addToAssertionCount(1);
+        return [$foo => $bar];
+    }
+
+    /**
+     * @group PR3349_Group9
+     * @depends \Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency
+     */
+    public function testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency(array $array): void
+    {
+        $this->assertEquals(\reset($array), \key($array).'-TEST');
+    }
+
+    /**
+     * @group PR3349_Group9
+     * @depends \Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency
+     * @testWith    ["45348fed-cc85-4bdf-9c6b-3d132c951bd2-TEST"]
+     *              ["bf62e6b7-1518-4a5b-9dbb-d803b52acf0a-TEST"]
+     *              ["f1b7df75-d148-458a-9bce-278e6d9b2766-TEST"]
+     *              ["c514d010-1cfc-49c4-9fc0-032fc6f5c6a0-TEST"]
+     */
+    public function testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency(string $expect, array $array): void
+    {
+        $this->assertEquals($expect, \key($array).'-TEST');
+    }
+
+    /**
+     * @group PR3349_Group9
+     * @depends \Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency
+     */
+    public function testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString(array $array): void
+    {
+        $this->assertEquals(\reset($array), '45348fed-cc85-4bdf-9c6b-3d132c951bd2-TEST');
+    }
+
+    /**
+     * @group PR3349_Group10
+     * @depends \Test\PR3349\Test_Dependencies::testExternalClassDependencyUsingDataSet_Dependency
+     */
+    public function testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency(array $array): void
+    {
+        $this->assertEquals(\reset($array), \key($array).'-TEST');
+    }
+
+    /**
+     * @group PR3349_Group10
+     * @depends \Test\PR3349\Test_Dependencies::testExternalClassDependencyUsingDataSet_Dependency
+     */
+    public function testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString(array $array): void
+    {
+        $this->assertEquals(\reset($array), '45348fed-cc85-4bdf-9c6b-3d132c951bd3-TEST');
+    }
+
+    /**
+     * @group PR3349_Group10
+     * @depends \Test\PR3349\Test_Dependencies::testExternalClassDependencyUsingDataSet_Dependency
+     * @testWith    ["45348fed-cc85-4bdf-9c6b-3d132c951bd3-TEST"]
+     *              ["bf62e6b7-1518-4a5b-9dbb-d803b52acf0b-TEST"]
+     *              ["f1b7df75-d148-458a-9bce-278e6d9b2767-TEST"]
+     *              ["c514d010-1cfc-49c4-9fc0-032fc6f5c6a2-TEST"]
+     */
+    public function testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency(string $expect, array $array): void
+    {
+        $this->assertEquals($expect, \key($array).'-TEST');
+    }
 }
 
 final class Test_Dependencies extends TestCase
@@ -144,6 +225,22 @@ final class Test_Dependencies extends TestCase
         $this->fail('Test Skipped With Purpose.');
 
         return 100;
+    }
+
+    /**
+     * @return array
+     * @group PR3349_Group10
+     *      * @see \Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency
+     * @see \Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString
+     * @testWith    ["45348fed-cc85-4bdf-9c6b-3d132c951bd3", "45348fed-cc85-4bdf-9c6b-3d132c951bd3-TEST"]
+     *              ["bf62e6b7-1518-4a5b-9dbb-d803b52acf0b", "bf62e6b7-1518-4a5b-9dbb-d803b52acf0b-TEST"]
+     *              ["f1b7df75-d148-458a-9bce-278e6d9b2767", "f1b7df75-d148-458a-9bce-278e6d9b2767-TEST"]
+     *              ["c514d010-1cfc-49c4-9fc0-032fc6f5c6a2", "c514d010-1cfc-49c4-9fc0-032fc6f5c6a2-TEST"]
+     */
+    public function testExternalClassDependencyUsingDataSet_Dependency(string $foo, string $bar): array
+    {
+        $this->addToAssertionCount(1);
+        return [$foo => $bar];
     }
 }
 

--- a/tests/_files/PR3349.php
+++ b/tests/_files/PR3349.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\PR3349;
+use PHPUnit\Framework\TestCase;
+
+final class Tests extends TestCase
+{
+
+    /**
+     * @see \Test\PR3349\Tests::testSameClassDependencyCorrectOrder
+     * @group PR3349_Group1
+     */
+    public function testSameClassDependencyCorrectOrderDependency(): int
+    {
+        $this->addToAssertionCount(1);
+        return 100;
+    }
+
+    /**
+     * @depends \Test\PR3349\Tests::testSameClassDependencyCorrectOrderDependency
+     * @group PR3349_Group1
+     */
+    public function testSameClassDependencyCorrectOrder(int $int): void
+    {
+        $this->assertEquals(100, $int);
+    }
+
+    /**
+     * @depends \Test\PR3349\Tests::testSameClassDependencyReversedOrderDependency
+     * @group PR3349_Group2
+     */
+    public function testSameClassDependencyReversedOrder(int $int): void
+    {
+        $this->addToAssertionCount(1);
+        $this->assertEquals(100, $int);
+    }
+
+    /**
+     * @see \Test\PR3349\Tests::testSameClassDependencyReversedOrder
+     * @group PR3349_Group2
+     */
+    public function testSameClassDependencyReversedOrderDependency(): int
+    {
+        $this->addToAssertionCount(1);
+        return 100;
+    }
+
+    /**
+     * @depends \Test\PR3349\Test_Dependencies::testExternalClassDependencySuccessReturn100
+     * @group PR3349_Group3
+     */
+    public function testExternalClassDependencyCorrectOrder(int $int): void
+    {
+        $this->assertEquals(100, $int);
+    }
+
+    /**
+     * @depends \Test\PR3349\Test_FailingSetUp::testExternalClassDependencySuccessReturn100WithFailingSetUp
+     * @group PR3349_Group4
+     */
+    public function testExternalClassDependencyFailingSetUp(int $int): void
+    {
+        $this->assertEquals(100, $int);
+    }
+
+    /**
+     * @depends \Test\PR3349\Test_ChainOne::testExternalClassDependencyChainFunctionOne
+     * @group PR3349_Group5
+     */
+    public function testExternalClassChainedMultipleDependencies(int $int): void
+    {
+        $this->assertEquals(100, $int);
+    }
+
+    /**
+     * @depends \Test\PR3349\Test_Dependencies::testExternalClassDependencyFailure
+     * @group PR3349_Group6
+     */
+    public function testExternalClassDependencyFailed(int $int): void
+    {
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @depends \Test\PR3349\Test_Dependencies::testExternalClassDependencySkipped
+     * @group PR3349_Group7
+     */
+    public function testExternalClassDependencySkipped(int $int): void
+    {
+        $this->addToAssertionCount(1);
+    }
+}
+
+final class Test_Dependencies extends TestCase
+{
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassDependencyCorrectOrder
+     * @group PR3349_Group3
+     */
+    public function testExternalClassDependencySuccessReturn100(): int
+    {
+        $this->addToAssertionCount(1);
+        return 100;
+    }
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassDependencyFailed
+     * @group PR3349_Group6
+     */
+    public function testExternalClassDependencyFailure(): int
+    {
+        $this->fail('Something Went Wrong With Purpose.');
+        return 100;
+    }
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassDependencySkipped
+     * @group PR3349_Group7
+     */
+    public function testExternalClassDependencySkipped(): int
+    {
+        $this->fail('Test Skipped With Purpose.');
+        return 100;
+    }
+}
+
+final class Test_FailingSetUp extends TestCase
+{
+    /**
+     * @throws \Exception
+     * @group PR3349_Group4
+     * @see \Test\PR3349\Tests::testExternalClassDependencyFailingSetUp
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        throw new \Exception('This is failing with purpose.');
+    }
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassDependencyFailingSetUp
+     * @group PR3349_Group4
+     */
+    public function testExternalClassDependencySuccessReturn100WithFailingSetUp(): int
+    {
+        $this->addToAssertionCount(1);
+        return 100;
+    }
+}
+
+final class Test_ChainOne extends TestCase{
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
+     * @group PR3349_Group5
+     * @depends \Test\PR3349\Test_ChainTwo::testExternalClassDependencyChainFunctionTwo
+     */
+    public function testExternalClassDependencyChainFunctionOne(int $int): int
+    {
+        $int += 40;
+        $this->assertEquals(100, $int);
+        return $int;
+    }
+}
+
+final class Test_ChainTwo extends TestCase{
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
+     * @group PR3349_Group5
+     * @depends \Test\PR3349\Test_ChainThree::testExternalClassDependencyChainFunctionThree
+     */
+    public function testExternalClassDependencyChainFunctionTwo(int $int): int
+    {
+        $int += 30;
+        $this->assertEquals(60, $int);
+        return $int;
+    }
+}
+
+final class Test_ChainThree extends TestCase{
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
+     * @group PR3349_Group5
+     * @depends \Test\PR3349\Test_ChainFour::testExternalClassDependencyChainFunctionFour
+     */
+    public function testExternalClassDependencyChainFunctionThree(int $int): int
+    {
+        $int += 20;
+        $this->assertEquals(30, $int);
+        return $int;
+    }
+}
+
+final class Test_ChainFour extends TestCase{
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
+     * @group PR3349_Group5
+     */
+    public function testExternalClassDependencyChainFunctionFour(): int
+    {
+        $this->addToAssertionCount(1);
+        return 10;
+    }
+}

--- a/tests/_files/PR3349.php
+++ b/tests/_files/PR3349.php
@@ -1,13 +1,20 @@
 <?php
 
 declare(strict_types=1);
-
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace Test\PR3349;
+
 use PHPUnit\Framework\TestCase;
 
 final class Tests extends TestCase
 {
-
     /**
      * @see \Test\PR3349\Tests::testSameClassDependencyCorrectOrder
      * @group PR3349_Group1
@@ -15,6 +22,7 @@ final class Tests extends TestCase
     public function testSameClassDependencyCorrectOrderDependency(): int
     {
         $this->addToAssertionCount(1);
+
         return 100;
     }
 
@@ -44,6 +52,7 @@ final class Tests extends TestCase
     public function testSameClassDependencyReversedOrderDependency(): int
     {
         $this->addToAssertionCount(1);
+
         return 100;
     }
 
@@ -102,6 +111,7 @@ final class Test_Dependencies extends TestCase
     public function testExternalClassDependencySuccessReturn100(): int
     {
         $this->addToAssertionCount(1);
+
         return 100;
     }
 
@@ -112,6 +122,7 @@ final class Test_Dependencies extends TestCase
     public function testExternalClassDependencyFailure(): int
     {
         $this->fail('Something Went Wrong With Purpose.');
+
         return 100;
     }
 
@@ -122,6 +133,7 @@ final class Test_Dependencies extends TestCase
     public function testExternalClassDependencySkipped(): int
     {
         $this->fail('Test Skipped With Purpose.');
+
         return 100;
     }
 }
@@ -131,11 +143,13 @@ final class Test_FailingSetUp extends TestCase
     /**
      * @throws \Exception
      * @group PR3349_Group4
+     *
      * @see \Test\PR3349\Tests::testExternalClassDependencyFailingSetUp
      */
     public function setUp(): void
     {
         parent::setUp();
+
         throw new \Exception('This is failing with purpose.');
     }
 
@@ -146,12 +160,13 @@ final class Test_FailingSetUp extends TestCase
     public function testExternalClassDependencySuccessReturn100WithFailingSetUp(): int
     {
         $this->addToAssertionCount(1);
+
         return 100;
     }
 }
 
-final class Test_ChainOne extends TestCase{
-
+final class Test_ChainOne extends TestCase
+{
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
      * @group PR3349_Group5
@@ -161,12 +176,13 @@ final class Test_ChainOne extends TestCase{
     {
         $int += 40;
         $this->assertEquals(100, $int);
+
         return $int;
     }
 }
 
-final class Test_ChainTwo extends TestCase{
-
+final class Test_ChainTwo extends TestCase
+{
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
      * @group PR3349_Group5
@@ -176,12 +192,13 @@ final class Test_ChainTwo extends TestCase{
     {
         $int += 30;
         $this->assertEquals(60, $int);
+
         return $int;
     }
 }
 
-final class Test_ChainThree extends TestCase{
-
+final class Test_ChainThree extends TestCase
+{
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
      * @group PR3349_Group5
@@ -191,12 +208,13 @@ final class Test_ChainThree extends TestCase{
     {
         $int += 20;
         $this->assertEquals(30, $int);
+
         return $int;
     }
 }
 
-final class Test_ChainFour extends TestCase{
-
+final class Test_ChainFour extends TestCase
+{
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
      * @group PR3349_Group5
@@ -204,6 +222,7 @@ final class Test_ChainFour extends TestCase{
     public function testExternalClassDependencyChainFunctionFour(): int
     {
         $this->addToAssertionCount(1);
+
         return 10;
     }
 }

--- a/tests/_files/PR3349.php
+++ b/tests/_files/PR3349.php
@@ -100,6 +100,15 @@ final class Tests extends TestCase
     {
         $this->addToAssertionCount(1);
     }
+
+    /**
+     * @depends \Test\PR3349\Test_ChainOne::testExternalClassDependencyChainFunctionOneWithFailureInChain
+     * @group PR3349_Group8
+     */
+    public function testExternalClassChainedMultipleDependenciesFailureInChain(int $int): void
+    {
+        $this->assertEquals(100, $int);
+    }
 }
 
 final class Test_Dependencies extends TestCase
@@ -179,6 +188,19 @@ final class Test_ChainOne extends TestCase
 
         return $int;
     }
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain
+     * @group PR3349_Group8
+     * @depends \Test\PR3349\Test_ChainTwo::testExternalClassDependencyChainFunctionTwo
+     */
+    public function testExternalClassDependencyChainFunctionOneWithFailureInChain(int $int): int
+    {
+        $int += 40;
+        $this->assertEquals(100, $int);
+
+        return $int;
+    }
 }
 
 final class Test_ChainTwo extends TestCase
@@ -195,13 +217,29 @@ final class Test_ChainTwo extends TestCase
 
         return $int;
     }
+
+    /**
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain
+     * @group PR3349_Group8
+     * @depends \Test\PR3349\Test_ChainThree::testExternalClassDependencyChainFunctionThree
+     */
+    public function testExternalClassDependencyChainFunctionTwoFailure(int $int): int
+    {
+        $int += 30;
+        $this->assertEquals(60, $int);
+        $this->fail('This failure is by purpose.');
+
+        return $int;
+    }
 }
 
 final class Test_ChainThree extends TestCase
 {
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain
      * @group PR3349_Group5
+     * @group PR3349_Group8
      * @depends \Test\PR3349\Test_ChainFour::testExternalClassDependencyChainFunctionFour
      */
     public function testExternalClassDependencyChainFunctionThree(int $int): int
@@ -217,7 +255,9 @@ final class Test_ChainFour extends TestCase
 {
     /**
      * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependencies
+     * @see \Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain
      * @group PR3349_Group5
+     * @group PR3349_Group8
      */
     public function testExternalClassDependencyChainFunctionFour(): int
     {

--- a/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
+++ b/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
@@ -34,6 +34,8 @@ Test 'Test\PR3349\Tests::testExternalClassDependencyFailed' started
 Test 'Test\PR3349\Tests::testExternalClassDependencyFailed' ended
 Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' started
 Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' ended
+Test 'Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain' started
+Test 'Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain' ended
 
 
 Time: %s, Memory: %s

--- a/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
+++ b/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
@@ -36,6 +36,38 @@ Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' started
 Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' ended
 Test 'Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain' started
 Test 'Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #0 ('45348fed-cc85-4bdf-9c6b-3d132c951bd2', '45348fed-cc85-4bdf-9c6b-3d132...2-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #0 ('45348fed-cc85-4bdf-9c6b-3d132c951bd2', '45348fed-cc85-4bdf-9c6b-3d132...2-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #1 ('bf62e6b7-1518-4a5b-9dbb-d803b52acf0a', 'bf62e6b7-1518-4a5b-9dbb-d803b...a-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #1 ('bf62e6b7-1518-4a5b-9dbb-d803b52acf0a', 'bf62e6b7-1518-4a5b-9dbb-d803b...a-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #2 ('f1b7df75-d148-458a-9bce-278e6d9b2766', 'f1b7df75-d148-458a-9bce-278e6...6-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #2 ('f1b7df75-d148-458a-9bce-278e6d9b2766', 'f1b7df75-d148-458a-9bce-278e6...6-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #3 ('c514d010-1cfc-49c4-9fc0-032fc6f5c6a0', 'c514d010-1cfc-49c4-9fc0-032fc...0-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSet_Dependency with data set #3 ('c514d010-1cfc-49c4-9fc0-032fc6f5c6a0', 'c514d010-1cfc-49c4-9fc0-032fc...0-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #0 ('45348fed-cc85-4bdf-9c6b-3d132...2-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #0 ('45348fed-cc85-4bdf-9c6b-3d132...2-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #1 ('bf62e6b7-1518-4a5b-9dbb-d803b...a-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #1 ('bf62e6b7-1518-4a5b-9dbb-d803b...a-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #2 ('f1b7df75-d148-458a-9bce-278e6...6-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #2 ('f1b7df75-d148-458a-9bce-278e6...6-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #3 ('c514d010-1cfc-49c4-9fc0-032fc...0-TEST')' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #3 ('c514d010-1cfc-49c4-9fc0-032fc...0-TEST')' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString' started
+Test 'Test\PR3349\Tests::testSameClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromDependency' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithoutUsingDatasetInTestExpectValueFromString' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #0 ('45348fed-cc85-4bdf-9c6b-3d132...3-TEST')' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #0 ('45348fed-cc85-4bdf-9c6b-3d132...3-TEST')' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #1 ('bf62e6b7-1518-4a5b-9dbb-d803b...b-TEST')' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #1 ('bf62e6b7-1518-4a5b-9dbb-d803b...b-TEST')' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #2 ('f1b7df75-d148-458a-9bce-278e6...7-TEST')' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #2 ('f1b7df75-d148-458a-9bce-278e6...7-TEST')' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #3 ('c514d010-1cfc-49c4-9fc0-032fc...2-TEST')' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyUsingDataSetWithUsingDatasetInTestExpectValueFromDependency with data set #3 ('c514d010-1cfc-49c4-9fc0-032fc...2-TEST')' ended
 
 
 Time: %s, Memory: %s
@@ -58,4 +90,4 @@ This test depends on "Test\PR3349\Test_Dependencies::testExternalClassDependency
 This test depends on "Test\PR3349\Test_ChainOne::testExternalClassDependencyChainFunctionOneWithFailureInChain" to pass.
 
 OK, but incomplete, skipped, or risky tests!
-Tests: 10, Assertions: 5, Skipped: 5.
+Tests: 26, Assertions: 21, Skipped: 5.

--- a/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
+++ b/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
@@ -1,0 +1,56 @@
+--TEST--
+phpunit --reverse-order --ignore-dependencies ../_files/PR3349.php
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--debug';
+$_SERVER['argv'][3] = '--verbose';
+$_SERVER['argv'][4] = 'StackTest';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/PR3349.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+Test 'Test\PR3349\Tests::testSameClassDependencyCorrectOrderDependency' started
+Test 'Test\PR3349\Tests::testSameClassDependencyCorrectOrderDependency' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyCorrectOrder' started
+Test 'Test\PR3349\Tests::testSameClassDependencyCorrectOrder' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyReversedOrder' started
+Test 'Test\PR3349\Tests::testSameClassDependencyReversedOrder' ended
+Test 'Test\PR3349\Tests::testSameClassDependencyReversedOrderDependency' started
+Test 'Test\PR3349\Tests::testSameClassDependencyReversedOrderDependency' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyCorrectOrder' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyCorrectOrder' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyFailingSetUp' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyFailingSetUp' ended
+Test 'Test\PR3349\Tests::testExternalClassChainedMultipleDependencies' started
+Test 'Test\PR3349\Tests::testExternalClassChainedMultipleDependencies' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencyFailed' started
+Test 'Test\PR3349\Tests::testExternalClassDependencyFailed' ended
+Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' started
+Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' ended
+
+
+Time: %s, Memory: %s
+
+There were 4 skipped tests:
+
+1) Test\PR3349\Tests::testSameClassDependencyReversedOrder
+Reordering same class dependency function is not implemented. Please reorder "testSameClassDependencyReversedOrderDependency" before "testSameClassDependencyReversedOrder".
+
+2) Test\PR3349\Tests::testExternalClassDependencyFailingSetUp
+This test depends on "Test\PR3349\Test_FailingSetUp::testExternalClassDependencySuccessReturn100WithFailingSetUp" to pass.
+
+3) Test\PR3349\Tests::testExternalClassDependencyFailed
+This test depends on "Test\PR3349\Test_Dependencies::testExternalClassDependencyFailure" to pass.
+
+4) Test\PR3349\Tests::testExternalClassDependencySkipped
+This test depends on "Test\PR3349\Test_Dependencies::testExternalClassDependencySkipped" to pass.
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 9, Assertions: 5, Skipped: 4.

--- a/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
+++ b/tests/end-to-end/depedency-not-run-yet-pr-3349.phpt
@@ -38,7 +38,7 @@ Test 'Test\PR3349\Tests::testExternalClassDependencySkipped' ended
 
 Time: %s, Memory: %s
 
-There were 4 skipped tests:
+There were 5 skipped tests:
 
 1) Test\PR3349\Tests::testSameClassDependencyReversedOrder
 Reordering same class dependency function is not implemented. Please reorder "testSameClassDependencyReversedOrderDependency" before "testSameClassDependencyReversedOrder".
@@ -52,5 +52,8 @@ This test depends on "Test\PR3349\Test_Dependencies::testExternalClassDependency
 4) Test\PR3349\Tests::testExternalClassDependencySkipped
 This test depends on "Test\PR3349\Test_Dependencies::testExternalClassDependencySkipped" to pass.
 
+5) Test\PR3349\Tests::testExternalClassChainedMultipleDependenciesFailureInChain
+This test depends on "Test\PR3349\Test_ChainOne::testExternalClassDependencyChainFunctionOneWithFailureInChain" to pass.
+
 OK, but incomplete, skipped, or risky tests!
-Tests: 9, Assertions: 5, Skipped: 4.
+Tests: 10, Assertions: 5, Skipped: 5.

--- a/tests/end-to-end/test-order-reversed-without-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-reversed-without-dependency-resolution.phpt
@@ -1,13 +1,14 @@
 --TEST--
-phpunit --order-by=no-depends,reverse ../_files/MultiDependencyTest.php
+phpunit --reverse-order --ignore-dependencies ../_files/MultiDependencyTest.php
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
 $_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--order-by=no-depends,reverse';
-$_SERVER['argv'][5] = 'MultiDependencyTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][4] = '--reverse-order';
+$_SERVER['argv'][5] = '--ignore-dependencies';
+$_SERVER['argv'][6] = 'MultiDependencyTest';
+$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
@@ -34,10 +35,10 @@ Time: %s, Memory: %s
 There were 2 skipped tests:
 
 1) MultiDependencyTest::testFour
-This test depends on "MultiDependencyTest::testThree" to pass.
+Reordering same class dependency function is not implemented. Please reorder "testThree" before "testFour".
 
 2) MultiDependencyTest::testThree
-This test depends on "MultiDependencyTest::testOne" to pass.
+Reordering same class dependency function is not implemented. Please reorder "testOne" before "testThree".
 
 OK, but incomplete, skipped, or risky tests!
 Tests: 5, Assertions: 3, Skipped: 2.


### PR DESCRIPTION
#2647 

As @sebastianbergmann said:
> That being said, yes, @depends can be used to denote a dependency on a test that is declared in another test case class.
> Keep in mind, though, that PHPUnit cannot ensure that a depended-upon test is executed before the test(s) that depend(s) on it.

**This PR will now ensure depended-upon test is executed before the test(s) that depend(s) on it.**

Some stuff to note:
- If you're depended-upon test which is failed, your test will be marked as skipped with warning: `This test depends on "%s" to pass.`
- If you're depended-upon test which is skipped, your test will be marked as skipped with warning: `This test depends on "%s" to pass.`

Fix:
In case of you're writing `@depends \Some\Project\Tests\Unit\Domain\ProductTest::test__toString` this will fail with message `This test depends on "%s" to pass.`. Why? Due the `\` at beginning of the string... I fixed this with following code:
```php
                if (\strpos($dependency, '\\') === 0)
                {
                    $dependency = \substr($dependency, 1);
                }
```


PS. I had issues creating tests for these changes. Can somebody show example or create tests?
PPS. Would it be possible to get this feature into 7.5 or 7.6 etc..?