### PR TITLE
Add support for multiple whitelisted directories in CLI args

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -724,7 +724,11 @@ class Command
                     break;
 
                 case '--whitelist':
-                    $this->arguments['whitelist'] = $option[1];
+                    if (!isset($this->arguments['whitelist'])) {
+                        $this->arguments['whitelist'] = [];
+                    }
+
+                    $this->arguments['whitelist'][] = $option[1];
 
                     break;
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -457,7 +457,15 @@ final class TestRunner extends BaseTestRunner
             $whitelistFromOption            = false;
 
             if (isset($arguments['whitelist'])) {
-                $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
+                if (!\is_array($arguments['whitelist'])) {
+                    $whitelistDirectories = [$arguments['whitelist']];
+                } else {
+                    $whitelistDirectories = $arguments['whitelist'];
+                }
+
+                foreach ($whitelistDirectories as $whitelistDirectory) {
+                    $this->codeCoverageFilter->addDirectoryToWhitelist($whitelistDirectory);
+                }
 
                 $whitelistFromOption = true;
             }

--- a/tests/_files/phpt-for-multiwhitelist-coverage.phpt
+++ b/tests/_files/phpt-for-multiwhitelist-coverage.phpt
@@ -1,0 +1,10 @@
+--TEST--
+PHPT for testing coverage using multiple whitespace arguments
+--FILE--
+<?php declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';
+$coveredClass = new CoveredClass();
+$coveredClass->publicMethod();
+$anotherCoveredClass = new SampleClass(1, 2, 'a');
+$testing = $anotherCoveredClass->a;
+--EXPECT--

--- a/tests/end-to-end/code-coverage-multiple-whitelist.phpt
+++ b/tests/end-to-end/code-coverage-multiple-whitelist.phpt
@@ -1,0 +1,46 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout ../../_files/phpt-for-coverage.phpt --whitelist ../../_files/CoveredClass.php
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--bootstrap';
+$_SERVER['argv'][3] = __DIR__ . '/../bootstrap.php';
+$_SERVER['argv'][4] = '--colors=never';
+$_SERVER['argv'][5] = '--coverage-text=php://stdout';
+$_SERVER['argv'][6] = __DIR__ . '/../_files/phpt-for-multiwhitelist-coverage.phpt';
+$_SERVER['argv'][7] = '--whitelist';
+$_SERVER['argv'][8] = __DIR__ . '/../_files/CoveredClass.php';
+$_SERVER['argv'][9] = '--whitelist';
+$_SERVER['argv'][10] = __DIR__ . '/../_files/SampleClass.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+
+Code Coverage Report:%w
+%s
+%w
+ Summary:%w
+  Classes: 100.00% (3/3)%w
+  Methods: 100.00% (%d/%d)%w
+  Lines:   100.00% (%d/%d)
+
+CoveredClass
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)
+CoveredParentClass
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)
+SampleClass
+  Methods: 100.00% ( %d/ %d)   Lines: 100.00% (  %d/  %d)


### PR DESCRIPTION
Previously inserting multiple `--whitelist` args would result in the
last one being the only effective one.

New implementation aggregates them and adds them to the code coverage
filtering one by one, allowing developers to use multiple directories
in whitelisting without relying on the XML configuration file.

This introduces no BC breaks, as the old behavior works in the same
way as always from the end user's perspective, internally an array
with a single item is used instead.

The way it can be used if this is merged:

    phpunit --coverage-text --whitelist=mydir1 --whitelist=mydir2/file123.php --whitelist=mydir3/file1.php ./testsuite