### PR TITLE
Make .travis.yml warning-free

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,10 @@ notifications:
 
 jobs:
   include:
-    - stage: Static Code Analysis
+    - stage: "Static Code Analysis"
       php: 7.3
-      env: php-cs-fixer
+      env:
+        - TOOL="php-cs-fixer"
       install:
         - phpenv config-rm xdebug.ini
       script:


### PR DESCRIPTION
- properly quote build stage names
- have a proper environment-value pair for the used tool in the stages