### PR TITLE
Cast exception message to string

### DIFF
--- a/src/Framework/Constraint/ExceptionMessage.php
+++ b/src/Framework/Constraint/ExceptionMessage.php
@@ -42,7 +42,7 @@ final class ExceptionMessage extends Constraint
             return $other->getMessage() === '';
         }
 
-        return \strpos($other->getMessage(), $this->expectedMessage) !== false;
+        return \strpos((string) $other->getMessage(), $this->expectedMessage) !== false;
     }
 
     /**


### PR DESCRIPTION
Since PHPUnit 8, the `PHPUnit\Framework\Constraint\ExceptionMessage` contains a `strict_types=1` annotation. 
This triggers an `TypeError` when exception's message is not a string, but a class with a `__toString` method like symfony/symfony does in `AutowiringFailedException`.

This PR cast the exception message to string