### PR TITLE
Add support for test suite chunking directly in phpunit.

### DIFF
--- a/src/Runner/Filter/ChunkIterator.php
+++ b/src/Runner/Filter/ChunkIterator.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\WarningTestCase;
+use PHPUnit\Util\RegularExpression;
+use RecursiveFilterIterator;
+use RecursiveIterator;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ChunkIterator extends RecursiveFilterIterator
+{
+    /**
+     * @var int
+     */
+    private $chunk;
+
+    /**
+     * @var int
+     */
+    private $numChunks;
+
+    /**
+     * @var Test[][]
+     */
+    private $chunks;
+
+    /**
+     * @throws \Exception
+     */
+    public function __construct(RecursiveIterator $iterator, array $args)
+    {
+        parent::__construct($iterator);
+
+        $this->chunk = $args['chunk'];
+        $this->numChunks = $args['numChunks'];
+
+        if ($this->chunk > $this->numChunks) {
+            throw new InvalidArgumentException(sprintf('You only configured %s chunks but passed chunk %s',
+                $this->numChunks,
+                $this->chunk
+            ));
+        }
+
+        $tests = iterator_to_array($iterator);
+        $numTests = count($tests);
+        $numTestsPerChunk = (int) round($numTests / $this->numChunks);
+
+        $this->chunks = array_chunk(iterator_to_array($iterator), $numTestsPerChunk);
+    }
+
+    public function accept(): bool
+    {
+        $chunkKey = $this->chunk - 1;
+
+        if (!isset($this->chunks[$chunkKey])) {
+            return false;
+        }
+
+        $chunk = $this->chunks[$chunkKey];
+
+        $test = $this->getInnerIterator()->current();
+
+        return in_array($test, $chunk, true);
+    }
+
+}

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -145,6 +145,8 @@ class Command
         'version'                   => null,
         'whitelist='                => null,
         'dump-xdebug-filter='       => null,
+        'chunk'                     => null,
+        'num-chunks'                => null,
     ];
 
     /**
@@ -762,6 +764,16 @@ class Command
 
                 case '--dump-xdebug-filter':
                     $this->arguments['xdebugFilterFile'] = $option[1];
+
+                    break;
+
+                case '--chunk':
+                    $this->arguments['chunk'] = (int) $option[1];
+
+                    break;
+
+                case '--num-chunks':
+                    $this->arguments['num-chunks'] = (int) $option[1];
 
                     break;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -1248,6 +1248,16 @@ final class TestRunner extends BaseTestRunner
             );
         }
 
+        if (isset($arguments['chunk']) && $arguments['chunk']) {
+            $filterFactory->addFilter(
+                new ReflectionClass(ChunkIterator::class),
+                [
+                    'chunk' => $arguments['chunk'],
+                    'numChunks' => $arguments['num-chunk'] ?? 2,
+                ]
+            );
+        }
+
         $suite->injectFilter($filterFactory);
     }
 

--- a/tests/unit/Runner/Filter/ChunkIteratorTest.php
+++ b/tests/unit/Runner/Filter/ChunkIteratorTest.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+
+class ChunkIteratorTest extends TestCase
+{
+    public function testChunkOne(): void
+    {
+        $tests = $this->getTestsChunk(1, 2);
+
+        $this->assertTrue(in_array(TestCase1Test::class.'::testTest', $tests));
+        $this->assertTrue(in_array(TestCase2Test::class.'::testTest', $tests));
+        $this->assertTrue(in_array(TestCase3Test::class.'::testTest', $tests));
+
+        $this->assertFalse(in_array(TestCase4Test::class.'::testTest', $tests));
+        $this->assertFalse(in_array(TestCase5Test::class.'::testTest', $tests));
+    }
+
+    public function testChunkTwo(): void
+    {
+        $tests = $this->getTestsChunk(2, 2);
+
+        $this->assertFalse(in_array(TestCase1Test::class.'::testTest', $tests));
+        $this->assertFalse(in_array(TestCase2Test::class.'::testTest', $tests));
+        $this->assertFalse(in_array(TestCase3Test::class.'::testTest', $tests));
+
+        $this->assertTrue(in_array(TestCase4Test::class.'::testTest', $tests));
+        $this->assertTrue(in_array(TestCase5Test::class.'::testTest', $tests));
+    }
+
+    public function testInvalidChunk(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You only configured 2 chunks but passed chunk 3');
+
+        $tests = $this->getTestsChunk(3, 2);
+    }
+
+    /**
+     * @return TestCase[]
+     */
+    private function getTestsChunk(int $chunk, int $numChunks): array
+    {
+        $suite = new TestSuite;
+        $suite->addTest(new TestCase1Test('testTest'));
+        $suite->addTest(new TestCase2Test('testTest'));
+        $suite->addTest(new TestCase3Test('testTest'));
+        $suite->addTest(new TestCase4Test('testTest'));
+        $suite->addTest(new TestCase5Test('testTest'));
+
+        $iterator = new ChunkIterator($suite->getIterator(), [
+            'chunk' => $chunk,
+            'numChunks' => $numChunks,
+        ]);
+
+        $iterator->rewind();
+
+        $tests = [];
+
+        foreach ($iterator as $test) {
+            $tests[] = get_class($test).'::'.$test->getName();
+        }
+
+        return $tests;
+    }
+}
+
+class TestCase1Test extends TestCase
+{
+    public function testTest() : void
+    {
+    }
+}
+
+class TestCase2Test extends TestCase
+{
+    public function testTest() : void
+    {
+    }
+}
+
+class TestCase3Test extends TestCase
+{
+    public function testTest() : void
+    {
+    }
+}
+
+class TestCase4Test extends TestCase
+{
+    public function testTest() : void
+    {
+    }
+}
+
+class TestCase5Test extends TestCase
+{
+    public function testTest() : void
+    {
+    }
+}


### PR DESCRIPTION
At my job we had 1 hour of functional tests. We built https://github.com/jwage/phpchunkit on top of phpunit to get the chunking functionality and with this we were able to achieve test builds in ~3 minutes. I thought it might be useful to have this built in to phpunit. If you use travis, circle ci, etc. it becomes trivial to configure multiple jobs, one for each chunk.

Before I continue work on this I wanted to know if something like this would be accepted? I am new to the internals of phpunit so I am not 100% sure if I even implemented this functionality the "correct" way.

Example, run your tests in two separate chunks across two different servers/processes

**server1**

```console
$ phpunit --chunk=1 --num-chunks=2 --group=functional
```

**server2**

```console
$ phpunit --chunk=2 --num-chunks=2 --group=functional
```

Thoughts?