### PR TITLE
7.5.x-branch: update Windows CI to use latest PHP 7.1 minor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
   COMPOSER_ROOT_VERSION: '7.0-dev'
 
   matrix:
-    - PHP_VERSION: '7.1.11'
+    - PHP_VERSION: '7.1'
       XDEBUG_VERSION: '2.5.5-7.1'
       DEPENDENCIES: '--prefer-lowest'
-    - PHP_VERSION: '7.1.11'
+    - PHP_VERSION: '7.1'
       XDEBUG_VERSION: '2.5.5-7.1'
       DEPENDENCIES: ''
 
@@ -31,7 +31,7 @@ install:
   - IF NOT EXIST c:\php mkdir c:\php
   - IF NOT EXIST c:\php\%PHP_VERSION% mkdir c:\php\%PHP_VERSION%
   - cd c:\php\%PHP_VERSION%
-  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC14-x86.zip https://windows.php.net/downloads/releases/archives/php-%PHP_VERSION%-Win32-VC14-x86.zip
+  - IF NOT EXIST php-installed.txt curl -fsS -o php-%PHP_VERSION%-Win32-VC14-x86.zip https://windows.php.net/downloads/releases/latest/php-%PHP_VERSION%-Win32-VC14-x86-latest.zip
   - IF NOT EXIST php-installed.txt 7z x php-%PHP_VERSION%-Win32-VC14-x86.zip -y >nul
   - IF NOT EXIST php-installed.txt del /Q *.zip
   - IF NOT EXIST php-installed.txt copy /Y php.ini-development php.ini

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -584,7 +584,7 @@ class TestRunner extends BaseTestRunner
 
             $script = (new XdebugFilterScriptGenerator)->generate($filterConfiguration['whitelist']);
 
-            if (!Filesystem::createDirectory(\dirname($arguments['xdebugFilterFile']))) {
+            if ($arguments['xdebugFilterFile'] !== 'php://stdout' && $arguments['xdebugFilterFile'] !== 'php://stderr' && !Filesystem::createDirectory(\dirname($arguments['xdebugFilterFile']))) {
                 $this->write(\sprintf('Cannot write Xdebug filter script to %s ' . \PHP_EOL, $arguments['xdebugFilterFile']));
 
                 exit(self::EXCEPTION_EXIT);


### PR DESCRIPTION
Updating AppVeyor CI to use new download location for latest PHP minor versions.
For the 7.5.x version of PHPUnit this means the 'latest' PHP 7.1.x