### PR TITLE
Add classname to exceptions - #3676

### DIFF
--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -152,7 +152,8 @@ final class Matcher implements MatcherInvocation
         } catch (ExpectationFailedException $e) {
             throw new ExpectationFailedException(
                 \sprintf(
-                    "Expectation failed for %s when %s\n%s",
+                    "Expectation failed for class \"%s\" with %s when %s\n%s",
+                    $invocation->getClassName(),
                     $this->methodNameMatcher->toString(),
                     $this->invocationMatcher->toString(),
                     $e->getMessage()
@@ -221,7 +222,8 @@ final class Matcher implements MatcherInvocation
         } catch (ExpectationFailedException $e) {
             throw new ExpectationFailedException(
                 \sprintf(
-                    "Expectation failed for %s when %s\n%s",
+                    "Expectation failed for class \"%s\" with %s when %s\n%s",
+                    $this->getClassName(),
                     $this->methodNameMatcher->toString(),
                     $this->invocationMatcher->toString(),
                     $e->getMessage()
@@ -266,7 +268,8 @@ final class Matcher implements MatcherInvocation
         } catch (ExpectationFailedException $e) {
             throw new ExpectationFailedException(
                 \sprintf(
-                    "Expectation failed for %s when %s.\n%s",
+                    "Expectation failed for class \"%s\" with %s when %s.\n%s",
+                    '',
                     $this->methodNameMatcher->toString(),
                     $this->invocationMatcher->toString(),
                     TestFailure::exceptionToString($e)

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -670,7 +670,7 @@ final class MockObjectTest extends TestCase
             $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s).\n" .
+                "Expectation failed for class \"SomeClass\" with method name is \"right\" when invoked 1 time(s).\n" .
                 'Method was expected to be called 1 times, actually called 0 times.' . "\n",
                 $e->getMessage()
             );
@@ -695,7 +695,7 @@ final class MockObjectTest extends TestCase
             $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s).\n" .
+                "Expectation failed for class \"SomeClass\" with method name is \"right\" when invoked 1 time(s).\n" .
                 'Method was expected to be called 1 times, actually called 0 times.' . "\n",
                 $e->getMessage()
             );
@@ -718,7 +718,7 @@ final class MockObjectTest extends TestCase
             $mock->right(['second']);
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s)\n" .
+                "Expectation failed for class \"SomeClass\" with method name is \"right\" when invoked 1 time(s)\n" .
                 'Parameter 0 for invocation SomeClass::right(Array (...)) does not match expected value.' . "\n" .
                 'Failed asserting that two arrays are equal.',
                 $e->getMessage()
@@ -732,7 +732,7 @@ final class MockObjectTest extends TestCase
 //            $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s).\n" .
+                "Expectation failed for class \"SomeClass\" with method name is \"right\" when invoked 1 time(s).\n" .
                 'Parameter 0 for invocation SomeClass::right(Array (...)) does not match expected value.' . "\n" .
                 'Failed asserting that two arrays are equal.' . "\n" .
                 '--- Expected' . "\n" .
@@ -811,7 +811,7 @@ final class MockObjectTest extends TestCase
             $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s)\n" .
+                "Expectation failed for class \"SomeClass\" with method name is \"right\" when invoked 1 time(s)\n" .
                 'Parameter count for invocation SomeClass::right() is too low.' . "\n" .
                 'To allow 0 or more parameters with any value, omit ->with() or use ->withAnyParameters() instead.',
                 $e->getMessage()


### PR DESCRIPTION
Not sure how we can get the classname in the `verify` method.