### PR TITLE
Implement sorting tests by size annotation

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -181,14 +181,17 @@
             <xs:enumeration value="depends,duration"/>
             <xs:enumeration value="depends,random"/>
             <xs:enumeration value="depends,reverse"/>
+            <xs:enumeration value="depends,size"/>
             <xs:enumeration value="duration"/>
             <xs:enumeration value="no-depends"/>
             <xs:enumeration value="no-depends,defects"/>
             <xs:enumeration value="no-depends,duration"/>
             <xs:enumeration value="no-depends,random"/>
             <xs:enumeration value="no-depends,reverse"/>
+            <xs:enumeration value="no-depends,size"/>
             <xs:enumeration value="random"/>
             <xs:enumeration value="reverse"/>
+            <xs:enumeration value="size"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="fileFilterType">

--- a/src/Framework/DataProviderTestSuite.php
+++ b/src/Framework/DataProviderTestSuite.php
@@ -9,6 +9,8 @@
  */
 namespace PHPUnit\Framework;
 
+use PHPUnit\Util\Test as TestUtil;
+
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
@@ -39,5 +41,17 @@ final class DataProviderTestSuite extends TestSuite
     public function hasDependencies(): bool
     {
         return \count($this->dependencies) > 0;
+    }
+
+    /**
+     * Returns the size of the each test created using the data provider(s)
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function getSize(): int
+    {
+        [$className, $methodName] = \explode('::', $this->getName());
+
+        return TestUtil::getSize($className, $methodName);
     }
 }

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\DataProviderTestSuite;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\Util\Test as TestUtil;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -62,6 +63,13 @@ final class TestSuiteSorter
         BaseTestRunner::STATUS_RISKY      => 2,
         BaseTestRunner::STATUS_SKIPPED    => 1,
         BaseTestRunner::STATUS_UNKNOWN    => 0,
+    ];
+
+    private const SIZE_SORT_WEIGHT = [
+        TestUtil::SMALL   => 1,
+        TestUtil::MEDIUM  => 2,
+        TestUtil::LARGE   => 3,
+        TestUtil::UNKNOWN => 4,
     ];
 
     /**
@@ -322,14 +330,18 @@ final class TestSuiteSorter
     }
 
     /**
-     * Compares test size for sorting test small->medium->large->unknown
+     * Compares test size for sorting tests small->medium->large->unknown
      */
     private function cmpSize(Test $a, Test $b): int
     {
-        $sizeA = ($size = $a->getSize()) !== -1 ? $size : 4;
-        $sizeB = ($size = $b->getSize()) !== -1 ? $size : 4;
+        $sizeA = ($a instanceof TestCase || $a instanceof DataProviderTestSuite)
+            ? $a->getSize()
+            : TestUtil::UNKNOWN;
+        $sizeB = ($b instanceof TestCase || $b instanceof DataProviderTestSuite)
+            ? $b->getSize()
+            : TestUtil::UNKNOWN;
 
-        return $sizeA <=> $sizeB;
+        return self::SIZE_SORT_WEIGHT[$sizeA] <=> self::SIZE_SORT_WEIGHT[$sizeB];
     }
 
     /**

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1302,6 +1302,11 @@ class Command
 
                     break;
 
+                case 'size':
+                    $this->arguments['executionOrder'] = TestSuiteSorter::ORDER_SIZE;
+
+                    break;
+
                 default:
                     $this->exitWithErrorMessage("unrecognized --order-by option: $order");
             }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -100,7 +100,7 @@ final class Help
             ['arg'    => '--printer <printer>', 'desc' => 'TestListener implementation to use'],
             ['spacer' => ''],
 
-            ['arg'  => '--order-by=<order>', 'desc' => 'Run tests in order: default|defects|duration|no-depends|random|reverse'],
+            ['arg'  => '--order-by=<order>', 'desc' => 'Run tests in order: default|defects|duration|no-depends|random|reverse|size'],
             ['arg'  => '--random-order-seed=<N>', 'desc' => 'Use a specific random seed <N> for random order'],
             ['arg'  => '--cache-result', 'desc' => 'Write test results to cache file'],
             ['arg'  => '--do-not-cache-result', 'desc' => 'Do not write test results to cache file'],

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -864,6 +864,11 @@ final class Configuration
                         $result['executionOrder'] = TestSuiteSorter::ORDER_REVERSED;
 
                         break;
+
+                    case 'size':
+                        $result['executionOrder'] = TestSuiteSorter::ORDER_SIZE;
+
+                        break;
                 }
             }
         }

--- a/tests/_files/TestWithDifferentSizes.php
+++ b/tests/_files/TestWithDifferentSizes.php
@@ -13,6 +13,7 @@ final class TestWithDifferentSizes extends TestCase
 {
     public function testWithSizeUnknown(): void
     {
+        $this->assertTrue(true);
     }
 
     /**
@@ -20,6 +21,7 @@ final class TestWithDifferentSizes extends TestCase
      */
     public function testWithSizeLarge(): void
     {
+        $this->assertTrue(true);
     }
 
     /**
@@ -28,6 +30,7 @@ final class TestWithDifferentSizes extends TestCase
      */
     public function testWithSizeMedium(): void
     {
+        $this->assertTrue(true);
     }
 
     /**
@@ -35,6 +38,7 @@ final class TestWithDifferentSizes extends TestCase
      */
     public function testWithSizeSmall(): void
     {
+        $this->assertTrue(true);
     }
 
     /**
@@ -43,6 +47,7 @@ final class TestWithDifferentSizes extends TestCase
      */
     public function testDataProviderWithSizeSmall(bool $value): void
     {
+        $this->assertTrue(true);
     }
 
     /**
@@ -51,6 +56,7 @@ final class TestWithDifferentSizes extends TestCase
      */
     public function testDataProviderWithSizeMedium(bool $value): void
     {
+        $this->assertTrue(true);
     }
 
     public function provider(): array

--- a/tests/_files/TestWithDifferentSizes.php
+++ b/tests/_files/TestWithDifferentSizes.php
@@ -23,6 +23,7 @@ final class TestWithDifferentSizes extends TestCase
     }
 
     /**
+     * @depends testDataProviderWithSizeMedium
      * @medium
      */
     public function testWithSizeMedium(): void
@@ -34,5 +35,29 @@ final class TestWithDifferentSizes extends TestCase
      */
     public function testWithSizeSmall(): void
     {
+    }
+
+    /**
+     * @dataProvider provider
+     * @small
+     */
+    public function testDataProviderWithSizeSmall(bool $value): void
+    {
+    }
+
+    /**
+     * @dataProvider provider
+     * @medium
+     */
+    public function testDataProviderWithSizeMedium(bool $value): void
+    {
+    }
+
+    public function provider(): array
+    {
+        return [
+            [false],
+            [true],
+        ];
     }
 }

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -99,7 +99,7 @@
   [32m--printer [36m<printer>[0m        [0m TestListener implementation to use
 
   [32m--order-by=[36m<order>[0m         [0m Run tests in order:
-                              default|defects|duration|no-depends|random|reverse
+                              default|defects|duration|no-depends|random|reverse|size
   [32m--random-order-seed=[36m<N>[0m    [0m Use a specific random seed <N> for random
                               order
   [32m--cache-result             [0m Write test results to cache file

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -77,7 +77,7 @@ Test Execution Options:
   --testdox-exclude-group     Exclude tests from the specified group(s)
   --printer <printer>         TestListener implementation to use
 
-  --order-by=<order>          Run tests in order: default|defects|duration|no-depends|random|reverse
+  --order-by=<order>          Run tests in order: default|defects|duration|no-depends|random|reverse|size
   --random-order-seed=<N>     Use a specific random seed <N> for random order
   --cache-result              Write test results to cache file
   --do-not-cache-result       Do not write test results to cache file

--- a/tests/end-to-end/execution-order/test-order-reversed-with-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-reversed-with-dependency-resolution.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --verbose --order-by=reverse ../_files/DependencySuccessTest.php
+phpunit --verbose --order-by=depends,reverse ../execution-order/_files/MultiDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [

--- a/tests/end-to-end/execution-order/test-order-size-with-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-size-with-dependency-resolution.phpt
@@ -1,0 +1,42 @@
+--TEST--
+phpunit --verbose --order-by=depends,reverse ../execution-order/_files/MultiDependencyTest.php
+--FILE--
+<?php declare(strict_types=1);
+$arguments = [
+    '--no-configuration',
+    '--debug',
+    '--verbose',
+    '--order-by=depends,size',
+    'TestWithDifferentSizes',
+    \realpath(__DIR__ . '/../../_files/TestWithDifferentSizes.php'),
+];
+\array_splice($_SERVER['argv'], 1, count($arguments), $arguments);
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+Test 'TestWithDifferentSizes::testWithSizeSmall' started
+Test 'TestWithDifferentSizes::testWithSizeSmall' ended
+Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #0 (false)' started
+Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #0 (false)' ended
+Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #1 (true)' started
+Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #1 (true)' ended
+Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #0 (false)' started
+Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #0 (false)' ended
+Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #1 (true)' started
+Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #1 (true)' ended
+Test 'TestWithDifferentSizes::testWithSizeMedium' started
+Test 'TestWithDifferentSizes::testWithSizeMedium' ended
+Test 'TestWithDifferentSizes::testWithSizeLarge' started
+Test 'TestWithDifferentSizes::testWithSizeLarge' ended
+Test 'TestWithDifferentSizes::testWithSizeUnknown' started
+Test 'TestWithDifferentSizes::testWithSizeUnknown' ended
+
+
+Time: %s, Memory: %s
+
+OK (8 tests, 8 assertions)

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -569,13 +569,14 @@ final class TestCaseTest extends TestCase
     /**
      * @backupGlobals enabled
      * @backupStaticAttributes enabled
+     * @depends testGlobalsBackupPost
      *
      * @doesNotPerformAssertions
      */
     public function testStaticAttributesBackupPre(): void
     {
         $GLOBALS['singleton'] = \Singleton::getInstance();
-        $GLOBALS['i']         = 'not reset by backup';
+        $GLOBALS['i']         = 'set by testStaticAttributesBackupPre';
 
         $GLOBALS['j']         = 'reset by backup';
         self::$testStatic     = 123;
@@ -588,7 +589,7 @@ final class TestCaseTest extends TestCase
     {
         // Snapshots made by @backupGlobals
         $this->assertSame(\Singleton::getInstance(), $GLOBALS['singleton']);
-        $this->assertSame('not reset by backup', $GLOBALS['i']);
+        $this->assertSame('set by testStaticAttributesBackupPre', $GLOBALS['i']);
 
         // Reset global
         $this->assertArrayNotHasKey('j', $GLOBALS);
@@ -925,10 +926,6 @@ final class TestCaseTest extends TestCase
         $this->assertFalse($test->hasSize());
 
         $this->assertSame(TestUtil::UNKNOWN, $test->getSize());
-
-        $this->assertFalse($test->isLarge());
-        $this->assertFalse($test->isMedium());
-        $this->assertFalse($test->isSmall());
     }
 
     public function testSizeLarge(): void
@@ -938,10 +935,6 @@ final class TestCaseTest extends TestCase
         $this->assertTrue($test->hasSize());
 
         $this->assertSame(TestUtil::LARGE, $test->getSize());
-
-        $this->assertTrue($test->isLarge());
-        $this->assertFalse($test->isMedium());
-        $this->assertFalse($test->isSmall());
     }
 
     public function testSizeMedium(): void
@@ -951,10 +944,6 @@ final class TestCaseTest extends TestCase
         $this->assertTrue($test->hasSize());
 
         $this->assertSame(TestUtil::MEDIUM, $test->getSize());
-
-        $this->assertFalse($test->isLarge());
-        $this->assertTrue($test->isMedium());
-        $this->assertFalse($test->isSmall());
     }
 
     public function testSizeSmall(): void
@@ -964,10 +953,6 @@ final class TestCaseTest extends TestCase
         $this->assertTrue($test->hasSize());
 
         $this->assertSame(TestUtil::SMALL, $test->getSize());
-
-        $this->assertFalse($test->isLarge());
-        $this->assertFalse($test->isMedium());
-        $this->assertTrue($test->isSmall());
     }
 
     public function testGetNameReturnsMethodName(): void

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -41,7 +41,7 @@ final class TestSuiteSorterTest extends TestCase
         $sorter = new TestSuiteSorter;
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('$order must be one of TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_REVERSED, or TestSuiteSorter::ORDER_RANDOMIZED, or TestSuiteSorter::ORDER_DURATION');
+        $this->expectExceptionMessage('$order must be one of TestSuiteSorter::ORDER_[DEFAULT|REVERSED|RANDOMIZED|DURATION|SIZE]');
         $sorter->reorderTestsInSuite($suite, -1, false, TestSuiteSorter::ORDER_DEFAULT);
     }
 
@@ -607,5 +607,27 @@ final class TestSuiteSorterTest extends TestCase
         }
 
         return $data;
+    }
+
+    public function testOrderBySize(): void
+    {
+        $suite = new TestSuite;
+        $suite->addTestSuite(\TestWithDifferentSizes::class);
+        $sorter = new TestSuiteSorter;
+
+        $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_SIZE, true, TestSuiteSorter::ORDER_DEFAULT);
+
+        $expectedOrder = [
+            \TestWithDifferentSizes::class . '::testWithSizeSmall',
+            \TestWithDifferentSizes::class . '::testDataProviderWithSizeSmall with data set #0',
+            \TestWithDifferentSizes::class . '::testDataProviderWithSizeSmall with data set #1',
+            \TestWithDifferentSizes::class . '::testDataProviderWithSizeMedium with data set #0',
+            \TestWithDifferentSizes::class . '::testDataProviderWithSizeMedium with data set #1',
+            \TestWithDifferentSizes::class . '::testWithSizeMedium',
+            \TestWithDifferentSizes::class . '::testWithSizeLarge',
+            \TestWithDifferentSizes::class . '::testWithSizeUnknown',
+        ];
+
+        $this->assertSame($expectedOrder, $sorter->getExecutionOrder());
     }
 }

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -121,6 +121,7 @@ final class ConfigurationTest extends TestCase
             'executionOrder default'                         => ['executionOrder', 'default', TestSuiteSorter::ORDER_DEFAULT],
             'executionOrder random'                          => ['executionOrder', 'random', TestSuiteSorter::ORDER_RANDOMIZED],
             'executionOrder reverse'                         => ['executionOrder', 'reverse', TestSuiteSorter::ORDER_REVERSED],
+            'executionOrder size'                            => ['executionOrder', 'size', TestSuiteSorter::ORDER_SIZE],
             'cacheResult=false'                              => ['cacheResult', 'false', false],
             'cacheResult=true'                               => ['cacheResult', 'true', true],
             'cacheResultFile absolute path'                  => ['cacheResultFile', '/path/to/result/cache', '/path/to/result/cache'],


### PR DESCRIPTION
Implements #3748: option to sort tests by `@small`, `@medium` and `@large` size annotation.

### Changes
- add `--order-by=size` CLI flag
- add `executionOrder=size` configuration attribute
- added size annotation support to `DataProviderTestSuite`
- expanded `TestWithDifferentSizes` including data providers and `@depends`
- removed unused `TestCase::is[Small|Medium|Large]`

### Testing
```
./phpunit --debug --order-by=size tests/_files/TestWithDifferentSizes.php   
[...]
                                          
Test 'TestWithDifferentSizes::testWithSizeSmall' started
Test 'TestWithDifferentSizes::testWithSizeSmall' ended
Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #0 (false)' started
Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #0 (false)' ended
Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #1 (true)' started
Test 'TestWithDifferentSizes::testDataProviderWithSizeSmall with data set #1 (true)' ended
Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #0 (false)' started
Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #0 (false)' ended
Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #1 (true)' started
Test 'TestWithDifferentSizes::testDataProviderWithSizeMedium with data set #1 (true)' ended
Test 'TestWithDifferentSizes::testWithSizeMedium' started
Test 'TestWithDifferentSizes::testWithSizeMedium' ended
Test 'TestWithDifferentSizes::testWithSizeLarge' started
Test 'TestWithDifferentSizes::testWithSizeLarge' ended
Test 'TestWithDifferentSizes::testWithSizeUnknown' started
Test 'TestWithDifferentSizes::testWithSizeUnknown' ended
[...]
```
