### PR TITLE
Fix assertObjectHasAttribute - Differentiate between class and object attribute names

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1252,7 +1252,7 @@ abstract class Assert
      */
     public static function assertClassHasAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
@@ -1271,7 +1271,7 @@ abstract class Assert
      */
     public static function assertClassNotHasAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
@@ -1296,7 +1296,7 @@ abstract class Assert
      */
     public static function assertClassHasStaticAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
@@ -1319,7 +1319,7 @@ abstract class Assert
      */
     public static function assertClassNotHasStaticAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
@@ -1346,7 +1346,7 @@ abstract class Assert
      */
     public static function assertObjectHasAttribute(string $attributeName, $object, string $message = ''): void
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidObjectAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
@@ -1371,7 +1371,7 @@ abstract class Assert
      */
     public static function assertObjectNotHasAttribute(string $attributeName, $object, string $message = ''): void
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidObjectAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(1, 'valid attribute name');
         }
 
@@ -2717,7 +2717,7 @@ abstract class Assert
      */
     public static function readAttribute($classOrObject, string $attributeName)
     {
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
@@ -2763,7 +2763,7 @@ abstract class Assert
             throw InvalidArgumentHelper::factory(1, 'class name');
         }
 
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
@@ -2803,7 +2803,7 @@ abstract class Assert
             throw InvalidArgumentHelper::factory(1, 'object');
         }
 
-        if (!self::isValidAttributeName($attributeName)) {
+        if (!self::isValidClassAttributeName($attributeName)) {
             throw InvalidArgumentHelper::factory(2, 'valid attribute name');
         }
 
@@ -2873,7 +2873,12 @@ abstract class Assert
         self::$count = 0;
     }
 
-    private static function isValidAttributeName(string $attributeName): bool
+    private static function isValidObjectAttributeName(string $attributeName): bool
+    {
+        return \preg_match('/[^\x00-\x1f\x7f-\x9f]+/', $attributeName);
+    }
+
+    private static function isValidClassAttributeName(string $attributeName): bool
     {
         return \preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName);
     }

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -968,28 +968,26 @@ XML;
 
     public function testAssertObjectHasAttributeNumericAttribute(): void
     {
-        $object = (object) [
-            '2016' => [
-                'hostCity' => 'Rio',
-                'games'    => 'summer',
-            ],
-            '2018' => [
-                'hostCity' => 'Pyeongchang',
-                'games'    => 'winter',
-            ],
-            '2020' => [
-                'hostCity' => 'Tokyo',
-                'games'    => 'summer',
-            ],
-        ];
+        $object = new \stdClass();
+        $object->{'2020'} = 'Tokyo';
 
-        $this->assertObjectHasAttribute('2016', $object);
-        $this->assertObjectHasAttribute('2018', $object);
         $this->assertObjectHasAttribute('2020', $object);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertObjectHasAttribute('foo', $object);
+        $this->assertObjectHasAttribute('2018', $object);
+    }
+
+    public function testAssertObjectHasAttributeMultiByteAttribute(): void
+    {
+        $object = new \stdClass();
+        $object->{'東京'} = 2020;
+
+        $this->assertObjectHasAttribute('東京', $object);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertObjectHasAttribute('長野', $object);
     }
 
     public function testAssertObjectNotHasAttribute(): void
@@ -1001,6 +999,30 @@ XML;
         $this->expectException(AssertionFailedError::class);
 
         $this->assertObjectNotHasAttribute('name', $o);
+    }
+
+    public function testAssertObjectNotHasAttributeNumericAttribute(): void
+    {
+        $object = new \stdClass();
+        $object->{'2020'} = 'Tokyo';
+
+        $this->assertObjectNotHasAttribute('2018', $object);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertObjectNotHasAttribute('2020', $object);
+    }
+
+    public function testAssertObjectNotHasAttributeMultiByteAttribute(): void
+    {
+        $object = new \stdClass();
+        $object->{'東京'} = 2020;
+
+        $this->assertObjectNotHasAttribute('長野', $object);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertObjectNotHasAttribute('東京', $object);
     }
 
     public function testAssertFinite(): void

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -966,6 +966,32 @@ XML;
         $this->assertObjectHasAttribute('foo', $o);
     }
 
+    public function testAssertObjectHasAttributeNumericAttribute(): void
+    {
+        $object = (object) [
+            '2016' => [
+                'hostCity' => 'Rio',
+                'games'    => 'summer',
+            ],
+            '2018' => [
+                'hostCity' => 'Pyeongchang',
+                'games'    => 'winter',
+            ],
+            '2020' => [
+                'hostCity' => 'Tokyo',
+                'games'    => 'summer',
+            ],
+        ];
+
+        $this->assertObjectHasAttribute('2016', $object);
+        $this->assertObjectHasAttribute('2018', $object);
+        $this->assertObjectHasAttribute('2020', $object);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertObjectHasAttribute('foo', $object);
+    }
+
     public function testAssertObjectNotHasAttribute(): void
     {
         $o = new \Author('Terry Pratchett');

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -968,7 +968,7 @@ XML;
 
     public function testAssertObjectHasAttributeNumericAttribute(): void
     {
-        $object = new \stdClass();
+        $object           = new \stdClass();
         $object->{'2020'} = 'Tokyo';
 
         $this->assertObjectHasAttribute('2020', $object);
@@ -980,7 +980,7 @@ XML;
 
     public function testAssertObjectHasAttributeMultiByteAttribute(): void
     {
-        $object = new \stdClass();
+        $object         = new \stdClass();
         $object->{'東京'} = 2020;
 
         $this->assertObjectHasAttribute('東京', $object);
@@ -1003,7 +1003,7 @@ XML;
 
     public function testAssertObjectNotHasAttributeNumericAttribute(): void
     {
-        $object = new \stdClass();
+        $object           = new \stdClass();
         $object->{'2020'} = 'Tokyo';
 
         $this->assertObjectNotHasAttribute('2018', $object);
@@ -1015,7 +1015,7 @@ XML;
 
     public function testAssertObjectNotHasAttributeMultiByteAttribute(): void
     {
-        $object = new \stdClass();
+        $object         = new \stdClass();
         $object->{'東京'} = 2020;
 
         $this->assertObjectNotHasAttribute('長野', $object);


### PR DESCRIPTION
```Assert::assertObjectHasAttribute()``` does not handle all possible valid attribute names.

The assertion first calls ```Assert::isValidAttributeName()``` which checks that the first character of the property name is not a number, among other characters. But this is incorrect.

PHP does not allow you to declare _class_ attributes in your PHP code that start with a number, for instance, but PHP does not prevent you from having an **object** that has attributes that start with a number.

For example, consider the following object that has a property set in this manner:
```php
public function testAssertObjectHasAttributeNumericAttributeSetObjectAttribute(): void
{
    // Given
    $object           = new \stdClass();
    $object->{'2020'} = 'Tokyo';

    // Then
    $this->assertObjectHasAttribute('2020', $object);
}
```

If you do a ```print_r($object)``` you will see this:
```
stdClass Object
(
    [2020] => Tokyo
)
```
The object clearly has the property '2020'. However, PHPUnit fails like this:

> PHPUnit\Framework\Exception: Argument #1 (No Value) of PHPUnit\Framework\Assert::assertObjectHasAttribute() must be a valid attribute name

Now this may seem like a contrived example, but this is actually very common. Consider these scenarios.

**Decoding JSON with numeric keys**
```php
public function testAssertObjectHasAttributeNumericAttributeJsonConversion(): void
{
    // Given
    $json = '{
        "2016": {
          "hostCity": "Rio",
          "games": "summer"
        },
        "2018": {
           "hostCity": "Pyeongchang",
           "games": "winter"
        },
        "2020": {
          "hostCity": "Tokyo",
          "games": "summer"
        }
    }';

    // When
    $object = json_decode($json);

    // Then
    $this->assertObjectHasAttribute('2016', $object);
    $this->assertObjectHasAttribute('2018', $object);
    $this->assertObjectHasAttribute('2020', $object);
}
```

**Array to object conversion**
```php
public function testAssertObjectHasAttributeNumericAttributeArrayConversion(): void
{
    // Given
    $array = [
        '2016' => [
            'hostCity' => 'Rio',
            'games'    => 'summer',
        ],
        '2018' => [
            'hostCity' => 'Pyeongchang',
            'games'    => 'winter',
        ],
        '2020' => [
            'hostCity' => 'Tokyo',
            'games'    => 'summer',
        ],
    ];

    // When
    $object = (object) $array;

    // Then
    $this->assertObjectHasAttribute('2016', $object);
    $this->assertObjectHasAttribute('2018', $object);
    $this->assertObjectHasAttribute('2020', $object);
}
```

Class with a custom __set defined
```php
class SomeClass
{
    public function __set($key, $value): void
    {
        $this->{$key} = $value;
    }
}
```
```php
public function testAssertObjectHasAttributeCustomSet(): void
{
    // Given
    $object = new SomeClass();

    // When
    $object->{'2020'} = 'Tokyo';

    // Then
    $this->assertObjectHasAttribute('2020', $object);
}
```

PHPUnit fails for all of these scenarios, even though they are valid objects with valid attributes.
> PHPUnit\Framework\Exception: Argument #1 (No Value) of PHPUnit\Framework\Assert::assertObjectHasAttribute() must be a valid attribute name

**Fix**
To fix this, the change I've introduced is to differentiate between class and object attribute names. Objects attributes have more flexibility in names than class attributes or class static attributes.

