### PR TITLE
add deprecation warning when called with just a class name

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -782,7 +782,8 @@ class Command
 
         if (isset($this->options[1][0]) &&
             \substr($this->options[1][0], -5, 5) !== '.phpt' &&
-            \substr($this->options[1][0], -4, 4) !== '.php'
+            \substr($this->options[1][0], -4, 4) !== '.php' &&
+            \substr($this->options[1][0], -1, 1) !== '/'
         ) {
             print 'Warning: Calling PHPUnit with a class name is deprecated and will be removed in PHPUnit 9.' . \PHP_EOL;
         }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -780,6 +780,13 @@ class Command
             $this->arguments['testSuffixes'] = ['Test.php', '.phpt'];
         }
 
+        if (isset($this->options[1][0]) &&
+            \substr($this->options[1][0], -5, 5) !== '.phpt' &&
+            \substr($this->options[1][0], -4, 4) !== '.php'
+        ) {
+            print 'Warning: Calling PHPUnit with a class name is deprecated and will be removed in PHPUnit 9.' . \PHP_EOL;
+        }
+
         if (!isset($this->arguments['test'])) {
             if (isset($this->options[1][0])) {
                 $this->arguments['test'] = $this->options[1][0];

--- a/tests/end-to-end/abstract-test-class.phpt
+++ b/tests/end-to-end/abstract-test-class.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit AbstractTest ../../_files/AbstractTest.php
+phpunit ../../_files/AbstractTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'AbstractTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/AbstractTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/AbstractTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/abstract-test-class.phpt
+++ b/tests/end-to-end/abstract-test-class.phpt
@@ -3,11 +3,13 @@ phpunit ../../_files/AbstractTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = __DIR__ . '/../_files/AbstractTest.php';
+$_SERVER['argv'][2] = 'AbstractTest';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/AbstractTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
+Warning: Calling PHPUnit with a class name is deprecated and will be removed in PHPUnit 9.
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 W                                                                   1 / 1 (100%)

--- a/tests/end-to-end/assertion.phpt
+++ b/tests/end-to-end/assertion.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit AssertionExampleTest ../../_files/AssertionExampleTest.php
+phpunit ../../_files/AssertionExampleTest.php
 --SKIPIF--
 <?php declare(strict_types=1);
 if (PHP_MAJOR_VERSION < 7) {
@@ -16,8 +16,7 @@ if (ini_get('assert.exception') != 1) {
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'AssertionExampleTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/AssertionExampleTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/AssertionExampleTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/cli/columns-max.phpt
+++ b/tests/end-to-end/cli/columns-max.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --columns=max BankAccountTest ../../_files/BankAccountTest.php
+phpunit --columns=max ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--columns=max';
-$_SERVER['argv'][3] = 'BankAccountTest';
-$_SERVER['argv'][4] = __DIR__ . '/../../_files/BankAccountTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../../_files/BankAccountTest.php';
 
 require __DIR__ . '/../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/cli/columns.phpt
+++ b/tests/end-to-end/cli/columns.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --columns=40 BankAccountTest ../../_files/BankAccountTest.php
+phpunit --columns=40 ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--columns=40';
-$_SERVER['argv'][3] = 'BankAccountTest';
-$_SERVER['argv'][4] = __DIR__ . '/../../_files/BankAccountTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../../_files/BankAccountTest.php';
 
 require __DIR__ . '/../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/cli/deprecation-warning-with-class.phpt
+++ b/tests/end-to-end/cli/deprecation-warning-with-class.phpt
@@ -1,0 +1,19 @@
+--TEST--
+phpunit DummyFooTest ../../_files/DummyFooTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = 'DummyFooTest';
+$_SERVER['argv'][3] = __DIR__ . '/../../_files/DummyFooTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+Warning: Calling PHPUnit with a class name is deprecated and will be removed in PHPUnit 9.
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/cli/mycommand.phpt
+++ b/tests/end-to-end/cli/mycommand.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit BankAccountTest ../../_files/BankAccountTest.php
+phpunit ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--my-option=123',
     '--my-other-option',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/cli/options-after-arguments.phpt
+++ b/tests/end-to-end/cli/options-after-arguments.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit BankAccountTest ../../_files/BankAccountTest.php --colors
+phpunit ../../_files/BankAccountTest.php --colors
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [

--- a/tests/end-to-end/cli/test-file-not-found.phpt
+++ b/tests/end-to-end/cli/test-file-not-found.phpt
@@ -1,12 +1,10 @@
 --TEST--
 Test incorrect testFile is reported
 --ARGS--
---no-configuration tests nonExistingFile.php
+--no-configuration nonExistingFile.php
 --FILE--
 <?php declare(strict_types=1);
 require __DIR__ . '/../../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann and contributors.
-
 Cannot open file "nonExistingFile.php".

--- a/tests/end-to-end/code-coverage-ignore.phpt
+++ b/tests/end-to-end/code-coverage-ignore.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --colors=never --coverage-text=php://stdout IgnoreCodeCoverageClassTest ../../_files/IgnoreCodeCoverageClassTest.php --whitelist ../../../tests/_files/IgnoreCodeCoverageClass.php
+phpunit --colors=never --coverage-text=php://stdout ../../_files/IgnoreCodeCoverageClassTest.php --whitelist ../../../tests/_files/IgnoreCodeCoverageClass.php
 --SKIPIF--
 <?php declare(strict_types=1);
 if (!extension_loaded('xdebug')) {

--- a/tests/end-to-end/concrete-test-class.phpt
+++ b/tests/end-to-end/concrete-test-class.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit ConcreteTest ../../_files/ConcreteTest.php
+phpunit ../../_files/ConcreteTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'ConcreteTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/ConcreteTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/ConcreteTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/dataprovider-issue-2833.phpt
+++ b/tests/end-to-end/dataprovider-issue-2833.phpt
@@ -1,9 +1,9 @@
 --TEST--
-phpunit ../../_files/DataProviderIssue2833
+phpunit ../../_files/DataProviderIssue2833/
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = __DIR__ . '/../_files/DataProviderIssue2833';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/DataProviderIssue2833/';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/dataprovider-issue-2922.phpt
+++ b/tests/end-to-end/dataprovider-issue-2922.phpt
@@ -1,10 +1,10 @@
 --TEST--
-phpunit --exclude-group=foo ../../_files/DataProviderIssue2922
+phpunit --exclude-group=foo ../../_files/DataProviderIssue2922/
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--exclude-group=foo';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/DataProviderIssue2922';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/DataProviderIssue2922/';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/dataprovider-log-xml-isolation.phpt
+++ b/tests/end-to-end/dataprovider-log-xml-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --log-junit php://stdout DataProviderTest ../../_files/DataProviderTest.php
+phpunit --process-isolation --log-junit php://stdout ../../_files/DataProviderTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--log-junit';
 $_SERVER['argv'][4] = 'php://stdout';
-$_SERVER['argv'][5] = 'DataProviderTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/dataprovider-log-xml.phpt
+++ b/tests/end-to-end/dataprovider-log-xml.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --log-junit php://stdout DataProviderTest ../../_files/DataProviderTest.php
+phpunit --log-junit php://stdout ../../_files/DataProviderTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--log-junit';
 $_SERVER['argv'][3] = 'php://stdout';
-$_SERVER['argv'][4] = 'DataProviderTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/default-isolation.phpt
+++ b/tests/end-to-end/default-isolation.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --process-isolation BankAccountTest ../../_files/BankAccountTest.php
+phpunit --process-isolation ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'BankAccountTest';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/default.phpt
+++ b/tests/end-to-end/default.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit BankAccountTest ../../_files/BankAccountTest.php
+phpunit ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'BankAccountTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/disable-code-coverage-ignore.phpt
+++ b/tests/end-to-end/disable-code-coverage-ignore.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --colors=never --coverage-text=php://stdout --disable-coverage-ignore IgnoreCodeCoverageClassTest tests/_files/IgnoreCodeCoverageClassTest.php --whitelist ../../../tests/_files/IgnoreCodeCoverageClass.php
+phpunit --colors=never --coverage-text=php://stdout --disable-coverage-ignore tests/_files/IgnoreCodeCoverageClassTest.php --whitelist ../../../tests/_files/IgnoreCodeCoverageClass.php
 --SKIPIF--
 <?php declare(strict_types=1);
 if (!extension_loaded('xdebug')) {

--- a/tests/end-to-end/empty-testcase.phpt
+++ b/tests/end-to-end/empty-testcase.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit EmptyTestCaseTest ../../_files/EmptyTestCaseTest.php
+phpunit ../../_files/EmptyTestCaseTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'EmptyTestCaseTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/EmptyTestCaseTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/EmptyTestCaseTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/exception-stack.phpt
+++ b/tests/end-to-end/exception-stack.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit ExceptionStackTest ../../_files/ExceptionStackTest.php
+phpunit ../../_files/ExceptionStackTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'ExceptionStackTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/ExceptionStackTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/ExceptionStackTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/exclude-group-isolation.phpt
+++ b/tests/end-to-end/exclude-group-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --exclude-group balanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --process-isolation --exclude-group balanceIsInitiallyZero ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--exclude-group';
 $_SERVER['argv'][4] = 'balanceIsInitiallyZero';
-$_SERVER['argv'][5] = 'BankAccountTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/exclude-group.phpt
+++ b/tests/end-to-end/exclude-group.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --exclude-group balanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --exclude-group balanceIsInitiallyZero ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--exclude-group';
 $_SERVER['argv'][3] = 'balanceIsInitiallyZero';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/execution-order/cache-result.phpt
+++ b/tests/end-to-end/execution-order/cache-result.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --order-by=no-depends,reverse --cache-result --cache-result-file MultiDependencyTest ./tests/_files/MultiDependencyTest.php
+phpunit --order-by=no-depends,reverse --cache-result --cache-result-file ./tests/_files/MultiDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $target = tempnam(sys_get_temp_dir(), __FILE__);
@@ -10,7 +10,6 @@ $arguments = [
     '--order-by=reverse',
     '--cache-result',
     '--cache-result-file=' . $target,
-    'MultiDependencyTest',
     realpath(__DIR__ . '/../execution-order/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/defects-first-order-via-cli.phpt
+++ b/tests/end-to-end/execution-order/defects-first-order-via-cli.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --order-by=defects MultiDependencyTest ./tests/_files/MultiDependencyTest.php
+phpunit --order-by=defects ./tests/_files/MultiDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $tmpResultCache = \tempnam(sys_get_temp_dir(), __FILE__);
@@ -11,7 +11,6 @@ $arguments = [
     '--order-by=defects',
     '--cache-result',
     '--cache-result-file=' . $tmpResultCache,
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/dependencies-clone.phpt
+++ b/tests/end-to-end/execution-order/dependencies-clone.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --verbose ClonedDependencyTest ../../_files/ClonedDependencyTest.php
+phpunit --verbose ../../_files/ClonedDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--verbose',
-    'ClonedDependencyTest',
     \realpath(__DIR__ . '/_files/ClonedDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/dependencies-isolation.phpt
+++ b/tests/end-to-end/execution-order/dependencies-isolation.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --process-isolation --verbose DependencyTestSuite ../../_files/DependencyTestSuite.php
+phpunit --process-isolation --verbose ../../_files/DependencyTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--process-isolation',
     '--verbose',
-    'DependencyTestSuite',
     \realpath(__DIR__ . '/_files/DependencyTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/depends-as-parameter-with-isolation.phpt
+++ b/tests/end-to-end/execution-order/depends-as-parameter-with-isolation.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --process-isolation StackTest _files/StackTest.php
+phpunit --process-isolation _files/StackTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--process-isolation',
-    'StackTest',
     \realpath(__DIR__ . '/_files/StackTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/depends-as-parameter.phpt
+++ b/tests/end-to-end/execution-order/depends-as-parameter.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit StackTest _files/StackTest.php
+phpunit _files/StackTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
-    'StackTest',
     \realpath(__DIR__ . '/_files/StackTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/depends-multiple-parameter-with-isolation.phpt
+++ b/tests/end-to-end/execution-order/depends-multiple-parameter-with-isolation.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --process-isolation MultiDependencyTest _files/MultiDependencyTest.php
+phpunit --process-isolation _files/MultiDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--process-isolation',
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/depends-multiple-parameters.phpt
+++ b/tests/end-to-end/execution-order/depends-multiple-parameters.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit MultiDependencyTest _files/MultiDependencyTest.php
+phpunit _files/MultiDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/execution-order-options-via-config.phpt
+++ b/tests/end-to-end/execution-order/execution-order-options-via-config.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit -c ../_files/configuration_stop_on_defect.xml MultiDependencyTest ./tests/_files/MultiDependencyTest.php
+phpunit -c ../_files/configuration_stop_on_defect.xml ./tests/_files/MultiDependencyTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--debug',
     '-c',
     \realpath(__DIR__ . '/../../_files/configuration_execution_order_options.xml'),
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/repeat.phpt
+++ b/tests/end-to-end/execution-order/repeat.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --repeat 3 BankAccountTest ../../_files/BankAccountTest.php
+phpunit --repeat 3 ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--repeat',
     '3',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-defect-via-cli.phpt
+++ b/tests/end-to-end/execution-order/stop-on-defect-via-cli.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --stop-on-defect StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+phpunit --stop-on-defect ./tests/_files/StopOnWarningTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--stop-on-defect',
-    'StopOnWarningTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnWarningTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-defect-via-config.phpt
+++ b/tests/end-to-end/execution-order/stop-on-defect-via-config.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit -c ../_files/configuration_stop_on_defect.xml StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+phpunit -c ../_files/configuration_stop_on_defect.xml ./tests/_files/StopOnWarningTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '-c',
     \realpath(__DIR__ . '/../../_files/configuration_stop_on_defect.xml'),
-    'StopOnWarningTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnWarningTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-error-via-cli.phpt
+++ b/tests/end-to-end/execution-order/stop-on-error-via-cli.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --stop-on-error StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+phpunit --stop-on-error ./tests/_files/StopOnErrorTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--stop-on-error',
-    'StopOnErrorTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnErrorTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-error-via-config.phpt
+++ b/tests/end-to-end/execution-order/stop-on-error-via-config.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit -c ../_files/configuration_stop_on_error.xml StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+phpunit -c ../_files/configuration_stop_on_error.xml ./tests/_files/StopOnErrorTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '-c',
     \realpath(__DIR__ . '/../../_files/configuration_stop_on_error.xml'),
-    'StopOnErrorTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnErrorTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-incomplete-via-cli.phpt
+++ b/tests/end-to-end/execution-order/stop-on-incomplete-via-cli.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --stop-on-error StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+phpunit --stop-on-error ./tests/_files/StopOnErrorTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--stop-on-incomplete',
-    'StopOnErrorTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnErrorTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-incomplete-via-config.phpt
+++ b/tests/end-to-end/execution-order/stop-on-incomplete-via-config.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit -c ../_files/configuration_stop_on_incomplete.xml StopOnErrorTestSuite ./tests/_files/StopOnErrorTestSuite.php
+phpunit -c ../_files/configuration_stop_on_incomplete.xml ./tests/_files/StopOnErrorTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '-c',
     \realpath(__DIR__ . '/../../_files/configuration_stop_on_incomplete.xml'),
-    'StopOnErrorTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnErrorTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-warning-via-cli.phpt
+++ b/tests/end-to-end/execution-order/stop-on-warning-via-cli.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --stop-on-warning StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+phpunit --stop-on-warning ./tests/_files/StopOnWarningTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--stop-on-warning',
-    'StopOnWarningTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnWarningTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/stop-on-warning-via-config.phpt
+++ b/tests/end-to-end/execution-order/stop-on-warning-via-config.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit -c ../../_files/configuration_stop_on_warning.xml --stop-on-warning StopOnWarningTestSuite ./tests/_files/StopOnWarningTestSuite.php
+phpunit -c ../../_files/configuration_stop_on_warning.xml --stop-on-warning ./tests/_files/StopOnWarningTestSuite.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '-c',
     \realpath(__DIR__ . '/../../_files/configuration_stop_on_warning.xml'),
     '--stop-on-warning',
-    'StopOnWarningTestSuite',
     \realpath(__DIR__ . '/../../_files/StopOnWarningTestSuite.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/test-order-randomized-seed-with-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-randomized-seed-with-dependency-resolution.phpt
@@ -7,7 +7,6 @@ $arguments = [
     '--debug',
     '--order-by=depends,random',
     '--random-order-seed=54321',
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/../execution-order/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/test-order-randomized-with-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-randomized-with-dependency-resolution.phpt
@@ -7,7 +7,6 @@ $arguments = [
     '--verbose',
     '--resolve-dependencies',     // keep coverage for legacy CLI option
     '--order-by=depends,random',
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/../execution-order/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/test-order-reversed-with-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-reversed-with-dependency-resolution.phpt
@@ -7,7 +7,6 @@ $arguments = [
     '--debug',
     '--verbose',
     '--order-by=depends,reverse',
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/../execution-order/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/test-order-reversed-without-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-reversed-without-dependency-resolution.phpt
@@ -7,7 +7,6 @@ $arguments = [
     '--debug',
     '--verbose',
     '--order-by=no-depends,reverse',
-    'MultiDependencyTest',
     \realpath(__DIR__ . '/../execution-order/_files/MultiDependencyTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/execution-order/test-order-size-with-dependency-resolution.phpt
+++ b/tests/end-to-end/execution-order/test-order-size-with-dependency-resolution.phpt
@@ -7,7 +7,6 @@ $arguments = [
     '--debug',
     '--verbose',
     '--order-by=depends,size',
-    'TestWithDifferentSizes',
     \realpath(__DIR__ . '/../../_files/TestWithDifferentSizes.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/failure-isolation.phpt
+++ b/tests/end-to-end/failure-isolation.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --process-isolation FailureTest ../../_files/FailureTest.php
+phpunit --process-isolation ../../_files/FailureTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'FailureTest';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/FailureTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/FailureTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/failure.phpt
+++ b/tests/end-to-end/failure.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit FailureTest ../../_files/FailureTest.php
+phpunit ../../_files/FailureTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'FailureTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/FailureTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/FailureTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/fatal-isolation.phpt
+++ b/tests/end-to-end/fatal-isolation.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit FatalTest --process-isolation ../../_files/FatalTest.php
+phpunit --process-isolation ../../_files/FatalTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'FatalTest';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/FatalTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/FatalTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-class-isolation.phpt
+++ b/tests/end-to-end/filter-class-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter BankAccountTest BankAccountTest ../../_files/BankAccountTest.php
+phpunit --process-isolation --filter BankAccountTest ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = 'BankAccountTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-class.phpt
+++ b/tests/end-to-end/filter-class.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter BankAccountTest BankAccountTest ../../_files/BankAccountTest.php
+phpunit --filter BankAccountTest ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'BankAccountTest';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-classname-and-range-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-classname-and-range-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter DataProviderFilterTest#1-3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter DataProviderFilterTest#1-3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'DataProviderFilterTest#1-3';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-classname-and-range.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-classname-and-range.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter DataProviderFilterTest#1-3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter DataProviderFilterTest#1-3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'DataProviderFilterTest#1-3';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-number-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-number-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter testTrue#3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter testTrue#3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'testTrue#3';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-number.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-number.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter testTrue#3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter testTrue#3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'testTrue#3';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-only-range-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-only-range-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter \#1-3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter \#1-3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = '#1-3';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-only-range.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-only-range.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter \#1-3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter \#1-3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = '#1-3';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-only-regexp-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-only-regexp-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter @false.* DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter @false.* ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = '@false.*';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-only-regexp.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-only-regexp.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter @false.* DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter @false.* ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = '@false.*';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-only-string-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-only-string-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter @false\ test DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter @false\ test ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = '@false test';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-only-string.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-only-string.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter @false\ test DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter @false\ test ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = '@false test';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-range-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-range-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter testTrue#1-3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter testTrue#1-3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'testTrue#1-3';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-range.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-range.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter testTrue#1-3 DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter testTrue#1-3 ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'testTrue#1-3';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-regexp-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-regexp-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter testFalse@false.* DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter testFalse@false.* ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'testFalse@false.*';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-regexp.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-regexp.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter testFalse@false.* DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter testFalse@false.* ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'testFalse@false.*';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-string-isolation.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-string-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter testFalse@false\ test DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --process-isolation --filter testFalse@false\ test ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'testFalse@false test';
-$_SERVER['argv'][5] = 'DataProviderFilterTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-dataprovider-by-string.phpt
+++ b/tests/end-to-end/filter-dataprovider-by-string.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter testFalse@false\ test DataProviderFilterTest ../../_files/DataProviderFilterTest.php
+phpunit --filter testFalse@false\ test ../../_files/DataProviderFilterTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'testFalse@false test';
-$_SERVER['argv'][4] = 'DataProviderFilterTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderFilterTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderFilterTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-method-case-insensitive.phpt
+++ b/tests/end-to-end/filter-method-case-insensitive.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter /balanceIsInitiallyZero/i BankAccountTest ../../_files/BankAccountTest.php
+phpunit --filter /balanceIsInitiallyZero/i ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = '/balanceIsInitiallyZero/i';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-method-case-sensitive-no-result.phpt
+++ b/tests/end-to-end/filter-method-case-sensitive-no-result.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter balanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --filter balanceIsInitiallyZero ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = '/balanceIsInitiallyZero/';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-method-isolation.phpt
+++ b/tests/end-to-end/filter-method-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --filter testBalanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --process-isolation --filter testBalanceIsInitiallyZero ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--filter';
 $_SERVER['argv'][4] = 'testBalanceIsInitiallyZero';
-$_SERVER['argv'][5] = 'BankAccountTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-method.phpt
+++ b/tests/end-to-end/filter-method.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter testBalanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --filter testBalanceIsInitiallyZero ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'testBalanceIsInitiallyZero';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/filter-no-results.phpt
+++ b/tests/end-to-end/filter-no-results.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --filter doesNotExist BankAccountTest ../../_files/BankAccountTest.php
+phpunit --filter doesNotExist ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--filter';
 $_SERVER['argv'][3] = 'doesNotExist';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/forward-compatibility.phpt
+++ b/tests/end-to-end/forward-compatibility.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit BankAccountTest ../../_files/BankAccountTest.php
+phpunit ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'BankAccountTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/getActualOutputForAssertion.phpt
+++ b/tests/end-to-end/getActualOutputForAssertion.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit ActualOutputTest ../../_files/ActualOutputTest.php
+phpunit ../../_files/ActualOutputTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--disallow-test-output';
-$_SERVER['argv'][3] = 'ActualOutputTest';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/ActualOutputTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/ActualOutputTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/group-isolation.phpt
+++ b/tests/end-to-end/group-isolation.phpt
@@ -1,13 +1,12 @@
 --TEST--
-phpunit --process-isolation --group balanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --process-isolation --group balanceIsInitiallyZero ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '--group';
 $_SERVER['argv'][4] = 'balanceIsInitiallyZero';
-$_SERVER['argv'][5] = 'BankAccountTest';
-$_SERVER['argv'][6] = __DIR__ . '/../_files/BankAccountTest.php';
+$_SERVER['argv'][5] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/group.phpt
+++ b/tests/end-to-end/group.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --group balanceIsInitiallyZero BankAccountTest ../../_files/BankAccountTest.php
+phpunit --no-configuration --testdox --group 3502 ../../_files/NumericGroupAnnotationTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--testdox';
 $_SERVER['argv'][3] = '--group';
 $_SERVER['argv'][4] = '3502';
-$_SERVER['argv'][5] = 'NumericGroupAnnotationTest';
 $_SERVER['argv'][6] = __DIR__ . '/../_files/NumericGroupAnnotationTest.php';
 
 require __DIR__ . '/../bootstrap.php';

--- a/tests/end-to-end/ini-isolation.phpt
+++ b/tests/end-to-end/ini-isolation.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --process-isolation -d default_mimetype=application/x-test IniTest ../../_files/IniTest.php
+phpunit --process-isolation -d default_mimetype=application/x-test ../../_files/IniTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
 $_SERVER['argv'][3] = '-d';
 $_SERVER['argv'][4] = 'default_mimetype=application/x-test';
-$_SERVER['argv'][5] = 'IniTest';
 $_SERVER['argv'][6] = __DIR__ . '/../_files/IniTest.php';
 
 require __DIR__ . '/../bootstrap.php';

--- a/tests/end-to-end/list-groups.phpt
+++ b/tests/end-to-end/list-groups.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit --list-groups BankAccountTest ../../_files/BankAccountTest.php
+phpunit --list-groups ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--list-groups';
-$_SERVER['argv'][3] = 'BankAccountTest';
 $_SERVER['argv'][4] = __DIR__ . '/../_files/BankAccountTest.php';
 
 require __DIR__ . '/../bootstrap.php';

--- a/tests/end-to-end/list-tests-dataprovider.phpt
+++ b/tests/end-to-end/list-tests-dataprovider.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --list-tests DataProviderTest ../../_files/DataProviderTest.php
+phpunit --list-tests ../../_files/DataProviderTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--list-tests';
-$_SERVER['argv'][3] = 'DataProviderTest';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/DataProviderTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/list-tests-xml-dataprovider.phpt
+++ b/tests/end-to-end/list-tests-xml-dataprovider.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --list-tests-xml DataProviderTest ../../_files/DataProviderTest.php
+phpunit --list-tests-xml ../../_files/DataProviderTest.php
 --FILE--
 <?php declare(strict_types=1);
 $target = tempnam(sys_get_temp_dir(), __FILE__);
@@ -7,8 +7,7 @@ $target = tempnam(sys_get_temp_dir(), __FILE__);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--list-tests-xml';
 $_SERVER['argv'][3] = $target;
-$_SERVER['argv'][4] = 'DataProviderTest';
-$_SERVER['argv'][5] = __DIR__ . '/../_files/DataProviderTest.php';
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main(false);

--- a/tests/end-to-end/loggers/custom-printer-debug.phpt
+++ b/tests/end-to-end/loggers/custom-printer-debug.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit -c ../../_files/configuration.custom-printer.xml --debug BankAccountTest ../../_files/BankAccountTest.php
+phpunit -c ../../_files/configuration.custom-printer.xml --debug ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '-c',
     \realpath(__DIR__ . '/_files/configuration.custom-printer.xml'),
     '--debug',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/custom-printer-verbose.phpt
+++ b/tests/end-to-end/loggers/custom-printer-verbose.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit -c _files/configuration.custom-printer.xml --verbose IncompleteTest ../../_files/IncompleteTest.php
+phpunit -c _files/configuration.custom-printer.xml --verbose ../../_files/IncompleteTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '-c',
     \realpath(__DIR__ . '/_files/configuration.custom-printer.xml'),
     '--verbose',
-    'IncompleteTest',
     \realpath(__DIR__ . '/../../_files/IncompleteTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/failure-reverse-list.phpt
+++ b/tests/end-to-end/loggers/failure-reverse-list.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --reverse-list FailureTest ../../_files/FailureTest.php
+phpunit --reverse-list ../../_files/FailureTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--reverse-list',
-    'FailureTest',
     \realpath(__DIR__ . '/../../_files/FailureTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/hooks.phpt
+++ b/tests/end-to-end/loggers/hooks.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --configuration _files/hooks.xml HookTest _files/HookTest.php
+phpunit --configuration _files/hooks.xml _files/HookTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--configuration',
     \realpath(__DIR__ . '/_files/hooks.xml'),
-    'HookTest',
     \realpath(__DIR__ . '/_files/HookTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/log-junit.phpt
+++ b/tests/end-to-end/loggers/log-junit.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --log-junit php://stdout StatusTest _files/StatusTest.php
+phpunit --log-junit php://stdout _files/StatusTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--log-junit',
     'php://stdout',
-    'StatusTest',
     \realpath(__DIR__ . '/../../basic/unit/StatusTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/log-teamcity.phpt
+++ b/tests/end-to-end/loggers/log-teamcity.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --log-teamcity php://stdout BankAccountTest ../../_files/BankAccountTest.php
+phpunit --log-teamcity php://stdout ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--log-teamcity',
     'php://stdout',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/teamcity-inner-exceptions.phpt
+++ b/tests/end-to-end/loggers/teamcity-inner-exceptions.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --teamcity ExceptionStackTest ../../_files/ExceptionStackTest.php
+phpunit --teamcity ../../_files/ExceptionStackTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--teamcity',
-    'ExceptionStackTest',
     \realpath(__DIR__ . '/../../_files/ExceptionStackTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/teamcity.phpt
+++ b/tests/end-to-end/loggers/teamcity.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --teamcity BankAccountTest ../../_files/BankAccountTest.php
+phpunit --teamcity ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--teamcity',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/testdox-dataprovider-placeholder.phpt
+++ b/tests/end-to-end/loggers/testdox-dataprovider-placeholder.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --testdox --colors=always --verbose RouterTest ../unit/Util/ColorTest.php
+phpunit --testdox --colors=always --verbose ../unit/Util/TestDox/ColorTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [

--- a/tests/end-to-end/loggers/testdox-exclude-group.phpt
+++ b/tests/end-to-end/loggers/testdox-exclude-group.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --testdox-text php://stdout --testdox-exclude-group one TestDoxGroupTest ../../_files/TestDoxGroupTest.php
+phpunit --testdox-text php://stdout --testdox-exclude-group one ../../_files/TestDoxGroupTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
@@ -8,7 +8,6 @@ $arguments = [
     'php://stdout',
     '--testdox-exclude-group',
     'one',
-    'TestDoxGroupTest',
     \realpath(__DIR__ . '/_files/TestDoxGroupTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/testdox-group.phpt
+++ b/tests/end-to-end/loggers/testdox-group.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --testdox-text php://stdout --testdox-group one TestDoxGroupTest ../../_files/TestDoxGroupTest.php
+phpunit --testdox-text php://stdout --testdox-group one ../../_files/TestDoxGroupTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
@@ -8,7 +8,6 @@ $arguments = [
     'php://stdout',
     '--testdox-group',
     'one',
-    'TestDoxGroupTest',
     \realpath(__DIR__ . '/_files/TestDoxGroupTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/testdox-html.phpt
+++ b/tests/end-to-end/loggers/testdox-html.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --testdox-html php://stdout BankAccountTest ../../_files/BankAccountTest.php
+phpunit --testdox-html php://stdout ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--testdox-html',
     'php://stdout',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/testdox-text.phpt
+++ b/tests/end-to-end/loggers/testdox-text.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --testdox-text php://stdout BankAccountTest ../../_files/BankAccountTest.php
+phpunit --testdox-text php://stdout ../../_files/BankAccountTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--testdox-text',
     'php://stdout',
-    'BankAccountTest',
     \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/loggers/testdox-xml.phpt
+++ b/tests/end-to-end/loggers/testdox-xml.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --testdox-xml php://stdout StatusTest ../../_files/StatusTest.php
+phpunit --testdox-xml php://stdout ../../_files/StatusTest.php
 --FILE--
 <?php declare(strict_types=1);
 $arguments = [
     '--no-configuration',
     '--testdox-xml',
     'php://stdout',
-    'StatusTest',
     \realpath(__DIR__ . '/../../basic/unit/StatusTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);

--- a/tests/end-to-end/phar-extension-suppressed.phpt
+++ b/tests/end-to-end/phar-extension-suppressed.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit --configuration tests/_files/phpunit-example-extension
+phpunit --configuration tests/_files/phpunit-example-extension --no-extensions
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--configuration';

--- a/tests/end-to-end/regression/GitHub/1149.phpt
+++ b/tests/end-to-end/regression/GitHub/1149.phpt
@@ -3,8 +3,7 @@ GH-1149: Test swallows output buffer when run in a separate process
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue1149Test';
-$_SERVER['argv'][3] = __DIR__ . '/1149/Issue1149Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/1149/Issue1149Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1265.phpt
+++ b/tests/end-to-end/regression/GitHub/1265.phpt
@@ -4,8 +4,7 @@ GH-1265: Could not use "PHPUnit\Runner\StandardTestSuiteLoader" as loader
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--configuration';
 $_SERVER['argv'][2] = __DIR__ . '/1265/phpunit1265.xml';
-$_SERVER['argv'][3] = 'Issue1265Test';
-$_SERVER['argv'][4] = __DIR__ . '/1265/Issue1265Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/1265/Issue1265Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1330.phpt
+++ b/tests/end-to-end/regression/GitHub/1330.phpt
@@ -5,8 +5,7 @@ GH-1330: Allow non-ambiguous shortened longopts
 $_SERVER['argv'][1] = '--deb';
 $_SERVER['argv'][2] = '--config';
 $_SERVER['argv'][3] = __DIR__ . '/1330/phpunit1330.xml';
-$_SERVER['argv'][4] = 'Issue1330Test';
-$_SERVER['argv'][5] = __DIR__ . '/1330/Issue1330Test.php';
+$_SERVER['argv'][4] = __DIR__ . '/1330/Issue1330Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1337.phpt
+++ b/tests/end-to-end/regression/GitHub/1337.phpt
@@ -4,8 +4,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1337
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'Issue1337Test';
-$_SERVER['argv'][4] = __DIR__ . '/1337/Issue1337Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/1337/Issue1337Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1348.phpt
+++ b/tests/end-to-end/regression/GitHub/1348.phpt
@@ -9,7 +9,6 @@ if (defined('HHVM_VERSION') || defined('PHPDBG_VERSION')) {
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][]  = '--process-isolation';
-$_SERVER['argv'][]  = 'Issue1348Test';
 $_SERVER['argv'][]  = __DIR__ . '/1348/Issue1348Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/end-to-end/regression/GitHub/1351.phpt
+++ b/tests/end-to-end/regression/GitHub/1351.phpt
@@ -9,8 +9,7 @@ if (!extension_loaded('pdo') || !in_array('sqlite', PDO::getAvailableDrivers()))
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'Issue1351Test';
-$_SERVER['argv'][4] = __DIR__ . '/1351/Issue1351Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/1351/Issue1351Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1374.phpt
+++ b/tests/end-to-end/regression/GitHub/1374.phpt
@@ -3,8 +3,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1374
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue1374Test';
-$_SERVER['argv'][3] = __DIR__ . '/1374/Issue1374Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/1374/Issue1374Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1437.phpt
+++ b/tests/end-to-end/regression/GitHub/1437.phpt
@@ -3,8 +3,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1437
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue1437Test';
-$_SERVER['argv'][3] = __DIR__ . '/1437/Issue1437Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/1437/Issue1437Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1468.phpt
+++ b/tests/end-to-end/regression/GitHub/1468.phpt
@@ -4,8 +4,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1468
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--disallow-todo-tests';
-$_SERVER['argv'][3] = 'Issue1468Test';
-$_SERVER['argv'][4] = __DIR__ . '/1468/Issue1468Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/1468/Issue1468Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1471.phpt
+++ b/tests/end-to-end/regression/GitHub/1471.phpt
@@ -3,8 +3,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1471
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue1471Test';
-$_SERVER['argv'][3] = __DIR__ . '/1471/Issue1471Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/1471/Issue1471Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1472.phpt
+++ b/tests/end-to-end/regression/GitHub/1472.phpt
@@ -3,8 +3,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1472
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue1472Test';
-$_SERVER['argv'][3] = __DIR__ . '/1472/Issue1472Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/1472/Issue1472Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/1570.phpt
+++ b/tests/end-to-end/regression/GitHub/1570.phpt
@@ -4,8 +4,7 @@ https://github.com/sebastianbergmann/phpunit/issues/1570
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--disallow-test-output';
-$_SERVER['argv'][3] = 'Issue1570Test';
-$_SERVER['argv'][4] = __DIR__ . '/1570/Issue1570Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/1570/Issue1570Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2137-filter.phpt
+++ b/tests/end-to-end/regression/GitHub/2137-filter.phpt
@@ -3,10 +3,9 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2137Test';
-$_SERVER['argv'][3] = __DIR__ . '/2137/Issue2137Test.php';
-$_SERVER['argv'][4] = '--filter';
-$_SERVER['argv'][5] = 'BrandService';
+$_SERVER['argv'][2] = __DIR__ . '/2137/Issue2137Test.php';
+$_SERVER['argv'][3] = '--filter';
+$_SERVER['argv'][4] = 'BrandService';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2137-no_filter.phpt
+++ b/tests/end-to-end/regression/GitHub/2137-no_filter.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2137Test';
-$_SERVER['argv'][3] = __DIR__ . '/2137/Issue2137Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2137/Issue2137Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2145.phpt
+++ b/tests/end-to-end/regression/GitHub/2145.phpt
@@ -3,9 +3,8 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2145Test';
-$_SERVER['argv'][3] = '--stop-on-error';
-$_SERVER['argv'][4] = __DIR__ . '/2145/Issue2145Test.php';
+$_SERVER['argv'][2] = '--stop-on-error';
+$_SERVER['argv'][3] = __DIR__ . '/2145/Issue2145Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2158.phpt
+++ b/tests/end-to-end/regression/GitHub/2158.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2158Test';
-$_SERVER['argv'][3] = __DIR__ . '/2158/Issue2158Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2158/Issue2158Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2366.phpt
+++ b/tests/end-to-end/regression/GitHub/2366.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2366Test';
-$_SERVER['argv'][3] = __DIR__ . '/2366/Issue2366Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2366/Issue2366Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2380.phpt
+++ b/tests/end-to-end/regression/GitHub/2380.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2380Test';
-$_SERVER['argv'][3] = __DIR__ . '/2380/Issue2380Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2380/Issue2380Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2382.phpt
+++ b/tests/end-to-end/regression/GitHub/2382.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2382Test';
-$_SERVER['argv'][3] = __DIR__ . '/2382/Issue2382Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2382/Issue2382Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2435.phpt
+++ b/tests/end-to-end/regression/GitHub/2435.phpt
@@ -3,8 +3,7 @@ GH-2435: Test empty @group annotation
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2435Test';
-$_SERVER['argv'][3] = __DIR__ . '/2435/Issue2435Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2435/Issue2435Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/2448-existing-test.phpt
+++ b/tests/end-to-end/regression/GitHub/2448-existing-test.phpt
@@ -3,7 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Test';
+$_SERVER['argv'][2] = 'Test.php';
 
 \chdir(__DIR__ . '/2448');
 

--- a/tests/end-to-end/regression/GitHub/2448-not-existing-test.phpt
+++ b/tests/end-to-end/regression/GitHub/2448-not-existing-test.phpt
@@ -3,7 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Test';
+$_SERVER['argv'][2] = 'Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main(false);

--- a/tests/end-to-end/regression/GitHub/2724-diff-pid-from-master-process.phpt
+++ b/tests/end-to-end/regression/GitHub/2724-diff-pid-from-master-process.phpt
@@ -3,8 +3,7 @@ GH-2724: Missing initialization of setRunClassInSeparateProcess() for tests with
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'SeparateClassRunMethodInNewProcessTest';
-$_SERVER['argv'][3] = __DIR__ . '/2724/SeparateClassRunMethodInNewProcessTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/2724/SeparateClassRunMethodInNewProcessTest.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 

--- a/tests/end-to-end/regression/GitHub/2731.phpt
+++ b/tests/end-to-end/regression/GitHub/2731.phpt
@@ -3,8 +3,7 @@ GH-2731: Empty exception message cannot be expected
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2731Test';
-$_SERVER['argv'][3] = __DIR__ . '/2731/Issue2731Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2731/Issue2731Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 

--- a/tests/end-to-end/regression/GitHub/2811.phpt
+++ b/tests/end-to-end/regression/GitHub/2811.phpt
@@ -3,8 +3,7 @@ GH-2811: expectExceptionMessage() does not work without expectException()
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2811Test';
-$_SERVER['argv'][3] = __DIR__ . '/2811/Issue2811Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2811/Issue2811Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 

--- a/tests/end-to-end/regression/GitHub/2830.phpt
+++ b/tests/end-to-end/regression/GitHub/2830.phpt
@@ -3,8 +3,7 @@ GH-2830: @runClassInSeparateProcess fails for tests with a @dataProvider
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue2830Test';
-$_SERVER['argv'][3] = __DIR__ . '/2830/Issue2830Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/2830/Issue2830Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 

--- a/tests/end-to-end/regression/GitHub/322.phpt
+++ b/tests/end-to-end/regression/GitHub/322.phpt
@@ -7,8 +7,7 @@ $_SERVER['argv'][2] = __DIR__ . '/322/phpunit322.xml';
 $_SERVER['argv'][3] = '--debug';
 $_SERVER['argv'][4] = '--group';
 $_SERVER['argv'][5] = 'one';
-$_SERVER['argv'][6] = 'Issue322Test';
-$_SERVER['argv'][7] = __DIR__ . '/322/Issue322Test.php';
+$_SERVER['argv'][6] = __DIR__ . '/322/Issue322Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/3739.phpt
+++ b/tests/end-to-end/regression/GitHub/3739.phpt
@@ -3,8 +3,7 @@ https://github.com/sebastianbergmann/phpunit/issues/3739
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue3739Test';
-$_SERVER['argv'][3] = __DIR__ . '/3739/Issue3739Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/3739/Issue3739Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 

--- a/tests/end-to-end/regression/GitHub/3904.phpt
+++ b/tests/end-to-end/regression/GitHub/3904.phpt
@@ -10,6 +10,7 @@ require __DIR__ . '/../../../bootstrap.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
+Warning: Calling PHPUnit with a class name is deprecated and will be removed in PHPUnit 9.
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 .                                                                   1 / 1 (100%)

--- a/tests/end-to-end/regression/GitHub/3904_2.phpt
+++ b/tests/end-to-end/regression/GitHub/3904_2.phpt
@@ -15,4 +15,5 @@ try {
 }
 ?>
 --EXPECTF--
+Warning: Calling PHPUnit with a class name is deprecated and will be removed in PHPUnit 9.
 Class 'Issue3904' could not be found in '%s'.

--- a/tests/end-to-end/regression/GitHub/433.phpt
+++ b/tests/end-to-end/regression/GitHub/433.phpt
@@ -3,8 +3,7 @@ GH-433: expectOutputString not completely working as expected
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue433Test';
-$_SERVER['argv'][3] = __DIR__ . '/433/Issue433Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/433/Issue433Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/445.phpt
+++ b/tests/end-to-end/regression/GitHub/445.phpt
@@ -4,8 +4,7 @@ GH-455: expectOutputString not working in strict mode
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--disallow-test-output';
-$_SERVER['argv'][3] = 'Issue445Test';
-$_SERVER['argv'][4] = __DIR__ . '/445/Issue445Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/445/Issue445Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/498.phpt
+++ b/tests/end-to-end/regression/GitHub/498.phpt
@@ -5,8 +5,7 @@ GH-498: The test methods won't be run if a dataProvider throws Exception and --g
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--group';
 $_SERVER['argv'][3] = 'trueOnly';
-$_SERVER['argv'][4] = 'Issue498Test';
-$_SERVER['argv'][5] = __DIR__ . '/498/Issue498Test.php';
+$_SERVER['argv'][4] = __DIR__ . '/498/Issue498Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/503.phpt
+++ b/tests/end-to-end/regression/GitHub/503.phpt
@@ -3,8 +3,7 @@ GH-503: assertEquals() Line Ending Differences Are Obscure
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue503Test';
-$_SERVER['argv'][3] = __DIR__ . '/503/Issue503Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/503/Issue503Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/581.phpt
+++ b/tests/end-to-end/regression/GitHub/581.phpt
@@ -3,8 +3,7 @@ GH-581: PHPUnit_Util_Type::export adds extra newlines in Windows
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue581Test';
-$_SERVER['argv'][3] = __DIR__ . '/581/Issue581Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/581/Issue581Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/74.phpt
+++ b/tests/end-to-end/regression/GitHub/74.phpt
@@ -4,8 +4,7 @@ GH-74: catchable fatal error in 3.5
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'Issue74Test';
-$_SERVER['argv'][4] = __DIR__ . '/74/Issue74Test.php';
+$_SERVER['argv'][3] = __DIR__ . '/74/Issue74Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/765.phpt
+++ b/tests/end-to-end/regression/GitHub/765.phpt
@@ -3,8 +3,7 @@ GH-765: Fatal error triggered in PHPUnit when exception is thrown in data provid
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue765Test';
-$_SERVER['argv'][3] = __DIR__ . '/765/Issue765Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/765/Issue765Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/863.phpt
+++ b/tests/end-to-end/regression/GitHub/863.phpt
@@ -5,8 +5,7 @@ GH-863: Number of tests to run calculated incorrectly when --repeat is used
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--repeat';
 $_SERVER['argv'][3] = '50';
-$_SERVER['argv'][4] = 'BankAccountTest';
-$_SERVER['argv'][5] = \dirname(\dirname(\dirname(__DIR__))) . '/_files/BankAccountTest.php';
+$_SERVER['argv'][4] = \dirname(\dirname(\dirname(__DIR__))) . '/_files/BankAccountTest.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/GitHub/873.phpt
+++ b/tests/end-to-end/regression/GitHub/873.phpt
@@ -8,8 +8,7 @@ if (PHP_MAJOR_VERSION < 7) {
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue873Test';
-$_SERVER['argv'][3] = __DIR__ . '/873/Issue873Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/873/Issue873Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/Trac/1021.phpt
+++ b/tests/end-to-end/regression/Trac/1021.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue1021Test';
-$_SERVER['argv'][3] = __DIR__ . '/1021/Issue1021Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/1021/Issue1021Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/Trac/578.phpt
+++ b/tests/end-to-end/regression/Trac/578.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue578Test';
-$_SERVER['argv'][3] = __DIR__ . '/578/Issue578Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/578/Issue578Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/Trac/684.phpt
+++ b/tests/end-to-end/regression/Trac/684.phpt
@@ -3,8 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'Issue684Test';
-$_SERVER['argv'][3] = __DIR__ . '/684/Issue684Test.php';
+$_SERVER['argv'][2] = __DIR__ . '/684/Issue684Test.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/regression/Trac/783.phpt
+++ b/tests/end-to-end/regression/Trac/783.phpt
@@ -5,8 +5,7 @@
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--group';
 $_SERVER['argv'][3] = 'foo,bar';
-$_SERVER['argv'][4] = 'ParentSuite';
-$_SERVER['argv'][5] = __DIR__ . '/783/ParentSuite.php';
+$_SERVER['argv'][4] = __DIR__ . '/783/ParentSuite.php';
 
 require __DIR__ . '/../../../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/report-tests-performing-assertions-when-annotated-with-does-not-perform-assertions.phpt
+++ b/tests/end-to-end/report-tests-performing-assertions-when-annotated-with-does-not-perform-assertions.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit NothingTest ../_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php
+phpunit ../_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'DoesNotPerformAssertionsButPerformingAssertionsTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/DoesNotPerformAssertionsButPerformingAssertionsTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/report-useless-tests-incomplete.phpt
+++ b/tests/end-to-end/report-useless-tests-incomplete.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit IncompleteTest ../../_files/IncompleteTest.php
+phpunit ../../_files/IncompleteTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'IncompleteTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/IncompleteTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/IncompleteTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/report-useless-tests-isolation.phpt
+++ b/tests/end-to-end/report-useless-tests-isolation.phpt
@@ -1,11 +1,10 @@
 --TEST--
-phpunit --process-isolation IncompleteTest ../../_files/IncompleteTest.php
+phpunit --process-isolation ../../_files/IncompleteTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
 $_SERVER['argv'][2] = '--process-isolation';
-$_SERVER['argv'][3] = 'NothingTest';
-$_SERVER['argv'][4] = __DIR__ . '/../_files/NothingTest.php';
+$_SERVER['argv'][3] = __DIR__ . '/../_files/NothingTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/report-useless-tests.phpt
+++ b/tests/end-to-end/report-useless-tests.phpt
@@ -1,10 +1,9 @@
 --TEST--
-phpunit NothingTest ../../_files/NothingTest.php
+phpunit ../../_files/NothingTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = 'NothingTest';
-$_SERVER['argv'][3] = __DIR__ . '/../_files/NothingTest.php';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/NothingTest.php';
 
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();

--- a/tests/end-to-end/requires-skip-code-location-hints.phpt
+++ b/tests/end-to-end/requires-skip-code-location-hints.phpt
@@ -1,12 +1,11 @@
 --TEST--
-phpunit --no-configuration RequirementsTest ../_files/RequirementsTest.php
+phpunit --no-configuration ../_files/RequirementsTest.php
 --FILE--
 <?php declare(strict_types=1);
 require_once(__DIR__ . '/../bootstrap.php');
 
 $arguments = [
     '--no-configuration',
-    'RequirementsTest',
     \realpath(__DIR__ . '/../_files/RequirementsTest.php'),
 ];
 \array_splice($_SERVER['argv'], 1, count($arguments), $arguments);


### PR DESCRIPTION
This adds the deprecation warning when calling PHPUnit with just a class name or class name and filename as discussed in issue #3859 

- [x] add deprecation warning
- [x] fix unit tests