### PR TITLE
InvokedAtIndex matcher counting fix

### DIFF
--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -211,10 +211,6 @@ final class Matcher implements MatcherInvocation
             throw new RuntimeException('No method matcher is set');
         }
 
-        if (!$this->invocationMatcher->matches($invocation)) {
-            return false;
-        }
-
         try {
             if (!$this->methodNameMatcher->matches($invocation)) {
                 return false;
@@ -231,7 +227,7 @@ final class Matcher implements MatcherInvocation
             );
         }
 
-        return true;
+        return $this->invocationMatcher->matches($invocation);
     }
 
     /**

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,4 +29,4 @@ Note: this section will change often while `tests/` is being refactored.
   - `basic/`: fast tests covering all basics
     - `configuration.basic.xml`: configuration file tailored for the `basic` suite
   - `end-to-end/`: run PHPUnit as a seperate process and observe its behaviour via console messages and the filesystem
-  - `unit/`: unit tests for individual smallest components and integration tests of common usa cases
+  - `unit/`: unit tests for individual smallest components and integration tests of common use cases

--- a/tests/unit/Framework/MockObject/MatcherTest.php
+++ b/tests/unit/Framework/MockObject/MatcherTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class MatcherTest extends TestCase
+{
+    public function testInvokedAtIndexCountsSpecifiedMethodOnly(): void
+    {
+        // Mock a class with at least two methods.
+        $mock = $this->getMockBuilder(SomeClass::class)
+                     ->getMock();
+
+        // First time the later called method gets invoked, return a predefined result.
+        $mock->expects($this->at(0))
+             ->method('doSomethingElse')
+             ->will($this->returnValue('mocked result'));
+
+        // Invoke unconstrained method
+        $mock->doSomething('a', 'b');
+
+        // Invoke mocked method first time.
+        $this->assertEquals('mocked result', $mock->doSomethingElse('c'));
+    }
+
+    public function testInvokedCountCountsSpecifiedMethodOnly(): void
+    {
+        // Mock a class with at least two methods.
+        $mock = $this->getMockBuilder(SomeClass::class)
+                     ->getMock();
+
+        // Expect the later called method be invoked once.
+        $mock->expects($this->once())
+             ->method('doSomethingElse');
+
+        // Invoke unconstrained method
+        $mock->doSomething('a', 'b');
+
+        // Invoke mocked method once.
+        $mock->doSomethingElse('c');
+    }
+}


### PR DESCRIPTION
The InvokedAtIndex matcher seems to count all method invocations, rather than the specified method only.
@sebastianbergmann Please read the implemented test case to make sure my idea of how this should work is valid.
After I apply my fix the test passes and the other tests remain unchanged.
Basically I just moved the method name check before the invocationMatcher check.