### PR TITLE
Cleanup: Improve a test name

### DIFF
--- a/tests/unit/Runner/DefaultTestResultCacheTest.php
+++ b/tests/unit/Runner/DefaultTestResultCacheTest.php
@@ -27,7 +27,7 @@ final class DefaultTestResultCacheTest extends TestCase
         $this->subject = new DefaultTestResultCache();
     }
 
-    public function testGetTimeForNonExistentTestNameReturnsZero(): void
+    public function testGetTimeForNonExistentTestNameReturnsFloatZero(): void
     {
         $this->assertSame(0.0, $this->subject->getTime('doesNotExist'));
     }


### PR DESCRIPTION
Make it obvious that the test is about the return type.