### PR TITLE
Fix TooManyArguments- error in Color::colorize call

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -289,9 +289,6 @@
     <PossiblyUndefinedVariable occurrences="1">
       <code>$color</code>
     </PossiblyUndefinedVariable>
-    <TooManyArguments occurrences="1">
-      <code>Color::colorize($color, \str_pad($line, $padding), false)</code>
-    </TooManyArguments>
   </file>
   <file src="src/TextUI/TestRunner.php">
     <LessSpecificReturnStatement occurrences="1"/>

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -522,7 +522,7 @@ class ResultPrinter extends Printer implements TestListener
         $styledLines = [];
 
         foreach ($lines as $line) {
-            $styledLines[] = Color::colorize($color, \str_pad($line, $padding), false);
+            $styledLines[] = Color::colorize($color, \str_pad($line, $padding));
         }
 
         return \implode(\PHP_EOL, $styledLines);


### PR DESCRIPTION
This PR does:

* remove parameter from method call which doesn't exist in method signature of Color::colorize
* update Psalm baseline