### PR TITLE
Fix: Remove unnecessary default value assignment

### DIFF
--- a/src/Framework/IncompleteTestCase.php
+++ b/src/Framework/IncompleteTestCase.php
@@ -37,7 +37,7 @@ final class IncompleteTestCase extends TestCase
     /**
      * @var string
      */
-    private $message = '';
+    private $message;
 
     public function __construct(string $className, string $methodName, string $message = '')
     {

--- a/src/Framework/SkippedTestCase.php
+++ b/src/Framework/SkippedTestCase.php
@@ -37,7 +37,7 @@ final class SkippedTestCase extends TestCase
     /**
      * @var string
      */
-    private $message = '';
+    private $message;
 
     public function __construct(string $className, string $methodName, string $message = '')
     {


### PR DESCRIPTION
This PR

* [x] removes unnecessary default value assignments

Follows #3646 and #3647.