### PR TITLE
Enhancement: Use built-in PHP 7.3 to speed up build for 7.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,4 @@ jobs:
         uses: actions/checkout@master
 
       - name: Run friendsofphp/php-cs-fixer
-        uses: docker://php:7.3-cli
-        with:
-          args: ./tools/php-cs-fixer fix --diff-format=udiff --dry-run --show-progress=dots --using-cache=no --verbose
+        run: php7.3 tools/php-cs-fixer fix --diff-format=udiff --dry-run --show-progress=dots --using-cache=no --verbose


### PR DESCRIPTION
This PR

* [x] uses the built-in binary for PHP 7.3 to run `php-cs-fixer` on `7.5.`

Follows #3809.

💁‍♂ As pointed out by @OskarStark, PHP binaries are available on `ubuntu-latest`. This should speed up the build significantly! 