### PR TITLE
Fix #3697 Respect @coversNothing at coverage driver start

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -156,6 +156,12 @@ final class Test
     {
         $annotations = $test->getAnnotations();
 
+        // If there is no @covers annotation but a @coversNothing annotation on
+        // the test method then code coverage data does not need to be collected
+        if (isset($annotations['method']['coversNothing'])) {
+            return false;
+        }
+
         // If there is at least one @covers annotation then
         // code coverage data needs to be collected
         if (isset($annotations['method']['covers'])) {

--- a/tests/_files/CoverageClassNothingTest.php
+++ b/tests/_files/CoverageClassNothingTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class CoverageClassNothingTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/CoverageClassWithoutAnnotationsTest.php
+++ b/tests/_files/CoverageClassWithoutAnnotationsTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class CoverageClassWithoutAnnotationsTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/CoverageMethodNothingCoversMethod.php
+++ b/tests/_files/CoverageMethodNothingCoversMethod.php
@@ -9,9 +9,10 @@
  */
 use PHPUnit\Framework\TestCase;
 
-class CoverageMethodNothingTest extends TestCase
+class CoverageMethodNothingCoversMethod extends TestCase
 {
     /**
+     * @covers CoveredClass::publicMethod
      * @coversNothing
      */
     public function testSomething(): void

--- a/tests/_files/CoverageMethodNothingTest.php
+++ b/tests/_files/CoverageMethodNothingTest.php
@@ -9,7 +9,7 @@
  */
 use PHPUnit\Framework\TestCase;
 
-class CoverageNothingTest extends TestCase
+class CoverageMethodNothingTest extends TestCase
 {
     /**
      * @covers CoveredClass::publicMethod

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -1065,10 +1065,14 @@ final class TestTest extends TestCase
             $expected = [
                 TEST_FILES_PATH . 'NamespaceCoveredClass.php' => $lines,
             ];
+        } elseif ($test === 'CoverageMethodNothingCoversMethod') {
+            $expected = false;
         } elseif ($test === 'CoverageCoversOverridesCoversNothingTest') {
             $expected = [TEST_FILES_PATH . 'CoveredClass.php' => $lines];
         } elseif ($test === 'CoverageNoneTest') {
             $expected = [];
+        } elseif ($test === 'CoverageClassNothingTest') {
+            $expected = false;
         } elseif ($test === 'CoverageMethodNothingTest') {
             $expected = false;
         } elseif ($test === 'CoverageFunctionTest') {
@@ -1292,12 +1296,20 @@ final class TestTest extends TestCase
                 \range(31, 35),
             ],
             [
+                'CoverageClassNothingTest',
+                false,
+            ],
+            [
                 'CoverageMethodNothingTest',
                 false,
             ],
             [
                 'CoverageCoversOverridesCoversNothingTest',
                 \range(29, 33),
+            ],
+            [
+                'CoverageMethodNothingCoversMethod',
+                false,
             ],
         ];
     }
@@ -1343,10 +1355,10 @@ final class TestTest extends TestCase
     {
         return [
             ['CoverageClassTest', false],
-            ['CoverageClassNothingTest', true],
-            ['CoverageMethodNothingTest', false],
             ['CoverageClassWithoutAnnotationsTest', false],
             ['CoverageCoversOverridesCoversNothingTest', false],
+            ['CoverageClassNothingTest', true],
+            ['CoverageMethodNothingTest', true],
         ];
     }
 

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -1069,7 +1069,7 @@ final class TestTest extends TestCase
             $expected = [TEST_FILES_PATH . 'CoveredClass.php' => $lines];
         } elseif ($test === 'CoverageNoneTest') {
             $expected = [];
-        } elseif ($test === 'CoverageNothingTest') {
+        } elseif ($test === 'CoverageMethodNothingTest') {
             $expected = false;
         } elseif ($test === 'CoverageFunctionTest') {
             $expected = [
@@ -1292,7 +1292,7 @@ final class TestTest extends TestCase
                 \range(31, 35),
             ],
             [
-                'CoverageNothingTest',
+                'CoverageMethodNothingTest',
                 false,
             ],
             [
@@ -1332,8 +1332,9 @@ final class TestTest extends TestCase
     {
         require_once TEST_FILES_PATH . $testCase . '.php';
 
-        $test            = new $testCase;
-        $canSkipCoverage = Test::requiresCodeCoverageDataCollection($test);
+        $test             = new $testCase('testSomething');
+        $coverageRequired = Test::requiresCodeCoverageDataCollection($test);
+        $canSkipCoverage  = !$coverageRequired;
 
         $this->assertEquals($expectedCanSkip, $canSkipCoverage);
     }
@@ -1341,8 +1342,10 @@ final class TestTest extends TestCase
     public function canSkipCoverageProvider(): array
     {
         return [
-            ['CoverageClassTest', true],
-            ['CoverageNothingTest', true],
+            ['CoverageClassTest', false],
+            ['CoverageClassNothingTest', true],
+            ['CoverageMethodNothingTest', false],
+            ['CoverageClassWithoutAnnotationsTest', false],
             ['CoverageCoversOverridesCoversNothingTest', false],
         ];
     }


### PR DESCRIPTION
As mentioned in #3697, the existing `@coversNothing` annotation works as expected for classes, but for methods the coverage data is still generated and it is later filtered out.

This change adds support for `@coversNothing` in the test method annotation, and attempts to address inverted assertions in the unit testing of the existing functionality.