### PR TITLE
Add 'Prophecy' namespace to the scoping whitelist

### DIFF
--- a/build/scoper.inc.php
+++ b/build/scoper.inc.php
@@ -13,6 +13,7 @@ $whitelistClasses = [
     'SebastianBergmann\CodeCoverage\*',
     'PharIo\*',
     'PHP_Token*',
+    'Prophecy\*',
 ];
 
 return [


### PR DESCRIPTION
In oder to setup or check test doubles with Prophecy it has to be
part of the public API of PHPUnit, even it not provided by PHPUnit
itself.

Issues:
- #3578 - Scoped PHAR Prophecy issue