### PR TITLE
Use TestHook Interface consistently

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -807,7 +807,7 @@ final class TestRunner extends BaseTestRunner
         return $this->loader;
     }
 
-    public function addExtension(TestHook $extension): void
+    public function addExtension(Hook $extension): void
     {
         $this->extensions[] = $extension;
     }
@@ -1083,7 +1083,7 @@ final class TestRunner extends BaseTestRunner
                     );
                 }
 
-                \assert($extensionObject instanceof TestHook);
+                \assert($extensionObject instanceof Hook);
 
                 $this->addExtension($extensionObject);
             }


### PR DESCRIPTION
Remove Hook interface and use TestHook for it
When using the AfterTestHook you had to explicitly implement also the TestHookInterface because of the 
`assert` check in TestRunner.php:1085