### PR TITLE
#4001 Check for 'false' line for PHP 7.4.

### DIFF
--- a/src/Util/PHP/DefaultPhpProcess.php
+++ b/src/Util/PHP/DefaultPhpProcess.php
@@ -144,7 +144,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
 
                         $line = \fread($pipe, 8192);
 
-                        if ($line === '') {
+                        if ($line === '' || $line === false) {
                             \fclose($pipes[$pipeOffset]);
 
                             unset($pipes[$pipeOffset]);


### PR DESCRIPTION
Fix `fread` error return on PHP 7.4