### PR TITLE
Add a method to create callable mock

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1596,6 +1596,18 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     }
 
     /**
+     * Returns a mock object for a callable.
+     *
+     * @psalm-return MockObject&callable
+     */
+    protected function createCallableMock(): MockObject
+    {
+        return $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['__invoke'])
+            ->getMock();
+    }
+
+    /**
      * Returns a partial mock object for the specified class.
      *
      * @param string|string[] $originalClassName

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -855,6 +855,14 @@ final class TestCaseTest extends TestCase
         $this->assertNull($mock->anotherMockableMethod());
     }
 
+    public function testCreateCallableMock(): void
+    {
+        $mock = $this->createCallableMock();
+
+        $this->assertIsCallable($mock);
+        $this->assertInstanceOf(MockObject::class, $mock);
+    }
+
     public function testCreatePartialMockDoesNotMockAllMethods(): void
     {
         /** @var \Mockable $mock */


### PR DESCRIPTION
In some case, it can be useful to mock a callable. So far, no method exists to provide it, but the following workaround is possible :

```php
$mock = $this->createPartialMock(\stdClass::class, ['__invoke']);
$mock
      ->expects(self::once())
      ->method('__invoke')
      ->with(1, 2)
      ->willReturn(3);
```

The mock of method that do not actually exists in original class is deprecated in version 8 and will no longer be supported for version >= 9.

The previous workaround can be replaced by the following one :

```php
$mock = $this->getMockBuilder(\stdClass::class)
    ->addMethods(['__invoke'])
    ->getMock();
$mock
      ->expects(self::once())
      ->method('__invoke')
      ->with(1, 2)
      ->willReturn(3);
```

This PR add a 'createCallableMock' method to provide the expected mock. If the PR is accepted, it would be possible to replace previous workaround by :

```php
$mock = $this->createCallableMock();
$mock
      ->expects(self::once())
      ->method('__invoke')
      ->with(1, 2)
      ->willReturn(3);
```