### PR TITLE
Bugfix for --group and numeric @group and @ticket annotations

### DIFF
--- a/src/Runner/Filter/GroupFilterIterator.php
+++ b/src/Runner/Filter/GroupFilterIterator.php
@@ -25,7 +25,7 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
         parent::__construct($iterator);
 
         foreach ($suite->getGroupDetails() as $group => $tests) {
-            if (\in_array($group, $groups, true)) {
+            if (\in_array((string) $group, $groups, true)) {
                 $testHashes = \array_map(
                     'spl_object_hash',
                     $tests

--- a/tests/_files/NumericGroupAnnotationTest.php
+++ b/tests/_files/NumericGroupAnnotationTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class NumericGroupAnnotationTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @testdox Empty test for @ticket numeric annotation values
+     * @ticket  3502
+     *
+     * @see https://github.com/sebastianbergmann/phpunit/issues/3502
+     */
+    public function testTicketAnnotationSupportsNumericValue(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @testdox Empty test for @group numeric annotation values
+     * @group   3502
+     *
+     * @see https://github.com/sebastianbergmann/phpunit/issues/3502
+     */
+    public function testGroupAnnotationSupportsNumericValue(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testDummyTestThatShouldNotRun(): void
+    {
+        $this->doesNotPerformAssertions();
+    }
+}

--- a/tests/end-to-end/group.phpt
+++ b/tests/end-to-end/group.phpt
@@ -3,18 +3,21 @@ phpunit --group balanceIsInitiallyZero BankAccountTest ../../_files/BankAccountT
 --FILE--
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--group';
-$_SERVER['argv'][3] = 'balanceIsInitiallyZero';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][2] = '--testdox';
+$_SERVER['argv'][3] = '--group';
+$_SERVER['argv'][4] = '3502';
+$_SERVER['argv'][5] = 'NumericGroupAnnotationTest';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/NumericGroupAnnotationTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-.                                                                   1 / 1 (100%)
+NumericGroupAnnotation
+ ✔ Empty test for @ticket numeric annotation values
+ ✔ Empty test for @group numeric annotation values
 
 Time: %s, Memory: %s
 
-OK (1 test, 1 assertion)
+OK (2 tests, 2 assertions)


### PR DESCRIPTION
FIxes #3502

**Fix**
I figured that casting `$group` once before the array search is preferable to untangling all use cases that touch the `$suite->groups` property.

```
./phpunit --group 3502 --testdox tests/_files/NumericGroupAnnotationTest.php
```

**Changes**
- force $group to string once before doing a faster typed array search
- added `NumericGroupAnnotationTest` for use in end-to-end test for `--group`
