### PR TITLE
Fix: Do not use deprecated inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           php-version: 7.3
           coverage: none
-          extension-csv: intl
+          extensions: intl
 
       - name: Run roave/backward-compatibility-check
         run: php ./tools/roave-backward-compatibility-check --from=8.5.0
@@ -100,8 +100,8 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: xdebug
-          extension-csv: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
-          ini-values-csv: assert.exception=1, zend.assertions=1
+          extensions: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
+          ini-values: assert.exception=1, zend.assertions=1
 
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1


### PR DESCRIPTION
This PR

* [x] stops using deprecated inputs

💁‍♂ For reference, see https://github.com/sebastianbergmann/phpunit/pull/3979/checks?check_run_id=339672157#step:3:1:

<img width="1242" alt="Screen Shot 2019-12-09 at 09 53 38" src="https://user-images.githubusercontent.com/605483/70421268-ca87b100-1a69-11ea-9b08-2aa5eb446d5a.png">
