### PR TITLE
Fix a TypeError in DocBlock::parseAnnotationContent

### DIFF
--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -327,8 +327,11 @@ final class DocBlock
      * Constants are specified using a starting '@'. For example: @ClassName::CONST_NAME
      *
      * If the constant is not found the string is used as is to ensure maximum BC.
+     *
+     * NOTE: This should not have a return type.
+     * If it did, then '(at)expectedExceptionCode ClassName::SOME_INT_CONSTANT' would cause a TypeError.
      */
-    private function parseAnnotationContent(string $message): string
+    private function parseAnnotationContent(string $message)
     {
         if (\defined($message) &&
             (\strpos($message, '::') !== false && \substr_count($message, '::') + 1 === 2)) {


### PR DESCRIPTION
This can happen when referring to an integer class constant,
e.g. `@expectedExceptionCode SomeClass::INTEGER_CONSTANT`
(this file has strict_types=1)

- constant() will return a class constant, which can be of type null/bool/int/float/string/array/resource

The type hint was added in c55e6f781c . PHPUnit 7 wasn't affected.

I didn't see any tests for DocBlock or `@expectedExceptionCode` to base new tests off of.
- EDIT: tests/end-to-end seems to be the most appropriate