### PR TITLE
8.5 php notice/warning

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -331,8 +331,7 @@ final class TestRunner extends BaseTestRunner
             }
         }
         
-        if(isset($arguments['warnings']))
-        {
+        if (isset($arguments['warnings'])) {
             foreach ($arguments['warnings'] as $warning) {
                 $this->writeMessage('Warning', $warning);
             }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -330,9 +330,12 @@ final class TestRunner extends BaseTestRunner
                 );
             }
         }
-
-        foreach ($arguments['warnings'] as $warning) {
-            $this->writeMessage('Warning', $warning);
+        
+        if(isset($arguments['warnings']))
+        {
+            foreach ($arguments['warnings'] as $warning) {
+                $this->writeMessage('Warning', $warning);
+            }
         }
 
         if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -330,7 +330,7 @@ final class TestRunner extends BaseTestRunner
                 );
             }
         }
-        
+
         if (isset($arguments['warnings'])) {
             foreach ($arguments['warnings'] as $warning) {
                 $this->writeMessage('Warning', $warning);


### PR DESCRIPTION
After upgrading to 8.5 I noticed the following notice/warning:
Notice: Undefined index: warnings in /vendor/phpunit/phpunit/src/TextUI/TestRunner.php on line 334
Warning:  Invalid argument supplied for foreach() in /vendor/phpunit/phpunit/src/TextUI/TestRunner.php on line 334

this fixes that.