### PR TITLE
Mocking an interface that extends another interface forgets to mock its own methods

### DIFF
--- a/tests/_files/ExceptionWithThrowable.php
+++ b/tests/_files/ExceptionWithThrowable.php
@@ -9,4 +9,5 @@
  */
 interface ExceptionWithThrowable extends \Throwable
 {
+    public function getAdditionalInformation();
 }


### PR DESCRIPTION
Fixes #3596.