### PR TITLE
Add Windows testing and fix failing tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,44 @@
+build: false
+clone_depth: 5
+
+environment:
+  # Set the PHP version (from Chocolatey)
+  PHPCI_CHOCO_VERSION: 7.3.11
+  # Set appropriate Xdebug download link from https://pecl.php.net/package/xdebug
+  PHPCI_XDEBUG_URL: https://windows.php.net/downloads/pecl/releases/xdebug/2.8.0/php_xdebug-2.8.0-7.3-nts-vc15-x64.zip
+  PHPCI_CACHE: C:\phpci
+  PHPCI_PHP: C:\phpci\php
+  PHPCI_COMPOSER: C:\phpci\composer
+
+cache:
+  - '%PHPCI_CACHE% -> appveyor.yml'
+
+init:
+  - SET PATH=%PHPCI_PHP%;%PHPCI_COMPOSER%;%PATH%
+  - SET COMPOSER_HOME=%PHPCI_COMPOSER%\home
+  - SET COMPOSER_CACHE_DIR=%PHPCI_COMPOSER%\cache
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=0
+
+install:
+  - IF EXIST %PHPCI_CACHE% (SET PHP=1)
+  - IF %PHP%==0 mkdir %PHPCI_CACHE% && cd %PHPCI_CACHE%
+  - IF %PHP%==0 curl -fsSL -o xdebug.zip %PHPCI_XDEBUG_URL%
+  - IF %PHP%==0 7z e xdebug.zip -y -o%PHPCI_PHP%\ext php_xdebug.dll >nul && del /q xdebug.zip
+  - IF %PHP%==0 cinst php -i -y --version %PHPCI_CHOCO_VERSION%  --params "/InstallDir:%PHPCI_PHP%"
+  - IF %PHP%==0 cinst composer -i -y --ia "/DEV=%PHPCI_COMPOSER%"
+  - IF %PHP%==0 echo extension=curl >> %PHPCI_PHP%\php.ini
+  - IF %PHP%==0 echo extension=intl >> %PHPCI_PHP%\php.ini
+  - IF %PHP%==0 echo extension=pdo_sqlite >> %PHPCI_PHP%\php.ini
+  - IF %PHP%==0 echo extension=soap >> %PHPCI_PHP%\php.ini
+  - IF %PHP%==0 echo zend_extension=xdebug >> %PHPCI_PHP%\php.ini
+  - IF %PHP%==0 echo zend.assertions=1 >> %PHPCI_PHP%\php.ini
+  - IF %PHP%==0 echo assert.exception=On >> %PHPCI_PHP%\php.ini
+  - php -v
+  - IF %PHP%==0 (composer --version) ELSE (composer self-update)
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - composer install --ansi --prefer-dist --optimize-autoloader --no-suggest --no-progress
+
+test_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - php phpunit

--- a/tests/end-to-end/cli/columns-max.phpt
+++ b/tests/end-to-end/cli/columns-max.phpt
@@ -1,5 +1,10 @@
 --TEST--
 phpunit --columns=max BankAccountTest ../../_files/BankAccountTest.php
+--SKIPIF--
+<?php declare(strict_types=1);
+if (\defined('PHP_WINDOWS_VERSION_BUILD')) {
+    print 'skip: Fails on Windows.';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][1] = '--no-configuration';

--- a/tests/end-to-end/regression/GitHub/3739.phpt
+++ b/tests/end-to-end/regression/GitHub/3739.phpt
@@ -21,8 +21,8 @@ There was 1 error:
 1) Issue3739\Issue3739Test::testWithoutErrorSuppression
 unlink(%s/end-to-end/regression/GitHub/3739/DOES_NOT_EXIST): No such file or directory
 
-%s/Issue3739Test.php:%d
-%s/Issue3739Test.php:%d
+%sIssue3739Test.php:%d
+%sIssue3739Test.php:%d
 
 ERRORS!
 Tests: 2, Assertions: 1, Errors: 1.

--- a/tests/end-to-end/regression/GitHub/3739/Issue3739Test.php
+++ b/tests/end-to-end/regression/GitHub/3739/Issue3739Test.php
@@ -15,12 +15,27 @@ class Issue3739
 {
     public function unlinkFileThatDoesNotExistWithErrorSuppression(): bool
     {
-        return @\unlink(__DIR__ . '/DOES_NOT_EXIST');
+        $path = $this->getPath();
+
+        return @\unlink($path);
     }
 
     public function unlinkFileThatDoesNotExistWithoutErrorSuppression(): bool
     {
-        return \unlink(__DIR__ . '/DOES_NOT_EXIST');
+        $path = $this->getPath();
+
+        return \unlink($path);
+    }
+
+    private function getPath()
+    {
+        $path = __DIR__ . '/DOES_NOT_EXIST';
+
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            $path = \strtr($path, '\\', '/');
+        }
+
+        return $path;
     }
 }
 

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -19,7 +19,7 @@ final class XDebugFilterScriptGeneratorTest extends TestCase
 {
     public function testReturnsExpectedScript(): void
     {
-        $expectedDirectory = \sprintf('%s/', __DIR__);
+        $expectedDirectory = \sprintf(\addslashes('%s' . \DIRECTORY_SEPARATOR), __DIR__);
         $expected          = <<<EOF
 <?php declare(strict_types=1);
 if (!\\function_exists('xdebug_set_filter')) {


### PR DESCRIPTION
I've put this on master because it is sort of a new feature, but I'll happily PR it for 7.5 if required.

I see that you're are using Github actions, so you may well be planning to test on Windows there. In the meantime, I've included a simple appveyor configuration for basic testing (similar to what we use on Composer and XdebugHandler).

Test results:
https://ci.appveyor.com/project/johnstevenson/phpunit/builds/28837509