### PR TITLE
Fixed handling of some edge cases in the name prettifier

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -54,14 +54,16 @@ final class NamePrettifier
         $parts     = \explode('\\', $className);
         $className = \array_pop($parts);
 
-        if (\substr($className, -1 * \strlen('Test')) === 'Test') {
+        if ($className !== 'Test' && \substr($className, -1 * \strlen('Test')) === 'Test') {
             $className = \substr($className, 0, \strlen($className) - \strlen('Test'));
         }
 
-        if (\strpos($className, 'Tests') === 0) {
-            $className = \substr($className, \strlen('Tests'));
-        } elseif (\strpos($className, 'Test') === 0) {
-            $className = \substr($className, \strlen('Test'));
+        if ($className !== 'Tests' && $className !== 'Test') {
+            if (\strpos($className, 'Tests') === 0) {
+                $className = \substr($className, \strlen('Tests'));
+            } elseif (\strpos($className, 'Test') === 0) {
+                $className = \substr($className, \strlen('Test'));
+            }
         }
 
         if (!empty($parts)) {

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -37,6 +37,10 @@ final class NamePrettifierTest extends TestCase
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('FooTest'));
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('TestFoo'));
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('TestFooTest'));
+        $this->assertEquals('Test', $this->namePrettifier->prettifyTestClass('Test'));
+        $this->assertEquals('Tests', $this->namePrettifier->prettifyTestClass('Tests'));
+        $this->assertEquals('Test', $this->namePrettifier->prettifyTestClass('TestTest'));
+        $this->assertEquals('Tests', $this->namePrettifier->prettifyTestClass('TestsTests'));
         $this->assertEquals('Foo (Test\Foo)', $this->namePrettifier->prettifyTestClass('Test\FooTest'));
         $this->assertEquals('Foo (Tests\Foo)', $this->namePrettifier->prettifyTestClass('Tests\FooTest'));
     }


### PR DESCRIPTION
When handling certain class names (including the PHPUnit's own ones), the name prettifier triggers notices:
```
$ phpunit tests/unit/Util/TestTest.php
PHPUnit 8.5-g61008719a by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.10 with Xdebug 2.7.2
Configuration: /home/morozov/Projects/phpunit/phpunit.xml


Notice: Uninitialized string offset: 0 in /home/morozov/Projects/phpunit/src/Util/TestDox/NamePrettifier.php on line 78

Call Stack:
    0.0082     478768   1. {main}() /home/morozov/Projects/phpunit/phpunit:0
    0.1007    2154312   2. PHPUnit\TextUI\Command::main(???) /home/morozov/Projects/phpunit/phpunit:61
    0.1007    2154424   3. PHPUnit\TextUI\Command->run(???, ???) /home/morozov/Projects/phpunit/src/TextUI/Command.php:159
    0.1309    3921528   4. PHPUnit\TextUI\TestRunner->doRun(???, ???, ???) /home/morozov/Projects/phpunit/src/TextUI/Command.php:200
    0.1992    5050712   5. PHPUnit\Framework\TestSuite->run(???) /home/morozov/Projects/phpunit/src/TextUI/TestRunner.php:616
    0.2135    5053544   6. PHPUnit\Framework\DataProviderTestSuite->run(???) /home/morozov/Projects/phpunit/src/Framework/TestSuite.php:569
    0.2140    5053736   7. PHPUnit\Util\TestTest->run(???) /home/morozov/Projects/phpunit/src/Framework/TestSuite.php:569
    0.2141    5053736   8. PHPUnit\Framework\TestResult->run(???) /home/morozov/Projects/phpunit/src/Framework/TestCase.php:752
    0.2142    5053736   9. PHPUnit\Framework\TestResult->startTest(???) /home/morozov/Projects/phpunit/src/Framework/TestResult.php:628
    0.2142    5053736  10. PHPUnit\Util\TestDox\TextResultPrinter->startTest(???) /home/morozov/Projects/phpunit/src/Framework/TestResult.php:411
    0.2142    5053736  11. PHPUnit\Util\TestDox\NamePrettifier->prettifyTestClass(???) /home/morozov/Projects/phpunit/src/Util/TestDox/ResultPrinter.php:234

Notice: Uninitialized string offset: -1 in /home/morozov/Projects/phpunit/src/Util/TestDox/NamePrettifier.php on line 78

Call Stack:
    0.0082     478768   1. {main}() /home/morozov/Projects/phpunit/phpunit:0
    0.1007    2154312   2. PHPUnit\TextUI\Command::main(???) /home/morozov/Projects/phpunit/phpunit:61
    0.1007    2154424   3. PHPUnit\TextUI\Command->run(???, ???) /home/morozov/Projects/phpunit/src/TextUI/Command.php:159
    0.1309    3921528   4. PHPUnit\TextUI\TestRunner->doRun(???, ???, ???) /home/morozov/Projects/phpunit/src/TextUI/Command.php:200
    0.1992    5050712   5. PHPUnit\Framework\TestSuite->run(???) /home/morozov/Projects/phpunit/src/TextUI/TestRunner.php:616
    0.2135    5053544   6. PHPUnit\Framework\DataProviderTestSuite->run(???) /home/morozov/Projects/phpunit/src/Framework/TestSuite.php:569
    0.2140    5053736   7. PHPUnit\Util\TestTest->run(???) /home/morozov/Projects/phpunit/src/Framework/TestSuite.php:569
    0.2141    5053736   8. PHPUnit\Framework\TestResult->run(???) /home/morozov/Projects/phpunit/src/Framework/TestCase.php:752
    0.2142    5053736   9. PHPUnit\Framework\TestResult->startTest(???) /home/morozov/Projects/phpunit/src/Framework/TestResult.php:628
    0.2142    5053736  10. PHPUnit\Util\TestDox\TextResultPrinter->startTest(???) /home/morozov/Projects/phpunit/src/Framework/TestResult.php:411
    0.2142    5053736  11. PHPUnit\Util\TestDox\NamePrettifier->prettifyTestClass(???) /home/morozov/Projects/phpunit/src/Util/TestDox/ResultPrinter.php:234

...............................................................................  79 / 146 ( 54%)
...................................................................             146 / 146 (100%)

Time: 1.94 seconds, Memory: 8.00 MB

OK (146 tests, 230 assertions)
```