### PR TITLE
[do not merge] testing code location hints in Windows environments

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -666,7 +666,7 @@ class PhptTestCase implements Test, SelfDescribing
         if (empty($needle)) {
             return [
                 'file'     => \realpath($this->filename),
-                'line'     => 'empty_needle',
+                'line'     => 1234,
             ];
         }
 
@@ -722,7 +722,7 @@ class PhptTestCase implements Test, SelfDescribing
         // No section specified, show user start of code
         return [
             'file'     => \realpath($this->filename),
-            'line'     => 'no_section',
+            'line'     => 2345,
         ];
     }
 }

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -666,7 +666,7 @@ class PhptTestCase implements Test, SelfDescribing
         if (empty($needle)) {
             return [
                 'file'     => \realpath($this->filename),
-                'line'     => 1,
+                'line'     => 0,
             ];
         }
 
@@ -722,7 +722,7 @@ class PhptTestCase implements Test, SelfDescribing
         // No section specified, show user start of code
         return [
             'file'     => \realpath($this->filename),
-            'line'     => 1,
+            'line'     => 0,
         ];
     }
 }

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -666,7 +666,7 @@ class PhptTestCase implements Test, SelfDescribing
         if (empty($needle)) {
             return [
                 'file'     => \realpath($this->filename),
-                'line'     => 0,
+                'line'     => 'empty_needle',
             ];
         }
 
@@ -722,7 +722,7 @@ class PhptTestCase implements Test, SelfDescribing
         // No section specified, show user start of code
         return [
             'file'     => \realpath($this->filename),
-            'line'     => 0,
+            'line'     => 'no_section',
         ];
     }
 }

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -666,7 +666,7 @@ class PhptTestCase implements Test, SelfDescribing
         if (empty($needle)) {
             return [
                 'file'     => \realpath($this->filename),
-                'line'     => 1234,
+                'line'     => 1,
             ];
         }
 
@@ -722,7 +722,7 @@ class PhptTestCase implements Test, SelfDescribing
         // No section specified, show user start of code
         return [
             'file'     => \realpath($this->filename),
-            'line'     => 2345,
+            'line'     => 1,
         ];
     }
 }

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -617,7 +617,7 @@ class PhptTestCase implements Test, SelfDescribing
         $previousLine = '';
         $block        = 'message';
 
-        foreach (\explode(\PHP_EOL, $message) as $line) {
+        foreach (\preg_split('/\r\n|\r|\n/', $message) as $line) {
             $line = \trim($line);
 
             if ($block === 'message' && $line === '--- Expected') {


### PR DESCRIPTION
Something is going on with the code location hints for PHPT `*_EXTERNAL` sections.
I'm using this pull request as a sandbox for AppVeyor's Windows CI.