### PR TITLE
Implement using @depends for depending on class

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -38,6 +38,11 @@ final class TestResult implements Countable
     private $passed = [];
 
     /**
+     * @var array<string>
+     */
+    private $passedClasses = [];
+
+    /**
      * @var TestFailure[]
      */
     private $errors = [];
@@ -383,6 +388,10 @@ final class TestResult implements Countable
      */
     public function endTestSuite(TestSuite $suite): void
     {
+        if ($this->wasSuccessful()) {
+            $this->passedClasses[] = $suite->getName();
+        }
+
         foreach ($this->listeners as $listener) {
             $listener->endTestSuite($suite);
         }
@@ -566,6 +575,15 @@ final class TestResult implements Countable
     public function passed(): array
     {
         return $this->passed;
+    }
+
+    /**
+     * Returns the names of the TestSuites that have passed.
+     * This enables @depends-annotations for TestClasName::class
+     */
+    public function passedClasses(): array
+    {
+        return $this->passedClasses;
     }
 
     /**

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -38,11 +38,6 @@ final class TestResult implements Countable
     private $passed = [];
 
     /**
-     * @var array<string>
-     */
-    private $passedClasses = [];
-
-    /**
      * @var TestFailure[]
      */
     private $errors = [];
@@ -183,6 +178,11 @@ final class TestResult implements Countable
      * @var bool
      */
     private $lastTestFailed = false;
+
+    /**
+     * @var array<string>
+     */
+    private $passedClasses = [];
 
     /**
      * @var int
@@ -388,8 +388,8 @@ final class TestResult implements Countable
      */
     public function endTestSuite(TestSuite $suite): void
     {
-        if ($this->wasSuccessful()) {
-            $this->passedClasses[] = $suite->getName();
+        if ($this->wasSuccessful() && !($suite instanceof DataProviderTestSuite)) {
+            $this->passedClasses[$suite->getName()] = true;
         }
 
         foreach ($this->listeners as $listener) {
@@ -583,7 +583,7 @@ final class TestResult implements Countable
      */
     public function passedClasses(): array
     {
-        return $this->passedClasses;
+        return \array_keys($this->passedClasses);
     }
 
     /**

--- a/tests/_files/DependencyOnClassTest.php
+++ b/tests/_files/DependencyOnClassTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class DependencyOnClassTest extends TestCase
+{
+    /**
+     * Guard support for using annotations to depend on a whole successful TestSuite
+     *
+     * @depends DependencySuccessTest::class
+     *
+     * @see https://github.com/sebastianbergmann/phpunit/issues/3519
+     */
+    public function testThatDependsOnASuccessfulClass(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Guard support for using annotations to depend on a whole failing TestSuite
+     *
+     * @depends DependencyFailureTest::class
+     *
+     * @see https://github.com/sebastianbergmann/phpunit/issues/3519
+     */
+    public function testThatDependsOnAFailingClass(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -762,6 +762,29 @@ class TestCaseTest extends TestCase
         $this->assertNull($test->getTestResultObject());
     }
 
+    public function testCanUseDependsToDependOnSuccessfulClass(): void
+    {
+        $result = new TestResult();
+        $suite  = new TestSuite();
+        $suite->addTestSuite(\DependencySuccessTest::class);
+        $suite->addTestSuite(\DependencyFailureTest::class);
+        $suite->addTestSuite(\DependencyOnClassTest::class);
+        $suite->run($result);
+
+        // Confirm only the passing TestSuite::class has passed
+        $this->assertContains(\DependencySuccessTest::class, $result->passedClasses());
+        $this->assertNotContains(\DependencyFailureTest::class, $result->passedClasses());
+
+        // Confirm the test depending on the passing TestSuite::class did run and has passed
+        $this->assertArrayHasKey(\DependencyOnClassTest::class . '::testThatDependsOnASuccessfulClass', $result->passed());
+
+        // Confirm the test depending on the failing TestSuite::class has been warn-skipped
+        $skipped = \array_map(function (TestFailure $t) {
+            return $t->getTestName();
+        }, $result->skipped());
+        $this->assertContains(\DependencyOnClassTest::class . '::testThatDependsOnAFailingClass', $skipped);
+    }
+
     /**
      * @return array<string, array>
      */


### PR DESCRIPTION
Exploring #3519. 

### Use case ###
_As a_ developer of a larger collection of tests
_I want to_ express dependencies on whole `TestCase` classes
_so that_ I don't waste time on maintaining lists of `@depends`

### Example ###
https://github.com/sebastianbergmann/phpunit/blob/131c59e237f1b4cd15c3513ab4a5a919537ac3f6/tests/_files/DependencyOnClassTest.php#L18-L25

### Changes ###
- [x] keep track of passing test suites in `TestResult`, seperate from passing tests
- [x] handle `@depends SomeTest::class` annotation skip/warn in `TestCase` dependency handler
- [ ] support `@depends SomeTest::class` annotation in execution reordering

ping @spriebsch