### PR TITLE
Removed `array ...$arguments` declaration: arguments are `mixed` by design

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -147,8 +147,6 @@ final class InvocationMocker implements MethodNameMatch
     }
 
     /**
-     * @param array ...$arguments
-     *
      * @throws RuntimeException
      */
     public function with(...$arguments): self


### PR DESCRIPTION
Without this, the interpreted signature is `with(array ...$arguments)`, which makes `$arguments` an `array[]`.