### PR TITLE
Implement option to disable Testdox progress animation

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -281,7 +281,7 @@
         <xs:attribute name="extensionsDirectory" type="xs:string"/>
         <xs:attribute name="executionOrder" type="executionOrderType" default="default"/>
         <xs:attribute name="resolveDependencies" type="xs:boolean" default="false"/>
-        <xs:attribute name="noProgress" type="xs:boolean" default="false"/>
+        <xs:attribute name="noInteraction" type="xs:boolean" default="false"/>
     </xs:attributeGroup>
     <xs:group name="configGroup">
         <xs:all>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -281,6 +281,7 @@
         <xs:attribute name="extensionsDirectory" type="xs:string"/>
         <xs:attribute name="executionOrder" type="executionOrderType" default="default"/>
         <xs:attribute name="resolveDependencies" type="xs:boolean" default="false"/>
+        <xs:attribute name="noProgress" type="xs:boolean" default="false"/>
     </xs:attributeGroup>
     <xs:group name="configGroup">
         <xs:all>

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -107,7 +107,7 @@ class Command
         'no-configuration'          => null,
         'no-coverage'               => null,
         'no-logging'                => null,
-        'no-progress'               => null,
+        'no-interaction'            => null,
         'no-extensions'             => null,
         'order-by='                 => null,
         'printer='                  => null,
@@ -641,8 +641,8 @@ class Command
 
                     break;
 
-                case '--no-progress':
-                    $this->arguments['noProgress'] = true;
+                case '--no-interaction':
+                    $this->arguments['noInteraction'] = true;
 
                     break;
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -107,6 +107,7 @@ class Command
         'no-configuration'          => null,
         'no-coverage'               => null,
         'no-logging'                => null,
+        'no-progress'               => null,
         'no-extensions'             => null,
         'order-by='                 => null,
         'printer='                  => null,
@@ -637,6 +638,11 @@ class Command
 
                 case '--no-logging':
                     $this->arguments['noLogging'] = true;
+
+                    break;
+
+                case '--no-progress':
+                    $this->arguments['noProgress'] = true;
 
                     break;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -316,7 +316,7 @@ final class TestRunner extends BaseTestRunner
                 if (isset($originalExecutionOrder) && ($this->printer instanceof CliTestDoxPrinter)) {
                     /* @var CliTestDoxPrinter */
                     $this->printer->setOriginalExecutionOrder($originalExecutionOrder);
-                    $this->printer->setShowProgressAnimation(!$arguments['noProgress']);
+                    $this->printer->setShowProgressAnimation(!$arguments['noInteraction']);
                 }
             }
         }
@@ -1030,8 +1030,8 @@ final class TestRunner extends BaseTestRunner
                 $arguments['resolveDependencies'] = $phpunitConfiguration['resolveDependencies'];
             }
 
-            if (isset($phpunitConfiguration['noProgress']) && !isset($arguments['noProgress'])) {
-                $arguments['noProgress'] = $phpunitConfiguration['noProgress'];
+            if (isset($phpunitConfiguration['noInteraction']) && !isset($arguments['noInteraction'])) {
+                $arguments['noInteraction'] = $phpunitConfiguration['noInteraction'];
             }
 
             $groupCliArgs = [];
@@ -1215,55 +1215,55 @@ final class TestRunner extends BaseTestRunner
             }
         }
 
-        $arguments['addUncoveredFilesFromWhitelist']                  = $arguments['addUncoveredFilesFromWhitelist'] ?? true;
-        $arguments['backupGlobals']                                   = $arguments['backupGlobals'] ?? null;
-        $arguments['backupStaticAttributes']                          = $arguments['backupStaticAttributes'] ?? null;
-        $arguments['beStrictAboutChangesToGlobalState']               = $arguments['beStrictAboutChangesToGlobalState'] ?? null;
-        $arguments['beStrictAboutResourceUsageDuringSmallTests']      = $arguments['beStrictAboutResourceUsageDuringSmallTests'] ?? false;
-        $arguments['cacheResult']                                     = $arguments['cacheResult'] ?? true;
-        $arguments['cacheTokens']                                     = $arguments['cacheTokens'] ?? false;
-        $arguments['colors']                                          = $arguments['colors'] ?? ResultPrinter::COLOR_DEFAULT;
-        $arguments['columns']                                         = $arguments['columns'] ?? 80;
-        $arguments['convertDeprecationsToExceptions']                 = $arguments['convertDeprecationsToExceptions'] ?? true;
-        $arguments['convertErrorsToExceptions']                       = $arguments['convertErrorsToExceptions'] ?? true;
-        $arguments['convertNoticesToExceptions']                      = $arguments['convertNoticesToExceptions'] ?? true;
-        $arguments['convertWarningsToExceptions']                     = $arguments['convertWarningsToExceptions'] ?? true;
-        $arguments['crap4jThreshold']                                 = $arguments['crap4jThreshold'] ?? 30;
-        $arguments['disallowTestOutput']                              = $arguments['disallowTestOutput'] ?? false;
-        $arguments['disallowTodoAnnotatedTests']                      = $arguments['disallowTodoAnnotatedTests'] ?? false;
-        $arguments['defaultTimeLimit']                                = $arguments['defaultTimeLimit'] ?? 0;
-        $arguments['enforceTimeLimit']                                = $arguments['enforceTimeLimit'] ?? false;
-        $arguments['excludeGroups']                                   = $arguments['excludeGroups'] ?? [];
-        $arguments['executionOrder']                                  = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
-        $arguments['executionOrderDefects']                           = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
-        $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? false;
-        $arguments['failOnWarning']                                   = $arguments['failOnWarning'] ?? false;
-        $arguments['groups']                                          = $arguments['groups'] ?? [];
-        $arguments['noProgress']                                      = $arguments['noProgress'] ?? false;
-        $arguments['processIsolation']                                = $arguments['processIsolation'] ?? false;
-        $arguments['processUncoveredFilesFromWhitelist']              = $arguments['processUncoveredFilesFromWhitelist'] ?? false;
-        $arguments['randomOrderSeed']                                 = $arguments['randomOrderSeed'] ?? \time();
-        $arguments['registerMockObjectsFromTestArgumentsRecursively'] = $arguments['registerMockObjectsFromTestArgumentsRecursively'] ?? false;
-        $arguments['repeat']                                          = $arguments['repeat'] ?? false;
-        $arguments['reportHighLowerBound']                            = $arguments['reportHighLowerBound'] ?? 90;
-        $arguments['reportLowUpperBound']                             = $arguments['reportLowUpperBound'] ?? 50;
-        $arguments['reportUselessTests']                              = $arguments['reportUselessTests'] ?? true;
-        $arguments['reverseList']                                     = $arguments['reverseList'] ?? false;
-        $arguments['resolveDependencies']                             = $arguments['resolveDependencies'] ?? true;
-        $arguments['stopOnError']                                     = $arguments['stopOnError'] ?? false;
-        $arguments['stopOnFailure']                                   = $arguments['stopOnFailure'] ?? false;
-        $arguments['stopOnIncomplete']                                = $arguments['stopOnIncomplete'] ?? false;
-        $arguments['stopOnRisky']                                     = $arguments['stopOnRisky'] ?? false;
-        $arguments['stopOnSkipped']                                   = $arguments['stopOnSkipped'] ?? false;
-        $arguments['stopOnWarning']                                   = $arguments['stopOnWarning'] ?? false;
-        $arguments['stopOnDefect']                                    = $arguments['stopOnDefect'] ?? false;
-        $arguments['strictCoverage']                                  = $arguments['strictCoverage'] ?? false;
-        $arguments['testdoxExcludeGroups']                            = $arguments['testdoxExcludeGroups'] ?? [];
-        $arguments['testdoxGroups']                                   = $arguments['testdoxGroups'] ?? [];
-        $arguments['timeoutForLargeTests']                            = $arguments['timeoutForLargeTests'] ?? 60;
-        $arguments['timeoutForMediumTests']                           = $arguments['timeoutForMediumTests'] ?? 10;
-        $arguments['timeoutForSmallTests']                            = $arguments['timeoutForSmallTests'] ?? 1;
-        $arguments['verbose']                                         = $arguments['verbose'] ?? false;
+        $arguments['addUncoveredFilesFromWhitelist']                      = $arguments['addUncoveredFilesFromWhitelist'] ?? true;
+        $arguments['backupGlobals']                                       = $arguments['backupGlobals'] ?? null;
+        $arguments['backupStaticAttributes']                              = $arguments['backupStaticAttributes'] ?? null;
+        $arguments['beStrictAboutChangesToGlobalState']                   = $arguments['beStrictAboutChangesToGlobalState'] ?? null;
+        $arguments['beStrictAboutResourceUsageDuringSmallTests']          = $arguments['beStrictAboutResourceUsageDuringSmallTests'] ?? false;
+        $arguments['cacheResult']                                         = $arguments['cacheResult'] ?? true;
+        $arguments['cacheTokens']                                         = $arguments['cacheTokens'] ?? false;
+        $arguments['colors']                                              = $arguments['colors'] ?? ResultPrinter::COLOR_DEFAULT;
+        $arguments['columns']                                             = $arguments['columns'] ?? 80;
+        $arguments['convertDeprecationsToExceptions']                     = $arguments['convertDeprecationsToExceptions'] ?? true;
+        $arguments['convertErrorsToExceptions']                           = $arguments['convertErrorsToExceptions'] ?? true;
+        $arguments['convertNoticesToExceptions']                          = $arguments['convertNoticesToExceptions'] ?? true;
+        $arguments['convertWarningsToExceptions']                         = $arguments['convertWarningsToExceptions'] ?? true;
+        $arguments['crap4jThreshold']                                     = $arguments['crap4jThreshold'] ?? 30;
+        $arguments['disallowTestOutput']                                  = $arguments['disallowTestOutput'] ?? false;
+        $arguments['disallowTodoAnnotatedTests']                          = $arguments['disallowTodoAnnotatedTests'] ?? false;
+        $arguments['defaultTimeLimit']                                    = $arguments['defaultTimeLimit'] ?? 0;
+        $arguments['enforceTimeLimit']                                    = $arguments['enforceTimeLimit'] ?? false;
+        $arguments['excludeGroups']                                       = $arguments['excludeGroups'] ?? [];
+        $arguments['executionOrder']                                      = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['executionOrderDefects']                               = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['failOnRisky']                                         = $arguments['failOnRisky'] ?? false;
+        $arguments['failOnWarning']                                       = $arguments['failOnWarning'] ?? false;
+        $arguments['groups']                                              = $arguments['groups'] ?? [];
+        $arguments['noInteraction']                                       = $arguments['noInteraction'] ?? false;
+        $arguments['processIsolation']                                    = $arguments['processIsolation'] ?? false;
+        $arguments['processUncoveredFilesFromWhitelist']                  = $arguments['processUncoveredFilesFromWhitelist'] ?? false;
+        $arguments['randomOrderSeed']                                     = $arguments['randomOrderSeed'] ?? \time();
+        $arguments['registerMockObjectsFromTestArgumentsRecursively']     = $arguments['registerMockObjectsFromTestArgumentsRecursively'] ?? false;
+        $arguments['repeat']                                              = $arguments['repeat'] ?? false;
+        $arguments['reportHighLowerBound']                                = $arguments['reportHighLowerBound'] ?? 90;
+        $arguments['reportLowUpperBound']                                 = $arguments['reportLowUpperBound'] ?? 50;
+        $arguments['reportUselessTests']                                  = $arguments['reportUselessTests'] ?? true;
+        $arguments['reverseList']                                         = $arguments['reverseList'] ?? false;
+        $arguments['resolveDependencies']                                 = $arguments['resolveDependencies'] ?? true;
+        $arguments['stopOnError']                                         = $arguments['stopOnError'] ?? false;
+        $arguments['stopOnFailure']                                       = $arguments['stopOnFailure'] ?? false;
+        $arguments['stopOnIncomplete']                                    = $arguments['stopOnIncomplete'] ?? false;
+        $arguments['stopOnRisky']                                         = $arguments['stopOnRisky'] ?? false;
+        $arguments['stopOnSkipped']                                       = $arguments['stopOnSkipped'] ?? false;
+        $arguments['stopOnWarning']                                       = $arguments['stopOnWarning'] ?? false;
+        $arguments['stopOnDefect']                                        = $arguments['stopOnDefect'] ?? false;
+        $arguments['strictCoverage']                                      = $arguments['strictCoverage'] ?? false;
+        $arguments['testdoxExcludeGroups']                                = $arguments['testdoxExcludeGroups'] ?? [];
+        $arguments['testdoxGroups']                                       = $arguments['testdoxGroups'] ?? [];
+        $arguments['timeoutForLargeTests']                                = $arguments['timeoutForLargeTests'] ?? 60;
+        $arguments['timeoutForMediumTests']                               = $arguments['timeoutForMediumTests'] ?? 10;
+        $arguments['timeoutForSmallTests']                                = $arguments['timeoutForSmallTests'] ?? 1;
+        $arguments['verbose']                                             = $arguments['verbose'] ?? false;
     }
 
     /**

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -316,6 +316,7 @@ final class TestRunner extends BaseTestRunner
                 if (isset($originalExecutionOrder) && ($this->printer instanceof CliTestDoxPrinter)) {
                     /* @var CliTestDoxPrinter */
                     $this->printer->setOriginalExecutionOrder($originalExecutionOrder);
+//                    $this->printer->setShowProgressAnimation(true);
                 }
             }
         }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -1030,6 +1030,10 @@ final class TestRunner extends BaseTestRunner
                 $arguments['resolveDependencies'] = $phpunitConfiguration['resolveDependencies'];
             }
 
+            if (isset($phpunitConfiguration['noProgress']) && !isset($arguments['noProgress'])) {
+                $arguments['noProgress'] = $phpunitConfiguration['noProgress'];
+            }
+
             $groupCliArgs = [];
 
             if (!empty($arguments['groups'])) {

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -316,7 +316,7 @@ final class TestRunner extends BaseTestRunner
                 if (isset($originalExecutionOrder) && ($this->printer instanceof CliTestDoxPrinter)) {
                     /* @var CliTestDoxPrinter */
                     $this->printer->setOriginalExecutionOrder($originalExecutionOrder);
-//                    $this->printer->setShowProgressAnimation(true);
+                    $this->printer->setShowProgressAnimation(!$arguments['noProgress']);
                 }
             }
         }
@@ -1230,10 +1230,12 @@ final class TestRunner extends BaseTestRunner
         $arguments['defaultTimeLimit']                                = $arguments['defaultTimeLimit'] ?? 0;
         $arguments['enforceTimeLimit']                                = $arguments['enforceTimeLimit'] ?? false;
         $arguments['excludeGroups']                                   = $arguments['excludeGroups'] ?? [];
+        $arguments['executionOrder']                                  = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['executionOrderDefects']                           = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
         $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? false;
         $arguments['failOnWarning']                                   = $arguments['failOnWarning'] ?? false;
-        $arguments['executionOrderDefects']                           = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
         $arguments['groups']                                          = $arguments['groups'] ?? [];
+        $arguments['noProgress']                                      = $arguments['noProgress'] ?? false;
         $arguments['processIsolation']                                = $arguments['processIsolation'] ?? false;
         $arguments['processUncoveredFilesFromWhitelist']              = $arguments['processUncoveredFilesFromWhitelist'] ?? false;
         $arguments['randomOrderSeed']                                 = $arguments['randomOrderSeed'] ?? \time();
@@ -1243,7 +1245,6 @@ final class TestRunner extends BaseTestRunner
         $arguments['reportLowUpperBound']                             = $arguments['reportLowUpperBound'] ?? 50;
         $arguments['reportUselessTests']                              = $arguments['reportUselessTests'] ?? true;
         $arguments['reverseList']                                     = $arguments['reverseList'] ?? false;
-        $arguments['executionOrder']                                  = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
         $arguments['resolveDependencies']                             = $arguments['resolveDependencies'] ?? true;
         $arguments['stopOnError']                                     = $arguments['stopOnError'] ?? false;
         $arguments['stopOnFailure']                                   = $arguments['stopOnFailure'] ?? false;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -849,9 +849,9 @@ final class Configuration
             );
         }
 
-        if ($root->hasAttribute('noProgress')) {
-            $result['noProgress'] = $this->getBoolean(
-                (string) $root->getAttribute('noProgress'),
+        if ($root->hasAttribute('noInteraction')) {
+            $result['noInteraction'] = $this->getBoolean(
+                (string) $root->getAttribute('noInteraction'),
                 false
             );
         }

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -849,6 +849,13 @@ final class Configuration
             );
         }
 
+        if ($root->hasAttribute('noProgress')) {
+            $result['noProgress'] = $this->getBoolean(
+                (string) $root->getAttribute('noProgress'),
+                false
+            );
+        }
+
         return $result;
     }
 

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -66,6 +66,11 @@ class TestDoxPrinter extends ResultPrinter
     protected $spinState = 0;
 
     /**
+     * @var bool
+     */
+    protected $showProgress = true;
+
+    /**
      * @param null|resource|string $out
      *
      * @throws \PHPUnit\Framework\Exception
@@ -81,6 +86,11 @@ class TestDoxPrinter extends ResultPrinter
     {
         $this->originalExecutionOrder = $order;
         $this->enableOutputBuffer     = !empty($order);
+    }
+
+    public function setShowProgressAnimation(bool $doShowSpinner): void
+    {
+        $this->showProgress = $doShowSpinner;
     }
 
     public function printResult(TestResult $result): void
@@ -260,18 +270,28 @@ class TestDoxPrinter extends ResultPrinter
 
     protected function showSpinner(): void
     {
+        if (!$this->showProgress) {
+            return;
+        }
+
         if ($this->spinState) {
             $this->undrawSpinner();
         }
+
         $this->spinState++;
         $this->drawSpinner();
     }
 
     protected function hideSpinner(): void
     {
+        if (!$this->showProgress) {
+            return;
+        }
+
         if ($this->spinState) {
             $this->undrawSpinner();
         }
+
         $this->spinState = 0;
     }
 

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -88,9 +88,9 @@ class TestDoxPrinter extends ResultPrinter
         $this->enableOutputBuffer     = !empty($order);
     }
 
-    public function setShowProgressAnimation(bool $doShowSpinner): void
+    public function setShowProgressAnimation(bool $showProgress): void
     {
-        $this->showProgress = $doShowSpinner;
+        $this->showProgress = $showProgress;
     }
 
     public function printResult(TestResult $result): void

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -33,7 +33,7 @@
          timeoutForLargeTests="60"
          verbose="false"
          executionOrder="default"
-         noProgress="true">
+         noInteraction="true">
     <testsuites>
         <testsuite name="My Test Suite">
             <directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">/path/to/files</directory>

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -32,7 +32,8 @@
          timeoutForMediumTests="10"
          timeoutForLargeTests="60"
          verbose="false"
-         executionOrder="default">
+         executionOrder="default"
+         noProgress="true">
     <testsuites>
         <testsuite name="My Test Suite">
             <directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">/path/to/files</directory>

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -34,7 +34,8 @@
          timeoutForLargeTests="60"
          verbose="false"
          executionOrder="default"
-         resolveDependencies="false">
+         resolveDependencies="false"
+         noProgress="true">
          <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
              href="configuration.xml"
              parse="xml"

--- a/tests/_files/configuration_xinclude.xml
+++ b/tests/_files/configuration_xinclude.xml
@@ -35,7 +35,7 @@
          verbose="false"
          executionOrder="default"
          resolveDependencies="false"
-         noProgress="true">
+         noInteraction="true">
          <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
              href="configuration.xml"
              parse="xml"

--- a/tests/end-to-end/loggers/testdox.phpt
+++ b/tests/end-to-end/loggers/testdox.phpt
@@ -7,6 +7,7 @@ $arguments = [
     realpath(__DIR__ . '/../../basic/configuration.basic.xml'),
     '--testdox',
     '--colors=never',
+    '--no-progress',
     realpath(__DIR__ . '/../../unit/Util/TestDox/ColorTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/testdox.phpt
+++ b/tests/end-to-end/loggers/testdox.phpt
@@ -7,7 +7,7 @@ $arguments = [
     realpath(__DIR__ . '/../../basic/configuration.basic.xml'),
     '--testdox',
     '--colors=never',
-    '--no-progress',
+    '--no-interaction',
     realpath(__DIR__ . '/../../unit/Util/TestDox/ColorTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -505,7 +505,7 @@ class ConfigurationTest extends TestCase
                 'executionOrder'                             => TestSuiteSorter::ORDER_DEFAULT,
                 'executionOrderDefects'                      => TestSuiteSorter::ORDER_DEFAULT,
                 'resolveDependencies'                        => false,
-                'noProgress'                                 => true,
+                'noInteraction'                              => true,
             ],
             $this->configuration->getPHPUnitConfiguration()
         );

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -505,6 +505,7 @@ class ConfigurationTest extends TestCase
                 'executionOrder'                             => TestSuiteSorter::ORDER_DEFAULT,
                 'executionOrderDefects'                      => TestSuiteSorter::ORDER_DEFAULT,
                 'resolveDependencies'                        => false,
+                'noProgress'                                 => true,
             ],
             $this->configuration->getPHPUnitConfiguration()
         );


### PR DESCRIPTION
Implements #3513 allowing the user to disable the Testdox progress animation.

#### Changes ####
- add `--no-interaction` command line option
- add `noInteraction` attribute for XML-configuration files
- update configuration unit tests and CLI option tests

Unfortunately I did not manage to get a screenshot.