### PR TITLE
Fix magic method __sleep signature

### DIFF
--- a/tests/_files/SingletonClass.php
+++ b/tests/_files/SingletonClass.php
@@ -17,7 +17,7 @@ class SingletonClass
     {
     }
 
-    private function __sleep(): void
+    public function __sleep(): array
     {
     }
 


### PR DESCRIPTION
https://www.php.net/manual/en/language.oop5.magic.php#object.sleep

Visibility for magic method __sleep must be public. Found: private
__sleep must return array