### PR TITLE
AppVeyor: bump PHP version to 7.2.14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
   COMPOSER_ROOT_VERSION: '7.0-dev'
 
   matrix:
-    - PHP_VERSION: '7.2.13'
+    - PHP_VERSION: '7.2.14'
       XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: '--prefer-lowest'
-    - PHP_VERSION: '7.2.13'
+    - PHP_VERSION: '7.2.14'
       XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: ''
 

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -613,25 +613,31 @@ class PhptTestCase implements Test, SelfDescribing
 
     private function getLocationHintFromDiff(string $message, array $sections): array
     {
-        $needle = '';
+        $needle       = '';
         $previousLine = '';
-        $block = 'message';
+        $block        = 'message';
 
-        foreach (explode(\PHP_EOL, $message) as $line) {
+        foreach (\explode(\PHP_EOL, $message) as $line) {
             $line = \trim($line);
+
             if ($block === 'message' && $line === '--- Expected') {
                 $block = 'expected';
             }
+
             if ($block === 'expected' && $line === '@@ @@') {
                 $block = 'diff';
             }
 
             if ($block === 'diff') {
-                if (substr($line, 0, 1) === '+') {
+                if (\substr($line, 0, 1) === '+') {
                     $needle = $this->getCleanDiffLine($previousLine);
+
                     break;
-                } elseif (substr($line, 0, 1) === '-') {
+                }
+
+                if (\substr($line, 0, 1) === '-') {
                     $needle = $this->getCleanDiffLine($line);
+
                     break;
                 }
             }
@@ -640,6 +646,7 @@ class PhptTestCase implements Test, SelfDescribing
                 $previousLine = $line;
             }
         }
+
         return $this->getLocationHint($needle, $sections);
     }
 

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -666,7 +666,7 @@ class PhptTestCase implements Test, SelfDescribing
         if (empty($needle)) {
             return [
                 'file'     => \realpath($this->filename),
-                'line'     => 0,
+                'line'     => 1,
             ];
         }
 
@@ -722,7 +722,7 @@ class PhptTestCase implements Test, SelfDescribing
         // No section specified, show user start of code
         return [
             'file'     => \realpath($this->filename),
-            'line'     => 0,
+            'line'     => 1,
         ];
     }
 }


### PR DESCRIPTION
- AppVeyor builds failed due to a 404. Updated PHP package download URL.
- fixed broken test that I overlooked because of making demo screenshots