### PR TITLE
Throw meaningful exception in TestSuiteIterator.getChildren()

### DIFF
--- a/src/Framework/TestSuiteIterator.php
+++ b/src/Framework/TestSuiteIterator.php
@@ -73,12 +73,19 @@ final class TestSuiteIterator implements RecursiveIterator
 
     /**
      * Returns the sub iterator for the current element.
+     *
+     * @throws \UnexpectedValueException if the current element is no TestSuite
      */
     public function getChildren(): self
     {
-        return new self(
-            $this->tests[$this->position]
-        );
+        if (!$this->hasChildren()) {
+            throw new UnexpectedValueException(
+                'The current item is no TestSuite instance and hence cannot have any children.',
+                1567849414
+            );
+        }
+
+        return new self($this->current());
     }
 
     /**
@@ -86,6 +93,6 @@ final class TestSuiteIterator implements RecursiveIterator
      */
     public function hasChildren(): bool
     {
-        return $this->tests[$this->position] instanceof TestSuite;
+        return $this->current() instanceof TestSuite;
     }
 }

--- a/src/Framework/UnexpectedValueException.php
+++ b/src/Framework/UnexpectedValueException.php
@@ -1,0 +1,14 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+class UnexpectedValueException extends Exception
+{
+}

--- a/tests/unit/Framework/TestSuiteIteratorTest.php
+++ b/tests/unit/Framework/TestSuiteIteratorTest.php
@@ -112,7 +112,6 @@ final class TestSuiteIteratorTest extends TestCase
         $testSuite = new TestSuite();
         $testSuite->addTest(new \EmptyTestCaseTest());
         $subject = new TestSuiteIterator($testSuite);
-        $subject->rewind();
 
         $subject->next();
 
@@ -124,7 +123,6 @@ final class TestSuiteIteratorTest extends TestCase
         $testSuite = new TestSuite();
         $testSuite->addTest(new \EmptyTestCaseTest());
         $subject = new TestSuiteIterator($testSuite);
-        $subject->rewind();
 
         $subject->next();
 
@@ -136,7 +134,6 @@ final class TestSuiteIteratorTest extends TestCase
         $testSuite = new TestSuite();
         $testSuite->addTest(new \EmptyTestCaseTest());
         $subject = new TestSuiteIterator($testSuite);
-        $subject->rewind();
 
         $subject->next();
 
@@ -147,21 +144,42 @@ final class TestSuiteIteratorTest extends TestCase
      * tests for getChildren
      */
 
+    public function testGetChildrenForEmptyTestSuiteThrowsException(): void
+    {
+        $testSuite = new TestSuite();
+        $subject   = new TestSuiteIterator($testSuite);
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $subject->getChildren();
+    }
+
+    public function testGetChildrenForCurrentTestThrowsException(): void
+    {
+        $testSuite = new TestSuite();
+        $testSuite->addTest(new \EmptyTestCaseTest());
+        $subject = new TestSuiteIterator($testSuite);
+
+        $this->expectException(UnexpectedValueException::class);
+
+        $subject->getChildren();
+    }
+
     public function testGetChildrenReturnsNewInstanceWithCurrentTestSuite(): void
     {
-        $this->markTestSkipped('This test needs a bug fix to pass.');
+        $childSuite = new TestSuite();
+        $test       = new \EmptyTestCaseTest();
+        $childSuite->addTest($test);
 
-        $testSuite       = new TestSuite();
-        $childSuite      = new TestSuite();
+        $testSuite  = new TestSuite();
         $testSuite->addTest($childSuite);
+
         $subject = new TestSuiteIterator($testSuite);
-        $subject->rewind();
 
         $children = $subject->getChildren();
-        $children->rewind();
 
         $this->assertNotSame($subject, $children);
-        $this->assertSame($childSuite, $children->current());
+        $this->assertSame($test, $children->current());
     }
 
     /*
@@ -170,33 +188,28 @@ final class TestSuiteIteratorTest extends TestCase
 
     public function testHasChildrenForCurrentTestSuiteReturnsTrue(): void
     {
-        $testSuite       = new TestSuite();
-        $childSuite      = new TestSuite();
+        $testSuite  = new TestSuite();
+        $childSuite = new TestSuite();
         $testSuite->addTest($childSuite);
         $subject = new TestSuiteIterator($testSuite);
-        $subject->rewind();
 
         $this->assertTrue($subject->hasChildren());
     }
 
-    public function testHasChildrenForCurrentTestSuiteReturnsFalse(): void
+    public function testHasChildrenForCurrentTestReturnsFalse(): void
     {
-        $testSuite       = new TestSuite();
-        $test            = new \EmptyTestCaseTest();
+        $testSuite = new TestSuite();
+        $test      = new \EmptyTestCaseTest();
         $testSuite->addTest($test);
         $subject = new TestSuiteIterator($testSuite);
-        $subject->rewind();
 
         $this->assertFalse($subject->hasChildren());
     }
 
     public function testHasChildrenForNoTestsReturnsFalse(): void
     {
-        $this->markTestSkipped('This test needs a bug fix to pass.');
-
-        $testSuite       = new TestSuite();
-        $subject         = new TestSuiteIterator($testSuite);
-        $subject->rewind();
+        $testSuite = new TestSuite();
+        $subject   = new TestSuiteIterator($testSuite);
 
         $this->assertFalse($subject->hasChildren());
     }


### PR DESCRIPTION
Also refactor the `getChildren()` and `hasChildren()`
to reduce code duplication.

Also drop some `rewind()` calls from the tests now that
the `TestSuite` already is properly rewound directly
after instantiation.