### PR TITLE
Fixed wrong message in ConstraintTestCase

### DIFF
--- a/tests/unit/Framework/Constraint/ConstraintTestCase.php
+++ b/tests/unit/Framework/Constraint/ConstraintTestCase.php
@@ -36,7 +36,7 @@ abstract class ConstraintTestCase extends TestCase
         $this->assertTrue($reflection->implementsInterface(SelfDescribing::class), \sprintf(
             'Failed to assert that "%s" implements "%s".',
             $className,
-            \Countable::class
+            SelfDescribing::class
         ));
     }
 


### PR DESCRIPTION
The SelfDescribing test was reporting lack of implementation of the
\Countable class not the SelfDescribing class. While not a problem, it
would be at least misleading to contributors seeing the error.

Since this is a TestCase I could not find any tests to update.