### PR TITLE
Allow using associative arrays in data providers

### DIFF
--- a/src/Framework/Exception/InvalidDataSetException.php
+++ b/src/Framework/Exception/InvalidDataSetException.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class InvalidDataSetException extends Exception
+{
+}

--- a/src/Util/DataSetTransformer.php
+++ b/src/Util/DataSetTransformer.php
@@ -25,28 +25,27 @@ final class DataSetTransformer
             return $dataSet;
         }
 
-        $argsKeys = \array_keys($dataSet);
-        $origArgs = $dataSet;
-        $newArgs  = [];
+        $dataSetKeys = \array_keys($dataSet);
+        $result      = [];
 
         foreach ($method->getParameters() as $parameter) {
-            if (!\in_array($parameter->getName(), $argsKeys)) {
+            if (!\in_array($parameter->getName(), $dataSetKeys)) {
                 if (!$parameter->isOptional()) {
                     throw new InvalidDataSetException(\sprintf('parameter $%s is not given', $parameter->getName()));
                 }
 
                 if ($parameter->isDefaultValueAvailable()) {
-                    $newArgs[] = $parameter->getDefaultValue();
+                    $result[] = $parameter->getDefaultValue();
                 }
 
                 continue;
             }
 
-            $paramValue = $origArgs[$parameter->getName()];
-            unset($origArgs[$parameter->getName()]);
+            $paramValue = $dataSet[$parameter->getName()];
+            unset($dataSet[$parameter->getName()]);
 
             if (!$parameter->isVariadic()) {
-                $newArgs[] = $paramValue;
+                $result[] = $paramValue;
 
                 continue;
             }
@@ -61,19 +60,19 @@ final class DataSetTransformer
                 ));
             }
 
-            $newArgs = \array_merge($newArgs, $paramValue);
+            $result = \array_merge($result, $paramValue);
         }
 
-        if ([] !== $origArgs) {
+        if ([] !== $dataSet) {
             throw new InvalidDataSetException(\sprintf(
                 'method %s::%s does not have the following parameters: %s',
                 $method->getDeclaringClass()->getName(),
                 $method->getName(),
-                \implode(', ', \array_keys($origArgs))
+                \implode(', ', \array_keys($dataSet))
             ));
         }
 
-        return $newArgs;
+        return $result;
     }
 
     private static function isAssociativeArray(array $array): bool

--- a/src/Util/DataSetTransformer.php
+++ b/src/Util/DataSetTransformer.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use PHPUnit\Framework\InvalidDataSetException;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class DataSetTransformer
+{
+    /**
+     * @throws InvalidDataSetException
+     */
+    public static function transform(\ReflectionMethod $method, array $dataSet): array
+    {
+        if (!self::isAssociativeArray($dataSet)) {
+            return $dataSet;
+        }
+
+        $argsKeys = \array_keys($dataSet);
+        $origArgs = $dataSet;
+        $newArgs  = [];
+
+        foreach ($method->getParameters() as $parameter) {
+            if (!\in_array($parameter->getName(), $argsKeys)) {
+                if (!$parameter->isOptional()) {
+                    throw new InvalidDataSetException(\sprintf('parameter $%s is not given', $parameter->getName()));
+                }
+
+                if ($parameter->isDefaultValueAvailable()) {
+                    $newArgs[] = $parameter->getDefaultValue();
+                }
+
+                continue;
+            }
+
+            $paramValue = $origArgs[$parameter->getName()];
+            unset($origArgs[$parameter->getName()]);
+
+            if (!$parameter->isVariadic()) {
+                $newArgs[] = $paramValue;
+
+                continue;
+            }
+
+            if (!\is_array($paramValue) || self::isAssociativeArray($paramValue)) {
+                throw new InvalidDataSetException(\sprintf(
+                    'parameter $%s in %s::%s is variadic, non-associative array required, %s given',
+                    $parameter->getName(),
+                    $method->getDeclaringClass()->getName(),
+                    $method->getName(),
+                    \is_object($paramValue) ? \get_class($paramValue) : \gettype($paramValue)
+                ));
+            }
+
+            $newArgs = \array_merge($newArgs, $paramValue);
+        }
+
+        if ([] !== $origArgs) {
+            throw new InvalidDataSetException(\sprintf(
+                'method %s::%s does not have the following parameters: %s',
+                $method->getDeclaringClass()->getName(),
+                $method->getName(),
+                \implode(', ', \array_keys($origArgs))
+            ));
+        }
+
+        return $newArgs;
+    }
+
+    private static function isAssociativeArray(array $array): bool
+    {
+        return !empty(\array_filter(\array_keys($array), 'is_string'));
+    }
+}

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -528,6 +528,7 @@ final class Test
                     throw new Exception(
                         \sprintf(
                             'Data set %s is invalid: %s.',
+                            \is_int($key) ? '#' . $key : '"' . $key . '"',
                             $exception->getMessage()
                         ),
                         0,

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\CodeCoverageException;
 use PHPUnit\Framework\InvalidCoversTargetException;
 use PHPUnit\Framework\InvalidDataProviderException;
+use PHPUnit\Framework\InvalidDataSetException;
 use PHPUnit\Framework\SelfDescribing;
 use PHPUnit\Framework\SkippedTestError;
 use PHPUnit\Framework\TestCase;
@@ -518,6 +519,19 @@ final class Test
                             'Data set %s is invalid.',
                             \is_int($key) ? '#' . $key : '"' . $key . '"'
                         )
+                    );
+                }
+
+                try {
+                    $data[$key] = DataSetTransformer::transform($reflector, $value);
+                } catch (InvalidDataSetException $exception) {
+                    throw new Exception(
+                        \sprintf(
+                            'Data set %s is invalid: %s.',
+                            $exception->getMessage()
+                        ),
+                        0,
+                        $exception
                     );
                 }
             }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -951,7 +951,7 @@ final class Test
     /**
      * @throws InvalidDataProviderException
      */
-    private static function getDataFromDataProviderAnnotation(string $docComment, string $className, string $methodName): ?iterable
+    private static function getDataFromDataProviderAnnotation(string $docComment, string $className, string $methodName): ?array
     {
         if (\preg_match_all(self::REGEX_DATA_PROVIDER, $docComment, $matches)) {
             $result = [];

--- a/tests/unit/Util/DataSetTransformerTest.php
+++ b/tests/unit/Util/DataSetTransformerTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use PHPUnit\Framework\InvalidDataSetException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @small
+ */
+final class DataSetTransformerTest extends TestCase
+{
+    /**
+     * @dataProvider transformProvider
+     */
+    public function testTransform(\ReflectionMethod $method, array $dataSet, array $expected): void
+    {
+        $this->assertSame($expected, DataSetTransformer::transform($method, $dataSet));
+    }
+
+    public function transformProvider(): array
+    {
+        $fn = new \ReflectionMethod(static::class, 'fn');
+
+        return [
+            [
+                $fn,
+                ['first', 'second', 'third'],
+                ['first', 'second', 'third'],
+            ],
+            [
+                $fn,
+                ['a' => 'first'],
+                ['first', null],
+            ],
+            [
+                $fn,
+                ['a' => 'first', 'b' => 'second'],
+                ['first', 'second'],
+            ],
+            [
+                $fn,
+                ['b' => 'second', 'a' => 'first'],
+                ['first', 'second'],
+            ],
+            [
+                $fn,
+                ['a' => 'first', 'b' => 'second', 'params' => ['third']],
+                ['first', 'second', 'third'],
+            ],
+            [
+                $fn,
+                ['a' => 'first', 'b' => 'second', 'params' => ['third', 'fourth']],
+                ['first', 'second', 'third', 'fourth'],
+            ],
+            [
+                $fn,
+                ['a' => 'first', 'params' => ['third', 'fourth']],
+                ['first', null, 'third', 'fourth'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidDataSetProvider
+     */
+    public function testInvalidDataSet(\ReflectionMethod $method, array $dataSet, string $message): void
+    {
+        $this->expectException(InvalidDataSetException::class);
+        $this->expectExceptionMessage($message);
+
+        DataSetTransformer::transform($method, $dataSet);
+    }
+
+    public function invalidDataSetProvider(): array
+    {
+        $fn = new \ReflectionMethod(static::class, 'fn');
+
+        return [
+            [
+                $fn,
+                ['b' => 'param b'],
+                'parameter $a is not given',
+            ],
+            [
+                $fn,
+                ['a' => 'a', 'd' => 'd', 'e' => 'e'],
+                'method PHPUnit\Util\DataSetTransformerTest::fn does not have the following parameters: d, e',
+            ],
+            [
+                $fn,
+                ['a' => 'a', 'params' => new \stdClass()],
+                'parameter $params in PHPUnit\Util\DataSetTransformerTest::fn is variadic, non-associative array required, stdClass given',
+            ],
+            [
+                $fn,
+                ['a' => 'a', 'params' => ['a' => 'b']],
+                'parameter $params in PHPUnit\Util\DataSetTransformerTest::fn is variadic, non-associative array required, array given',
+            ],
+        ];
+    }
+
+    public function fn($a, $b = null, ...$params): void
+    {
+    }
+}


### PR DESCRIPTION
Let's consider the following test:

```php
    /**
     * @dataProvider additionProvider
     *
     * @param int $a
     * @param int $b
     * @param int $expected
     */
    public function testAddition(int $a, int $b, int $expected): void
    {
        $this->assertSame($expected, $a + $b);
    }

    public function additionProvider(): array
    {
        return [
            'first' => ['a' => 2, 'b' => 2, 'expected' => 4],
            'second' => ['expected' => 4, 'a' => 2, 'b' => 2],
        ];
    }
```

PHPUnit will return:

```
1) MyTest::testAddition with data set "second" (4, 2, 2)
Failed asserting that 6 is identical to 2.
```

For first data set test is green. For second data set test is red. Looks weird, right? Would be nice to have official support for associative arrays in data providers. What do you think?