### PR TITLE
Fix code coverage error on @runTestsInSeparateProcesses

### DIFF
--- a/src/Util/PHP/Template/PhptTestCase.tpl
+++ b/src/Util/PHP/Template/PhptTestCase.tpl
@@ -1,5 +1,5 @@
 <?php
-use SebastianBergmann\CodeCoverage\CodeCoverage;
+use PHPUnit\SebastianBergmann\CodeCoverage\CodeCoverage;
 
 $composerAutoload = {composerAutoload};
 $phar             = {phar};
@@ -22,7 +22,7 @@ if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
     require_once $GLOBALS['__PHPUNIT_BOOTSTRAP'];
 }
 
-if (class_exists('SebastianBergmann\CodeCoverage\CodeCoverage')) {
+if (class_exists('PHPUnit\SebastianBergmann\CodeCoverage\CodeCoverage')) {
     $coverage =	new CodeCoverage(null);
     $coverage->start(__FILE__);
 }

--- a/src/Util/PHP/Template/TestCaseClass.tpl
+++ b/src/Util/PHP/Template/TestCaseClass.tpl
@@ -1,5 +1,5 @@
 <?php
-use SebastianBergmann\CodeCoverage\CodeCoverage;
+use PHPUnit\SebastianBergmann\CodeCoverage\CodeCoverage;
 
 if (!defined('STDOUT')) {
     // php://stdout does not obey output buffering. Any output would break

--- a/src/Util/PHP/Template/TestCaseMethod.tpl
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl
@@ -1,6 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
-use SebastianBergmann\CodeCoverage\CodeCoverage;
+use PHPUnit\SebastianBergmann\CodeCoverage\CodeCoverage;
 
 if (!defined('STDOUT')) {
     // php://stdout does not obey output buffering. Any output would break


### PR DESCRIPTION
To fix bug
https://github.com/sebastianbergmann/phpunit/issues/3492

Current error text:
```
PHP Fatal error:  Uncaught Error: Class 'SebastianBergmann\CodeCoverage\CodeCoverage' not found in Standard input code:302
Stack trace:
#0 Standard input code(2250): __phpunit_run_isolated_test()
#1 {main}
  thrown in Standard input code on line 302
```