### PR TITLE
Enrich exception message thrown when someone tries to redefine method name for the matcher

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -193,7 +193,10 @@ final class InvocationMocker implements MethodNameMatch
     {
         if ($this->matcher->hasMethodNameMatcher()) {
             throw new RuntimeException(
-                'Method name matcher is already defined, cannot redefine'
+                \sprintf(
+                    'Method name matcher is already defined%s, cannot redefine',
+                    \is_string($constraint) ? \sprintf(' for "%s"', $constraint) : ''
+                )
             );
         }
 


### PR DESCRIPTION
The purpose of this PR is to improve the descriptivity of an exception message, thus pointing the developer more quickly to the offending code.