### PR TITLE
Enhancement: Cache dependencies installed with composer between builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - name: "Cache dependencies installed with composer"
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache
+          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-
+
       - name: Install lowest dependencies with composer
         if: matrix.dependencies == 'lowest'
         run: ${{ matrix.php-binary }} ./tools/composer update --no-ansi --no-interaction --no-progress --no-suggest --prefer-lowest


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer` between builds

💁‍♂ This is inspired by the work of @bendavies on https://github.com/localheinz/php-library-template/pull/131. 

For reference, see https://github.blog/changelog/2019-11-04-github-actions-adds-dependency-caching/.