### PR TITLE
Don't escape unicode in prettified JSON

### DIFF
--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -31,7 +31,7 @@ final class Json
             );
         }
 
-        return \json_encode($decodedJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES);
+        return \json_encode($decodedJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
     }
 
     /*

--- a/tests/unit/Util/JsonTest.php
+++ b/tests/unit/Util/JsonTest.php
@@ -61,6 +61,7 @@ final class JsonTest extends TestCase
         return [
             ['{"name":"John","age": "5"}', "{\n    \"name\": \"John\",\n    \"age\": \"5\"\n}"],
             ['{"url":"https://www.example.com/"}', "{\n    \"url\": \"https://www.example.com/\"\n}"],
+            ['"Кириллица and 中文"', '"Кириллица and 中文"'],
         ];
     }
 


### PR DESCRIPTION
Sometimes it's usefull to see actual unicode strings in failed assertions.
Example of current unicode representation
```
Failed asserting that '"中文"' matches JSON string ""Кириллица"".
--- Expected
+++ Actual
@@ @@
-"\u041a\u0438\u0440\u0438\u043b\u043b\u0438\u0446\u0430"
+"\u4e2d\u6587"
```

After this PR it will be
```
Failed asserting that '"中文"' matches JSON string ""Кириллица"".
--- Expected
+++ Actual
@@ @@
-"Кириллица"
+"中文"
```