### PR TITLE
Backport of #3459 to PHPUnit 6.5.x

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -37,7 +37,7 @@ class Test
     const REGEX_REQUIRES_VERSION            = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m';
     const REGEX_REQUIRES_VERSION_CONSTRAINT = '/@requires\s+(?P<name>PHP(?:Unit)?)\s+(?P<constraint>[\d\t -.|~^]+)[ \t]*\r?$/m';
     const REGEX_REQUIRES_OS                 = '/@requires\s+(?P<name>OS(?:FAMILY)?)\s+(?P<value>.+?)[ \t]*\r?$/m';
-    const REGEX_REQUIRES                    = '/@requires\s+(?P<name>function|extension)\s+(?P<value>([^ ]+?))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
+    const REGEX_REQUIRES                    = '/@requires\s+(?P<name>function|extension)\s+(?P<value>([^\s<>=!]+))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
 
     const UNKNOWN = -1;
     const SMALL   = 0;

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -80,6 +80,14 @@ class RequirementsTest extends TestCase
     }
 
     /**
+     * @requires function testFunc2
+     * @see https://github.com/sebastianbergmann/phpunit/issues/3459
+     */
+    public function testRequiresFunctionWithDigit()
+    {
+    }
+
+    /**
      * @requires OS SunOS
      * @requires OSFAMILY Solaris
      */
@@ -92,9 +100,9 @@ class RequirementsTest extends TestCase
      * @requires PHPUnit 9-dev
      * @requires OS DOESNOTEXIST
      * @requires function testFuncOne
-     * @requires function testFuncTwo
+     * @requires function testFunc2
      * @requires extension testExtOne
-     * @requires extension testExtTwo
+     * @requires extension testExt2
      * @requires extension testExtThree 2.0
      */
     public function testAllPossibleRequirements()

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -556,9 +556,9 @@ class TestCaseTest extends TestCase
             'PHPUnit >= 9-dev is required.' . PHP_EOL .
             'Operating system matching /DOESNOTEXIST/i is required.' . PHP_EOL .
             'Function testFuncOne is required.' . PHP_EOL .
-            'Function testFuncTwo is required.' . PHP_EOL .
+            'Function testFunc2 is required.' . PHP_EOL .
             'Extension testExtOne is required.' . PHP_EOL .
-            'Extension testExtTwo is required.' . PHP_EOL .
+            'Extension testExt2 is required.' . PHP_EOL .
             'Extension testExtThree >= 2.0 is required.',
             $test->getStatusMessage()
         );

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -154,11 +154,11 @@ class TestTest extends TestCase
                     'OS'        => 'DOESNOTEXIST',
                     'functions' => [
                         'testFuncOne',
-                        'testFuncTwo',
+                        'testFunc2',
                     ],
                     'extensions' => [
                         'testExtOne',
-                        'testExtTwo',
+                        'testExt2',
                         'testExtThree',
                     ],
                     'extension_versions' => [
@@ -508,9 +508,9 @@ class TestTest extends TestCase
               'PHPUnit >= 9-dev is required.',
               'Operating system matching /DOESNOTEXIST/i is required.',
               'Function testFuncOne is required.',
-              'Function testFuncTwo is required.',
+              'Function testFunc2 is required.',
               'Extension testExtOne is required.',
-              'Extension testExtTwo is required.',
+              'Extension testExt2 is required.',
               'Extension testExtThree >= 2.0 is required.',
             ]],
             ['testPHPVersionOperatorLessThan', ['PHP < 5.4 is required.']],


### PR DESCRIPTION
The fix for #3459 didn't help out @MaxSem who originally reported it: https://github.com/wikimedia/mediawiki/commit/9c5174669eecd1b8729e99b0d96750db26bf94f6
As I'd like to support both Wikimedia _and_ their security unit testing, I have manually backported and tested the fix, just this once. ;-)

![image](https://user-images.githubusercontent.com/26651359/51251436-a165ba00-1999-11e9-93fb-923a5c1737a4.png)

It's just the `@requires` regex and its tests. Why Github says it cannot merge automatically, no idea. It works just fine when I try it:

```sh
 ~/proj/phpunit  6.5  git merge origin/issue-3459-fix-requires-annotation-phpunit65                                                                                          ✔  14:11:09 
Updating ea739aae4..96d3f0409
Fast-forward
 src/Util/Test.php                 |  2 +-
 tests/Framework/TestCaseTest.php  |  4 ++--
 tests/Util/TestTest.php           |  8 ++++----
 tests/_files/RequirementsTest.php | 12 ++++++++++--
 4 files changed, 17 insertions(+), 9 deletions(-)

[...]
PHPUnit 6.5.7-2-g96d3f0409 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.11 with Xdebug 2.6.0
Configuration: /Users/ewout/proj/phpunit/phpunit.xml

[...]
OK, but incomplete, skipped, or risky tests!
Tests: 1675, Assertions: 2930, Skipped: 2.
```