### PR TITLE
Use correct article ("a" or "an") in InvalidArgumentHelper

### DIFF
--- a/src/Util/InvalidArgumentHelper.php
+++ b/src/Util/InvalidArgumentHelper.php
@@ -27,7 +27,7 @@ final class InvalidArgumentHelper
                 $value !== null ? ' (' . \gettype($value) . '#' . $value . ')' : ' (No Value) ',
                 $stack[1]['class'],
                 $stack[1]['function'],
-                \in_array($type[0], ['a', 'e', 'i', 'o', 'u']) ? 'an' : 'a',
+                \in_array(\lcfirst($type)[0], ['a', 'e', 'i', 'o', 'u']) ? 'an' : 'a',
                 $type
             )
         );

--- a/src/Util/InvalidArgumentHelper.php
+++ b/src/Util/InvalidArgumentHelper.php
@@ -27,7 +27,7 @@ final class InvalidArgumentHelper
                 $value !== null ? ' (' . \gettype($value) . '#' . $value . ')' : ' (No Value) ',
                 $stack[1]['class'],
                 $stack[1]['function'],
-                \in_array($type[0], ['a', 'e', 'i', 'o', 'u']) ? 'a' : 'an',
+                \in_array($type[0], ['a', 'e', 'i', 'o', 'u']) ? 'an' : 'a',
                 $type
             )
         );

--- a/src/Util/InvalidArgumentHelper.php
+++ b/src/Util/InvalidArgumentHelper.php
@@ -22,11 +22,12 @@ final class InvalidArgumentHelper
 
         return new Exception(
             \sprintf(
-                'Argument #%d%sof %s::%s() must be a %s',
+                'Argument #%d%sof %s::%s() must be %s %s',
                 $argument,
                 $value !== null ? ' (' . \gettype($value) . '#' . $value . ')' : ' (No Value) ',
                 $stack[1]['class'],
                 $stack[1]['function'],
+                \in_array($type[0], ['a', 'e', 'i', 'o', 'u']) ? 'a' : 'an',
                 $type
             )
         );

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1524,6 +1524,9 @@ XML;
         $this->fail();
     }
 
+    /**
+     * @testdox InvalidArgumentException uses correct article for variable type
+     */
     public function testInvalidArgumentExceptionUsesCorrectArticleInErrorMessage(): void
     {
         try {

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1524,7 +1524,7 @@ XML;
         $this->fail();
     }
 
-    public function testInvalidArgumentExceptionUseCorrectArticleInErrorMessage(): void
+    public function testInvalidArgumentExceptionUsesCorrectArticleInErrorMessage(): void
     {
         try {
             $this->assertArrayHasKey('key', 'not an array');

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1524,6 +1524,19 @@ XML;
         $this->fail();
     }
 
+    public function testInvalidArgumentExceptionUseCorrectArticleInErrorMessage(): void
+    {
+        try {
+            $this->assertArrayHasKey('key', 'not an array');
+        } catch (Exception $e) {
+            $this->assertEquals('Argument #2 (No Value) of PHPUnit\Framework\Assert::assertArrayHasKey() must be an array or ArrayAccess', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail();
+    }
+
     public function testAssertNotCount(): void
     {
         $this->assertNotCount(2, [1, 2, 3]);


### PR DESCRIPTION
Development
- [x] code complete
- [x] fix PHPUnit self-tests locally

Create pull request
- [x] add title
- [x] add description of change
- [x] request review

This PR might change InvalidArgumentHelper exception message, especially article before `$type`.
If `$type` starts with vowel, "an" will be used, "a" otherwise.