### PR TITLE
Don't export development-only files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,17 @@
+/.docker export-ignore
+/.github export-ignore
+/.psalm export-ignore
 /build export-ignore
+/tests export-ignore
 /tools export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/.phpstorm.meta.php export-ignore
+/.travis.yml export-ignore
+/build.xml export-ignore
+/phive.xml export-ignore
+/phpunit.xml export-ignore
 
 *.php diff=php
-


### PR DESCRIPTION
The files that are used for developing PHPUnit
(but not for developing _with_ PHPUnit) should not be
exported.

This should reduce the size of the Composer packages
that are installed with the `--prefer-dist` option
(which is the default) considerably.