### PR TITLE
Enhancement: Run roave/backward-compatibility-check using GitHub actions

### DIFF
--- a/.docker/php-7.3/Dockerfile
+++ b/.docker/php-7.3/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:7.3-cli
+
+RUN apt-get update \
+    && apt-get install --assume-yes \
+        apt-utils \
+        git \
+        libzip-dev \
+        zip \
+        zlib1g-dev \
+    && apt-get clean --assume-yes \
+    && docker-php-ext-install \
+        zip
+
+RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memory-limit.ini
+
+COPY --from=composer:1.9.0 /usr/bin/composer /usr/local/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,20 @@ jobs:
         uses: docker://php:7.3-cli
         with:
           args: ./tools/psalm --config=.psalm/config.xml --no-progress --shepherd --show-info=false --stats
+
+  backward-compatibility:
+    name: Backward Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Build Docker image for PHP 7.3
+        uses: ./.docker/php-7.3
+        with:
+          args: php -v
+
+      - name: Run roave/backward-compatibility-check
+        uses: ./.docker/php-7.3
+        with:
+          args: ./tools/roave-backward-compatibility-check --from=8.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,3 @@ after_success:
 
 notifications:
   email: false
-
-jobs:
-  include:
-    - stage: "Static Code Analysis"
-      php: 7.3
-      env:
-        - TOOL="roave-backward-compatibility-check"
-      install:
-          - phpenv config-rm xdebug.ini
-      script:
-          - ./tools/roave-backward-compatibility-check --from=8.3.3


### PR DESCRIPTION
This PR

* [x] runs `roave/backward-compatibility-check` (as installed with `phive` to `/tools`) using GitHub actions

Replaces #3823.

💁‍♂ As discussed earlier, we'll follow Kent Beck here with _Make it work, make it right, make it fast_!