### PR TITLE
Fixed a fatal TypeError when an incorrect file path is given as second argument

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -778,7 +778,17 @@ class Command
             }
 
             if (isset($this->options[1][1])) {
-                $this->arguments['testFile'] = \realpath($this->options[1][1]);
+                $testFile = \realpath($this->options[1][1]);
+
+                if ($testFile === false) {
+                    $this->exitWithErrorMessage(
+                        \sprintf(
+                            'Cannot open file "%s".',
+                            $this->options[1][1]
+                        )
+                    );
+                }
+                $this->arguments['testFile'] = $testFile;
             } else {
                 $this->arguments['testFile'] = '';
             }

--- a/tests/end-to-end/cli/test-file-not-found.phpt
+++ b/tests/end-to-end/cli/test-file-not-found.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test incorrect testFile is reported
+--ARGS--
+--no-configuration tests nonExistingFile.php
+--FILE--
+<?php declare(strict_types=1);
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Cannot open file "nonExistingFile.php".


### PR DESCRIPTION
The following command will now return a helpful error message, instead of a TypeError:
`phpunit tests /wrong/path/to/file.php`