### PR TITLE
Fix StringEndsWith matches too loosely (numeric strings)

### DIFF
--- a/src/Framework/Constraint/StringEndsWith.php
+++ b/src/Framework/Constraint/StringEndsWith.php
@@ -43,6 +43,6 @@ class StringEndsWith extends Constraint
      */
     protected function matches($other): bool
     {
-        return \substr($other, 0 - \strlen($this->suffix)) == $this->suffix;
+        return \substr($other, 0 - \strlen($this->suffix)) === $this->suffix;
     }
 }

--- a/tests/unit/Framework/Constraint/StringEndsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringEndsWithTest.php
@@ -17,13 +17,29 @@ class StringEndsWithTest extends ConstraintTestCase
     public function testConstraintStringEndsWithCorrectValueAndReturnResult(): void
     {
         $constraint = new StringEndsWith('suffix');
+
         $this->assertTrue($constraint->evaluate('foosuffix', '', true));
     }
 
     public function testConstraintStringEndsWithNotCorrectValueAndReturnResult(): void
     {
         $constraint = new StringEndsWith('suffix');
+
         $this->assertFalse($constraint->evaluate('suffixerror', '', true));
+    }
+
+    public function testConstraintStringEndsWithCorrectNumericValueAndReturnResult(): void
+    {
+        $constraint = new StringEndsWith('0E1');
+
+        $this->assertTrue($constraint->evaluate('zzz0E1', '', true));
+    }
+
+    public function testConstraintStringEndsWithNotCorrectNumericValueAndReturnResult(): void
+    {
+        $constraint = new StringEndsWith('0E1');
+
+        $this->assertFalse($constraint->evaluate('zzz0E2', '', true));
     }
 
     public function testConstraintStringEndsWithToStringMethod(): void

--- a/tests/unit/Framework/Constraint/StringStartsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringStartsWithTest.php
@@ -28,6 +28,20 @@ class StringStartsWithTest extends ConstraintTestCase
         $this->assertFalse($constraint->evaluate('error', '', true));
     }
 
+    public function testConstraintStringStartsWithCorrectNumericValueAndReturnResult(): void
+    {
+        $constraint = new StringStartsWith('0E1');
+
+        $this->assertTrue($constraint->evaluate('0E1zzz', '', true));
+    }
+
+    public function testConstraintStringStartsWithNotCorrectNumericValueAndReturnResult(): void
+    {
+        $constraint = new StringStartsWith('0E1');
+
+        $this->assertFalse($constraint->evaluate('0E2zzz', '', true));
+    }
+
     public function testConstraintStringStartsWithToStringMethod(): void
     {
         $constraint = new StringStartsWith('prefix');
@@ -73,7 +87,8 @@ EOF
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
                 <<<EOF
-custom message\nFailed asserting that 'error' starts with "prefix".
+custom message
+Failed asserting that 'error' starts with "prefix".
 
 EOF
                 ,


### PR DESCRIPTION
Fixes #3461 (for 7.5 since 6.5 support just ended)