### PR TITLE
Remove PHP_Token and CodeCoverage from whitelist

### DIFF
--- a/build/scoper.inc.php
+++ b/build/scoper.inc.php
@@ -11,8 +11,6 @@
 return [
     'whitelist' => [
         'PHPUnit\*',
-        'SebastianBergmann\CodeCoverage\*',
-        'PHP_Token*',
         'Prophecy\*',
     ],
 ];


### PR DESCRIPTION
Since CodeCoverage and PHP_Token are not part of the public API of
PHPUnit they can safely be removed from the whitelist.

Issue #3750