### PR TITLE
Automatically use latest PHP minor version for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ install:
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
   - IF NOT EXIST php-installed.txt curl --fail --location --silent --show-error -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
-  - IF NOT EXIST php-installed.txt dir *.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%*-Win32-VC15-x86-latest.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
   COMPOSER_ROOT_VERSION: '7.0-dev'
 
   matrix:
-    - PHP_VERSION: '7.2.14'
+    - PHP_VERSION: '7.3'
       XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: '--prefer-lowest'
-    - PHP_VERSION: '7.2.14'
+    - PHP_VERSION: '7.3'
       XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: ''
 
@@ -31,8 +31,8 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC15-x86.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86.zip
-  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC15-x86.zip -y >nul
+  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
+  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC15-x86-latest.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
   - IF NOT EXIST php-installed.txt echo max_execution_time=1200 >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
   - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
-  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC15-x86-latest.zip -y >nul
+  - IF NOT EXIST php-installed.txt 7z x php-*-latest.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
   - IF NOT EXIST php-installed.txt echo max_execution_time=1200 >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,7 @@ install:
   - IF NOT EXIST php-installed.txt curl -fsS -o composer.phar https://getcomposer.org/composer.phar
   - IF NOT EXIST php-installed.txt echo @php %%~dp0composer.phar %%* > composer.bat
   - IF NOT EXIST php-installed.txt curl -fsS -o c:\php\%PHP_VERSION%\ext\php_xdebug-%XDEBUG_VERSION%-vc15.dll https://xdebug.org/files/php_xdebug-%XDEBUG_VERSION%-vc15.dll
+  - IF NOT EXIST php-installed.txt dir c:\php\%PHP_VERSION%\ext\
   - IF NOT EXIST php-installed.txt echo zend_extension=php_xdebug-%XDEBUG_VERSION%-vc15.dll >> php.ini
   - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
   - cd c:\phpunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,8 @@ install:
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
   - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
-  - IF NOT EXIST php-installed.txt 7z x php-*-latest.zip -y >nul
+  - IF NOT EXIST php-installed.txt dir *.zip
+  - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%*-Win32-VC15-x86-latest.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini
   - IF NOT EXIST php-installed.txt echo max_execution_time=1200 >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
   COMPOSER_ROOT_VERSION: '7.0-dev'
 
   matrix:
-    - PHP_VERSION: '7.3'
+    - PHP_VERSION: '7.2'
       XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: '--prefer-lowest'
-    - PHP_VERSION: '7.3'
+    - PHP_VERSION: '7.2'
       XDEBUG_VERSION: '2.6.1-7.2'
       DEPENDENCIES: ''
 
@@ -49,7 +49,6 @@ install:
   - IF NOT EXIST php-installed.txt curl -fsS -o composer.phar https://getcomposer.org/composer.phar
   - IF NOT EXIST php-installed.txt echo @php %%~dp0composer.phar %%* > composer.bat
   - IF NOT EXIST php-installed.txt curl -fsS -o c:\php\%PHP_VERSION%\ext\php_xdebug-%XDEBUG_VERSION%-vc15.dll https://xdebug.org/files/php_xdebug-%XDEBUG_VERSION%-vc15.dll
-  - IF NOT EXIST php-installed.txt dir c:\php\%PHP_VERSION%\ext\
   - IF NOT EXIST php-installed.txt echo zend_extension=php_xdebug-%XDEBUG_VERSION%-vc15.dll >> php.ini
   - IF NOT EXIST php-installed.txt type nul >> php-installed.txt
   - cd c:\phpunit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
+  - IF NOT EXIST php-installed.txt curl --fail --location --silent --show-error -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
   - IF NOT EXIST php-installed.txt dir *.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%*-Win32-VC15-x86-latest.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip


### PR DESCRIPTION
Implement the suggestion by @weltling in https://github.com/sebastianbergmann/phpunit/issues/3419#issuecomment-453862347

No `*-latest.tzg` link for Xdebug yet, but this is one less thing to worry about. @IchHabRecht if you have ideas to improve this further :-)