### PR TITLE
Fix: Do not export .docker directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
-/build export-ignore
-/tools export-ignore
+/.docker    export-ignore
+/build      export-ignore
+/tools      export-ignore
 
 *.php diff=php
 


### PR DESCRIPTION
This PR

* [x] adjusts `.gitattributes` to ignore the `.docker` directory

Follows #3824.