### PR TITLE
Explicity return floats for DefaultTestResultCache::getTime

### DIFF
--- a/src/Runner/DefaultTestResultCache.php
+++ b/src/Runner/DefaultTestResultCache.php
@@ -127,7 +127,7 @@ final class DefaultTestResultCache implements \Serializable, TestResultCache
 
     public function getTime($testName): float
     {
-        return $this->times[$testName] ?? 0;
+        return $this->times[$testName] ?? 0.0;
     }
 
     public function load(): void

--- a/tests/unit/Runner/DefaultTestResultCacheTest.php
+++ b/tests/unit/Runner/DefaultTestResultCacheTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PHPUnit\Runner\DefaultTestResultCache
+ * @small
+ */
+final class DefaultTestResultCacheTest extends TestCase
+{
+    /**
+     * @var DefaultTestResultCache
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DefaultTestResultCache();
+    }
+
+    public function testGetTimeForInexistentTestNameReturnsZero(): void
+    {
+        $this->assertSame(0.0, $this->subject->getTime('doesNotExist'));
+    }
+}


### PR DESCRIPTION
This method has a float return type, and the fallback return value
should also be an explicit float, not an int.