### PR TITLE
Adapted the verification methods the ConsecutiveParameters class and the withConsecutive exp…

### DIFF
--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -69,13 +69,10 @@ class ConsecutiveParameters extends StatelessInvocation
         $this->parameterVerificationResults[$callIndex] = null;
 
         if (!$this->shouldInvocationBeVerified($callIndex)) {
-            return false;
+            return true;
         }
 
-        $this->parameterVerificationResults[$callIndex] =
-            $this->verifyInvocation($invocation, $callIndex);
-
-        return $this->parameterVerificationResults[$callIndex];
+        return false;
     }
 
     /**

--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -41,9 +41,6 @@ class ConsecutiveParameters extends StatelessInvocation
      */
     private $parameterVerificationResults = [];
 
-    /**
-     * @param array $parameterGroups
-     */
     public function __construct(array $parameterGroups)
     {
         foreach ($parameterGroups as $index => $parameters) {
@@ -63,14 +60,12 @@ class ConsecutiveParameters extends StatelessInvocation
     }
 
     /**
-     * @param BaseInvocation $invocation
-     *
      * @throws \PHPUnit\Framework\ExpectationFailedException
      */
     public function matches(BaseInvocation $invocation): bool
     {
-        $this->invocations[] = $invocation;
-        $callIndex           = \count($this->invocations) - 1;
+        $this->invocations[]                            = $invocation;
+        $callIndex                                      = \count($this->invocations) - 1;
         $this->parameterVerificationResults[$callIndex] = null;
 
         if (!$this->shouldInvocationBeVerified($callIndex)) {
@@ -89,7 +84,6 @@ class ConsecutiveParameters extends StatelessInvocation
     public function verify(): bool
     {
         foreach ($this->invocations as $callIndex => $invocation) {
-
             if (!$this->shouldInvocationBeVerified($callIndex)) {
                 continue;
             }
@@ -104,6 +98,7 @@ class ConsecutiveParameters extends StatelessInvocation
                 throw $this->parameterVerificationResults[$callIndex];
             }
         }
+
         return true;
     }
 

--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -66,9 +66,8 @@ class ConsecutiveParameters extends StatelessInvocation
      * @param BaseInvocation $invocation
      *
      * @throws \PHPUnit\Framework\ExpectationFailedException
-     * @return bool
      */
-    public function matches(BaseInvocation $invocation)
+    public function matches(BaseInvocation $invocation): bool
     {
         $this->invocations[] = $invocation;
         $callIndex           = \count($this->invocations) - 1;
@@ -86,10 +85,8 @@ class ConsecutiveParameters extends StatelessInvocation
 
     /**
      * Verify all constraints within this expectation
-     *
-     * @return bool|mixed
      */
-    public function verify()
+    public function verify(): bool
     {
         foreach ($this->invocations as $callIndex => $invocation) {
 
@@ -107,6 +104,7 @@ class ConsecutiveParameters extends StatelessInvocation
                 throw $this->parameterVerificationResults[$callIndex];
             }
         }
+        return true;
     }
 
     /**
@@ -116,11 +114,8 @@ class ConsecutiveParameters extends StatelessInvocation
      *  2. check is performed for all _and_ individual callbacks
      *
      * to avoid duplication, it was exported into a separate method
-     *
-     * @param $callIndex
-     * @return bool
      */
-    private function shouldInvocationBeVerified($callIndex): bool
+    private function shouldInvocationBeVerified(int $callIndex): bool
     {
         // skip check if there is no parameter assertion for this call index and invocation already evaluated
         if (!isset($this->parameterGroups[$callIndex])
@@ -134,13 +129,8 @@ class ConsecutiveParameters extends StatelessInvocation
 
     /**
      * Verify a single invocation
-     *
-     * @param BaseInvocation|null $invocation
-     * @param int $callIndex
-     *
-     * @return bool
      */
-    private function verifyInvocation(?BaseInvocation $invocation, $callIndex): bool
+    private function verifyInvocation(?BaseInvocation $invocation, int $callIndex): bool
     {
         if ($invocation === null) {
             throw new ExpectationFailedException(

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -66,6 +66,9 @@ class ConsecutiveParametersTest extends TestCase
         $mock->foo('invalid');
     }
 
+    /**
+     * Test for the issue https://github.com/sebastianbergmann/phpunit/issues/3590
+     */
     public function testMutableObjectsChangeSuccess()
     {
         /** @var \DateTime|MockObject $b */
@@ -94,7 +97,6 @@ class ConsecutiveParametersTest extends TestCase
         $arg->setDate(1970, 4, 5);
         $b->diff($arg);
 
-        // actually this equals to [1970, 1970] at this point, which is an error
         $this->assertEquals([0 => 2019, 1 => 1970], $validationValues);
     }
 }

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -69,23 +69,25 @@ class ConsecutiveParametersTest extends TestCase
     /**
      * Test for the issue https://github.com/sebastianbergmann/phpunit/issues/3590
      */
-    public function testMutableObjectsChangeSuccess()
+    public function testMutableObjectsChangeSuccess(): void
     {
-        /** @var \DateTime|MockObject $b */
-        $b = $this->getMockBuilder(\DateTime::class)
+        /** @var \DateTime|MockObject $mock */
+        $mock = $this
+            ->getMockBuilder(\DateTime::class)
             ->setMethods(['diff'])
             ->getMock();
 
         $validationValues = [];
 
-        $b->expects($this->exactly(2))
-        ->method('diff')
+        $mock
+            ->expects($this->exactly(2))
+            ->method('diff')
             ->withConsecutive([
                 $this->callback(function (\DateTime $it) use (&$validationValues) {
                     $validationValues[0] = $it->format('Y');
                     return $it->format('Y') === '2019';
                 })],
-                [$this->callback(function (\DateTime $it) use (&$validationValues)  {
+                [$this->callback(function (\DateTime $it) use (&$validationValues) {
                     $validationValues[1] = $it->format('Y');
                     return $it->format('Y') === '1970';
                 })]
@@ -93,9 +95,9 @@ class ConsecutiveParametersTest extends TestCase
 
         $arg = \DateTime::createFromFormat('Y-m-d', '2019-01-01');
 
-        $b->diff($arg);
+        $mock->diff($arg);
         $arg->setDate(1970, 4, 5);
-        $b->diff($arg);
+        $mock->diff($arg);
 
         $this->assertEquals([0 => 2019, 1 => 1970], $validationValues);
     }

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -82,15 +82,21 @@ class ConsecutiveParametersTest extends TestCase
         $mock
             ->expects($this->exactly(2))
             ->method('diff')
-            ->withConsecutive([
-                $this->callback(function (\DateTime $it) use (&$validationValues) {
-                    $validationValues[0] = $it->format('Y');
-                    return $it->format('Y') === '2019';
-                })],
-                [$this->callback(function (\DateTime $it) use (&$validationValues) {
-                    $validationValues[1] = $it->format('Y');
-                    return $it->format('Y') === '1970';
-                })]
+            ->withConsecutive(
+                [
+                    $this->callback(function (\DateTime $it) use (&$validationValues) {
+                        $validationValues[0] = $it->format('Y');
+
+                        return $it->format('Y') === '2019';
+                    }),
+                ],
+                [
+                    $this->callback(function (\DateTime $it) use (&$validationValues) {
+                        $validationValues[1] = $it->format('Y');
+
+                        return $it->format('Y') === '1970';
+                    }),
+                ]
             );
 
         $arg = \DateTime::createFromFormat('Y-m-d', '2019-01-01');

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -107,4 +107,36 @@ class ConsecutiveParametersTest extends TestCase
 
         $this->assertEquals([0 => 2019, 1 => 1970], $validationValues);
     }
+
+    public function testMutableObjectsIgnoreOneExpectationFailure(): void
+    {
+        /** @var \DateTimeImmutable|MockObject $mock */
+        $mock = $this
+            ->getMockBuilder(\DateTimeImmutable::class)
+            ->setMethods(['diff'])
+            ->getMock();
+
+        $mock
+            ->expects($this->exactly(3))
+            ->method('diff')
+            ->withConsecutive(
+                [
+                    $this->isInstanceOf(DateTimeImmutable::class),
+                ],
+                [],
+                [
+                    21, 23,
+                ]
+            );
+
+        $arg = \DateTimeImmutable::createFromFormat('Y-m-d', '2019-01-01');
+
+        $mock->diff($arg);
+
+        $mock->diff(null);
+
+        $this->expectException(ExpectationFailedException::class);
+
+        $mock->diff($arg);
+    }
 }


### PR DESCRIPTION
Adapted the verification methods the ConsecutiveParameters class
The `withConsecutive` expectation constraints

Fix for https://github.com/sebastianbergmann/phpunit/issues/3590