### PR TITLE
Fix validation regex for @requires annotation

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -88,7 +88,7 @@ final class Test
     /**
      * @var string
      */
-    private const REGEX_REQUIRES = '/@requires\s+(?P<name>function|extension)\s+(?P<value>([^ ]+?))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
+    private const REGEX_REQUIRES = '/@requires\s+(?P<name>function|extension)\s+(?P<value>([^\s<>=!]+))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
 
     /**
      * @var array

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -76,7 +76,7 @@ class RequirementsTest extends TestCase
      * @requires function testFunc2
      * @see https://github.com/sebastianbergmann/phpunit/issues/3459
      */
-    public function testRequireFunctionWithDigit(): void
+    public function testRequiresFunctionWithDigit(): void
     {
     }
 
@@ -102,7 +102,7 @@ class RequirementsTest extends TestCase
      * @requires function testFuncOne
      * @requires function testFunc2
      * @requires extension testExtOne
-     * @requires extension testExtTwo
+     * @requires extension testExt2
      * @requires extension testExtThree 2.0
      * @requires setting not_a_setting Off
      */

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -74,6 +74,7 @@ class RequirementsTest extends TestCase
 
     /**
      * @requires function testFunc2
+     *
      * @see https://github.com/sebastianbergmann/phpunit/issues/3459
      */
     public function testRequiresFunctionWithDigit(): void

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -73,6 +73,14 @@ class RequirementsTest extends TestCase
     }
 
     /**
+     * @requires function testFunc2
+     * @see https://github.com/sebastianbergmann/phpunit/issues/3459
+     */
+    public function testRequireFunctionWithDigit(): void
+    {
+    }
+
+    /**
      * @requires extension testExt
      */
     public function testTen(): void
@@ -92,7 +100,7 @@ class RequirementsTest extends TestCase
      * @requires PHPUnit 9-dev
      * @requires OS DOESNOTEXIST
      * @requires function testFuncOne
-     * @requires function testFuncTwo
+     * @requires function testFunc2
      * @requires extension testExtOne
      * @requires extension testExtTwo
      * @requires extension testExtThree 2.0

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -587,10 +587,10 @@ class TestCaseTest extends TestCase
             'PHPUnit >= 9-dev is required.' . \PHP_EOL .
             'Operating system matching /DOESNOTEXIST/i is required.' . \PHP_EOL .
             'Function testFuncOne is required.' . \PHP_EOL .
-            'Function testFuncTwo is required.' . \PHP_EOL .
+            'Function testFunc2 is required.' . \PHP_EOL .
             'Setting "not_a_setting" must be "Off".' . \PHP_EOL .
             'Extension testExtOne is required.' . \PHP_EOL .
-            'Extension testExtTwo is required.' . \PHP_EOL .
+            'Extension testExt2 is required.' . \PHP_EOL .
             'Extension testExtThree >= 2.0 is required.',
             $test->getStatusMessage()
         );

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -157,14 +157,14 @@ class TestTest extends TestCase
                     'OS'        => 'DOESNOTEXIST',
                     'functions' => [
                         'testFuncOne',
-                        'testFuncTwo',
+                        'testFunc2',
                     ],
                     'setting'   => [
                         'not_a_setting' => 'Off',
                     ],
                     'extensions' => [
                         'testExtOne',
-                        'testExtTwo',
+                        'testExt2',
                         'testExtThree',
                     ],
                     'extension_versions' => [
@@ -526,10 +526,10 @@ class TestTest extends TestCase
                 'PHPUnit >= 9-dev is required.',
                 'Operating system matching /DOESNOTEXIST/i is required.',
                 'Function testFuncOne is required.',
-                'Function testFuncTwo is required.',
+                'Function testFunc2 is required.',
                 'Setting "not_a_setting" must be "Off".',
                 'Extension testExtOne is required.',
-                'Extension testExtTwo is required.',
+                'Extension testExt2 is required.',
                 'Extension testExtThree >= 2.0 is required.',
             ]],
             ['testPHPVersionOperatorLessThan', ['PHP < 5.4 is required.']],


### PR DESCRIPTION
Fixes #3459 

The regex used for parsing the `@require` annotation would put any trailing digits of the `value` into the `version` field when there wasn't an operator. This caused trailing digits on `function` and `extension` names to be clipped.

### Changes ###
- regex fixed
- add test for `@requires function|extension someNameWithDigits123`