### PR TITLE
Add output buffering spinner to colored testdox printer

### DIFF
--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -46,6 +46,13 @@ class CliTestDoxPrinter extends TestDoxPrinter
         'last'    => '┴',
     ];
 
+    private const SPINNER_ICONS = [
+        " \e[36m◐\e[0m running tests",
+        " \e[36m◓\e[0m running tests",
+        " \e[36m◑\e[0m running tests",
+        " \e[36m◒\e[0m running tests",
+    ];
+
     /**
      * @var int[]
      */
@@ -299,6 +306,22 @@ class CliTestDoxPrinter extends TestDoxPrinter
         $out .= $this->prefixLines($prefix['last'], \PHP_EOL) . \PHP_EOL;
 
         return $out;
+    }
+
+    protected function drawSpinner(): void
+    {
+        if ($this->colors) {
+            $id =  $this->spinState % \count(self::SPINNER_ICONS);
+            $this->write(self::SPINNER_ICONS[$id]);
+        }
+    }
+
+    protected function undrawSpinner(): void
+    {
+        if ($this->colors) {
+            $id =  $this->spinState % \count(self::SPINNER_ICONS);
+            $this->write("\e[1K\e[" . \strlen(self::SPINNER_ICONS[$id]) . 'D');
+        }
     }
 
     private function formatRuntime(float $time, string $color = ''): string

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -61,6 +61,11 @@ class TestDoxPrinter extends ResultPrinter
     protected $originalExecutionOrder = [];
 
     /**
+     * @var int
+     */
+    protected $spinState = 0;
+
+    /**
      * @param null|mixed $out
      *
      * @throws \PHPUnit\Framework\Exception
@@ -247,13 +252,43 @@ class TestDoxPrinter extends ResultPrinter
                 $result  = $this->getTestResultByName($this->originalExecutionOrder[$this->testFlushIndex]);
 
                 if (!empty($result)) {
+                    $this->hideSpinner();
                     $this->writeTestResult($prevResult, $result);
                     $this->testFlushIndex++;
                     $prevResult = $result;
                     $flushed    = true;
+                } else {
+                    $this->showSpinner();
                 }
             } while ($flushed && $this->testFlushIndex < $this->testIndex);
         }
+    }
+
+    protected function showSpinner(): void
+    {
+        if ($this->spinState) {
+            $this->undrawSpinner();
+        }
+        $this->spinState++;
+        $this->drawSpinner();
+    }
+
+    protected function hideSpinner(): void
+    {
+        if ($this->spinState) {
+            $this->undrawSpinner();
+        }
+        $this->spinState = 0;
+    }
+
+    protected function drawSpinner(): void
+    {
+        // optional for CLI printers: show the user a 'buffering output' spinner
+    }
+
+    protected function undrawSpinner(): void
+    {
+        // remove the spinner from the current line
     }
 
     protected function writeTestResult(array $prevResult, array $result): void


### PR DESCRIPTION
The [TestDox printer will buffer test result output](https://github.com/sebastianbergmann/phpunit/pull/3417) when the execution has been changed by `--order-by`. When this happens the prettified printer will let the user know by showing a little spinner:

![image](https://user-images.githubusercontent.com/26651359/51547878-6d8e0700-1e67-11e9-8538-008894c37acd.png)

Quick way to see it at work, run:  ```phpunit --testdox --order-by=random --testsuite end-to-end```

To prevent visual noise the spinner will only appear when out of sequence results are detected by the colorized printer and hidden when it has caught up. No further configuration or changes needed.

That's it. :)
