### PR TITLE
Fix: Test name will not be null

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1169,9 +1169,9 @@ abstract class TestCase extends Assert implements Test, SelfDescribing
      */
     protected function runTest()
     {
-        if ($this->name === null) {
+        if (\trim($this->name) === '') {
             throw new Exception(
-                'PHPUnit\Framework\TestCase::$name must not be null.'
+                'PHPUnit\Framework\TestCase::$name must be a non-blank string.'
             );
         }
 

--- a/tests/_files/TestWithDifferentNames.php
+++ b/tests/_files/TestWithDifferentNames.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+final class TestWithDifferentNames extends TestCase
+{
+    public function testWithName(): void
+    {
+    }
+}

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -970,6 +970,44 @@ final class TestCaseTest extends TestCase
         $this->assertTrue($test->isSmall());
     }
 
+    public function testGetNameReturnsMethodName(): void
+    {
+        $methodName = 'testWithName';
+
+        $testCase = new \TestWithDifferentNames($methodName);
+
+        $this->assertSame($methodName, $testCase->getName());
+    }
+
+    public function testGetNameReturnsEmptyStringAsDefault(): void
+    {
+        $testCase = new \TestWithDifferentNames();
+
+        $this->assertSame('', $testCase->getName());
+    }
+
+    /**
+     * @dataProvider providerInvalidName
+     */
+    public function testRunBareThrowsExceptionWhenTestHasInvalidName($name): void
+    {
+        $testCase = new \TestWithDifferentNames($name);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('PHPUnit\Framework\TestCase::$name must be a non-blank string.');
+
+        $testCase->runBare();
+    }
+
+    public function providerInvalidName(): array
+    {
+        return [
+            'null'         => [null],
+            'string-empty' => [''],
+            'string-blank' => ['  '],
+        ];
+    }
+
     public function testHasFailedReturnsFalseWhenTestHasNotRunYet(): void
     {
         $test = new \TestWithDifferentStatuses();


### PR DESCRIPTION
This PR

* [x] adds tests for `TestCase` related to blank or empty names
* [x] fixes a condition and adjusts an exception message

Follows #3655.