### PR TITLE
Add getter support for dependencyInput

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -968,6 +968,11 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->dependencyInput = $dependencyInput;
     }
 
+    public function getDependencyInput(): array
+    {
+        return $this->dependencyInput;
+    }
+
     public function setBeStrictAboutChangesToGlobalState(?bool $beStrictAboutChangesToGlobalState): void
     {
         $this->beStrictAboutChangesToGlobalState = $beStrictAboutChangesToGlobalState;


### PR DESCRIPTION
This is needed to access `dependencyInput` as it became private in 7.x and above. 

This variable is used because we have a custom implementation of `runTest` as we auto generate a dynamic testsuite for our framework. 

Same reason as this PR a while ago: https://github.com/sebastianbergmann/phpunit/pull/2230