### PR TITLE
Make return type of TestCase::getName non-nullable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -131,7 +131,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @var string
      */
-    private $name;
+    private $name = '';
 
     /**
      * @var string[]
@@ -477,7 +477,7 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
     /**
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
-    public function getName(bool $withDataSet = true): ?string
+    public function getName(bool $withDataSet = true): string
     {
         if ($withDataSet) {
             return $this->name . $this->getDataSetAsString(false);


### PR DESCRIPTION
Many places in the code rely on the return type not being null.
So now this is ensured to actually never be null.