### PR TITLE
WIP Add code location hints from plain PHPT exception messages

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -3002,6 +3002,7 @@ abstract class Assert
     {
         if ($hint = self::detectLocationHint($message)) {
             $trace = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+            \array_unshift($trace, $hint);
 
             throw new SyntheticSkippedError($hint['message'], 0, $hint['file'], $hint['line'], $trace);
         }

--- a/tests/end-to-end/phpt/expect-location-hint.phpt
+++ b/tests/end-to-end/phpt/expect-location-hint.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PHPT skip condition results in correct code location hint
+PHPT EXPECT comparison returns correct code location hint
 --FILE--
 <?php
 $arguments = [


### PR DESCRIPTION
Improvement for #3467: add code location hints for comparison exceptions that do not support `ExpectationFailedException::getComparisonFailure()->getDiff()`

Quick demo by manually breaking two tests in the self-test collection:

![image](https://user-images.githubusercontent.com/26651359/51036876-c2e82f80-15ae-11e9-9c81-fa772aa9650e.png)

This used to look like this :-)
![image](https://user-images.githubusercontent.com/26651359/51037197-d8118e00-15af-11e9-9094-49401a1a2e1a.png)
