### PR TITLE
Handled the empty @depends on tests

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1891,7 +1891,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->result->addError(
             $this,
             new SkippedTestError(
-                \sprintf('This test has dependency declared but no method specified.')
+                \sprintf('This method is invalid at depends annotation.')
             ),
             0
         );

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1880,7 +1880,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         return true;
     }
 
-    private function markSkippedForNotSpecifyingDependency()
+    private function markSkippedForNotSpecifyingDependency(): void
     {
         $this->status = BaseTestRunner::STATUS_SKIPPED;
 
@@ -1889,9 +1889,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->result->addError(
             $this,
             new SkippedTestError(
-                \sprintf(
-                    'This test has no dependency specified.'
-                )
+                \sprintf('This test has no dependency specified.')
             ),
             0
         );

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1814,6 +1814,8 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
 
                 if (empty($dependency)) {
                     $this->markSkippedForNotSpecifyingDependency();
+
+                    return false;
                 }
 
                 if (\strpos($dependency, 'clone ') === 0) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1812,6 +1812,10 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
                 $deepClone    = false;
                 $shallowClone = false;
 
+                if (empty($dependency)) {
+                    $this->markSkippedForNotSpecifyingDependency();
+                }
+
                 if (\strpos($dependency, 'clone ') === 0) {
                     $deepClone  = true;
                     $dependency = \substr($dependency, \strlen('clone '));
@@ -1874,6 +1878,25 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         }
 
         return true;
+    }
+
+    private function markSkippedForNotSpecifyingDependency()
+    {
+        $this->status = BaseTestRunner::STATUS_SKIPPED;
+
+        $this->result->startTest($this);
+
+        $this->result->addError(
+            $this,
+            new SkippedTestError(
+                \sprintf(
+                    'This test has no dependency specified.'
+                )
+            ),
+            0
+        );
+
+        $this->result->endTest($this, 0);
     }
 
     private function markSkippedForMissingDependency(string $dependency): void

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1891,7 +1891,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->result->addError(
             $this,
             new SkippedTestError(
-                \sprintf('This test has no dependency specified.')
+                \sprintf('This test has dependency declared but no method specified.')
             ),
             0
         );

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1891,7 +1891,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
         $this->result->addError(
             $this,
             new SkippedTestError(
-                \sprintf('This method is invalid at depends annotation.')
+                \sprintf('This method has an invalid @depends annotation.')
             ),
             0
         );

--- a/tests/_files/DependencyFailureTest.php
+++ b/tests/_files/DependencyFailureTest.php
@@ -52,4 +52,12 @@ class DependencyFailureTest extends TestCase
     {
         $this->assertTrue(true);
     }
+
+    /**
+     * @depends
+     */
+    public function testHandlesDependsAnnotationWithNoMethodSpecified(): void
+    {
+        $this->assertTrue(true);
+    }
 }

--- a/tests/end-to-end/execution-order/dependencies-isolation.phpt
+++ b/tests/end-to-end/execution-order/dependencies-isolation.phpt
@@ -49,7 +49,7 @@ This test depends on "DependencyFailureTest::testTwo" to pass.
 This test depends on "DependencyFailureTest::testOne" to pass.
 
 4) DependencyFailureTest::testHandlesDependsAnnotationWithNoMethodSpecified
-This test has dependency declared but no method specified.
+This method is invalid at depends annotation.
 
 FAILURES!
 Tests: 9, Assertions: 4, Failures: 1, Warnings: 1, Skipped: 4.

--- a/tests/end-to-end/execution-order/dependencies-isolation.phpt
+++ b/tests/end-to-end/execution-order/dependencies-isolation.phpt
@@ -49,7 +49,7 @@ This test depends on "DependencyFailureTest::testTwo" to pass.
 This test depends on "DependencyFailureTest::testOne" to pass.
 
 4) DependencyFailureTest::testHandlesDependsAnnotationWithNoMethodSpecified
-This method is invalid at depends annotation.
+This method has an invalid @depends annotation.
 
 FAILURES!
 Tests: 9, Assertions: 4, Failures: 1, Warnings: 1, Skipped: 4.

--- a/tests/end-to-end/execution-order/dependencies-isolation.phpt
+++ b/tests/end-to-end/execution-order/dependencies-isolation.phpt
@@ -18,7 +18,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime:       %s
 
-...FSSSW                                                            8 / 8 (100%)
+...FSSSWS                                                           9 / 9 (100%)
 
 Time: %s, Memory: %s
 
@@ -37,7 +37,7 @@ There was 1 failure:
 
 --
 
-There were 3 skipped tests:
+There were 4 skipped tests:
 
 1) DependencyFailureTest::testTwo
 This test depends on "DependencyFailureTest::testOne" to pass.
@@ -48,5 +48,8 @@ This test depends on "DependencyFailureTest::testTwo" to pass.
 3) DependencyFailureTest::testFour
 This test depends on "DependencyFailureTest::testOne" to pass.
 
+4) DependencyFailureTest::testHandlesDependsAnnotationWithNoMethodSpecified
+This test has no dependency specified.
+
 FAILURES!
-Tests: 8, Assertions: 4, Failures: 1, Warnings: 1, Skipped: 3.
+Tests: 9, Assertions: 4, Failures: 1, Warnings: 1, Skipped: 4.

--- a/tests/end-to-end/execution-order/dependencies-isolation.phpt
+++ b/tests/end-to-end/execution-order/dependencies-isolation.phpt
@@ -49,7 +49,7 @@ This test depends on "DependencyFailureTest::testTwo" to pass.
 This test depends on "DependencyFailureTest::testOne" to pass.
 
 4) DependencyFailureTest::testHandlesDependsAnnotationWithNoMethodSpecified
-This test has no dependency specified.
+This test has dependency declared but no method specified.
 
 FAILURES!
 Tests: 9, Assertions: 4, Failures: 1, Warnings: 1, Skipped: 4.


### PR DESCRIPTION
Added the condition to check if the method in dependency is null and they just specified '@depends' without anything than the test should just skip it and mention that there is no method specified