### PR TITLE
Convert unhandled PHPT exceptions to skipped test result

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -109,13 +109,21 @@ class PhptTestCase implements Test, SelfDescribing
      */
     public function run(TestResult $result = null): TestResult
     {
-        $sections = $this->parse();
-        $code     = $this->render($sections['FILE']);
-
         if ($result === null) {
             $result = new TestResult;
         }
 
+        try {
+            $sections = $this->parse();
+        } catch (Exception $e) {
+            $result->startTest($this);
+            $result->addFailure($this, new SkippedTestError($e->getMessage()), 0);
+            $result->endTest($this, 0);
+
+            return $result;
+        }
+
+        $code     = $this->render($sections['FILE']);
         $xfail    = false;
         $settings = $this->parseIniSection(self::SETTINGS);
 
@@ -383,7 +391,7 @@ class PhptTestCase implements Test, SelfDescribing
             }
 
             if (empty($section)) {
-                throw new Exception('Invalid PHPT file');
+                throw new Exception('Invalid PHPT file: empty section header');
             }
 
             $sections[$section] .= $line;
@@ -403,7 +411,7 @@ class PhptTestCase implements Test, SelfDescribing
         foreach ($unsupportedSections as $section) {
             if (isset($sections[$section])) {
                 throw new Exception(
-                    'PHPUnit does not support this PHPT file'
+                    "PHPUnit does not support PHPT $section sections"
                 );
             }
         }

--- a/tests/_files/phpt-unsupported-section.phpt
+++ b/tests/_files/phpt-unsupported-section.phpt
@@ -1,0 +1,10 @@
+--TEST--
+PHPT runner handles unsupported --SECTION-- gracefully
+--FILE--
+<?php
+echo "Hello world";
+?>
+--GET--
+Gerste, Hopfen und Wasser
+--EXPECT--
+Hello world

--- a/tests/end-to-end/phpt-parsing.phpt
+++ b/tests/end-to-end/phpt-parsing.phpt
@@ -1,0 +1,26 @@
+--TEST--
+PHPT runner supports XFAIL section
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--verbose';
+$_SERVER['argv'][3] = \realpath(__DIR__ . '/../_files/phpt-unsupported-section.phpt');
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+S                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) %stests%e_files%ephpt-unsupported-section.phpt
+PHPUnit does not support PHPT GET sections
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 1, Assertions: 1, Skipped: 1.

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -250,7 +250,27 @@ EOF
         $result = $this->testCase->run();
 
         $this->assertCount(1, $result->skipped());
-        $this->assertSame('Invalid PHPT file', $result->skipped()[0]->thrownException()->getMessage());
+        $skipMessage = $result->skipped()[0]->thrownException()->getMessage();
+        $this->assertSame('Invalid PHPT file', $skipMessage);
+    }
+
+    public function testShouldSkipTestWhenSectionHeaderIsMalformed(): void
+    {
+        $this->setPhpContent(
+            <<<EOF
+----
+--TEST--
+This is not going to work out
+--EXPECT--
+Tears and misery
+EOF
+        );
+
+        $result = $this->testCase->run();
+
+        $this->assertCount(1, $result->skipped());
+        $skipMessage = $result->skipped()[0]->thrownException()->getMessage();
+        $this->assertSame('Invalid PHPT file: empty section header', $skipMessage);
     }
 
     public function testShouldValidateExpectSession(): void

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -208,39 +208,38 @@ EOF
         $this->testCase->run();
     }
 
-    public function testShouldThrowsAnExceptionWhenPhptFileIsEmpty(): void
+    public function testShouldSkipTestWhenPhptFileIsEmpty(): void
     {
         $this->setPhpContent('');
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Invalid PHPT file');
-
-        $this->testCase->run();
+        $result = $this->testCase->run();
+        $this->assertCount(1, $result->skipped());
+        $this->assertSame('Invalid PHPT file', $result->skipped()[0]->thrownException()->getMessage());
     }
 
-    public function testShouldThrowsAnExceptionWhenFileSectionIsMissing(): void
+    public function testShouldSkipTestWhenFileSectionIsMissing(): void
     {
         $this->setPhpContent(
             <<<EOF
 --TEST--
-Something to decribe it
+Something to describe it
 --EXPECT--
 Something
 EOF
         );
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Invalid PHPT file');
+        $result = $this->testCase->run();
 
-        $this->testCase->run();
+        $this->assertCount(1, $result->skipped());
+        $this->assertSame('Invalid PHPT file', $result->skipped()[0]->thrownException()->getMessage());
     }
 
-    public function testShouldThrowsAnExceptionWhenThereIsNoExpecOrExpectifOrExpecregexSectionInPhptFile(): void
+    public function testShouldSkipTestWhenThereIsNoExpecOrExpectifOrExpecregexSectionInPhptFile(): void
     {
         $this->setPhpContent(
             <<<EOF
 --TEST--
-Something to decribe it
+Something to describe it
 --FILE--
 <?php
 echo "Hello world!\n";
@@ -248,10 +247,10 @@ echo "Hello world!\n";
 EOF
         );
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Invalid PHPT file');
+        $result = $this->testCase->run();
 
-        $this->testCase->run();
+        $this->assertCount(1, $result->skipped());
+        $this->assertSame('Invalid PHPT file', $result->skipped()[0]->thrownException()->getMessage());
     }
 
     public function testShouldValidateExpectSession(): void


### PR DESCRIPTION
Fixes #3011 which is very much like #3490

#### Verification ####
You can see the exception handling at work when you manually run the new end-to-end test:

```
phpunit --testdox tests/_files/phpt-unsupported-section.phpt

[...]
PHPUnit\Runner\PhptTestCase
 → tests/_files/phpt-unsupported-section.phpt [0.00 ms]
   │
   │ PHPUnit does not support PHPT GET sections
   │ 
[...]
```

#### Changes ####
- PHPT parsing exceptions now result in a properly skipped test instead of stopping PHPUnit
- update existing `PhptTestCase` unit tests
- add new end-to-end test with unsupported PHPT `--SECTION--`

#### Note ####
The improved exception handling is designed to prevent PHPUnit from crashing out during a run, which works in both the 7.x and 8.x major versions. Version 8 additionally has the improved Testdox and error output which provides much more detailed code locations.
