### PR TITLE
Fix: Use hash of composer.json instead of commit hash for cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache
-          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ github.sha }}
+          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-
 


### PR DESCRIPTION
This PR

* [x] uses a hash of the contents of `composer.json` instead of the commit hash for the cache key

💁‍♂ For reference, see https://github.com/actions/cache/issues/65.