### PR TITLE
Add CLI option to restart without Xdebug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-mbstring": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
+        "composer/xdebug-handler": "^1.4",
         "doctrine/instantiator": "^1.2.0",
         "myclabs/deep-copy": "^1.9.1",
         "phar-io/manifest": "^1.0.3",

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -30,6 +30,7 @@ use PHPUnit\Util\Log\TeamCity;
 use PHPUnit\Util\Printer;
 use PHPUnit\Util\TestDox\CliTestDoxPrinter;
 use PHPUnit\Util\TextTestListRenderer;
+use PHPUnit\Util\XdebugManager;
 use PHPUnit\Util\XmlTestListRenderer;
 use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 
@@ -144,6 +145,7 @@ class Command
         'version'                   => null,
         'whitelist='                => null,
         'dump-xdebug-filter='       => null,
+        'no-xdebug'                 => null,
     ];
 
     /**
@@ -195,6 +197,10 @@ class Command
         }
 
         unset($this->arguments['test'], $this->arguments['testFile']);
+
+        $xdebug = new XdebugManager($this->arguments);
+        $xdebug->check();
+        unset($xdebug);
 
         try {
             $result = $runner->doRun($suite, $this->arguments, $exit);
@@ -754,6 +760,11 @@ class Command
 
                 case '--dump-xdebug-filter':
                     $this->arguments['xdebugFilterFile'] = $option[1];
+
+                    break;
+
+                case '--no-xdebug':
+                    $this->arguments['noXdebug'] = true;
 
                     break;
 

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -118,6 +118,7 @@ final class Help
             ['arg' => '-d <key[=value]>', 'desc' => 'Sets a php.ini value'],
             ['arg' => '--generate-configuration', 'desc' => 'Generate configuration file with suggested settings'],
             ['arg' => '--cache-result-file=<file>', 'desc' => 'Specify result cache path and filename'],
+            ['arg' => '--no-xdebug', 'desc' => 'Remove Xdebug from a CLI process if it is loaded'],
         ],
 
         'Miscellaneous Options' => [

--- a/src/Util/XdebugManager.php
+++ b/src/Util/XdebugManager.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use Composer\XdebugHandler\XdebugHandler;
+use PHPUnit\TextUI\ResultPrinter;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class XdebugManager extends XdebugHandler
+{
+    /**
+     * @var bool
+     */
+    private $noXdebug;
+
+    public function __construct(array $arguments)
+    {
+        $this->noXdebug = $arguments['noXdebug'] ?? false;
+        parent::__construct('phpunit', '--colors=' . ResultPrinter::COLOR_ALWAYS);
+
+        // Use persistent restart settings if we restart
+        $this->setPersistent();
+    }
+
+    protected function requiresRestart($isLoaded)
+    {
+        return $isLoaded && $this->noXdebug;
+    }
+}

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -122,6 +122,8 @@
   [32m--generate-configuration   [0m Generate configuration file with
                               suggested settings
   [32m--cache-result-file=[36m<file>[0m [0m Specify result cache path and filename
+  [32m--no-xdebug                [0m Remove Xdebug from a CLI process if it is
+                              loaded
 
 [33mMiscellaneous Options:[0m
   [32m-h|--help                  [0m Prints this usage information

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -95,6 +95,7 @@ Configuration Options:
   -d <key[=value]>            Sets a php.ini value
   --generate-configuration    Generate configuration file with suggested settings
   --cache-result-file=<file>  Specify result cache path and filename
+  --no-xdebug                 Remove Xdebug from a CLI process if it is loaded
 
 Miscellaneous Options:
 

--- a/tests/end-to-end/xdebug-handler/NoXdebug.phpt
+++ b/tests/end-to-end/xdebug-handler/NoXdebug.phpt
@@ -1,0 +1,44 @@
+--TEST--
+phpunit NoXdebugWhenLoadedTest.php or NoXdebugWhenNotLoadedTest.php
+--SKIPIF--
+<?php declare(strict_types=1);
+if (PHP_SAPI !== 'cli') {
+    print 'skip: PHP runtime required';
+}
+--FILE--
+<?php declare(strict_types=1);
+require __DIR__ . '/../../bootstrap.php';
+
+$testEnv = 'PHPUNIT_XDEBUG_HANDLER_TEST';
+$loadedTest = 'NoXdebugWhenLoadedTest.php';
+
+if (getenv($testEnv)) {
+    // We are in a restart
+    $file = $loadedTest;
+} elseif (extension_loaded('xdebug')) {
+    // We will be restarted
+    $file = $loadedTest;
+    putenv($testEnv . '=1');
+} else {
+    // Check if we have been restarted prior to this test
+    if (PHPUnit\Util\XdebugManager::getRestartSettings()) {
+        $file = $loadedTest;
+    } else {
+        $file = 'NoXdebugWhenNotLoadedTest.php';
+    }
+}
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2]  = '--no-xdebug';
+$_SERVER['argv'][3]  = __DIR__ . '/' . $file;
+
+PHPUnit\TextUI\Command::main();
+putenv($testEnv);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 2 assertions)

--- a/tests/end-to-end/xdebug-handler/NoXdebugWhenLoadedTest.php
+++ b/tests/end-to-end/xdebug-handler/NoXdebugWhenLoadedTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\XdebugManager;
+
+class NoXdebugWhenLoadedTest extends TestCase
+{
+    public function testNoXdebugWhenLoaded(): void
+    {
+        // Check that we have restart settings
+        $this->assertNotNull(XdebugManager::getRestartSettings());
+        $this->assertFalse(\extension_loaded('xdebug'));
+    }
+}

--- a/tests/end-to-end/xdebug-handler/NoXdebugWhenNotLoadedTest.php
+++ b/tests/end-to-end/xdebug-handler/NoXdebugWhenNotLoadedTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\XdebugManager;
+
+class NoXdebugWhenNotLoadedTest extends TestCase
+{
+    public function testNoXdebugWhenNotLoaded(): void
+    {
+        // If Xdebug was not loaded, there will be no restart settings
+        $this->assertNull(XdebugManager::getRestartSettings());
+        $this->assertFalse(\extension_loaded('xdebug'));
+    }
+}


### PR DESCRIPTION
This adds a `--no-xdebug` CLI option to restart the main process without
loading the Xdebug extension, using the composer/xdebug-handler package.

The process is restarted using persistent settings, which ensures that
Xdebug is not loaded in any PHP sub-process.

This may are may not be something you wish to incorporate. If it is, then it is perhaps worth also considering an alternative strategy that would automatically remove Xdebug unless it is needed.