### PR TITLE
Small updates (typo fix, type correction, var declaration and added coverage)

### DIFF
--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -296,7 +296,7 @@ final class MockBuilder
             if ($reflector->hasMethod($method)) {
                 throw new RuntimeException(
                     \sprintf(
-                        'Trying to set mock method "%s" with addMethod, but it exists in class "%s". Use onlyMethods() for methods that exist in the class.',
+                        'Trying to set mock method "%s" with addMethods, but it exists in class "%s". Use onlyMethods() for methods that exist in the class.',
                         $method,
                         $this->type
                     )

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -734,7 +734,7 @@ final class PhptTestCase implements SelfDescribing, Test
             }
         }
 
-        if ($sectionName) {
+        if ($sectionName && isset($sectionOffset)) {
             // String not found in specified section, show user the start of the named section
             return [[
                 'file' => \realpath($this->filename),
@@ -742,7 +742,7 @@ final class PhptTestCase implements SelfDescribing, Test
             ]];
         }
 
-        // No section specified, show user start of code
+        // No section specified or located, show user start of code
         return [[
             'file' => \realpath($this->filename),
             'line' => 1,

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -41,27 +41,29 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
             $loadedClasses = \array_values(
                 \array_diff(\get_declared_classes(), $loadedClasses)
             );
-        }
 
-        if (!empty($loadedClasses) && !\class_exists($suiteClassName, false)) {
-            $offset = 0 - \strlen($suiteClassName);
+            if (!empty($loadedClasses)) {
+                $offset = 0 - \strlen($suiteClassName);
 
-            foreach ($loadedClasses as $loadedClass) {
-                try {
-                    $class = new ReflectionClass($loadedClass);
-                } catch (\ReflectionException $e) {
-                    throw new Exception(
-                        $e->getMessage(),
-                        (int) $e->getCode(),
-                        $e
-                    );
-                }
+                foreach ($loadedClasses as $loadedClass) {
+                    try {
+                        $class = new ReflectionClass($loadedClass);
+                    } catch (\ReflectionException $e) {
+                        throw new Exception(
+                            $e->getMessage(),
+                            (int) $e->getCode(),
+                            $e
+                        );
+                    }
 
-                if (\substr($loadedClass, $offset) === $suiteClassName &&
-                    $class->getFileName() == $filename) {
-                    $suiteClassName = $loadedClass;
+                    if (
+                        \substr($loadedClass, $offset) === $suiteClassName &&
+                        $class->getFileName() == $filename
+                    ) {
+                        $suiteClassName = $loadedClass;
 
-                    break;
+                        break;
+                    }
                 }
             }
         }

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -432,17 +432,14 @@ class ResultPrinter extends Printer implements TestListener
                 );
             } else {
                 $this->write("\n");
+                $color = 'fg-white, bg-red';
 
                 if ($result->errorCount()) {
-                    $color = 'fg-white, bg-red';
-
                     $this->writeWithColor(
                         $color,
                         'ERRORS!'
                     );
                 } elseif ($result->failureCount()) {
-                    $color = 'fg-white, bg-red';
-
                     $this->writeWithColor(
                         $color,
                         'FAILURES!'

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -318,14 +318,14 @@ final class TestRunner extends BaseTestRunner
             foreach ($arguments['loadedExtensions'] as $extension) {
                 $this->writeMessage(
                     'Extension',
-                    $extension
+                    (string) $extension
                 );
             }
 
             foreach ($arguments['notLoadedExtensions'] as $extension) {
                 $this->writeMessage(
                     'Extension',
-                    $extension
+                    (string) $extension
                 );
             }
         }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -453,9 +453,6 @@ final class TestRunner extends BaseTestRunner
         }
 
         if ($codeCoverageReports > 0 || isset($arguments['xdebugFilterFile'])) {
-            $whitelistFromConfigurationFile = false;
-            $whitelistFromOption            = false;
-
             if (isset($arguments['whitelist'])) {
                 $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
 

--- a/tests/_files/NamedConstraint.php
+++ b/tests/_files/NamedConstraint.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 final class NamedConstraint extends Constraint
 {
     /**
-     * @var int
+     * @var string
      */
     private $name;
 

--- a/tests/end-to-end/report-empty-whitelist-config.phpt
+++ b/tests/end-to-end/report-empty-whitelist-config.phpt
@@ -1,0 +1,27 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout ../../_files/BankAccountTest.php
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = 'BankAccountTest';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Error:         No whitelist is configured, no code coverage will be generated.
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)

--- a/tests/end-to-end/report-incorrect-whitelist-config.phpt
+++ b/tests/end-to-end/report-incorrect-whitelist-config.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit --colors=never --coverage-text=php://stdout ../../_files/BankAccountTest.php
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug is required.';
+}
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--colors=never';
+$_SERVER['argv'][3] = '--coverage-text=php://stdout';
+$_SERVER['argv'][4] = 'BankAccountTest';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][6] = '--whitelist';
+$_SERVER['argv'][7] = 'foo';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Error:         Incorrect whitelist config, no code coverage will be generated.
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)


### PR DESCRIPTION
I have made a few small changes:

- Fixed typo of function name in a message
- Corrected a property type in a docblock
- Declared some vars because they could potentially be undeclared in following `if` or `try` blocks

This last change led me to discover that the part I changed wasn't covered in tests, so I've added 2 `.phpt` files that now cover this.