### PR TITLE
Fix trailing slash in XdebugFilterScriptGenerator - closes #3834

### DIFF
--- a/src/Util/XdebugFilterScriptGenerator.php
+++ b/src/Util/XdebugFilterScriptGenerator.php
@@ -56,7 +56,7 @@ EOF;
                 $path = \realpath($directory['path']);
 
                 if (\is_string($path)) {
-                    $files[] = \sprintf('%s/', $path);
+                    $files[] = \sprintf(\addslashes('%s' . \DIRECTORY_SEPARATOR), $path);
                 }
             }
         }


### PR DESCRIPTION
This should properly add the trailing slash to files in `xdebug-filter.php` as reported in #3834 