### PR TITLE
Do not ignore constructor arguments based on type being mocked

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -593,9 +593,7 @@ class Generator
     {
         $this->evalClass($code, $className);
 
-        if ($callOriginalConstructor &&
-            \is_string($type) &&
-            !\interface_exists($type, $callAutoload)) {
+        if ($callOriginalConstructor) {
             if (\count($arguments) === 0) {
                 $object = new $className;
             } else {

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -220,6 +220,12 @@ class GeneratorTest extends TestCase
         $this->assertInstanceOf(MockObject::class, $stub);
     }
 
+    public function testMockingOfThrowableConstructorArguments(): void
+    {
+        $mock = $this->generator->getMock(Throwable::class, null, ['It works']);
+        $this->assertSame('It works', $mock->getMessage());
+    }
+
     public function testVariadicArgumentsArePassedToOriginalMethod()
     {
         /** @var ClassWithVariadicArgumentMethod|MockObject $mock */


### PR DESCRIPTION
Currently, it is impossible to mock the message or code on a `Throwable`. On the one hand, `getMessage()` and `getCode()` are `final` in `Exception`, on the other, the mock generator ignores constructor arguments if the type being mocked is an interface.

The existing behavior doesn't seem correct because on the one hand, PHP currently allows passing more arguments than the method expects (including class constructors). On the other, if it stops doing so at some point later, it should be a test error, not the PHPUnit's call to ignore the arguments.