### PR TITLE
Fix: Fetch tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Fetch tags"
+        run: git fetch --tags
+
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@master
         with:


### PR DESCRIPTION
This PR

* [x] fetches tags before running `roave/backward-compability-check`

Follows #3970.

💁‍♂ For reference, see https://github.com/actions/checkout/issues/85.