### PR TITLE
Use path of configuration or executable to pin result cache in place

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -188,12 +188,16 @@ class TestRunner extends BaseTestRunner
         }
 
         if ($arguments['cacheResult']) {
-            if (isset($arguments['cacheResultFile'])) {
-                $cache = new TestResultCache($arguments['cacheResultFile']);
-            } else {
-                $cache = new TestResultCache;
+            if (!isset($arguments['cacheResultFile'])) {
+                if ($arguments['configuration'] instanceof Configuration) {
+                    $cacheLocation = $arguments['configuration']->getFilename();
+                } else {
+                    $cacheLocation = $_SERVER['PHP_SELF'];
+                }
+                $arguments['cacheResultFile'] = \dirname(\realpath($cacheLocation));
             }
 
+            $cache              = new TestResultCache($arguments['cacheResultFile']);
             $this->extensions[] = new ResultCacheExtension($cache);
         }
 

--- a/src/Util/TestResultCache.php
+++ b/src/Util/TestResultCache.php
@@ -64,9 +64,14 @@ class TestResultCache implements \Serializable, TestResultCacheInterface
      */
     private $times = [];
 
-    public function __construct($filename = null)
+    public function __construct($filepath = null)
     {
-        $this->cacheFilename = $filename ?? $_ENV['PHPUNIT_RESULT_CACHE'] ?? self::DEFAULT_RESULT_CACHE_FILENAME;
+        if ($filepath !== null && \is_dir($filepath)) {
+            // cache path provided, use default cache filename in that location
+            $filepath = $filepath . \DIRECTORY_SEPARATOR . self::DEFAULT_RESULT_CACHE_FILENAME;
+        }
+
+        $this->cacheFilename = $filepath ?? $_ENV['PHPUNIT_RESULT_CACHE'] ?? self::DEFAULT_RESULT_CACHE_FILENAME;
     }
 
     public function persist(): void


### PR DESCRIPTION
Implements a nicer way of result cache file placement.

Fixes #3587 