### PR TITLE
Fix: Build for any push or pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 on:
-  pull_request:
-  push:
-    branches:
-      - 7.5
-    tags:
-      - "**"
+  - pull_request
+  - push
 
 name: CI
 


### PR DESCRIPTION
This PR

* [x] ensures that pushes to `master` are built

💁‍♂ This probably also makes it a lot easier merging from [`7.5`](https://github.com/sebastianbergmann/phpunit/tree/7.5) to [`8.4`](https://github.com/sebastianbergmann/phpunit/tree/8.4) to [`8.5`](https://github.com/sebastianbergmann/phpunit/tree/8.5) to [`master`](https://github.com/sebastianbergmann/phpunit/tree/master).

 For reference, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#on.