### PR TITLE
Prevent too greedy selection for annotation parsing - closes #3693

### DIFF
--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -653,7 +653,7 @@ final class Test
         // Strip away the docblock header and footer to ease parsing of one line annotations
         $docBlock = (string) \substr($docBlock, 3, -2);
 
-        if (\preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docBlock, $matches)) {
+        if (\preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>[^\r\n]*?))?[ \t]*\r?$/m', $docBlock, $matches)) {
             $numMatches = \count($matches[0]);
 
             for ($i = 0; $i < $numMatches; ++$i) {


### PR DESCRIPTION
This should fix #3693 where the greedy selector also included newlines (namely `\n` and `\r`).