### PR TITLE
Use strlen to validate non-empty string for StringStartsWith

### DIFF
--- a/src/Framework/Constraint/StringStartsWith.php
+++ b/src/Framework/Constraint/StringStartsWith.php
@@ -26,7 +26,7 @@ class StringStartsWith extends Constraint
     {
         parent::__construct();
 
-        if (strlen($prefix) === 0) {
+        if (\strlen($prefix) === 0) {
             throw InvalidArgumentHelper::factory(1, 'non-empty string');
         }
 

--- a/src/Framework/Constraint/StringStartsWith.php
+++ b/src/Framework/Constraint/StringStartsWith.php
@@ -26,7 +26,7 @@ class StringStartsWith extends Constraint
     {
         parent::__construct();
 
-        if (empty($prefix)) {
+        if (strlen($prefix) === 0) {
             throw InvalidArgumentHelper::factory(1, 'non-empty string');
         }
 

--- a/tests/unit/Framework/Constraint/StringStartsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringStartsWithTest.php
@@ -35,6 +35,13 @@ class StringStartsWithTest extends ConstraintTestCase
         $this->assertTrue($constraint->evaluate('0E1zzz', '', true));
     }
 
+    public function testConstraintStringStartsWithCorrectSingleZeroAndReturnResult(): void
+    {
+        $constraint = new StringStartsWith('0');
+        
+        $this->assertTrue($constraint->evaluate('0ABC', '', true));
+    }
+    
     public function testConstraintStringStartsWithNotCorrectNumericValueAndReturnResult(): void
     {
         $constraint = new StringStartsWith('0E1');

--- a/tests/unit/Framework/Constraint/StringStartsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringStartsWithTest.php
@@ -38,10 +38,10 @@ class StringStartsWithTest extends ConstraintTestCase
     public function testConstraintStringStartsWithCorrectSingleZeroAndReturnResult(): void
     {
         $constraint = new StringStartsWith('0');
-        
+
         $this->assertTrue($constraint->evaluate('0ABC', '', true));
     }
-    
+
     public function testConstraintStringStartsWithNotCorrectNumericValueAndReturnResult(): void
     {
         $constraint = new StringStartsWith('0E1');


### PR DESCRIPTION
Fixes regression caused by 91936e4f7f1bbaca710da2c07be0e8bab32a5f3e which would cause tests to fail if the string to test for was just `"0"` due to how PHP handles truthy-ness in `empty`.