### PR TITLE
Flush all remaining results from buffered Testdox printer

### DIFF
--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -169,7 +169,7 @@ class TestDoxPrinter extends ResultPrinter
 
     public function flush(): void
     {
-        $this->flushOutputBuffer();
+        $this->flushOutputBuffer(true);
     }
 
     /**
@@ -222,7 +222,7 @@ class TestDoxPrinter extends ResultPrinter
         return false;
     }
 
-    protected function flushOutputBuffer(): void
+    protected function flushOutputBuffer(bool $forceFlush = false): void
     {
         if ($this->testFlushIndex === $this->testIndex) {
             return;
@@ -243,7 +243,14 @@ class TestDoxPrinter extends ResultPrinter
         } else {
             do {
                 $flushed = false;
-                $result  = $this->getTestResultByName($this->originalExecutionOrder[$this->testFlushIndex]);
+
+                if (!$forceFlush && isset($this->originalExecutionOrder[$this->testFlushIndex])) {
+                    $result  = $this->getTestResultByName($this->originalExecutionOrder[$this->testFlushIndex]);
+                } else {
+                    // This test(name) cannot found in original execution order,
+                    // flush result to output stream right away
+                    $result = $this->testResults[$this->testFlushIndex];
+                }
 
                 if (!empty($result)) {
                     $this->hideSpinner();

--- a/tests/end-to-end/loggers/testdox-force-flush.phpt
+++ b/tests/end-to-end/loggers/testdox-force-flush.phpt
@@ -1,0 +1,25 @@
+--TEST--
+phpunit --testdox --colors=never -c tests/basic/configuration.basic.xml --filter Success
+--FILE--
+<?php declare(strict_types=1);
+$arguments = [
+    '-c',
+    realpath(__DIR__ . '/../../basic/configuration.basic.xml'),
+    '--testdox',
+    '--colors=never',
+    '--filter', 'Success'
+];
+\array_splice($_SERVER['argv'], 1, count($arguments), $arguments);
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Test result status with and without message
+ ✔ Success
+ ✔ Success with message
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)


### PR DESCRIPTION
This is the `8.0` implementation of #3561 

The test could be cherry picked. I added the out-of-order flushing mechanism created for `tearDownAfterClass` which the forced flush is built on.

Fixes #3560 