### PR TITLE
Fix: Remove unused field

### DIFF
--- a/src/Framework/IncompleteTestCase.php
+++ b/src/Framework/IncompleteTestCase.php
@@ -39,11 +39,6 @@ final class IncompleteTestCase extends TestCase
      */
     private $message = '';
 
-    /**
-     * @var bool
-     */
-    private $useOutputBuffering = false;
-
     public function __construct(string $className, string $methodName, string $message = '')
     {
         parent::__construct($className . '::' . $methodName);


### PR DESCRIPTION
This PR

* [x] removes an apparently unused field