### PR TITLE
Test class run in a separate PHP process are passing when "exit" called inside

### DIFF
--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Util\PHP;
 
 use __PHP_Incomplete_Class;
 use ErrorException;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\SyntheticError;
 use PHPUnit\Framework\Test;
@@ -248,6 +249,14 @@ abstract class AbstractPhpProcess
 
                 $childResult = \unserialize(\str_replace("#!/usr/bin/env php\n", '', $stdout));
                 \restore_error_handler();
+
+                if ($childResult === false) {
+                    $result->addFailure(
+                        $test,
+                        new AssertionFailedError('Test was run in child process and ended unexpectedly'),
+                        $time
+                    );
+                }
             } catch (ErrorException $e) {
                 \restore_error_handler();
                 $childResult = false;

--- a/tests/_files/SeparateProcessesTest.php
+++ b/tests/_files/SeparateProcessesTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class SeparateProcessesTest extends TestCase
+{
+    public function testFoo(): void
+    {
+        $this->assertTrue(true);
+        exit(0);
+    }
+
+    public function testBar(): void
+    {
+        $this->assertTrue(true);
+        $this->assertTrue(true);
+        exit(1);
+    }
+}

--- a/tests/end-to-end/separate-processes-test.phpt
+++ b/tests/end-to-end/separate-processes-test.phpt
@@ -1,0 +1,17 @@
+--TEST--
+phpunit --no-configuration ../../_files/SeparateProcessesTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = __DIR__ . '/../_files/SeparateProcessesTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 0 assertions)

--- a/tests/end-to-end/separate-processes-test.phpt
+++ b/tests/end-to-end/separate-processes-test.phpt
@@ -10,8 +10,17 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-..                                                                  2 / 2 (100%)
+FF                                                                  2 / 2 (100%)
 
 Time: %s, Memory: %s
 
-OK (2 tests, 0 assertions)
+There were 2 failures:
+
+1) SeparateProcessesTest::testFoo
+Test was run in child process and ended unexpectedly
+
+2) SeparateProcessesTest::testBar
+Test was run in child process and ended unexpectedly
+
+FAILURES!
+Tests: 2, Assertions: 0, Failures: 2.


### PR DESCRIPTION
- [x] adding a test with incorrect behaviour
- [x] updating the test with expected behaviour
- [x] adding fix