### PR TITLE
Clean up ErrorHandler

### DIFF
--- a/src/Framework/Error/Deprecated.php
+++ b/src/Framework/Error/Deprecated.php
@@ -14,5 +14,4 @@ namespace PHPUnit\Framework\Error;
  */
 final class Deprecated extends Error
 {
-    public static $enabled = true;
 }

--- a/src/Framework/Error/Error.php
+++ b/src/Framework/Error/Error.php
@@ -16,11 +16,20 @@ use PHPUnit\Framework\Exception;
  */
 class Error extends Exception
 {
-    public function __construct(string $message, int $code, string $file, int $line, \Exception $previous = null)
+
+    private $severity;
+
+    public function __construct(string $message, int $code, int $severity, string $file, int $line, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
-
+        $this->severity = $severity;
         $this->file = $file;
         $this->line = $line;
     }
+
+    public function getSeverity() {
+        return $this->severity;
+    }
+
+
 }

--- a/src/Framework/Error/Notice.php
+++ b/src/Framework/Error/Notice.php
@@ -14,5 +14,4 @@ namespace PHPUnit\Framework\Error;
  */
 final class Notice extends Error
 {
-    public static $enabled = true;
 }

--- a/src/Framework/Error/Warning.php
+++ b/src/Framework/Error/Warning.php
@@ -14,5 +14,4 @@ namespace PHPUnit\Framework\Error;
  */
 final class Warning extends Error
 {
-    public static $enabled = true;
 }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\MockObject\Stub\ReturnStub;
 use PHPUnit\Framework\MockObject\Stub\ReturnValueMap as ReturnValueMapStub;
 use PHPUnit\Runner\BaseTestRunner;
 use PHPUnit\Runner\PhptTestCase;
+use PHPUnit\Util\ErrorHandler;
 use PHPUnit\Util\GlobalState;
 use PHPUnit\Util\PHP\AbstractPhpProcess;
 use PHPUnit\Util\Test as TestUtil;
@@ -2294,5 +2295,25 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         }
 
         return TestUtil::isTestMethod($method);
+    }
+
+    protected function convertErrorsToExceptions(bool $convert = true): void
+    {
+        $this->setUseErrorHandler($convert);
+    }
+
+    protected function convertDeprecationsToExceptions(bool $convert = true) : void
+    {
+        ErrorHandler::getInstance()->setConvertDeprecated($convert);
+    }
+
+    protected function convertNoticesToExceptions(bool $convert = true) : void
+    {
+        ErrorHandler::getInstance()->setConvertNotice($convert);
+    }
+
+    protected function convertWarningsToExceptions(bool $convert = true) : void
+    {
+        ErrorHandler::getInstance()->setConvertWarning($convert);
     }
 }

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -621,7 +621,7 @@ final class TestResult implements Countable
 
         if ($this->convertErrorsToExceptions) {
             $oldErrorHandler = \set_error_handler(
-                [ErrorHandler::class, 'handleError'],
+                [ErrorHandler::getInstance(), 'handleError'],
                 \E_ALL | \E_STRICT
             );
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -9,9 +9,6 @@
  */
 namespace PHPUnit\TextUI;
 
-use PHPUnit\Framework\Error\Deprecated;
-use PHPUnit\Framework\Error\Notice;
-use PHPUnit\Framework\Error\Warning;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +33,7 @@ use PHPUnit\Runner\TestSuiteLoader;
 use PHPUnit\Runner\TestSuiteSorter;
 use PHPUnit\Runner\Version;
 use PHPUnit\Util\Configuration;
+use PHPUnit\Util\ErrorHandler;
 use PHPUnit\Util\Filesystem;
 use PHPUnit\Util\Log\JUnit;
 use PHPUnit\Util\Log\TeamCity;
@@ -219,15 +217,15 @@ final class TestRunner extends BaseTestRunner
         }
 
         if (!$arguments['convertDeprecationsToExceptions']) {
-            Deprecated::$enabled = false;
+            ErrorHandler::getInstance()->setConvertDeprecated(true);
         }
 
         if (!$arguments['convertNoticesToExceptions']) {
-            Notice::$enabled = false;
+            ErrorHandler::getInstance()->setConvertNotice(true);
         }
 
         if (!$arguments['convertWarningsToExceptions']) {
-            Warning::$enabled = false;
+            ErrorHandler::getInstance()->setConvertWarning(true);
         }
 
         if ($arguments['stopOnError']) {

--- a/tests/unit/Framework/TestFailureTest.php
+++ b/tests/unit/Framework/TestFailureTest.php
@@ -76,7 +76,7 @@ final class TestFailureTest extends TestCase
 
     public function testExceptionToStringForFrameworkError(): void
     {
-        $exception = new Error('message', 0, 'file', 1);
+        $exception = new Error('message', 0, E_WARNING,'file', 1);
 
         $this->assertEquals("message\n", TestFailure::exceptionToString($exception));
     }


### PR DESCRIPTION
cleans up error handler as requested in #3503

`TestCase` was extended to controll behavior of error handler
```
$this->convertErrorsToExceptions(false);
$this->convertDeprecationsToExceptions(false);
$this->convertNoticesToExceptions(false);
$this->convertWarningsToExceptions(false);
```