### PR TITLE
Fix: edge case in Testdox prettifier

### DIFF
--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -49,6 +49,7 @@ final class NamePrettifier
                 return $annotations['class']['testdox'][0];
             }
         } catch (UtilException $e) {
+            // ignore, determine className by parsing the provided name
         }
 
         $parts     = \explode('\\', $className);
@@ -62,6 +63,10 @@ final class NamePrettifier
             $className = \substr($className, \strlen('Tests'));
         } elseif (\strpos($className, 'Test') === 0) {
             $className = \substr($className, \strlen('Test'));
+        }
+
+        if (empty($className)) {
+            $className = 'UnnamedTests';
         }
 
         if (!empty($parts)) {

--- a/tests/unit/Util/GlobalStateTest.php
+++ b/tests/unit/Util/GlobalStateTest.php
@@ -24,7 +24,7 @@ final class GlobalStateTest extends TestCase
             $dir . '/ConfigurationTest.php',
             $dir . '/GlobalStateTest.php',
             'vfs://' . $dir . '/RegexTest.php',
-            'phpvfs53e46260465c7://' . $dir . '/TestTest.php',
+            'phpvfs53e46260465c7://' . $dir . '/TestClassTest.php',
             'file://' . $dir . '/XmlTest.php',
         ];
 

--- a/tests/unit/Util/TestClassTest.php
+++ b/tests/unit/Util/TestClassTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Util\Annotation\DocBlock;
 /**
  * @small
  */
-final class TestTest extends TestCase
+final class TestClassTest extends TestCase
 {
     /**
      * @var string

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -39,6 +39,7 @@ final class NamePrettifierTest extends TestCase
         $this->assertEquals('Foo', $this->namePrettifier->prettifyTestClass('TestFooTest'));
         $this->assertEquals('Foo (Test\Foo)', $this->namePrettifier->prettifyTestClass('Test\FooTest'));
         $this->assertEquals('Foo (Tests\Foo)', $this->namePrettifier->prettifyTestClass('Tests\FooTest'));
+        $this->assertEquals('Unnamed Tests', $this->namePrettifier->prettifyTestClass('TestTest'));
     }
 
     public function testTestNameIsConvertedToASentence(): void


### PR DESCRIPTION
The Testdox prettifier removes both a `Test` prefix and postfix, causing a lot of warning noise in PHPUnit's selftest suite. Thankfully this bug is of little concern to normal users, however it does get in the way while working on Testdox.

### Fix
- add boundary check in prettifier
- rename `TestTest` to hide the shame
- pretend this never happened

### Example error output
```
Notice: Uninitialized string offset: 0 in /Users/ewout/proj/phpunit-3900/src/Util/TestDox/NamePrettifier.php on line 82
[...]
PHP  10. PHPUnit\Framework\TestResult->run() /Users/ewout/proj/phpunit-3900/src/Framework/TestCase.php:751
PHP  11. PHPUnit\Framework\TestResult->endTest() /Users/ewout/proj/phpunit-3900/src/Framework/TestResult.php:933
PHP  12. PHPUnit\Util\TestDox\CliTestDoxPrinter->endTest() /Users/ewout/proj/phpunit-3900/src/Framework/TestResult.php:423
PHP  13. PHPUnit\Util\TestDox\CliTestDoxPrinter->registerTestResult() /Users/ewout/proj/phpunit-3900/src/Util/TestDox/TestDoxPrinter.php:110
PHP  14. PHPUnit\Util\TestDox\CliTestDoxPrinter->registerTestResult() /Users/ewout/proj/phpunit-3900/src/Util/TestDox/CliTestDoxPrinter.php:141
PHP  15. PHPUnit\Util\TestDox\CliTestDoxPrinter->formatClassName() /Users/ewout/proj/phpunit-3900/src/Util/TestDox/TestDoxPrinter.php:186
PHP  16. PHPUnit\Util\TestDox\NamePrettifier->prettifyTestClass() /Users/ewout/proj/phpunit-3900/src/Util/TestDox/CliTestDoxPrinter.php:126
```