### PR TITLE
#3120 implemented `TestCase#createStub()`

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -9,6 +9,13 @@ namespace PHPSTORM_META {
     );
 
     override(
+        \PHPUnit\Framework\TestCase::createStub(0),
+        map([
+            '@&\PHPUnit\Framework\MockObject\Stub',
+        ])
+    );
+
+    override(
         \PHPUnit\Framework\TestCase::createConfiguredMock(0),
         map([
             '@&\PHPUnit\Framework\MockObject\MockObject',

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -97,6 +97,9 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>self</code>
     </ImplementedReturnTypeMismatch>
+    <MethodSignatureMismatch occurrences="1">
+      <code>InvocationMocker</code>
+    </MethodSignatureMismatch>
     <UndefinedInterfaceMethod occurrences="1">
       <code>registerId</code>
     </UndefinedInterfaceMethod>

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -107,9 +107,6 @@
       <code>$this-&gt;will($stub)</code>
       <code>$this-&gt;will($stub)</code>
     </LessSpecificReturnStatement>
-    <MethodSignatureMismatch occurrences="1">
-      <code>InvocationMocker</code>
-    </MethodSignatureMismatch>
     <MoreSpecificReturnType occurrences="8">
       <code>self</code>
       <code>self</code>

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.x-dev@0279c6f6d9bbe22854526c45eaf1f5482c12ade3">
+<files psalm-version="3.4.12@86e5e50c1bb492045e70f2ebe1da3cad06e4e9b2">
   <file src="src/Framework/Assert.php">
     <ArgumentTypeCoercion occurrences="2">
       <code>$expectedElement-&gt;childNodes-&gt;item($i)</code>
@@ -97,26 +97,6 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>self</code>
     </ImplementedReturnTypeMismatch>
-    <LessSpecificReturnStatement occurrences="8">
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-      <code>$this-&gt;will($stub)</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="8">
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-      <code>self</code>
-    </MoreSpecificReturnType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>registerId</code>
     </UndefinedInterfaceMethod>
@@ -397,9 +377,7 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/Util/Log/TeamCity.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>$split[0]</code>
-      <code>$split[0]</code>
+    <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
     <UndefinedInterfaceMethod occurrences="7">
@@ -455,18 +433,14 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Util/Test.php">
-    <ArgumentTypeCoercion occurrences="5">
+    <ArgumentTypeCoercion occurrences="4">
       <code>$className</code>
-      <code>$pieces[0]</code>
       <code>$className</code>
       <code>$className</code>
       <code>$dataProviderClassName</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="4">
+    <InvalidArgument occurrences="1">
       <code>$e</code>
-      <code>$operator</code>
-      <code>$operator</code>
-      <code>$operator</code>
     </InvalidArgument>
     <InvalidCatch occurrences="1"/>
     <InvalidReturnStatement occurrences="1">

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -97,9 +97,29 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>self</code>
     </ImplementedReturnTypeMismatch>
+    <LessSpecificReturnStatement occurrences="8">
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+      <code>$this-&gt;will($stub)</code>
+    </LessSpecificReturnStatement>
     <MethodSignatureMismatch occurrences="1">
       <code>InvocationMocker</code>
     </MethodSignatureMismatch>
+    <MoreSpecificReturnType occurrences="8">
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+      <code>self</code>
+    </MoreSpecificReturnType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>registerId</code>
     </UndefinedInterfaceMethod>

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\MockObject\Stub\Stub;
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class InvocationMocker implements MethodNameMatch
+final class InvocationMocker implements InvocationStubber, MethodNameMatch
 {
     /**
      * @var MatcherCollection
@@ -68,7 +68,7 @@ final class InvocationMocker implements MethodNameMatch
         return $this;
     }
 
-    public function will(Stub $stub): Identity
+    public function will(Stub $stub): self
     {
         $this->matcher->setStub($stub);
 
@@ -92,9 +92,7 @@ final class InvocationMocker implements MethodNameMatch
         return $this->will($stub);
     }
 
-    /**
-     * @param mixed $reference
-     */
+    /** {@inheritDoc} */
     public function willReturnReference(&$reference): self
     {
         $stub = new ReturnReference($reference);
@@ -116,9 +114,7 @@ final class InvocationMocker implements MethodNameMatch
         return $this->will($stub);
     }
 
-    /**
-     * @param callable $callback
-     */
+    /** {@inheritDoc} */
     public function willReturnCallback($callback): self
     {
         $stub = new ReturnCallback($callback);

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -68,7 +68,7 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         return $this;
     }
 
-    public function will(Stub $stub): self
+    public function will(Stub $stub): Identity
     {
         $this->matcher->setStub($stub);
 

--- a/src/Framework/MockObject/Builder/InvocationStubber.php
+++ b/src/Framework/MockObject/Builder/InvocationStubber.php
@@ -14,11 +14,6 @@ use PHPUnit\Framework\MockObject\Stub\Stub;
 /** @internal This class is not covered by the backward compatibility promise for PHPUnit */
 interface InvocationStubber
 {
-    /**
-     * @TODO is "will" actually sensible in a stub context? Should a stub produce side-effects?
-     *
-     * Note: probably yes, since you want a stub of a promise to be able to resolve a real callback, for example
-     */
     public function will(Stub $stub): Identity;
 
     /** @return self */

--- a/src/Framework/MockObject/Builder/InvocationStubber.php
+++ b/src/Framework/MockObject/Builder/InvocationStubber.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Builder;
+
+use PHPUnit\Framework\MockObject\Stub\Stub;
+
+/** @internal This class is not covered by the backward compatibility promise for PHPUnit */
+interface InvocationStubber
+{
+    /**
+     * @TODO is "will" actually sensible in a stub context? Should a stub produce side-effects?
+     *
+     * Note: probably yes, since you want a stub of a promise to be able to resolve a real callback, for example
+     */
+    public function will(Stub $stub): Identity;
+
+    public function willReturn($value, ...$nextValues): self;
+
+    /** @param mixed $reference */
+    public function willReturnReference(&$reference): self;
+
+    /** @param array<int, array<int, mixed>> $valueMap */
+    public function willReturnMap(array $valueMap): self;
+
+    /** @param int $argumentIndex */
+    public function willReturnArgument($argumentIndex): self;
+
+    /** @param callable $callback */
+    public function willReturnCallback($callback): self;
+
+    public function willReturnSelf(): self;
+
+    /** @param mixed $values */
+    public function willReturnOnConsecutiveCalls(...$values): self;
+
+    public function willThrowException(\Throwable $exception): self;
+}

--- a/src/Framework/MockObject/Builder/InvocationStubber.php
+++ b/src/Framework/MockObject/Builder/InvocationStubber.php
@@ -17,46 +17,46 @@ interface InvocationStubber
     public function will(Stub $stub): Identity;
 
     /** @return self */
-    public function willReturn($value, ...$nextValues);
+    public function willReturn($value, ...$nextValues) /*: self */;
 
     /**
      * @param mixed $reference
      *
      * @return self
      */
-    public function willReturnReference(&$reference);
+    public function willReturnReference(&$reference) /*: self */;
 
     /**
      * @param array<int, array<int, mixed>> $valueMap
      *
      * @return self
      */
-    public function willReturnMap(array $valueMap);
+    public function willReturnMap(array $valueMap) /*: self */;
 
     /**
      * @param int $argumentIndex
      *
      * @return self
      */
-    public function willReturnArgument($argumentIndex);
+    public function willReturnArgument($argumentIndex) /*: self */;
 
     /**
      * @param callable $callback
      *
      * @return self
      */
-    public function willReturnCallback($callback);
+    public function willReturnCallback($callback) /*: self */;
 
     /** @return self */
-    public function willReturnSelf();
+    public function willReturnSelf() /*: self */;
 
     /**
      * @param mixed $values
      *
      * @return self
      */
-    public function willReturnOnConsecutiveCalls(...$values);
+    public function willReturnOnConsecutiveCalls(...$values) /*: self */;
 
     /** @return self */
-    public function willThrowException(\Throwable $exception);
+    public function willThrowException(\Throwable $exception) /*: self */;
 }

--- a/src/Framework/MockObject/Builder/InvocationStubber.php
+++ b/src/Framework/MockObject/Builder/InvocationStubber.php
@@ -21,24 +21,47 @@ interface InvocationStubber
      */
     public function will(Stub $stub): Identity;
 
-    public function willReturn($value, ...$nextValues): self;
+    /** @return self */
+    public function willReturn($value, ...$nextValues);
 
-    /** @param mixed $reference */
-    public function willReturnReference(&$reference): self;
+    /**
+     * @param mixed $reference
+     *
+     * @return self
+     */
+    public function willReturnReference(&$reference);
 
-    /** @param array<int, array<int, mixed>> $valueMap */
-    public function willReturnMap(array $valueMap): self;
+    /**
+     * @param array<int, array<int, mixed>> $valueMap
+     *
+     * @return self
+     */
+    public function willReturnMap(array $valueMap);
 
-    /** @param int $argumentIndex */
-    public function willReturnArgument($argumentIndex): self;
+    /**
+     * @param int $argumentIndex
+     *
+     * @return self
+     */
+    public function willReturnArgument($argumentIndex);
 
-    /** @param callable $callback */
-    public function willReturnCallback($callback): self;
+    /**
+     * @param callable $callback
+     *
+     * @return self
+     */
+    public function willReturnCallback($callback);
 
-    public function willReturnSelf(): self;
+    /** @return self */
+    public function willReturnSelf();
 
-    /** @param mixed $values */
-    public function willReturnOnConsecutiveCalls(...$values): self;
+    /**
+     * @param mixed $values
+     *
+     * @return self
+     */
+    public function willReturnOnConsecutiveCalls(...$values);
 
-    public function willThrowException(\Throwable $exception): self;
+    /** @return self */
+    public function willThrowException(\Throwable $exception);
 }

--- a/src/Framework/MockObject/Stub.php
+++ b/src/Framework/MockObject/Stub.php
@@ -9,10 +9,10 @@
  */
 namespace PHPUnit\Framework\MockObject;
 
-use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMocker;
+use PHPUnit\Framework\MockObject\Builder\InvocationStubber;
 
 /**
- * @method BuilderInvocationMocker method($constraint)
+ * @method InvocationStubber method($constraint)
  */
 interface Stub
 {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\MockObject\Matcher\InvokedAtMostCount as InvokedAtMostCoun
 use PHPUnit\Framework\MockObject\Matcher\InvokedCount as InvokedCountMatcher;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls as ConsecutiveCallsStub;
 use PHPUnit\Framework\MockObject\Stub\Exception as ExceptionStub;
 use PHPUnit\Framework\MockObject\Stub\ReturnArgument as ReturnArgumentStub;
@@ -1541,6 +1542,18 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
                 'invalid.'
             );
         }
+    }
+
+    /**
+     * Makes configurable stub for the specified class.
+     *
+     * @psalm-template RealInstanceType of object
+     * @psalm-param    class-string<RealInstanceType> $originalClassName
+     * @psalm-return   Stub&RealInstanceType
+     */
+    protected function createStub(string $originalClassName): Stub
+    {
+        return $this->createMock($originalClassName);
     }
 
     /**

--- a/tests/static-analysis/TestUsingMocks.php
+++ b/tests/static-analysis/TestUsingMocks.php
@@ -35,6 +35,17 @@ final class TestUsingMocks extends TestCase
         self::assertSame('hello mock!', $mock->sayHello());
     }
 
+    public function testWillSayHelloThroughCreateStub(): void
+    {
+        $mock = $this->createStub(HelloWorldClass::class);
+
+        $mock
+            ->method('sayHello')
+            ->willReturn('hello mock!');
+
+        self::assertSame('hello mock!', $mock->sayHello());
+    }
+
     public function testWillSayHelloThroughCreateConfiguredMock(): void
     {
         $mock = $this->createConfiguredMock(HelloWorldClass::class, []);

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -10,7 +10,7 @@
 namespace PHPUnit\Framework;
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub\Stub;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Runner\BaseTestRunner;
 use PHPUnit\Util\Test as TestUtil;
 

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Framework;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub\Stub;
 use PHPUnit\Runner\BaseTestRunner;
 use PHPUnit\Util\Test as TestUtil;
 
@@ -832,8 +833,23 @@ final class TestCaseTest extends TestCase
 
     public function testCreateMockMocksAllMethods(): void
     {
-        /** @var \Mockable $mock */
         $mock = $this->createMock(\Mockable::class);
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->anotherMockableMethod());
+    }
+
+    public function testCreateStubFromClassName(): void
+    {
+        $mock = $this->createStub(\Mockable::class);
+
+        $this->assertInstanceOf(\Mockable::class, $mock);
+        $this->assertInstanceOf(Stub::class, $mock);
+    }
+
+    public function testCreateStubMocksAllMethods(): void
+    {
+        $mock = $this->createStub(\Mockable::class);
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->anotherMockableMethod());
@@ -879,7 +895,6 @@ final class TestCaseTest extends TestCase
 
     public function testCreateMockSkipsConstructor(): void
     {
-        /** @var \Mockable $mock */
         $mock = $this->createMock(\Mockable::class);
 
         $this->assertNull($mock->constructorArgs);
@@ -887,8 +902,22 @@ final class TestCaseTest extends TestCase
 
     public function testCreateMockDisablesOriginalClone(): void
     {
-        /** @var \Mockable $mock */
         $mock = $this->createMock(\Mockable::class);
+
+        $cloned = clone $mock;
+        $this->assertNull($cloned->cloned);
+    }
+
+    public function testCreateStubSkipsConstructor(): void
+    {
+        $mock = $this->createStub(\Mockable::class);
+
+        $this->assertNull($mock->constructorArgs);
+    }
+
+    public function testCreateStubDisablesOriginalClone(): void
+    {
+        $mock = $this->createStub(\Mockable::class);
 
         $cloned = clone $mock;
         $this->assertNull($cloned->cloned);
@@ -924,6 +953,7 @@ final class TestCaseTest extends TestCase
             [123],
             ['foo'],
             [$this->createMock(\Mockable::class)],
+            [$this->createStub(\Mockable::class)],
         ];
 
         $test = new \TestAutoreferenced('testJsonEncodeException', [$data]);


### PR DESCRIPTION
Fixes #3120 

In practice, a `MockObject` is also a `Stub`, so we are just aliasing methods, but it is also true that the type-checker now does the heavy lifting for us. If people use `MockObject` methods after being told explicitly that a `Stub` is returned, that's a type error downstream.

Auto-completion now restricts methods correctly, so we're good :+1: