### PR TITLE
Reject non-iterable parameter groups

### DIFF
--- a/src/Framework/Exception/InvalidParameterGroupException.php
+++ b/src/Framework/Exception/InvalidParameterGroupException.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class InvalidParameterGroupException extends Exception
+{
+}

--- a/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Matcher/ConsecutiveParameters.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Framework\MockObject\Matcher;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidParameterGroupException;
 use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 
 /**
@@ -35,6 +36,16 @@ final class ConsecutiveParameters extends StatelessInvocation
     public function __construct(array $parameterGroups)
     {
         foreach ($parameterGroups as $index => $parameters) {
+            if (!\is_iterable($parameters)) {
+                throw new InvalidParameterGroupException(
+                    \sprintf(
+                        'Parameter group #%d must be an array or Traversable, got %s',
+                        $index,
+                        \gettype($parameters)
+                    )
+                );
+            }
+
             foreach ($parameters as $parameter) {
                 if (!$parameter instanceof Constraint) {
                     $parameter = new IsEqual($parameter);

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -9,6 +9,7 @@
  */
 
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidParameterGroupException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -67,5 +68,22 @@ final class ConsecutiveParametersTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
 
         $mock->foo('invalid');
+    }
+
+    public function testIntegrationFailsWithNonIterableParameterGroup(): void
+    {
+        $mock = $this->getMockBuilder(stdClass::class)
+            ->setMethods(['foo'])
+            ->getMock();
+
+        $this->expectException(InvalidParameterGroupException::class);
+        $this->expectExceptionMessage('Parameter group #1 must be an array or Traversable, got object');
+
+        $mock->expects($this->any())
+            ->method('foo')
+            ->withConsecutive(
+                ['bar'],
+                $this->identicalTo([21, 42]) // this is not an array
+            );
     }
 }


### PR DESCRIPTION
Related to #3134

Currently, passing a non-iterable object to `withConsecutive()` will silently fail and perform no assertions. This can easily happen if someone forgets to enclose a single expected parameter in an array:

```php
    $exampleMock->expects($this->once())
        ->method('foo')
        ->withConsecutive(
            // missing arrays, nothing will be asserted!
            $this->identicalTo($objectA),
            $this->identicalTo($objectB)
        );
```

This PR adds a check in `ConsecutiveParameters` to prevent this from happening.