### PR TITLE
Document replacement methods

### DIFF
--- a/src/Framework/TestListener.php
+++ b/src/Framework/TestListener.php
@@ -16,31 +16,43 @@ interface TestListener
 {
     /**
      * An error occurred.
+     *
+     * @deprecated Use `AfterTestErrorHook::executeAfterTestError` instead
      */
     public function addError(Test $test, \Throwable $t, float $time): void;
 
     /**
      * A warning occurred.
+     *
+     * @deprecated Use `AfterTestWarningHook::executeAfterTestWarning` instead
      */
     public function addWarning(Test $test, Warning $e, float $time): void;
 
     /**
      * A failure occurred.
+     *
+     * @deprecated Use `AfterTestFailureHook::executeAfterTestFailure` instead
      */
     public function addFailure(Test $test, AssertionFailedError $e, float $time): void;
 
     /**
      * Incomplete test.
+     *
+     * @deprecated Use `AfterIncompleteTestHook::executeAfterIncompleteTest` instead
      */
     public function addIncompleteTest(Test $test, \Throwable $t, float $time): void;
 
     /**
      * Risky test.
+     *
+     * @deprecated Use `AfterRiskyTestHook::executeAfterRiskyTest` instead
      */
     public function addRiskyTest(Test $test, \Throwable $t, float $time): void;
 
     /**
      * Skipped test.
+     *
+     * @deprecated Use `AfterSkippedTestHook::executeAfterSkippedTest` instead
      */
     public function addSkippedTest(Test $test, \Throwable $t, float $time): void;
 
@@ -56,11 +68,15 @@ interface TestListener
 
     /**
      * A test started.
+     *
+     * @deprecated Use `BeforeTestHook::executeBeforeTest` instead
      */
     public function startTest(Test $test): void;
 
     /**
      * A test ended.
+     *
+     * @deprecated Use `AfterTestHook::executeAfterTest` instead
      */
     public function endTest(Test $test, float $time): void;
 }


### PR DESCRIPTION
This PR is incomplete, because I could not find a suitable replacement for `startTestSuite` and `endTestSuite`. It might be `BeforeFirstTestHook::executeBeforeFirstTest` and `AfterLastTestHook::executeAfterLastTest` but I'm not sure of that, for 2 reasons:
1. These methods do not have a `TestSuite` argument.
2. The adapter establishes no such correspondance: https://github.com/sebastianbergmann/phpunit/blob/b61d4d78a2657f5c65a296ffc86944b473211c88/src/Runner/Hook/TestListenerAdapter.php#L133-L139

Please comment on how people should migrate away from these 2 methods.