### PR TITLE
Fix class name in doc block

### DIFF
--- a/src/Framework/MockObject/MockObject.php
+++ b/src/Framework/MockObject/MockObject.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMo
 use PHPUnit\Framework\MockObject\Matcher\Invocation;
 
 /**
- * @method InvocationMocker method($constraint)
+ * @method BuilderInvocationMocker method($constraint)
  */
 interface MockObject /*extends Verifiable*/
 {


### PR DESCRIPTION
When putting the annotation back we forgot to use the aliased name. This fixes it, making static analysers and IDEs work as expected.

More info: 31df2e805fe0cf184bdfcb528a696dc1daae40c3