### PR TITLE
Prevent undefined stdout index error - #3727

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -177,7 +177,7 @@ class PhptTestCase implements SelfDescribing, Test
         }
 
         try {
-            $this->assertPhptExpectation($sections, $jobResult['stdout']);
+            $this->assertPhptExpectation($sections, $this->output);
         } catch (AssertionFailedError $e) {
             $failure = $e;
 


### PR DESCRIPTION
I guess we should use the `$this->output` to prevent the undefined index error.

See #3727