### PR TITLE
Added --no-interaction to the usage text

### DIFF
--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -97,6 +97,7 @@ final class Help
             ['arg'    => '--testdox', 'desc' => 'Report test execution progress in TestDox format'],
             ['arg'    => '--testdox-group', 'desc' => 'Only include tests from the specified group(s)'],
             ['arg'    => '--testdox-exclude-group', 'desc' => 'Exclude tests from the specified group(s)'],
+            ['arg'    => '--no-interaction', 'desc' => 'Disable TestDox progress animation'],
             ['arg'    => '--printer <printer>', 'desc' => 'TestListener implementation to use'],
             ['spacer' => ''],
 

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -96,6 +96,7 @@
   [32m--testdox-group            [0m Only include tests from the specified
                               group(s)
   [32m--testdox-exclude-group    [0m Exclude tests from the specified group(s)
+  [32m--no-interaction           [0m Disable TestDox progress animation
   [32m--printer [36m<printer>[0m        [0m TestListener implementation to use
 
   [32m--order-by=[36m<order>[0m         [0m Run tests in order:

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -75,6 +75,7 @@ Test Execution Options:
   --testdox                   Report test execution progress in TestDox format
   --testdox-group             Only include tests from the specified group(s)
   --testdox-exclude-group     Exclude tests from the specified group(s)
+  --no-interaction            Disable TestDox progress animation
   --printer <printer>         TestListener implementation to use
 
   --order-by=<order>          Run tests in order: default|defects|duration|no-depends|random|reverse|size


### PR DESCRIPTION
The `--no-interaction` command-line option was introduced in #3528 but wasn't added to the usage text.