### PR TITLE
forceCoversAnnotations not respected in Util\Test::requiresCodeCoverageDataCollection()

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -87,6 +87,11 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     /**
      * @var bool
      */
+    protected $forceCoversAnnotation = true;
+
+    /**
+     * @var bool
+     */
     private $runClassInSeparateProcess;
 
     /**
@@ -1044,6 +1049,16 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     public function isInIsolation(): bool
     {
         return $this->inIsolation;
+    }
+
+    public function setForceCoversAnnotation(bool $forceCoversAnnotation): void
+    {
+        $this->forceCoversAnnotation = $forceCoversAnnotation;
+    }
+
+    public function getForceCoversAnnotation(): bool
+    {
+        return $this->forceCoversAnnotation;
     }
 
     public function getResult()

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -41,6 +41,11 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
     protected $runTestInSeparateProcess = false;
 
     /**
+     * @var bool
+     */
+    protected $forceCoversAnnotation = false;
+
+    /**
      * The name of the test suite.
      *
      * @var string
@@ -542,6 +547,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
                 $test->setBackupGlobals($this->backupGlobals);
                 $test->setBackupStaticAttributes($this->backupStaticAttributes);
                 $test->setRunTestInSeparateProcess($this->runTestInSeparateProcess);
+                $test->setForceCoversAnnotation($this->forceCoversAnnotation);
             }
 
             $test->run($result);
@@ -575,6 +581,11 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
     public function setRunTestInSeparateProcess(bool $runTestInSeparateProcess): void
     {
         $this->runTestInSeparateProcess = $runTestInSeparateProcess;
+    }
+
+    public function setForceCoversAnnotation(bool $forceCoversAnnotation): void
+    {
+        $this->forceCoversAnnotation = $forceCoversAnnotation;
     }
 
     public function setName(string $name): void

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -162,14 +162,18 @@ final class Test
             return true;
         }
 
+        // If there is no @covers annotation and forceCoversAnnotation is set,
+        // then code coverage data does not need to be collected.
+        if ($test->getForceCoversAnnotation()) {
+            return false;
+        }
+
         // If there is no @covers annotation but a @coversNothing annotation
         // then code coverage data does not need to be collected
         if (isset($annotations['class']['coversNothing'])) {
             return false;
         }
 
-        // If there is no @coversNothing annotation then
-        // code coverage data may be collected
         return true;
     }
 

--- a/tests/_files/CoverageClassNothingTest.php
+++ b/tests/_files/CoverageClassNothingTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class CoverageClassNothingTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/CoverageClassWithoutAnnotationsTest.php
+++ b/tests/_files/CoverageClassWithoutAnnotationsTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+class CoverageClassWithoutAnnotationsTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $o = new CoveredClass;
+        $o->publicMethod();
+    }
+}

--- a/tests/_files/CoverageMethodNothingTest.php
+++ b/tests/_files/CoverageMethodNothingTest.php
@@ -9,7 +9,7 @@
  */
 use PHPUnit\Framework\TestCase;
 
-class CoverageNothingTest extends TestCase
+class CoverageMethodNothingTest extends TestCase
 {
     /**
      * @covers CoveredClass::publicMethod

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -1328,11 +1328,12 @@ final class TestTest extends TestCase
     /**
      * @dataProvider canSkipCoverageProvider
      */
-    public function testCanSkipCoverage($testCase, $expectedCanSkip): void
+    public function testCanSkipCoverage($testCase, $expectedCanSkip, $forceCoversAnnotation): void
     {
         require_once TEST_FILES_PATH . $testCase . '.php';
 
         $test             = new $testCase('testSomething');
+        $test->setForceCoversAnnotation($forceCoversAnnotation);
         $coverageRequired = Test::requiresCodeCoverageDataCollection($test);
         $canSkipCoverage  = !$coverageRequired;
 
@@ -1342,11 +1343,17 @@ final class TestTest extends TestCase
     public function canSkipCoverageProvider(): array
     {
         return [
-            ['CoverageClassTest', false],
-            ['CoverageClassNothingTest', true],
-            ['CoverageMethodNothingTest', false],
-            ['CoverageClassWithoutAnnotationsTest', false],
-            ['CoverageCoversOverridesCoversNothingTest', false],
+            ['CoverageClassTest', false, false],
+            ['CoverageClassNothingTest', true, false],
+            ['CoverageMethodNothingTest', false, false],
+            ['CoverageClassWithoutAnnotationsTest', false, false],
+            ['CoverageCoversOverridesCoversNothingTest', false, false],
+
+            ['CoverageClassTest', false, true],
+            ['CoverageClassNothingTest', true, false],
+            ['CoverageMethodNothingTest', false, true],
+            ['CoverageClassWithoutAnnotationsTest', true, true],
+            ['CoverageCoversOverridesCoversNothingTest', false, true],
         ];
     }
 

--- a/tests/unit/Util/TestTest.php
+++ b/tests/unit/Util/TestTest.php
@@ -1069,7 +1069,7 @@ final class TestTest extends TestCase
             $expected = [TEST_FILES_PATH . 'CoveredClass.php' => $lines];
         } elseif ($test === 'CoverageNoneTest') {
             $expected = [];
-        } elseif ($test === 'CoverageNothingTest') {
+        } elseif ($test === 'CoverageMethodNothingTest') {
             $expected = false;
         } elseif ($test === 'CoverageFunctionTest') {
             $expected = [
@@ -1292,7 +1292,7 @@ final class TestTest extends TestCase
                 \range(31, 35),
             ],
             [
-                'CoverageNothingTest',
+                'CoverageMethodNothingTest',
                 false,
             ],
             [
@@ -1332,8 +1332,9 @@ final class TestTest extends TestCase
     {
         require_once TEST_FILES_PATH . $testCase . '.php';
 
-        $test            = new $testCase;
-        $canSkipCoverage = Test::requiresCodeCoverageDataCollection($test);
+        $test             = new $testCase('testSomething');
+        $coverageRequired = Test::requiresCodeCoverageDataCollection($test);
+        $canSkipCoverage  = !$coverageRequired;
 
         $this->assertEquals($expectedCanSkip, $canSkipCoverage);
     }
@@ -1341,8 +1342,10 @@ final class TestTest extends TestCase
     public function canSkipCoverageProvider(): array
     {
         return [
-            ['CoverageClassTest', true],
-            ['CoverageNothingTest', true],
+            ['CoverageClassTest', false],
+            ['CoverageClassNothingTest', true],
+            ['CoverageMethodNothingTest', false],
+            ['CoverageClassWithoutAnnotationsTest', false],
             ['CoverageCoversOverridesCoversNothingTest', false],
         ];
     }


### PR DESCRIPTION
| Q                   | A
| --------------------| ---------------
| PHPUnit version     | master
| PHP version         | 7.3.5
| Installation Method | Git

If you have specified the `forceCoversAnnotation` setting in your configuration, I would expect this to influence the result of `requiresCodeCoverageDataCollection()` such that the Coverage Driver is only started if any coverage is required.

It appears that the configuration value is only used at the end of the run when generating the coverage report, and is ignored when starting the driver.

Related to #3697/#3699.