### PR TITLE
Add onlyMethods + addMethods and soft deprecate setMethods

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -201,7 +201,7 @@
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion occurrences="2">
       <code>$this->type</code>
     </ArgumentTypeCoercion>
   </file>

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -220,7 +220,8 @@
     </TypeDoesNotContainNull>
   </file>
   <file src="src/Framework/TestCase.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$class_name</code>
       <code>$this-&gt;expectedException</code>
     </ArgumentTypeCoercion>
     <InvalidArgument occurrences="2">

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -201,6 +201,9 @@
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this->type</code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="src/Framework/MockObject/MockMethod.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -87,6 +87,11 @@ final class MockBuilder
     private $generator;
 
     /**
+     * @var bool
+     */
+    private $alreadyUsedMockMethodConfiguration = false;
+
+    /**
      * @param string|string[] $type
      *
      * @psalm-param class-string<MockedType>|string|string[] $type
@@ -200,6 +205,12 @@ final class MockBuilder
      */
     public function onlyMethods(array $methods): self
     {
+        if ($this->alreadyUsedMockMethodConfiguration) {
+            throw new RuntimeException('Can\'t use onlyMethods after already configuring mock methods on the mock.');
+        }
+
+        $this->alreadyUsedMockMethodConfiguration = true;
+
         $reflection = new \ReflectionClass($this->type);
 
         foreach ($methods as $method) {
@@ -228,6 +239,12 @@ final class MockBuilder
      */
     public function addMethods(array $methods): self
     {
+        if ($this->alreadyUsedMockMethodConfiguration) {
+            throw new RuntimeException('Can\'t use addMethods after already configuring mock methods on the mock.');
+        }
+
+        $this->alreadyUsedMockMethodConfiguration = true;
+
         $reflection = new \ReflectionClass($this->type);
 
         foreach ($methods as $method) {

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -193,21 +193,22 @@ final class MockBuilder
      * Specifies the subset of methods to mock, requiring each to exist in the class
      *
      * @param string[] $methods
+     *
+     * @throws RuntimeException
      */
     public function setRealMethods(array $methods): self
     {
-        if ($methods) {
-            $reflection = new \ReflectionClass($this->type);
+        $reflection = new \ReflectionClass($this->type);
 
-            foreach ($methods as $method) {
-                if (!$reflection->hasMethod($method)) {
-                    throw new RuntimeException(
-                        \sprintf(
-                            'Trying to set mock method "%s" which cannot be configured because it does not exist',
-                            $method
-                        )
-                    );
-                }
+        foreach ($methods as $method) {
+            if (!$reflection->hasMethod($method)) {
+                throw new RuntimeException(
+                    \sprintf(
+                        'Trying to set mock method "%s", but it does not exist in class "%s"',
+                        $method,
+                        $this->type
+                    )
+                );
             }
         }
 

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -181,6 +181,8 @@ final class MockBuilder
 
     /**
      * Specifies the subset of methods to mock. Default is to mock none of them.
+     *
+     * @deprecated https://github.com/sebastianbergmann/phpunit/pull/3687
      */
     public function setMethods(array $methods = null): self
     {
@@ -196,7 +198,7 @@ final class MockBuilder
      *
      * @throws RuntimeException
      */
-    public function setRealMethods(array $methods): self
+    public function onlyMethods(array $methods): self
     {
         $reflection = new \ReflectionClass($this->type);
 
@@ -204,7 +206,35 @@ final class MockBuilder
             if (!$reflection->hasMethod($method)) {
                 throw new RuntimeException(
                     \sprintf(
-                        'Trying to set mock method "%s", but it does not exist in class "%s"',
+                        'Trying to set mock method "%s" with onlyMethods, but it does not exist in class "%s". Use addMethods() for methods that don\'t exist in the class.',
+                        $method,
+                        $this->type
+                    )
+                );
+            }
+        }
+
+        $this->methods = $methods;
+
+        return $this;
+    }
+
+    /**
+     * Specifies methods that don't exist in the class which you want to mock
+     *
+     * @param string[] $methods
+     *
+     * @throws RuntimeException
+     */
+    public function addMethods(array $methods): self
+    {
+        $reflection = new \ReflectionClass($this->type);
+
+        foreach ($methods as $method) {
+            if ($reflection->hasMethod($method)) {
+                throw new RuntimeException(
+                    \sprintf(
+                        'Trying to set mock method "%s" with addMethod, but it exists in class "%s". Use onlyMethods() for methods that exist in the class.',
                         $method,
                         $this->type
                     )

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -193,6 +193,8 @@ final class MockBuilder
     {
         $this->methods = $methods;
 
+        $this->alreadyUsedMockMethodConfiguration = true;
+
         return $this;
     }
 
@@ -206,7 +208,12 @@ final class MockBuilder
     public function onlyMethods(array $methods): self
     {
         if ($this->alreadyUsedMockMethodConfiguration) {
-            throw new RuntimeException('Can\'t use onlyMethods after already configuring mock methods on the mock.');
+            throw new RuntimeException(
+                \sprintf(
+                    'Can\'t use onlyMethods on "%s" mock because mocked methods were already configured.',
+                    $this->type
+                )
+            );
         }
 
         $this->alreadyUsedMockMethodConfiguration = true;
@@ -240,7 +247,12 @@ final class MockBuilder
     public function addMethods(array $methods): self
     {
         if ($this->alreadyUsedMockMethodConfiguration) {
-            throw new RuntimeException('Can\'t use addMethods after already configuring mock methods on the mock.');
+            throw new RuntimeException(
+                \sprintf(
+                    'Can\'t use addMethods on "%s" mock because mocked methods were already configured.',
+                    $this->type
+                )
+            );
         }
 
         $this->alreadyUsedMockMethodConfiguration = true;

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -190,6 +190,31 @@ final class MockBuilder
     }
 
     /**
+     * Specifies the subset of methods to mock, requiring each to exist in the class
+     */
+    public function setRealMethods(array $methods = null): self
+    {
+        if ($methods) {
+            $reflection = new \ReflectionClass($this->type);
+
+            foreach ($methods as $method) {
+                if (!$reflection->hasMethod($method)) {
+                    throw new RuntimeException(
+                        \sprintf(
+                            'Trying to set mock method "%s" which cannot be configured because it does not exist',
+                            $method
+                        )
+                    );
+                }
+            }
+        }
+
+        $this->methods = $methods;
+
+        return $this;
+    }
+
+    /**
      * Specifies the subset of methods to not mock. Default is to mock all of them.
      */
     public function setMethodsExcept(array $methods = []): self

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -191,8 +191,10 @@ final class MockBuilder
 
     /**
      * Specifies the subset of methods to mock, requiring each to exist in the class
+     *
+     * @param string[] $methods
      */
-    public function setRealMethods(array $methods = null): self
+    public function setRealMethods(array $methods): self
     {
         if ($methods) {
             $reflection = new \ReflectionClass($this->type);

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1521,6 +1521,26 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
      */
     protected function createPartialMock($originalClassName, array $methods): MockObject
     {
+        $class_names = \is_array($originalClassName) ? $originalClassName : [$originalClassName];
+
+        foreach ($class_names as $class_name) {
+            $reflection = new \ReflectionClass($class_name);
+
+            $mockedMethodsThatDontExist = \array_filter($methods, function (string $method) use ($reflection) {
+                return !$reflection->hasMethod($method);
+            });
+
+            if ($mockedMethodsThatDontExist) {
+                $this->addWarning(
+                    \sprintf(
+                        'createPartialMock called with method(s) %s that do not exist in %s. This will not be allowed in future versions of PHPUnit.',
+                        \implode(', ', $mockedMethodsThatDontExist),
+                        $class_name
+                    )
+                );
+            }
+        }
+
         return $this->getMockBuilder($originalClassName)
                     ->disableOriginalConstructor()
                     ->disableOriginalClone()

--- a/tests/_files/TestWithDifferentStatuses.php
+++ b/tests/_files/TestWithDifferentStatuses.php
@@ -45,4 +45,15 @@ final class TestWithDifferentStatuses extends TestCase
     {
         $this->addWarning('Sorry, Dave!');
     }
+
+    public function testWithCreatePartialMockWarning(): void
+    {
+        $this->createPartialMock(\Mockable::class, ['mockableMethod', 'fakeMethod1', 'fakeMethod2']);
+    }
+
+    public function testWithCreatePartialMockPassesNoWarning(): void
+    {
+        $mock = $this->createPartialMock(\Mockable::class, ['mockableMethod']);
+        $this->assertNull($mock->mockableMethod());
+    }
 }

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -108,6 +108,26 @@ final class MockBuilderTest extends TestCase
         $this->assertNull($mock->anotherMockableMethod());
     }
 
+    public function testNotAbleToUseAddMethodsAfterOnlyMethods(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->getMockBuilder(Mockable::class)
+             ->onlyMethods(['mockableMethod'])
+             ->addMethods(['mockableMethodWithFakeMethod'])
+             ->getMock();
+    }
+
+    public function testNotAbleToUseOnlyMethodsAfterAddMethods(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->getMockBuilder(Mockable::class)
+             ->addMethods(['mockableMethodWithFakeMethod'])
+             ->onlyMethods(['mockableMethod'])
+             ->getMock();
+    }
+
     public function testByDefaultDoesNotPassArgumentsToTheConstructor(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)->getMock();

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -54,8 +54,8 @@ final class MockBuilderTest extends TestCase
     public function testSetMethodsAllowsNonExistentMethodNames(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-          ->setMethods(['mockableMethodWithCrazyName'])
-          ->getMock();
+                     ->setMethods(['mockableMethodWithCrazyName'])
+                     ->getMock();
 
         $this->assertNull($mock->mockableMethodWithCrazyName());
     }
@@ -65,8 +65,8 @@ final class MockBuilderTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $this->getMockBuilder(Mockable::class)
-          ->onlyMethods(['mockableMethodWithCrazyName'])
-          ->getMock();
+             ->onlyMethods(['mockableMethodWithCrazyName'])
+             ->getMock();
     }
 
     public function testOnlyMethodsWithExistingMethodNames(): void
@@ -101,8 +101,8 @@ final class MockBuilderTest extends TestCase
     public function testEmptyMethodExceptionsToMockCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethodsExcept()
-                     ->getMock();
+            ->setMethodsExcept()
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->anotherMockableMethod());
@@ -124,6 +124,46 @@ final class MockBuilderTest extends TestCase
 
         $this->getMockBuilder(Mockable::class)
              ->addMethods(['mockableMethodWithFakeMethod'])
+             ->onlyMethods(['mockableMethod'])
+             ->getMock();
+    }
+
+    public function testAbleToUseSetMethodsAfterOnlyMethods(): void
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+                     ->onlyMethods(['mockableMethod'])
+                     ->setMethods(['mockableMethodWithCrazyName'])
+                     ->getMock();
+
+        $this->assertNull($mock->mockableMethodWithCrazyName());
+    }
+
+    public function testAbleToUseSetMethodsAfterAddMethods(): void
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+                     ->addMethods(['notAMethod'])
+                     ->setMethods(['mockableMethodWithCrazyName'])
+                     ->getMock();
+
+        $this->assertNull($mock->mockableMethodWithCrazyName());
+    }
+
+    public function testNotAbleToUseAddMethodsAfterSetMethods(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->getMockBuilder(Mockable::class)
+              ->setMethods(['mockableMethod'])
+              ->addMethods(['mockableMethodWithFakeMethod'])
+              ->getMock();
+    }
+
+    public function testNotAbleToUseOnlyMethodsAfterSetMethods(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->getMockBuilder(Mockable::class)
+             ->setMethods(['mockableMethodWithFakeMethod'])
              ->onlyMethods(['mockableMethod'])
              ->getMock();
     }

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -60,30 +60,49 @@ final class MockBuilderTest extends TestCase
         $this->assertNull($mock->mockableMethodWithCrazyName());
     }
 
-    public function testSetRealMethodsWithNonExistentMethodNames(): void
+    public function testOnlyMethodsWithNonExistentMethodNames(): void
     {
         $this->expectException(RuntimeException::class);
 
         $this->getMockBuilder(Mockable::class)
-          ->setRealMethods(['mockableMethodWithCrazyName'])
+          ->onlyMethods(['mockableMethodWithCrazyName'])
           ->getMock();
     }
 
-    public function testSetRealMethodsWithExistingMethodNames(): void
+    public function testOnlyMethodsWithExistingMethodNames(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-            ->setRealMethods(['mockableMethod'])
-            ->getMock();
+                     ->onlyMethods(['mockableMethod'])
+                     ->getMock();
 
         $this->assertNull($mock->mockableMethod());
+        $this->assertTrue($mock->anotherMockableMethod());
+    }
+
+    public function testAddMethodsWithNonExistentMethodNames(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->getMockBuilder(Mockable::class)
+             ->addMethods(['mockableMethod'])
+             ->getMock();
+    }
+
+    public function testAddMethodsWithExistingMethodNames(): void
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+                     ->addMethods(['mockableMethodWithFakeMethod'])
+                     ->getMock();
+
+        $this->assertNull($mock->mockableMethodWithFakeMethod());
         $this->assertTrue($mock->anotherMockableMethod());
     }
 
     public function testEmptyMethodExceptionsToMockCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-            ->setMethodsExcept()
-            ->getMock();
+                     ->setMethodsExcept()
+                     ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->anotherMockableMethod());

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -51,6 +51,34 @@ final class MockBuilderTest extends TestCase
         $this->assertNull($mock->anotherMockableMethod());
     }
 
+    public function testSetMethodsAllowsNonExistentMethodNames(): void
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+          ->setMethods(['mockableMethodWithCrazyName'])
+          ->getMock();
+
+        $this->assertNull($mock->mockableMethodWithCrazyName());
+    }
+
+    public function testSetRealMethodsWithNonExistentMethodNames(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->getMockBuilder(Mockable::class)
+          ->setRealMethods(['mockableMethodWithCrazyName'])
+          ->getMock();
+    }
+
+    public function testSetRealMethodsWithExistingMethodNames(): void
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+            ->setRealMethods(['mockableMethod'])
+            ->getMock();
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertTrue($mock->anotherMockableMethod());
+    }
+
     public function testEmptyMethodExceptionsToMockCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -857,6 +857,26 @@ final class TestCaseTest extends TestCase
         $this->assertTrue($mock->anotherMockableMethod());
     }
 
+    public function testCreatePartialMockWithFakeMethods(): void
+    {
+        $test = new \TestWithDifferentStatuses('testWithCreatePartialMockWarning');
+
+        $test->run();
+
+        $this->assertSame(BaseTestRunner::STATUS_WARNING, $test->getStatus());
+        $this->assertFalse($test->hasFailed());
+    }
+
+    public function testCreatePartialMockWithRealMethods(): void
+    {
+        $test = new \TestWithDifferentStatuses('testWithCreatePartialMockPassesNoWarning');
+
+        $test->run();
+
+        $this->assertSame(BaseTestRunner::STATUS_PASSED, $test->getStatus());
+        $this->assertFalse($test->hasFailed());
+    }
+
     public function testCreateMockSkipsConstructor(): void
     {
         /** @var \Mockable $mock */


### PR DESCRIPTION
The purpose of this PR is to provide important testing functionality when using setMethods() on a mock, to which there is currently no workaround to accomplish otherwise (as far as I can see, please correct me if I'm wrong). Right now, any time setMethods is used, the test using it is completely unprotected against any of the methods sent to setMethods not actually existing in the class. In practice, for the large majority of use-cases where setMethods is appropriate, this means that the tests using it are likely not functioning as the test writer expected because the methods in setMethods are not asserted in any way to actually exist, so you can easily just delete methods while refactoring code and have properly written tests still pass with no warning. In practice, this behavior is made even more confusing because so far every developer I've talked to mixes up the strictness of createMock (which tells you when you try to mock a method that didn't exist) with also offering that functionality when you use setMethods, which unfortunately is not the case.

This change provides a simple backwards-compatible way to address this issue, and provide the functionality that most casual PHPUnit users already think they are getting. Anyone who wants the stricter functionality can just search and replace setMethods with the stricter version that asserts the methods actually exist. Also, just to add, the name I added for this new method is kind of just one I came up with quickly - so feedback on that and anything else in this is definitely appreciated.