### PR TITLE
Fix: Avoid using master for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v1
 
       - name: Update dependencies with composer
         run: php7.3 ./tools/composer update --no-interaction --no-ansi --no-progress --no-suggest
@@ -44,12 +44,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v1
         with:
           fetch-depth: 0
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           php-version: 7.3
           coverage: none
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: "Install PHP with extensions"
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v1
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug


### PR DESCRIPTION
This PR

* [x] avoids using `master` as version constraint for composed GitHub actions

Follows #3972.