### PR TITLE
Always print seed used for --order-by=random

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -338,13 +338,6 @@ class TestRunner extends BaseTestRunner
 
             $this->writeMessage('Runtime', $runtime);
 
-            if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
-                $this->writeMessage(
-                    'Random seed',
-                    $arguments['randomOrderSeed']
-                );
-            }
-
             if (isset($arguments['configuration'])) {
                 $this->writeMessage(
                     'Configuration',
@@ -365,6 +358,13 @@ class TestRunner extends BaseTestRunner
                     $extension
                 );
             }
+        }
+
+        if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
+            $this->writeMessage(
+                'Random seed',
+                $arguments['randomOrderSeed']
+            );
         }
 
         if (isset($tooFewColumnsRequested)) {

--- a/tests/end-to-end/test-order-randomized-seed-with-dependency-resolution.phpt
+++ b/tests/end-to-end/test-order-randomized-seed-with-dependency-resolution.phpt
@@ -4,12 +4,11 @@ phpunit --random-order --random-order-seed=54321 --resolve-dependencies ../_file
 <?php
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--debug';
-$_SERVER['argv'][3] = '--verbose';
-$_SERVER['argv'][4] = '--random-order';
-$_SERVER['argv'][5] = '--random-order-seed=54321';
-$_SERVER['argv'][6] = '--resolve-dependencies';
-$_SERVER['argv'][7] = 'MultiDependencyTest';
-$_SERVER['argv'][8] = __DIR__ . '/../_files/MultiDependencyTest.php';
+$_SERVER['argv'][3] = '--random-order';
+$_SERVER['argv'][4] = '--random-order-seed=54321';
+$_SERVER['argv'][5] = '--resolve-dependencies';
+$_SERVER['argv'][6] = 'MultiDependencyTest';
+$_SERVER['argv'][7] = __DIR__ . '/../_files/MultiDependencyTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
@@ -17,7 +16,6 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-Runtime:       %s
 Random seed:   54321
 
 Test 'MultiDependencyTest::testTwo' started


### PR DESCRIPTION
Fix #3515 by combining randomness and predictability ☯️ 