### PR TITLE
Add ability to combine onlyMethods and addMethod

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -185,7 +185,7 @@ final class Generator
      *
      * @throws RuntimeException
      */
-    public function getMockForAbstractClass(string $originalClassName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = [], bool $cloneArguments = true): MockObject
+    public function getMockForAbstractClass(string $originalClassName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = null, bool $cloneArguments = true): MockObject
     {
         if (\class_exists($originalClassName, $callAutoload) ||
             \interface_exists($originalClassName, $callAutoload)) {
@@ -202,7 +202,7 @@ final class Generator
             $methods = $mockedMethods;
 
             foreach ($reflector->getMethods() as $method) {
-                if ($method->isAbstract() && !\in_array($method->getName(), $methods, true)) {
+                if ($method->isAbstract() && !\in_array($method->getName(), $methods ?? [], true)) {
                     $methods[] = $method->getName();
                 }
             }
@@ -235,7 +235,7 @@ final class Generator
      *
      * @throws RuntimeException
      */
-    public function getMockForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = [], bool $cloneArguments = true): MockObject
+    public function getMockForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = null, bool $cloneArguments = true): MockObject
     {
         if (!\trait_exists($traitName, $callAutoload)) {
             throw new RuntimeException(

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -27,7 +27,7 @@ final class MockBuilder
     private $type;
 
     /**
-     * @var string[]
+     * @var string[]|null
      */
     private $methods = [];
 
@@ -90,11 +90,6 @@ final class MockBuilder
      * @var Generator
      */
     private $generator;
-
-    /**
-     * @var bool
-     */
-    private $alreadyUsedMockMethodConfiguration = false;
 
     /**
      * @param string|string[] $type
@@ -196,9 +191,11 @@ final class MockBuilder
      */
     public function setMethods(array $methods = null): self
     {
-        $this->methods = $methods;
-
-        $this->alreadyUsedMockMethodConfiguration = true;
+        if ($methods === null) {
+            $this->methods = $methods;
+        } else {
+            $this->methods = array_merge($this->methods ?? [], $methods);
+        }
 
         return $this;
     }
@@ -217,17 +214,6 @@ final class MockBuilder
 
             return $this;
         }
-
-        if ($this->alreadyUsedMockMethodConfiguration) {
-            throw new RuntimeException(
-                \sprintf(
-                    'Cannot use onlyMethods() on "%s" mock because mocked methods were already configured.',
-                    $this->type
-                )
-            );
-        }
-
-        $this->alreadyUsedMockMethodConfiguration = true;
 
         try {
             $reflector = new \ReflectionClass($this->type);
@@ -251,7 +237,7 @@ final class MockBuilder
             }
         }
 
-        $this->methods = $methods;
+        $this->methods = array_merge($this->methods ?? [], $methods);
 
         return $this;
     }
@@ -270,17 +256,6 @@ final class MockBuilder
 
             return $this;
         }
-
-        if ($this->alreadyUsedMockMethodConfiguration) {
-            throw new RuntimeException(
-                \sprintf(
-                    'Cannot use addMethods() on "%s" mock because mocked methods were already configured.',
-                    $this->type
-                )
-            );
-        }
-
-        $this->alreadyUsedMockMethodConfiguration = true;
 
         try {
             $reflector = new \ReflectionClass($this->type);
@@ -304,7 +279,7 @@ final class MockBuilder
             }
         }
 
-        $this->methods = $methods;
+        $this->methods = array_merge($this->methods ?? [], $methods);
 
         return $this;
     }

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -27,7 +27,7 @@ final class MockBuilder
     private $type;
 
     /**
-     * @var string[]|null
+     * @var null|string[]
      */
     private $methods = [];
 
@@ -189,12 +189,12 @@ final class MockBuilder
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/pull/3687
      */
-    public function setMethods(array $methods = null): self
+    public function setMethods(?array $methods = null): self
     {
         if ($methods === null) {
             $this->methods = $methods;
         } else {
-            $this->methods = array_merge($this->methods ?? [], $methods);
+            $this->methods = \array_merge($this->methods ?? [], $methods);
         }
 
         return $this;
@@ -237,7 +237,7 @@ final class MockBuilder
             }
         }
 
-        $this->methods = array_merge($this->methods ?? [], $methods);
+        $this->methods = \array_merge($this->methods ?? [], $methods);
 
         return $this;
     }
@@ -279,7 +279,7 @@ final class MockBuilder
             }
         }
 
-        $this->methods = array_merge($this->methods ?? [], $methods);
+        $this->methods = \array_merge($this->methods ?? [], $methods);
 
         return $this;
     }

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -128,26 +128,26 @@ final class MockBuilderTest extends TestCase
         $this->assertNull($mock->anotherMockableMethod());
     }
 
-    public function testNotAbleToUseAddMethodsAfterOnlyMethods(): void
+    public function testAbleToUseAddMethodsAfterOnlyMethods(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot use addMethods() on "Mockable" mock because mocked methods were already configured.');
+        $mock = $this->getMockBuilder(Mockable::class)
+                     ->onlyMethods(['mockableMethod'])
+                     ->addMethods(['mockableMethodWithFakeMethod'])
+                     ->getMock();
 
-        $this->getMockBuilder(Mockable::class)
-             ->onlyMethods(['mockableMethod'])
-             ->addMethods(['mockableMethodWithFakeMethod'])
-             ->getMock();
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->mockableMethodWithFakeMethod());
     }
 
-    public function testNotAbleToUseOnlyMethodsAfterAddMethods(): void
+    public function testAbleToUseOnlyMethodsAfterAddMethods(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot use onlyMethods() on "Mockable" mock because mocked methods were already configured.');
+        $mock = $this->getMockBuilder(Mockable::class)
+                     ->addMethods(['mockableMethodWithFakeMethod'])
+                     ->onlyMethods(['mockableMethod'])
+                     ->getMock();
 
-        $this->getMockBuilder(Mockable::class)
-             ->addMethods(['mockableMethodWithFakeMethod'])
-             ->onlyMethods(['mockableMethod'])
-             ->getMock();
+        $this->assertNull($mock->mockableMethodWithFakeMethod());
+        $this->assertNull($mock->mockableMethod());
     }
 
     public function testAbleToUseSetMethodsAfterOnlyMethods(): void
@@ -170,26 +170,36 @@ final class MockBuilderTest extends TestCase
         $this->assertNull($mock->mockableMethodWithCrazyName());
     }
 
-    public function testNotAbleToUseAddMethodsAfterSetMethods(): void
+    public function testAbleToUseAddMethodsAfterSetMethods(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot use addMethods() on "Mockable" mock because mocked methods were already configured.');
-
-        $this->getMockBuilder(Mockable::class)
+        $mock = $this->getMockBuilder(Mockable::class)
               ->setMethods(['mockableMethod'])
               ->addMethods(['mockableMethodWithFakeMethod'])
               ->getMock();
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->mockableMethodWithFakeMethod());
     }
 
-    public function testNotAbleToUseOnlyMethodsAfterSetMethods(): void
+    public function testAbleToUseOnlyMethodsAfterSetMethods(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot use onlyMethods() on "Mockable" mock because mocked methods were already configured.');
-
-        $this->getMockBuilder(Mockable::class)
+        $mock = $this->getMockBuilder(Mockable::class)
              ->setMethods(['mockableMethodWithFakeMethod'])
              ->onlyMethods(['mockableMethod'])
              ->getMock();
+
+        $this->assertNull($mock->mockableMethod());
+        $this->assertNull($mock->mockableMethodWithFakeMethod());
+    }
+
+    public function testAbleToUseAddMethodsAfterSetMethodsWithNull(): void
+    {
+        $mock = $this->getMockBuilder(Mockable::class)
+              ->setMethods()
+              ->addMethods(['mockableMethodWithFakeMethod'])
+              ->getMock();
+
+        $this->assertNull($mock->mockableMethodWithFakeMethod());
     }
 
     public function testByDefaultDoesNotPassArgumentsToTheConstructor(): void


### PR DESCRIPTION
Related Issue: https://github.com/sebastianbergmann/phpunit/issues/3858
Reverts some codes that was added in this https://github.com/sebastianbergmann/phpunit/pull/3687/

This PR gives the ability to combine two new methods together -  `onlyMethods` and `addMethods`
so we can write UTs like this
```
$this->getMockBuilder(SomeClass::class)
    ->onlyMethods(['aMethodThatExists'])
    ->addMethods(['aMethodThatDoesNotExist']);
```