### PR TITLE
Cleaner TestDox failure and diff output

### DIFF
--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -19,9 +19,9 @@ use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 use PHPUnit\Runner\PhptTestCase;
+use PHPUnit\Util\Color;
 use PHPUnit\Util\InvalidArgumentHelper;
 use PHPUnit\Util\Printer;
-use PHPUnit\Util\TestDox\Color;
 use SebastianBergmann\Environment\Console;
 use SebastianBergmann\Timer\Timer;
 

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -505,7 +505,7 @@ class ResultPrinter extends Printer implements TestListener
      * Formats a buffer with a specified ANSI color sequence if colors are
      * enabled.
      */
-    protected function formatWithColor(string $color, string $buffer): string
+    protected function colorizeTextBox(string $color, string $buffer): string
     {
         if (!$this->colors) {
             return $buffer;
@@ -528,7 +528,7 @@ class ResultPrinter extends Printer implements TestListener
      */
     protected function writeWithColor(string $color, string $buffer, bool $lf = true): void
     {
-        $this->write($this->formatWithColor($color, $buffer));
+        $this->write($this->colorizeTextBox($color, $buffer));
 
         if ($lf) {
             $this->write("\n");
@@ -540,7 +540,7 @@ class ResultPrinter extends Printer implements TestListener
      */
     protected function writeProgressWithColor(string $color, string $buffer): void
     {
-        $buffer = $this->formatWithColor($color, $buffer);
+        $buffer = $this->colorizeTextBox($color, $buffer);
         $this->writeProgress($buffer);
     }
 

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-namespace PHPUnit\Util\TestDox;
+namespace PHPUnit\Util;
 
 class Color
 {

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestResult;
 use PHPUnit\Runner\BaseTestRunner;
 use PHPUnit\Runner\PhptTestCase;
+use PHPUnit\Util\Color;
 use SebastianBergmann\Timer\Timer;
 
 /**
@@ -162,7 +163,7 @@ class CliTestDoxPrinter extends TestDoxPrinter
 
     protected function colorizeMessageAndDiff(string $style, string $message): string
     {
-        $lines   = $message ?\array_map('\rtrim', \explode(\PHP_EOL, $message)) : [];
+        $lines      = $message ?\array_map('\rtrim', \explode(\PHP_EOL, $message)) : [];
         $throwable  = [];
         $diff       = [];
         $insideDiff = false;

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Util\TestDox;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Color;
 use SebastianBergmann\Exporter\Exporter;
 
 /**

--- a/tests/end-to-end/loggers/_files/raw_output_ColorTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_ColorTest.txt
@@ -6,6 +6,8 @@ Runtime:       %s
  [32m✔[0m Colorize with [36mno[2m·[22mcolor[0m [32m %f ms[0m
  [32m✔[0m Colorize with [36mone[2m·[22mcolor[0m [32m %f ms[0m
  [32m✔[0m Colorize with [36mmultiple[2m·[22mcolors[0m [32m %f ms[0m
+ [32m✔[0m Colorize with [36minvalid[2m·[22mcolor[0m [32m %f ms[0m
+ [32m✔[0m Colorize with [36mvalid[2m·[22mand[2m·[22minvalid[2m·[22mcolors[0m [32m %f ms[0m
  [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36mNULL[0m [32m %f ms[0m
  [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m[2;4mempty[0m[0m [32m %f ms[0m
  [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m%e[0m [32m %f ms[0m
@@ -25,4 +27,4 @@ Runtime:       %s
 
 Time: %s, Memory: %s
 
-[30;42mOK (19 tests, 19 assertions)[0m
+[30;42mOK (21 tests, 21 assertions)[0m

--- a/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
@@ -23,10 +23,10 @@ Runtime:       %s
    [33m│[0m %stests[2m%e[22mend-to-end[2m%e[22mloggers[2m%e[22m_files[2m%e[22mStatusTest.php[2m:[22m[34m34[0m
    [33m│[0m 
 
- [33m→[0m Skipped [33m %f ms[0m
-   [33m│[0m
-   [33m│[0m %stests[2m%e[22mend-to-end[2m%e[22mloggers[2m%e[22m_files[2m%e[22mStatusTest.php[2m:[22m[34m39[0m
-   [33m│[0m 
+ [36m↩[0m Skipped [36m %f ms[0m
+   [36m│[0m
+   [36m│[0m %stests[2m%e[22mend-to-end[2m%e[22mloggers[2m%e[22m_files[2m%e[22mStatusTest.php[2m:[22m[34m39[0m
+   [36m│[0m 
 
  [33m☢[0m Risky [33m %f ms[0m
    [33m│[0m
@@ -36,7 +36,7 @@ Runtime:       %s
    [33m│[0m%w
    [33m│[0m 
 
- [33m✘[0m Warning [33m %f ms[0m
+ [33m⚠[0m Warning [33m %f ms[0m
    [33m│[0m
    [33m│[0m %stests[2m%e[22mend-to-end[2m%e[22mloggers[2m%e[22m_files[2m%e[22mStatusTest.php[2m:[22m[34m48[0m
    [33m│[0m 

--- a/tests/end-to-end/loggers/testdox.phpt
+++ b/tests/end-to-end/loggers/testdox.phpt
@@ -19,6 +19,8 @@ Basic ANSI color highlighting support
  ✔ Colorize with no color
  ✔ Colorize with one color
  ✔ Colorize with multiple colors
+ ✔ Colorize with invalid color
+ ✔ Colorize with valid and invalid colors
  ✔ Colorize path %ephp%eunit%etest.phpt after NULL
  ✔ Colorize path %ephp%eunit%etest.phpt after ''
  ✔ Colorize path %ephp%eunit%etest.phpt after %e
@@ -39,4 +41,4 @@ Basic ANSI color highlighting support
 
 Time: %s, Memory: %s
 
-OK (19 tests, 19 assertions)
+OK (21 tests, 21 assertions)

--- a/tests/unit/Util/TestDox/CliTestDoxPrinterColorTest.php
+++ b/tests/unit/Util/TestDox/CliTestDoxPrinterColorTest.php
@@ -35,7 +35,7 @@ final class CliTestDoxPrinterColorTest extends TestCase
 
     public function testColorizesDiffInFailureMessage(): void
     {
-        $raw = "some message\n--- Expected\n+++ Actual\n@@ @@\n";
+        $raw     = \implode(\PHP_EOL, ['some message', '--- Expected', '+++ Actual', '@@ @@']);
         $failure = new AssertionFailedError($raw);
 
         $this->printer->startTest($this);

--- a/tests/unit/Util/TestDox/CliTestDoxPrinterColorTest.php
+++ b/tests/unit/Util/TestDox/CliTestDoxPrinterColorTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util\TestDox;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Color;
+
+/**
+ * @group testdox
+ */
+final class CliTestDoxPrinterColorTest extends TestCase
+{
+    /**
+     * @var TestableCliTestDoxPrinter
+     */
+    private $printer;
+
+    protected function setUp(): void
+    {
+        $this->printer        = new TestableCliTestDoxPrinter(null, true, \PHPUnit\TextUI\ResultPrinter::COLOR_ALWAYS);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->printer        = null;
+    }
+
+    public function testColorizesDiffInFailureMessage(): void
+    {
+        $raw = "some message\n--- Expected\n+++ Actual\n@@ @@\n";
+        $failure = new AssertionFailedError($raw);
+
+        $this->printer->startTest($this);
+        $this->printer->addFailure($this, $failure, 0);
+        $this->printer->endTest($this, 0.001);
+
+        $this->assertStringContainsString(Color::colorize('bg-red,fg-white', 'some message'), $this->printer->getBuffer());
+        $this->assertStringContainsString(Color::colorize('fg-red', '--- Expected'), $this->printer->getBuffer());
+        $this->assertStringContainsString(Color::colorize('fg-green', '+++ Actual'), $this->printer->getBuffer());
+        $this->assertStringContainsString(Color::colorize('fg-cyan', '@@ @@'), $this->printer->getBuffer());
+    }
+}

--- a/tests/unit/Util/TestDox/CliTestDoxPrinterTest.php
+++ b/tests/unit/Util/TestDox/CliTestDoxPrinterTest.php
@@ -88,13 +88,13 @@ final class CliTestDoxPrinterTest extends TestCase
         $this->assertStringContainsString('│', $this->printer->getBuffer());
     }
 
-    public function testPrintsCrossForTestWithWarning(): void
+    public function testPrintsWarningTriangleForTestWithWarning(): void
     {
         $this->printer->startTest($this);
         $this->printer->addWarning($this, new Warning, 0);
         $this->printer->endTest($this, 0.001);
 
-        $this->assertStringContainsString('✘', $this->printer->getBuffer());
+        $this->assertStringContainsString('⚠', $this->printer->getBuffer());
     }
 
     public function testPrintsAdditionalInformationForTestWithWarning(): void
@@ -185,7 +185,7 @@ final class CliTestDoxPrinterTest extends TestCase
         $this->printer->addSkippedTest($this, new Exception, 0);
         $this->printer->endTest($this, 0.001);
 
-        $this->assertStringContainsString('→', $this->printer->getBuffer());
+        $this->assertStringContainsString('↩', $this->printer->getBuffer());
     }
 
     public function testDoesNotPrintAdditionalInformationForSkippedTestByDefault(): void

--- a/tests/unit/Util/TestDox/CliTestDoxPrinterTest.php
+++ b/tests/unit/Util/TestDox/CliTestDoxPrinterTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
 
+/**
+ * @group testdox
+ */
 final class CliTestDoxPrinterTest extends TestCase
 {
     /**

--- a/tests/unit/Util/TestDox/ColorTest.php
+++ b/tests/unit/Util/TestDox/ColorTest.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Util\TestDox;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Color;
 
 /**
  * @testdox Basic ANSI color highlighting support
@@ -89,9 +90,11 @@ class ColorTest extends TestCase
     public function colorizeProvider(): array
     {
         return [
-            'no color'        => ['', 'string', 'string'],
-            'one color'       => ['fg-blue', 'string', "\x1b[34mstring\x1b[0m"],
-            'multiple colors' => ['bold,dim,fg-blue,bg-yellow', 'string', "\x1b[1;2;34;43mstring\x1b[0m"],
+            'no color'                 => ['', 'string', 'string'],
+            'one color'                => ['fg-blue', 'string', "\x1b[34mstring\x1b[0m"],
+            'multiple colors'          => ['bold,dim,fg-blue,bg-yellow', 'string', "\x1b[1;2;34;43mstring\x1b[0m"],
+            'invalid color'            => ['fg-invalid', 'some text', 'some text'],
+            'valid and invalid colors' => ['fg-invalid,bg-blue', 'some text', "\e[44msome text\e[0m"],
         ];
     }
 

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -11,6 +11,9 @@ namespace PHPUnit\Util\TestDox;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group testdox
+ */
 class NamePrettifierTest extends TestCase
 {
     /**


### PR DESCRIPTION
Exactly as I'd hoped, working on the new self-test suite (#3453) I'm running into logging corner cases and unexpected weirdness. The basic handling of test-result colors is much more useful and visually pleasing with a few tweaks.

### Changes
- TestDox
  - improve colorization for failure messages with diff output
  - for tests with warnings, use UTF warning sign `⚠`
  - for skipped tests, use UTF turnaround symbol `↩` and colder non-error color. Most skips are intentional, by way of `@requires`-annotation of `--SKIPIF--`-condition
- general housekeeping
  - move `Color` utility class out of the TestDox namespace
  - rename `formatWithColor` to reflect what it actually does: `colorizeTextBox`

### Examples
Example from before the change:
![image](https://user-images.githubusercontent.com/26651359/50737418-4f6aaa80-11c9-11e9-9f4e-8314be9ae13c.png)

The improved coloring turned out to be useful during development and self-testing already:
![image](https://user-images.githubusercontent.com/26651359/50737431-77f2a480-11c9-11e9-9109-5e8796924335.png)

