### PR TITLE
Fix: Check out entire history for backward-compatibility job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@master


### PR DESCRIPTION
This PR

* [x] checks out the entire history for the `backward-compatibility` job

💁‍♂ Hopefully this fixes the following error:

```
Comparing from 42afe2b8b42077b26148272bd03da4ab6e46a072 to 3ee1c1fd6fc264480c25b6fb8285edefe1702dab...

In Process.php line 255:

  The command "'git' 'checkout' '42afe2b8b42077b26148272bd03da4ab6e46a072'" failed.                                                                       

  Exit Code: 128(Invalid exit argument)                                        

  Working directory: /tmp/api-compare-42afe2b8b42077b26148272bd03da4ab6e46a072_5de9ec71d5270                                                              

  Output:                                                                      

  ================                                                             
  Error Output:                                                                
  ================                                                             

  fatal: reference is not a tree: 42afe2b8b42077b26148272bd03da4ab6e46a072     
```

For reference, see https://github.com/sebastianbergmann/phpunit/runs/336217322#step:4:22.