### PR TITLE
Support to pass an expected exception to a callback for validation

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -130,6 +130,13 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     private $expectedExceptionCode;
 
     /**
+     * The callback to validate the expected Exception.
+     *
+     * @var null|callable
+     */
+    private $expectedExceptionCallback;
+
+    /**
      * @var string
      */
     private $name = '';
@@ -519,6 +526,17 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
         $this->expectException(\get_class($exception));
         $this->expectExceptionMessage($exception->getMessage());
         $this->expectExceptionCode($exception->getCode());
+    }
+
+    public function expectExceptionCallback(callable $callback): void
+    {
+        if (!$this->expectedException) {
+            // TODO: If we could find the argument type of the callback,
+            // we could both tighten this expectation to provide better
+            // diagnostics and validate the callback argument.
+            $this->expectedException = \Exception::class;
+        }
+        $this->expectedExceptionCallback = $callback;
     }
 
     public function expectNotToPerformAssertions(): void
@@ -1445,6 +1463,10 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
                         $this->expectedExceptionCode
                     )
                 );
+            }
+
+            if ($this->expectedExceptionCallback !== null) {
+                ($this->expectedExceptionCallback)($exception);
             }
 
             return;

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -458,6 +458,20 @@ final class TestCaseTest extends TestCase
         $this->assertFalse($result->wasSuccessful());
     }
 
+    public function testExpectExceptionCallbackWithDifferentExceptionClass(): void
+    {
+        $test = new \ThrowExceptionTestCase('test');
+        $test->expectExceptionCallback(function (\InvalidArgumentException $e): void {
+            // this is never called, because the exception type doesn't match
+        });
+
+        $result = $test->run();
+
+        $this->assertEquals(1, $result->failureCount());
+        $this->assertCount(1, $result);
+        $this->assertFalse($result->wasSuccessful());
+    }
+
     public function testExpectExceptionObjectWithEqualException(): void
     {
         $exception = new \RuntimeException(

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -428,7 +428,32 @@ final class TestCaseTest extends TestCase
         $test->expectExceptionObject($exception);
 
         $result = $test->run();
+        $this->assertFalse($result->wasSuccessful());
+    }
 
+    public function testExpectExceptionCallback(): void
+    {
+        $test = new \ThrowExceptionTestCase('test');
+        $test->expectExceptionCallback(function (\RuntimeException $e): void {
+            $this->assertInstanceof(\RuntimeException::class, $e);
+        });
+
+        $result = $test->run();
+
+        $this->assertCount(1, $result);
+        $this->assertTrue($result->wasSuccessful());
+    }
+
+    public function testExpectExceptionCallbackFailure(): void
+    {
+        $test = new \ThrowExceptionTestCase('test');
+        $test->expectExceptionCallback(function (\RuntimeException $e): void {
+            $this->fail('test failure');
+        });
+
+        $result = $test->run();
+
+        $this->assertEquals(1, $result->failureCount());
         $this->assertCount(1, $result);
         $this->assertFalse($result->wasSuccessful());
     }


### PR DESCRIPTION
Heya!

I found https://github.com/sebastianbergmann/phpunit/pull/1726 in my personal backlog, and rebased in onto the current master branch. Anyhow, so much for the background of this... ;)

### Rationale
In some cases I want to inspect more of the thrown exceptions than just the type, message and errorcode. Up to now, I have to do it manually:

```
try {
    $testee->run();
    $this->fail("expected exception not raised");
} catch (\MyException $e) {
    $this->assertEquals(MyException::CATEGORY_FATAL, $e->category());
}
```

There are a few downsides to this:
 * I need to check the failure to throw explicitly.
 * I should check for wrong exceptions. I don't it above, because it's just too much code.

### Solution
The pull request here adds another function to validate expected exceptions using a callback. It allows this kind of test instead:

```
$this->expectExceptionCallback(
    function (\MyException $e) {
        $this->assertEquals(MyException::CATEGORY_FATAL, $e->category());
    }
);
$testee->run();
```
This code allows you to
 * verify that the exception type matches.
 * verify that the exception is thrown.
 * write custom validation code for the exception type.


What do you think?