### PR TITLE
Unique Log Files

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,10 +15,6 @@
         </testsuite>
     </testsuites>
 
-    <logging>
-        <log type="testdox-text" target="./tests/logs/testdox.log" timestamps="true"/>
-    </logging>
-
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,10 @@
         </testsuite>
     </testsuites>
 
+    <logging>
+        <log type="testdox-text" target="./tests/logs/testdox.log" timestamps="true"/>
+    </logging>
+
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -149,6 +149,7 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="target" type="xs:anyURI"/>
+        <xs:attribute name="timestamps" type="xs:boolean" default="false"/>
         <xs:attribute name="lowUpperBound" type="xs:nonNegativeInteger" default="35"/>
         <xs:attribute name="highLowerBound" type="xs:nonNegativeInteger" default="70"/>
         <xs:attribute name="showUncoveredFiles" type="xs:boolean" default="false"/>

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -272,7 +272,18 @@ final class Configuration
             \assert($log instanceof DOMElement);
 
             $type   = (string) $log->getAttribute('type');
-            $target = (string) $log->getAttribute('target');
+            if ($log->getAttribute('timestamps') == true)
+                //User wants timestamps prefixing the logfile name
+            {
+                $targetArray = explode("/", $log->getAttribute('target'));
+                $end = sizeof($targetArray)-1;
+                //prefix unix timestamp
+                //add unique identifier to allow for concurrent phpunit tests to be run without collisions on
+                $targetArray[$end] = time() . "-" . uniqid() . "-" . $targetArray[$end];
+                $target = (string)implode("/",$targetArray);
+            } else {
+                $target = (string)$log->getAttribute('target');
+            }
 
             if (!$target) {
                 continue;

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -272,17 +272,17 @@ final class Configuration
             \assert($log instanceof DOMElement);
 
             $type   = (string) $log->getAttribute('type');
-            if ($log->getAttribute('timestamps') == true)
+
+            if ($log->getAttribute('timestamps') == true) {
                 //User wants timestamps prefixing the logfile name
-            {
-                $targetArray = explode("/", $log->getAttribute('target'));
-                $end = sizeof($targetArray)-1;
+                $targetArray = \explode('/', $log->getAttribute('target'));
+                $end         = \count($targetArray) - 1;
                 //prefix unix timestamp
                 //add unique identifier to allow for concurrent phpunit tests to be run without collisions on
-                $targetArray[$end] = time() . "-" . uniqid() . "-" . $targetArray[$end];
-                $target = (string)implode("/",$targetArray);
+                $targetArray[$end] = \time() . '-' . \uniqid() . '-' . $targetArray[$end];
+                $target            = (string) \implode('/', $targetArray);
             } else {
-                $target = (string)$log->getAttribute('target');
+                $target = (string) $log->getAttribute('target');
             }
 
             if (!$target) {


### PR DESCRIPTION
This allows the user to make a unique log file for every run of phpunit by prepending the log file name with a timestamp and a random string (to assure tests run within a second of each other are unique).

This would be especially useful when running tests in parallel as the current way will overwrite the log file so that only the last test run will be logged.