### PR TITLE
Let AfterTestHook extend TestHook instead of Hook

### DIFF
--- a/src/Runner/Hook/AfterTestHook.php
+++ b/src/Runner/Hook/AfterTestHook.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Runner;
 
-interface AfterTestHook extends Hook
+interface AfterTestHook extends TestHook
 {
     /**
      * This hook will fire after any test, regardless of the result.


### PR DESCRIPTION
`AfterTestHook` has to extend `TestHook` instead of `Hook` to be added to the `TestListenerAdapter`, otherwise `executeAfterTest()` is never called.