### PR TITLE
Fix: Ignore codecov failures for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
       - name: Send code coverage report to Codecov.io
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
+        run: bash <(curl -s https://codecov.io/bash) || true


### PR DESCRIPTION
This PR

* [x] ignores codecov failures for now

Follows #3931.