### PR TITLE
Prevent tearDownAfterClass exceptions from killing PHPUnit

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -703,10 +703,10 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                     \call_user_func([$this->name, $beforeClassMethod]);
                 }
             }
-        } catch (SkippedTestSuiteError $e) {
+        } catch (SkippedTestSuiteError $error) {
             foreach ($this->tests() as $test) {
                 $result->startTest($test);
-                $result->addFailure($test, $e, 0);
+                $result->addFailure($test, $error, 0);
                 $result->endTest($test, 0);
             }
 
@@ -756,7 +756,12 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                 }
             }
         } catch (Throwable $t) {
-            \trigger_error($t->__toString(), \E_USER_WARNING);
+            $error = new SyntheticError($t->getMessage(), 0, $t->getFile(), $t->getLine(), $t->getTrace());
+            $test  = new \Failure('tearDownAfterClass');
+
+            $result->startTest($test);
+            $result->addFailure($test, $error, 0);
+            $result->endTest($test, 0);
         }
 
         $this->tearDown();

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -756,8 +756,9 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
                 }
             }
         } catch (Throwable $t) {
-            $error = new SyntheticError($t->getMessage(), 0, $t->getFile(), $t->getLine(), $t->getTrace());
-            $test  = new \Failure('tearDownAfterClass');
+            $message = "Exception in {$this->name}::$afterClassMethod" . \PHP_EOL . $t->getMessage();
+            $error   = new SyntheticError($message, 0, $t->getFile(), $t->getLine(), $t->getTrace());
+            $test    = new \Failure($afterClassMethod);
 
             $result->startTest($test);
             $result->addFailure($test, $error, 0);

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -748,13 +748,15 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
 
         try {
             foreach ($hookMethods['afterClass'] as $afterClassMethod) {
-                if ($this->testCase === true && \class_exists($this->name, false) && \method_exists($this->name,
-                        $afterClassMethod)) {
+                if ($this->testCase === true && \class_exists($this->name, false) && \method_exists(
+                    $this->name,
+                        $afterClassMethod
+                )) {
                     \call_user_func([$this->name, $afterClassMethod]);
                 }
             }
-        } catch(Throwable $t) {
-            trigger_error($t->__toString(), E_USER_WARNING);
+        } catch (Throwable $t) {
+            \trigger_error($t->__toString(), \E_USER_WARNING);
         }
 
         $this->tearDown();

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -746,10 +746,15 @@ class TestSuite implements Test, SelfDescribing, IteratorAggregate
             $test->run($result);
         }
 
-        foreach ($hookMethods['afterClass'] as $afterClassMethod) {
-            if ($this->testCase === true && \class_exists($this->name, false) && \method_exists($this->name, $afterClassMethod)) {
-                \call_user_func([$this->name, $afterClassMethod]);
+        try {
+            foreach ($hookMethods['afterClass'] as $afterClassMethod) {
+                if ($this->testCase === true && \class_exists($this->name, false) && \method_exists($this->name,
+                        $afterClassMethod)) {
+                    \call_user_func([$this->name, $afterClassMethod]);
+                }
             }
+        } catch(Throwable $t) {
+            trigger_error($t->__toString(), E_USER_WARNING);
         }
 
         $this->tearDown();

--- a/tests/_files/ExceptionInTearDownAfterClassTest.php
+++ b/tests/_files/ExceptionInTearDownAfterClassTest.php
@@ -11,52 +11,18 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionInTearDownAfterClassTest extends TestCase
 {
-    public $setUp                = false;
-
-    public $assertPreConditions  = false;
-
-    public $assertPostConditions = false;
-
-    public $tearDown             = false;
-
-    public $tearDownAfterClass   = false;
-
-    public $testSomething        = false;
-
     public static function tearDownAfterClass(): void
     {
         throw new Exception('throw Exception in tearDownAfterClass()');
     }
 
-    protected function setUp(): void
-    {
-        $this->setUp = true;
-    }
-
-    protected function tearDown(): void
-    {
-        $this->tearDown = true;
-    }
-
     public function testOne(): void
     {
-        $this->testSomething = true;
         $this->assertTrue(true);
     }
 
     public function testTwo(): void
     {
-        $this->testSomething = $this->testSomething && true;
         $this->assertTrue(true);
-    }
-
-    protected function assertPreConditions(): void
-    {
-        $this->assertPreConditions = true;
-    }
-
-    protected function assertPostConditions(): void
-    {
-        $this->assertPostConditions = true;
     }
 }

--- a/tests/_files/ExceptionInTearDownAfterClassTest.php
+++ b/tests/_files/ExceptionInTearDownAfterClassTest.php
@@ -9,7 +9,7 @@
  */
 use PHPUnit\Framework\TestCase;
 
-class ExceptionInTearDownTest extends TestCase
+class ExceptionInTearDownAfterClassTest extends TestCase
 {
     public $setUp                = false;
 
@@ -19,7 +19,14 @@ class ExceptionInTearDownTest extends TestCase
 
     public $tearDown             = false;
 
+    public $tearDownAfterClass   = false;
+
     public $testSomething        = false;
+
+    public static function tearDownAfterClass(): void
+    {
+        throw new Exception('throw Exception in tearDownAfterClass()');
+    }
 
     protected function setUp(): void
     {
@@ -29,13 +36,18 @@ class ExceptionInTearDownTest extends TestCase
     protected function tearDown(): void
     {
         $this->tearDown = true;
-
-        throw new Exception('throw Exception in tearDown()');
     }
 
-    public function testSomething(): void
+    public function testOne(): void
     {
         $this->testSomething = true;
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        $this->testSomething = $this->testSomething && true;
+        $this->assertTrue(true);
     }
 
     protected function assertPreConditions(): void

--- a/tests/_files/ExceptionInTearDownTest.php
+++ b/tests/_files/ExceptionInTearDownTest.php
@@ -30,7 +30,7 @@ class ExceptionInTearDownTest extends TestCase
     {
         $this->tearDown = true;
 
-        throw new Exception;
+        throw new Exception("throw Exception in tearDown()");
     }
 
     public function testSomething(): void

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -175,6 +175,7 @@ class TestCaseTest extends TestCase
         $this->assertTrue($test->assertPostConditions);
         $this->assertTrue($test->tearDown);
         $this->assertEquals(BaseTestRunner::STATUS_ERROR, $test->getStatus());
+        $this->assertSame('throw Exception in tearDown()', $test->getStatusMessage());
     }
 
     public function testExceptionInTestIsDetectedInTeardown(): void

--- a/tests/unit/Framework/TestSuiteTest.php
+++ b/tests/unit/Framework/TestSuiteTest.php
@@ -228,6 +228,9 @@ class TestSuiteTest extends TestCase
         TestSuite::createTest($reflection, 'TestForConstructorlessTestClass');
     }
 
+    /**
+     * @testdox Handles exceptions in tearDownAfterClass()
+     */
     public function testTearDownAfterClassInTestSuite(): void
     {
         $suite = new TestSuite(\ExceptionInTearDownAfterClassTest::class);
@@ -238,6 +241,10 @@ class TestSuiteTest extends TestCase
 
         /** @var TestFailure $failure */
         $failure = $this->result->failures()[0];
-        $this->assertSame('throw Exception in tearDownAfterClass()', $failure->thrownException()->getMessage());
+        $this->assertSame(
+            'Exception in ExceptionInTearDownAfterClassTest::tearDownAfterClass' . \PHP_EOL .
+            'throw Exception in tearDownAfterClass()',
+            $failure->thrownException()->getMessage()
+        );
     }
 }

--- a/tests/unit/Framework/TestSuiteTest.php
+++ b/tests/unit/Framework/TestSuiteTest.php
@@ -227,4 +227,17 @@ class TestSuiteTest extends TestCase
             ->willReturn(__CLASS__);
         TestSuite::createTest($reflection, 'TestForConstructorlessTestClass');
     }
+
+    public function testTearDownAfterClassInTestSuite(): void
+    {
+        $suite = new TestSuite(\ExceptionInTearDownAfterClassTest::class);
+        $suite->run($this->result);
+
+        $this->assertSame(3, $this->result->count());
+        $this->assertCount(1, $this->result->failures());
+
+        /** @var TestFailure $failure */
+        $failure = $this->result->failures()[0];
+        $this->assertSame('throw Exception in tearDownAfterClass()', $failure->thrownException()->getMessage());
+    }
 }

--- a/tests/unit/Framework/TestSuiteTest.php
+++ b/tests/unit/Framework/TestSuiteTest.php
@@ -239,8 +239,8 @@ class TestSuiteTest extends TestCase
         $this->assertSame(3, $this->result->count());
         $this->assertCount(1, $this->result->failures());
 
-        /** @var TestFailure $failure */
         $failure = $this->result->failures()[0];
+        \assert($failure instanceof TestFailure);
         $this->assertSame(
             'Exception in ExceptionInTearDownAfterClassTest::tearDownAfterClass' . \PHP_EOL .
             'throw Exception in tearDownAfterClass()',


### PR DESCRIPTION
Found out yesterday that `tearDown[AfterClass]` exceptions were not handled by `TestSuite` the way it does for `setUp[BeforeClass]`. PHP simply exits to the command line:

![image](https://user-images.githubusercontent.com/26651359/51385232-f0892780-1b1e-11e9-922b-a63d0ff732e0.png)

This fix will report exceptions in `tearDownAfterClass()` by adding a dummy test at the end of a `TestSuite` called `tearDownAfterClass` with the original message and stack trace. A corrected code location hint is added to the top pointing to the offending line.

On the command line:

```
./phpunit tests/_files/ExceptionInTearDownAfterClassTest.php                                                         ✔ 

[header]
..                                                                  2 / 2 (100%)F

Time: 251 ms, Memory: 4.00MB

There was 1 failure:

1) Failure::tearDownAfterClass
throw Exception in tearDownAfterClass()

/Users/ewout/proj/phpunit/tests/_files/ExceptionInTearDownAfterClassTest.php:28
/Users/ewout/proj/phpunit/src/Framework/TestSuite.php:755
[etc]

FAILURES!
Tests: 3, Assertions: 2, Failures: 1.
```

In IntelliJ it looks like this:

![image](https://user-images.githubusercontent.com/26651359/51410064-d0c82280-1b63-11e9-9f9c-e61f70d98dd6.png)
