### PR TITLE
Allow using duration for the --order-by option as well as for the executionOrder attribute in phpunit.xml

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -176,19 +176,19 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="default"/>
             <xs:enumeration value="defects"/>
-            <xs:enumeration value="duration"/>
             <xs:enumeration value="depends"/>
             <xs:enumeration value="depends,defects"/>
-            <xs:enumeration value="random"/>
-            <xs:enumeration value="reverse"/>
+            <xs:enumeration value="depends,duration"/>
             <xs:enumeration value="depends,random"/>
             <xs:enumeration value="depends,reverse"/>
-            <xs:enumeration value="depends,duration"/>
+            <xs:enumeration value="duration"/>
             <xs:enumeration value="no-depends"/>
             <xs:enumeration value="no-depends,defects"/>
+            <xs:enumeration value="no-depends,duration"/>
             <xs:enumeration value="no-depends,random"/>
             <xs:enumeration value="no-depends,reverse"/>
-            <xs:enumeration value="no-depends,duration"/>
+            <xs:enumeration value="random"/>
+            <xs:enumeration value="reverse"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="fileFilterType">

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1257,16 +1257,6 @@ class Command
 
                     break;
 
-                case 'reverse':
-                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
-
-                    break;
-
-                case 'random':
-                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
-
-                    break;
-
                 case 'defects':
                     $this->arguments['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFECTS_FIRST;
 
@@ -1277,13 +1267,23 @@ class Command
 
                     break;
 
+                case 'duration':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+
+                    break;
+
                 case 'no-depends':
                     $this->arguments['resolveDependencies'] = false;
 
                     break;
 
-                case 'duration':
-                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+                case 'random':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
+
+                    break;
+
+                case 'reverse':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
 
                     break;
 

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1282,6 +1282,11 @@ class Command
 
                     break;
 
+                case 'duration':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+
+                    break;
+
                 default:
                     $this->exitWithErrorMessage("unrecognized --order-by option: $order");
             }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -100,7 +100,7 @@ final class Help
             ['arg'    => '--printer <printer>', 'desc' => 'TestListener implementation to use'],
             ['spacer' => ''],
 
-            ['arg'  => '--order-by=<order>', 'desc' => 'Run tests in order: default|reverse|random|defects|no-depends|duration'],
+            ['arg'  => '--order-by=<order>', 'desc' => 'Run tests in order: default|defects|duration|no-depends|random|reverse'],
             ['arg'  => '--random-order-seed=<N>', 'desc' => 'Use a specific random seed <N> for random order'],
             ['arg'  => '--cache-result', 'desc' => 'Write test results to cache file'],
             ['arg'  => '--do-not-cache-result', 'desc' => 'Do not write test results to cache file'],

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -100,7 +100,7 @@ final class Help
             ['arg'    => '--printer <printer>', 'desc' => 'TestListener implementation to use'],
             ['spacer' => ''],
 
-            ['arg'  => '--order-by=<order>', 'desc' => 'Run tests in order: default|reverse|random|defects|no-depends'],
+            ['arg'  => '--order-by=<order>', 'desc' => 'Run tests in order: default|reverse|random|defects|no-depends|duration'],
             ['arg'  => '--random-order-seed=<N>', 'desc' => 'Use a specific random seed <N> for random order'],
             ['arg'  => '--cache-result', 'desc' => 'Write test results to cache file'],
             ['arg'  => '--do-not-cache-result', 'desc' => 'Do not write test results to cache file'],

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -834,28 +834,34 @@ final class Configuration
                         $result['resolveDependencies']   = false;
 
                         break;
-                    case 'reverse':
-                        $result['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
 
-                        break;
-                    case 'random':
-                        $result['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
-
-                        break;
                     case 'defects':
                         $result['executionOrderDefects'] = TestSuiteSorter::ORDER_DEFECTS_FIRST;
 
                         break;
+
                     case 'depends':
                         $result['resolveDependencies'] = true;
 
                         break;
+
+                    case 'duration':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+
+                        break;
+
                     case 'no-depends':
                         $result['resolveDependencies'] = false;
 
                         break;
-                    case 'duration':
-                        $result['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+
+                    case 'random':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_RANDOMIZED;
+
+                        break;
+
+                    case 'reverse':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
 
                         break;
                 }

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -854,6 +854,10 @@ final class Configuration
                         $result['resolveDependencies'] = false;
 
                         break;
+                    case 'duration':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_DURATION;
+
+                        break;
                 }
             }
         }

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -99,7 +99,7 @@
   [32m--printer [36m<printer>[0m        [0m TestListener implementation to use
 
   [32m--order-by=[36m<order>[0m         [0m Run tests in order:
-                              default|reverse|random|defects|no-depends
+                              default|reverse|random|defects|no-depends|duration
   [32m--random-order-seed=[36m<N>[0m    [0m Use a specific random seed <N> for random
                               order
   [32m--cache-result             [0m Write test results to cache file

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -99,7 +99,7 @@
   [32m--printer [36m<printer>[0m        [0m TestListener implementation to use
 
   [32m--order-by=[36m<order>[0m         [0m Run tests in order:
-                              default|reverse|random|defects|no-depends|duration
+                              default|defects|duration|no-depends|random|reverse
   [32m--random-order-seed=[36m<N>[0m    [0m Use a specific random seed <N> for random
                               order
   [32m--cache-result             [0m Write test results to cache file

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -77,7 +77,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|no-depends
+  --order-by=<order>          Run tests in order: default|reverse|random|defects|no-depends|duration
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -77,7 +77,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --order-by=<order>          Run tests in order: default|reverse|random|defects|no-depends|duration
+  --order-by=<order>          Run tests in order: default|defects|duration|no-depends|random|reverse
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/execution-order/_files/TestWithDifferentDurations.php
+++ b/tests/end-to-end/execution-order/_files/TestWithDifferentDurations.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+final class TestWithDifferentDurations extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testThree(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/execution-order/_files/TestWithDifferentDurations.phpunit.result.cache.txt
+++ b/tests/end-to-end/execution-order/_files/TestWithDifferentDurations.phpunit.result.cache.txt
@@ -1,0 +1,1 @@
+C:37:"PHPUnit\Runner\DefaultTestResultCache":199:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:3:{s:35:"TestWithDifferentDurations::testOne";d:1.000;s:35:"TestWithDifferentDurations::testTwo";d:0.500;s:37:"TestWithDifferentDurations::testThree";d:1.500;}}}

--- a/tests/end-to-end/execution-order/_files/order-by-duration.phpunit.xml
+++ b/tests/end-to-end/execution-order/_files/order-by-duration.phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+    executionOrder="duration"
+>
+    <testsuites>
+        <testsuite name="order-by-duration">
+            <file>./TestWithDifferentDurations.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/execution-order/order-by-duration-via-cli.phpt
+++ b/tests/end-to-end/execution-order/order-by-duration-via-cli.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit --order-by=duration ./tests/end-to-end/execution-order/_files/TestWithDifferentDurations.php
+--FILE--
+<?php
+
+$tmpResultCache = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/_files/TestWithDifferentDurations.phpunit.result.cache.txt'));
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--debug';
+$_SERVER['argv'][3] = '--order-by=duration';
+$_SERVER['argv'][4] = '--cache-result';
+$_SERVER['argv'][5] = '--cache-result-file=' . $tmpResultCache;
+$_SERVER['argv'][6] = __DIR__ . '/_files/TestWithDifferentDurations.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+
+unlink($tmpResultCache);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Test 'TestWithDifferentDurations::testTwo' started
+Test 'TestWithDifferentDurations::testTwo' ended
+Test 'TestWithDifferentDurations::testOne' started
+Test 'TestWithDifferentDurations::testOne' ended
+Test 'TestWithDifferentDurations::testThree' started
+Test 'TestWithDifferentDurations::testThree' ended
+
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/tests/end-to-end/execution-order/order-by-duration-via-phpunit-xml.phpt
+++ b/tests/end-to-end/execution-order/order-by-duration-via-phpunit-xml.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit --configuration=order-by-duration.phpunit.xml
+--FILE--
+<?php
+
+$tmpResultCache = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($tmpResultCache, file_get_contents(__DIR__ . '/_files/TestWithDifferentDurations.phpunit.result.cache.txt'));
+
+$phpunitXmlConfig = __DIR__ . '/_files/order-by-duration.phpunit.xml';
+
+$_SERVER['argv'][1] = '--configuration=' . $phpunitXmlConfig;
+$_SERVER['argv'][2] = '--debug';
+$_SERVER['argv'][3] = '--cache-result';
+$_SERVER['argv'][4] = '--cache-result-file=' . $tmpResultCache;
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+
+unlink($tmpResultCache);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Test 'TestWithDifferentDurations::testTwo' started
+Test 'TestWithDifferentDurations::testTwo' ended
+Test 'TestWithDifferentDurations::testOne' started
+Test 'TestWithDifferentDurations::testOne' ended
+Test 'TestWithDifferentDurations::testThree' started
+Test 'TestWithDifferentDurations::testThree' ended
+
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)


### PR DESCRIPTION
This PR

* [x] allows specifying `duration` as value for the `order-by` option via CLI as well as for the `executionOrder` attribute in `phpunit.xml`

Fixes #3681.

Also see https://github.com/sebastianbergmann/phpunit-documentation-english/pull/143.