### PR TITLE
Add warnings to JUnit report - closes #3793

### DIFF
--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -65,6 +65,11 @@ final class JUnit extends Printer implements TestListener
     /**
      * @var int[]
      */
+    private $testSuiteWarnings = [0];
+
+    /**
+     * @var int[]
+     */
     private $testSuiteFailures = [0];
 
     /**
@@ -128,7 +133,7 @@ final class JUnit extends Printer implements TestListener
     public function addWarning(Test $test, Warning $e, float $time): void
     {
         $this->doAddFault($test, $e, $time, 'warning');
-        $this->testSuiteFailures[$this->testSuiteLevel]++;
+        $this->testSuiteWarnings[$this->testSuiteLevel]++;
     }
 
     /**
@@ -208,6 +213,7 @@ final class JUnit extends Printer implements TestListener
         $this->testSuiteTests[$this->testSuiteLevel]      = 0;
         $this->testSuiteAssertions[$this->testSuiteLevel] = 0;
         $this->testSuiteErrors[$this->testSuiteLevel]     = 0;
+        $this->testSuiteWarnings[$this->testSuiteLevel]   = 0;
         $this->testSuiteFailures[$this->testSuiteLevel]   = 0;
         $this->testSuiteSkipped[$this->testSuiteLevel]    = 0;
         $this->testSuiteTimes[$this->testSuiteLevel]      = 0;
@@ -234,6 +240,11 @@ final class JUnit extends Printer implements TestListener
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'warnings',
+            (string) $this->testSuiteWarnings[$this->testSuiteLevel]
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'failures',
             (string) $this->testSuiteFailures[$this->testSuiteLevel]
         );
@@ -252,6 +263,7 @@ final class JUnit extends Printer implements TestListener
             $this->testSuiteTests[$this->testSuiteLevel - 1] += $this->testSuiteTests[$this->testSuiteLevel];
             $this->testSuiteAssertions[$this->testSuiteLevel - 1] += $this->testSuiteAssertions[$this->testSuiteLevel];
             $this->testSuiteErrors[$this->testSuiteLevel - 1] += $this->testSuiteErrors[$this->testSuiteLevel];
+            $this->testSuiteWarnings[$this->testSuiteLevel - 1] += $this->testSuiteWarnings[$this->testSuiteLevel];
             $this->testSuiteFailures[$this->testSuiteLevel - 1] += $this->testSuiteFailures[$this->testSuiteLevel];
             $this->testSuiteSkipped[$this->testSuiteLevel - 1] += $this->testSuiteSkipped[$this->testSuiteLevel];
             $this->testSuiteTimes[$this->testSuiteLevel - 1] += $this->testSuiteTimes[$this->testSuiteLevel];

--- a/tests/end-to-end/dataprovider-log-xml-isolation.phpt
+++ b/tests/end-to-end/dataprovider-log-xml-isolation.phpt
@@ -16,8 +16,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ..F.                                                                4 / 4 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
-    <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
+  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" warnings="0" failures="1" skipped="0" time="%f">
+    <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" warnings="0" failures="1" skipped="0" time="%f">
       <testcase name="testAdd with data set #0" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #1" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #2" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f">

--- a/tests/end-to-end/dataprovider-log-xml.phpt
+++ b/tests/end-to-end/dataprovider-log-xml.phpt
@@ -15,8 +15,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 ..F.                                                                4 / 4 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
-    <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
+  <testsuite name="DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" warnings="0" failures="1" skipped="0" time="%f">
+    <testsuite name="DataProviderTest::testAdd" tests="4" assertions="4" errors="0" warnings="0" failures="1" skipped="0" time="%f">
       <testcase name="testAdd with data set #0" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #1" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f"/>
       <testcase name="testAdd with data set #2" class="DataProviderTest" classname="DataProviderTest" file="%sDataProviderTest.php" line="%d" assertions="1" time="%f">

--- a/tests/end-to-end/loggers/log-junit-phpt.phpt
+++ b/tests/end-to-end/loggers/log-junit-phpt.phpt
@@ -17,7 +17,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 .                                                                   1 / 1 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="%s">
+  <testsuite name="" tests="1" assertions="1" errors="0" warnings="0" failures="0" skipped="0" time="%s">
     <testcase name="%send-to-end%ephpt-stderr.phpt" assertions="1" time="%s">
       <system-out>PHPUnit must look at STDERR when running PHPT tests.</system-out>
     </testcase>

--- a/tests/end-to-end/loggers/log-junit.phpt
+++ b/tests/end-to-end/loggers/log-junit.phpt
@@ -18,7 +18,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 .FEISRW.FEISRW                                                    14 / 14 (100%)<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="PHPUnit\SelfTest\Basic\StatusTest" file="%s%eStatusTest.php" tests="14" assertions="4" errors="4" failures="4" skipped="4" time="%f">
+  <testsuite name="PHPUnit\SelfTest\Basic\StatusTest" file="%s%eStatusTest.php" tests="14" assertions="4" errors="4" warnings="2" failures="2" skipped="4" time="%f">
     <testcase name="testSuccess" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="1" time="%f"/>
     <testcase name="testFailure" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" file="%s%eStatusTest.php" line="%d" assertions="1" time="%f">
       <failure type="PHPUnit\Framework\ExpectationFailedException">PHPUnit\SelfTest\Basic\StatusTest::testFailure


### PR DESCRIPTION
This should properly add the `warnings` to the output of the JUnit log, see #3793.