### PR TITLE
8.x-branch: update Windows CI to use latest PHP 7.2 minor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt curl --fail --location --silent --show-error -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
+  - IF NOT EXIST php-installed.txt curl --fail --location --silent --show-error -o php-%PHP_VERSION%-Win32-VC15-x86-latest.zip https://windows.php.net/downloads/releases/latest/php-%PHP_VERSION%-Win32-VC15-x86-latest.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%*-Win32-VC15-x86-latest.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini


### PR DESCRIPTION
Updating AppVeyor CI to use new download location for latest PHP minor versions