### PR TITLE
Flush all remaining results from buffered Testdox printer

### DIFF
--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -252,7 +252,7 @@ class TestDoxPrinter extends ResultPrinter
             $this->writeTestResult($prevResult, $this->testResults[$this->testFlushIndex++]);
         } else {
             do {
-                $flushed = $forceFlush;
+                $flushed = false;
 
                 if (!$forceFlush && isset($this->originalExecutionOrder[$this->testFlushIndex])) {
                     $result  = $this->getTestResultByName($this->originalExecutionOrder[$this->testFlushIndex]);

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -179,7 +179,7 @@ class TestDoxPrinter extends ResultPrinter
 
     public function flush(): void
     {
-        $this->flushOutputBuffer();
+        $this->flushOutputBuffer(true);
     }
 
     /**
@@ -232,7 +232,7 @@ class TestDoxPrinter extends ResultPrinter
         return false;
     }
 
-    protected function flushOutputBuffer(): void
+    protected function flushOutputBuffer(bool $forceFlush = false): void
     {
         if ($this->testFlushIndex === $this->testIndex) {
             return;
@@ -252,9 +252,9 @@ class TestDoxPrinter extends ResultPrinter
             $this->writeTestResult($prevResult, $this->testResults[$this->testFlushIndex++]);
         } else {
             do {
-                $flushed = false;
+                $flushed = $forceFlush;
 
-                if (isset($this->originalExecutionOrder[$this->testFlushIndex])) {
+                if (!$forceFlush && isset($this->originalExecutionOrder[$this->testFlushIndex])) {
                     $result  = $this->getTestResultByName($this->originalExecutionOrder[$this->testFlushIndex]);
                 } else {
                     // This test(name) cannot found in original execution order,

--- a/tests/end-to-end/loggers/testdox-force-flush.phpt
+++ b/tests/end-to-end/loggers/testdox-force-flush.phpt
@@ -1,0 +1,25 @@
+--TEST--
+phpunit --testdox --colors=never -c tests/basic/configuration.basic.xml --filter Success
+--FILE--
+<?php declare(strict_types=1);
+$arguments = [
+    '-c',
+    realpath(__DIR__ . '/../../basic/configuration.basic.xml'),
+    '--testdox',
+    '--colors=never',
+    '--filter', 'Success'
+];
+\array_splice($_SERVER['argv'], 1, count($arguments), $arguments);
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Test result status with and without message
+ ✔ Success
+ ✔ Success with message
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)


### PR DESCRIPTION
When running with `--filter` the buffering Testdox printer would omit results it couldn't put in the correct order. Fixed by flushing any remaining results in the buffer at the end of the run.

The target for the change is `master` as it relies on a previous improvement to the output flusher in #3545 

Restoring the old behaviour shows the results disappearing:

![image](https://user-images.githubusercontent.com/26651359/54310431-a4181080-45d2-11e9-9646-ccfd5198cf52.png)

Fixes #3560 