### PR TITLE
Fix: Use offical Docker image for composer to install dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           args: php -v
 
       - name: Update dependencies with composer
-        uses: ./.docker/php-7.3
+        uses: docker://composer:1.9.0
         with:
           args: composer update --no-interaction --no-ansi --no-progress --no-suggest
 


### PR DESCRIPTION
This PR

* [x] uses the official Docker image for `composer` to install dependencies

💁‍♂ This should be fine since the platform is configured in `composer.json`, see 

https://github.com/sebastianbergmann/phpunit/blob/d4fe4c6142f9a88dee3bbbdcf15481eb7188de69/composer.json#L54-L56