### PR TITLE
Fix: Apply realpath() to items in Xdebug filter list

### DIFF
--- a/src/Util/XdebugFilterScriptGenerator.php
+++ b/src/Util/XdebugFilterScriptGenerator.php
@@ -19,7 +19,7 @@ final class XdebugFilterScriptGenerator
             function ($item) {
                 return \sprintf(
                     "        '%s'",
-                    $item
+                    \realpath($item) ?: $item
                 );
             },
             $items


### PR DESCRIPTION
This PR

* [x] applies `realpath()` to items in Xdebug filter list

Fixes https://github.com/sebastianbergmann/phpunit/issues/3482.