### PR TITLE
Additional PHPT code hint and color refinements

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -186,8 +186,8 @@ class PhptTestCase implements Test, SelfDescribing
                         $diff = $e->getMessage();
                     }
 
-                    $hint  = $this->getLocationHintFromDiff($diff, $sections);
-                    $trace = \array_merge($hint, \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
+                    $hint    = $this->getLocationHintFromDiff($diff, $sections);
+                    $trace   = \array_merge($hint, \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                     $failure = new PHPTAssertionFailedError(
                         $e->getMessage(),
                         0,

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -71,7 +71,7 @@ final class Color
             return $buffer;
         }
 
-        return \sprintf("\x1b[%sm", \implode(';', $styles)) . $buffer . "\x1b[0m";
+        return self::optimizeColor(\sprintf("\x1b[%sm", \implode(';', $styles)) . $buffer . "\x1b[0m");
     }
 
     public static function colorizePath(string $path, ?string $prevPath = null, bool $colorizeFilename = false): string
@@ -123,6 +123,12 @@ final class Color
 
     private static function optimizeColor(string $buffer): string
     {
-        return \str_replace("\e[22m\e[2m", '', $buffer);
+        $patterns = [
+            "/\e\\[22m\e\\[2m/"                   => '',
+            "/\e\\[([^m]*)m\e\\[([1-9][0-9;]*)m/" => "\e[$1;$2m",
+            "/(\e\\[[^m]*m)+(\e\\[0m)/"           => '$2',
+        ];
+
+        return \preg_replace(\array_keys($patterns), \array_values($patterns), $buffer);
     }
 }

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -259,7 +259,7 @@ class CliTestDoxPrinter extends TestDoxPrinter
             $color = 'fg-magenta';
         }
 
-        return Color::colorize($color, \sprintf(' %d ms', \ceil($time * 1000)));
+        return Color::colorize($color, ' ' . (int) \ceil($time * 1000) . ' ' . Color::dim('ms'));
     }
 
     private function printNonSuccessfulTestsSummary(int $numberOfExecutedTests): void

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -283,7 +283,7 @@ class TestDoxPrinter extends ResultPrinter
                 function (string $text) use ($prefix) {
                     return '   ' . $prefix . ($text ? ' ' . $text : '');
                 },
-                \explode(\PHP_EOL, $message)
+                \preg_split('/\r\n|\r|\n/', $message)
             )
         );
     }

--- a/tests/end-to-end/loggers/_files/raw_output_ColorTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_ColorTest.txt
@@ -3,27 +3,27 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Runtime:       %s
 
 [4mBasic ANSI color highlighting support[0m
- [32m✔[0m Colorize with [36mno[2m·[22mcolor[0m [32m %f ms[0m
- [32m✔[0m Colorize with [36mone[2m·[22mcolor[0m [32m %f ms[0m
- [32m✔[0m Colorize with [36mmultiple[2m·[22mcolors[0m [32m %f ms[0m
- [32m✔[0m Colorize with [36minvalid[2m·[22mcolor[0m [32m %f ms[0m
- [32m✔[0m Colorize with [36mvalid[2m·[22mand[2m·[22minvalid[2m·[22mcolors[0m [32m %f ms[0m
- [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36mNULL[0m [32m %f ms[0m
- [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m[2;4mempty[0m[0m [32m %f ms[0m
- [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m%e[0m [32m %f ms[0m
- [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m%ephp%e[0m [32m %f ms[0m
- [32m✔[0m Colorize path [36m%e_d-i.r%et-e_s.t.phpt[0m after [36m[2;4mempty[0m[0m [32m %f ms[0m
- [32m✔[0m dim($m) and colorize('dim',$m) return different ANSI codes [32m %f ms[0m
- [32m✔[0m Visualize all whitespace characters in [36mno-spaces[0m [32m %f ms[0m
- [32m✔[0m Visualize all whitespace characters in [36m[2m·[22mspace[2m···[22minvaders[2m·[22m[0m [32m %s ms[0m
- [32m✔[0m Visualize all whitespace characters in [36m[2m⇥[22mindent,[2m·[22mspace[2m·[22mand[2m·[22m\n[2m↵[22m\r[2m⟵[22m[0m [32m %s ms[0m
- [32m✔[0m Visualize whitespace but ignore EOL [32m %f ms[0m
- [32m✔[0m Prettify unnamed dataprovider[2m with data set [22m[36m0[0m [32m %f ms[0m
- [32m✔[0m Prettify unnamed dataprovider[2m with data set [22m[36m1[0m [32m %f ms[0m
- [32m✔[0m Prettify named dataprovider[2m with [22m[36mone[0m [32m %f ms[0m
- [32m✔[0m Prettify named dataprovider[2m with [22m[36mtwo[0m [32m %f ms[0m
- [32m✔[0m TestDox shows name of data set [36mone[0m with value [36m1[0m [32m %f ms[0m
- [32m✔[0m TestDox shows name of data set [36mtwo[0m with value [36m2[0m [32m %f ms[0m
+ [32m✔[0m Colorize with [36mno[2m·[22mcolor[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize with [36mone[2m·[22mcolor[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize with [36mmultiple[2m·[22mcolors[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize with [36minvalid[2m·[22mcolor[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize with [36mvalid[2m·[22mand[2m·[22minvalid[2m·[22mcolors[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36mNULL[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36;2;4mempty[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m%e[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m%ephp%e[0m [32m %f [2mms[0m
+ [32m✔[0m Colorize path [36m%e_d-i.r%et-e_s.t.phpt[0m after [36;2;4mempty[0m [32m %f [2mms[0m
+ [32m✔[0m dim($m) and colorize('dim',$m) return different ANSI codes [32m %f [2mms[0m
+ [32m✔[0m Visualize all whitespace characters in [36mno-spaces[0m [32m %f [2mms[0m
+ [32m✔[0m Visualize all whitespace characters in [36;2m·[22mspace[2m···[22minvaders[2m·[0m [32m %f [2mms[0m
+ [32m✔[0m Visualize all whitespace characters in [36;2m⇥[22mindent,[2m·[22mspace[2m·[22mand[2m·[22m\n[2m↵[22m\r[2m⟵[0m [32m %f [2mms[0m
+ [32m✔[0m Visualize whitespace but ignore EOL [32m %f [2mms[0m
+ [32m✔[0m Prettify unnamed dataprovider[2m with data set [22m[36m0[0m [32m %f [2mms[0m
+ [32m✔[0m Prettify unnamed dataprovider[2m with data set [22m[36m1[0m [32m %f [2mms[0m
+ [32m✔[0m Prettify named dataprovider[2m with [22m[36mone[0m [32m %f [2mms[0m
+ [32m✔[0m Prettify named dataprovider[2m with [22m[36mtwo[0m [32m %f [2mms[0m
+ [32m✔[0m TestDox shows name of data set [36mone[0m with value [36m1[0m [32m %f [2mms[0m
+ [32m✔[0m TestDox shows name of data set [36mtwo[0m with value [36m2[0m [32m %f [2mms[0m
 
 Time: %s, Memory: %s
 

--- a/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
@@ -6,86 +6,84 @@ Configuration: %stests%ebasic%econfiguration.basic.xml
 [4mTest result status with and without message[0m
  [32m✔[0m Success [32m %f [2mms[0m
  [31m✘[0m Failure [31m %f [2mms[0m
+   [31m┐[0m
+   [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m [41;37mFailed asserting that false is true.[0m
-   [31m│[0m 
-   [31m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [31m│[0m 
+   [31m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [31m┴[0m
 
  [33m✘[0m Error [33m %f [2mms[0m
+   [33m┐[0m
+   [33m├[0m [43;30mRuntimeException:[0m
    [33m│[0m
-   [33m│[0m [43;30mRuntimeException:[0m
-   [33m│[0m 
-   [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [33m│[0m 
+   [33m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [33m┴[0m
 
  [33m∅[0m Incomplete [33m %f [2mms[0m
-   [33m│[0m
-   [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [33m│[0m 
+   [33m┐[0m
+   [33m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [33m┴[0m
 
  [36m↩[0m Skipped [36m %f [2mms[0m
-   [36m│[0m
-   [36m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [36m│[0m 
+   [36m┐[0m
+   [36m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [36m┴[0m
 
  [33m☢[0m Risky [33m %f [2mms[0m
-   [33m│[0m
-   [33m│[0m [33mThis test did not perform any assertions%w[0m
-   [33m│[0m%w 
-   [33m│[0m [33m%stests%ebasic%eunit%eStatusTest.php:%d[0m%w
-   [33m│[0m%w
-   [33m│[0m 
+   [33m┐[0m
+   [33m├[0m [33mThis test did not perform any assertions%w[0m
+   [33m├[0m%w
+   [33m├[0m [33m%stests%ebasic%eunit%eStatusTest.php:%d[0m%w
+   [33m┴[0m
 
  [33m⚠[0m Warning [33m %f [2mms[0m
-   [33m│[0m
-   [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [33m│[0m 
+   [33m┐[0m
+   [33m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [33m┴[0m
 
  [32m✔[0m Success with message [32m %f [2mms[0m
  [31m✘[0m Failure with message [31m %f [2mms[0m
+   [31m┐[0m
+   [31m├[0m [41;37mfailure with custom message%w[0m
+   [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m [41;37mfailure with custom message%w[0m
-   [31m│[0m [41;37mFailed asserting that false is true.[0m
-   [31m│[0m 
-   [31m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [31m│[0m 
+   [31m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [31m┴[0m
 
  [33m✘[0m Error with message [33m %f [2mms[0m
+   [33m┐[0m
+   [33m├[0m [43;30mRuntimeException: error with custom message[0m
    [33m│[0m
-   [33m│[0m [43;30mRuntimeException: error with custom message[0m
-   [33m│[0m 
-   [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [33m│[0m 
+   [33m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [33m┴[0m
 
  [33m∅[0m Incomplete with message [33m %f [2mms[0m
+   [33m┐[0m
+   [33m├[0m [33mincomplete with custom message[0m
    [33m│[0m
-   [33m│[0m [33mincomplete with custom message[0m
-   [33m│[0m 
-   [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [33m│[0m 
+   [33m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [33m┴[0m
 
  [36m↩[0m Skipped with message [36m %f [2mms[0m
+   [36m┐[0m
+   [36m├[0m [36mskipped with custom message[0m
    [36m│[0m
-   [36m│[0m [36mskipped with custom message[0m
-   [36m│[0m 
-   [36m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [36m│[0m 
+   [36m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [36m┴[0m
 
  [33m☢[0m Risky with message [33m %f [2mms[0m
-   [33m│[0m
-   [33m│[0m [33mThis test did not perform any assertions%w[0m
-   [33m│[0m%w 
-   [33m│[0m [33m%stests%ebasic%eunit%eStatusTest.php:%d[0m%w
-   [33m│[0m%w
-   [33m│[0m 
+   [33m┐[0m
+   [33m├[0m [33mThis test did not perform any assertions%w[0m
+   [33m├[0m%w
+   [33m├[0m [33m%stests%ebasic%eunit%eStatusTest.php:%d[0m%w
+   [33m┴[0m
 
  [33m⚠[0m Warning with message [33m %f [2mms[0m
+   [33m┐[0m
+   [33m├[0m [33mwarning with custom message[0m
    [33m│[0m
-   [33m│[0m [33mwarning with custom message[0m
-   [33m│[0m 
-   [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
-   [33m│[0m 
+   [33m╵[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
+   [33m┴[0m
 
 Time: %s, Memory: %s
 

--- a/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
@@ -4,32 +4,32 @@ Runtime:       %s
 Configuration: %stests%ebasic%econfiguration.basic.xml
 
 [4mTest result status with and without message[0m
- [32m✔[0m Success [32m %f ms[0m
- [31m✘[0m Failure [31m %f ms[0m
+ [32m✔[0m Success [32m %f [2mms[0m
+ [31m✘[0m Failure [31m %f [2mms[0m
    [31m│[0m
    [31m│[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m 
    [31m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [31m│[0m 
 
- [33m✘[0m Error [33m %f ms[0m
+ [33m✘[0m Error [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m [43;30mRuntimeException:[0m
    [33m│[0m 
    [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [33m│[0m 
 
- [33m∅[0m Incomplete [33m %f ms[0m
+ [33m∅[0m Incomplete [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [33m│[0m 
 
- [36m↩[0m Skipped [36m %f ms[0m
+ [36m↩[0m Skipped [36m %f [2mms[0m
    [36m│[0m
    [36m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [36m│[0m 
 
- [33m☢[0m Risky [33m %f ms[0m
+ [33m☢[0m Risky [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m [33mThis test did not perform any assertions%w[0m
    [33m│[0m%w 
@@ -37,13 +37,13 @@ Configuration: %stests%ebasic%econfiguration.basic.xml
    [33m│[0m%w
    [33m│[0m 
 
- [33m⚠[0m Warning [33m %f ms[0m
+ [33m⚠[0m Warning [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [33m│[0m 
 
- [32m✔[0m Success with message [32m %f ms[0m
- [31m✘[0m Failure with message [31m %f ms[0m
+ [32m✔[0m Success with message [32m %f [2mms[0m
+ [31m✘[0m Failure with message [31m %f [2mms[0m
    [31m│[0m
    [31m│[0m [41;37mfailure with custom message%w[0m
    [31m│[0m [41;37mFailed asserting that false is true.[0m
@@ -51,28 +51,28 @@ Configuration: %stests%ebasic%econfiguration.basic.xml
    [31m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [31m│[0m 
 
- [33m✘[0m Error with message [33m %f ms[0m
+ [33m✘[0m Error with message [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m [43;30mRuntimeException: error with custom message[0m
    [33m│[0m 
    [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [33m│[0m 
 
- [33m∅[0m Incomplete with message [33m %f ms[0m
+ [33m∅[0m Incomplete with message [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m [33mincomplete with custom message[0m
    [33m│[0m 
    [33m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [33m│[0m 
 
- [36m↩[0m Skipped with message [36m %f ms[0m
+ [36m↩[0m Skipped with message [36m %f [2mms[0m
    [36m│[0m
    [36m│[0m [36mskipped with custom message[0m
    [36m│[0m 
    [36m│[0m %stests[2m%e[22mbasic[2m%e[22munit[2m%e[22mStatusTest.php[2m:[22m[34m%d[0m
    [36m│[0m 
 
- [33m☢[0m Risky with message [33m %f ms[0m
+ [33m☢[0m Risky with message [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m [33mThis test did not perform any assertions%w[0m
    [33m│[0m%w 
@@ -80,7 +80,7 @@ Configuration: %stests%ebasic%econfiguration.basic.xml
    [33m│[0m%w
    [33m│[0m 
 
- [33m⚠[0m Warning with message [33m %f ms[0m
+ [33m⚠[0m Warning with message [33m %f [2mms[0m
    [33m│[0m
    [33m│[0m [33mwarning with custom message[0m
    [33m│[0m 

--- a/tests/end-to-end/phpt/expect-external-location-hint.phpt
+++ b/tests/end-to-end/phpt/expect-external-location-hint.phpt
@@ -26,6 +26,7 @@ There was 1 failure:
 Failed asserting that two strings are equal.
 
 %stests%eend-to-end%e_files%eexpect_external.txt:1
+%stests%eend-to-end%e_files%ephpt-expect-external-location-hint-example.phpt:10
 
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/end-to-end/regression/GitHub/3107/issue-3107-test.phpt
+++ b/tests/end-to-end/regression/GitHub/3107/issue-3107-test.phpt
@@ -17,9 +17,9 @@ Issue3107\Issue3107
  ✘ One
    │
    │ Error: Call to undefined function %Sdoes_not_exist()
-   │ 
+   │
    │ %sIssue3107Test.php:%d
-   │ 
+   │
 
 Time: %s, Memory: %s
 


### PR DESCRIPTION
While working on self-test collection and listener/printer refactoring I enjoy playing with little output enhancements. This is the latest (and last, for now) set of little changes that have made my development cycle a bit more smooth and enjoyable.

In one screenshot:

![image](https://user-images.githubusercontent.com/26651359/51123070-95ec8480-181b-11e9-9a08-214d2341a8ac.png)

- add PHPT source file to the stack trace of assertions caused by PHPT EXPECT*_EXTERNAL sections
- when colored use additional UTF eye candy to give the left margin more visual texture. I found the 'railway map' to be really helpful when scrolling through my terminal windows.
  - clear start and end of the information block
  - exception message section (if available)
  - assertion value-diff section (if available)
  - exception stack trace (if available)
- ANSI color codes are a bit more efficient

![image](https://user-images.githubusercontent.com/26651359/51124817-85d6a400-181f-11e9-999b-c392010c539c.png)
