### PR TITLE
Drop unneeded field initialization from WarningTestCase

### DIFF
--- a/src/Framework/WarningTestCase.php
+++ b/src/Framework/WarningTestCase.php
@@ -37,7 +37,7 @@ final class WarningTestCase extends TestCase
     /**
      * @var string
      */
-    private $message = '';
+    private $message;
 
     /**
      * @param string $message


### PR DESCRIPTION
The value is overwritten first thing in the constructor anyway.