### PR TITLE
Keep php-cs-fixer from removing or simplifying "return null;"

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -171,7 +171,7 @@ return PhpCsFixer\Config::create()
             'semicolon_after_instruction' => true,
             'set_type_to_cast' => true,
             'short_scalar_cast' => true,
-            'simplified_null_return' => true,
+            'simplified_null_return' => false,
             'single_blank_line_at_eof' => true,
             'single_import_per_statement' => true,
             'single_line_after_imports' => true,


### PR DESCRIPTION
`return null;` semantically is something different than `return;`
and should be kept.