### PR TITLE
Count Constaint - check \Countable first

### DIFF
--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -49,12 +49,12 @@ class Count extends Constraint
      */
     protected function getCountOf($other): ?int
     {
-        if ($other instanceof \EmptyIterator) {
-            return 0;
-        }
-
         if ($other instanceof Countable || \is_array($other)) {
             return \count($other);
+        }
+
+        if ($other instanceof \EmptyIterator) {
+            return 0;
         }
 
         if ($other instanceof Traversable) {


### PR DESCRIPTION
A problem in a project where a class has been created `EmptyIteratorWithCount` meant to iterate nothing, but still have a count on it. It is used to display a count somewhere in the project where an iterator is expected, but we don't want to actually fetch any data.

Unit-tests on this project suddenly started to fail after upgrading to latest PhpUnit because it checks EmptyIterator first.