### PR TITLE
Bug: can't rely on already loaded class

### DIFF
--- a/tests/end-to-end/regression/GitHub/4037-namespaced.phpt
+++ b/tests/end-to-end/regression/GitHub/4037-namespaced.phpt
@@ -1,0 +1,34 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/pull/4037
+--FILE--
+<?php declare(strict_types=1);
+require __DIR__ . '/../../../bootstrap.php';
+
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = __DIR__ . '/4037-namespaced/';
+$_SERVER['argv'][3] = __DIR__ . '/4037-namespaced/LastNamespacePart/Issue4037ATest.php';
+
+PHPUnit\TextUI\Command::main(false);
+
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = __DIR__ . '/4037-namespaced/';
+$_SERVER['argv'][3] = __DIR__ . '/4037-namespaced/LastNamespacePart/Issue4037BTest.php';
+
+PHPUnit\TextUI\Command::main(false);
+
+@unlink(__DIR__ . '/4037-namespaced/.phpunit.result.cache');
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037ATest.php
+++ b/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037ATest.php
@@ -7,7 +7,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace FirstNamespacePart\LastNamespacePart;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037ATest.php
+++ b/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037ATest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FirstNamespacePart\LastNamespacePart;
+
+use PHPUnit\Framework\TestCase;
+
+final class Issue4037ATest extends TestCase
+{
+    public function testA(): void
+    {
+        require __DIR__ . '/Issue4037BTest.php';
+        $this->assertTrue(Issue4037BTest::ok());
+    }
+}

--- a/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037BTest.php
+++ b/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037BTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FirstNamespacePart\LastNamespacePart;
+
+use PHPUnit\Framework\TestCase;
+
+final class Issue4037BTest extends TestCase
+{
+    public static function ok(): bool
+    {
+        return true;
+    }
+
+    public function testB(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037BTest.php
+++ b/tests/end-to-end/regression/GitHub/4037-namespaced/LastNamespacePart/Issue4037BTest.php
@@ -7,7 +7,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace FirstNamespacePart\LastNamespacePart;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/end-to-end/regression/GitHub/4037-namespaced/phpunit.xml
+++ b/tests/end-to-end/regression/GitHub/4037-namespaced/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.4/phpunit.xsd">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/regression/GitHub/4037.phpt
+++ b/tests/end-to-end/regression/GitHub/4037.phpt
@@ -1,5 +1,5 @@
 --TEST--
-https://github.com/sebastianbergmann/phpunit/issues/4037
+https://github.com/sebastianbergmann/phpunit/pull/4037
 --FILE--
 <?php declare(strict_types=1);
 require __DIR__ . '/../../../bootstrap.php';

--- a/tests/end-to-end/regression/GitHub/4037.phpt
+++ b/tests/end-to-end/regression/GitHub/4037.phpt
@@ -1,0 +1,34 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/4037
+--FILE--
+<?php declare(strict_types=1);
+require __DIR__ . '/../../../bootstrap.php';
+
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = __DIR__ . '/4037/';
+$_SERVER['argv'][3] = __DIR__ . '/4037/Issue4037ATest.php';
+
+PHPUnit\TextUI\Command::main(false);
+
+$_SERVER['argv'][1] = '--configuration';
+$_SERVER['argv'][2] = __DIR__ . '/4037/';
+$_SERVER['argv'][3] = __DIR__ . '/4037/Issue4037BTest.php';
+
+PHPUnit\TextUI\Command::main(false);
+
+@unlink(__DIR__ . '/4037/.phpunit.result.cache');
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/GitHub/4037/Issue4037ATest.php
+++ b/tests/end-to-end/regression/GitHub/4037/Issue4037ATest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+final class Issue4037ATest extends TestCase
+{
+    public function testA(): void
+    {
+        require __DIR__ . '/Issue4037BTest.php';
+        $this->assertTrue(Issue4037BTest::ok());
+    }
+}

--- a/tests/end-to-end/regression/GitHub/4037/Issue4037BTest.php
+++ b/tests/end-to-end/regression/GitHub/4037/Issue4037BTest.php
@@ -11,13 +11,13 @@ use PHPUnit\Framework\TestCase;
 
 final class Issue4037BTest extends TestCase
 {
-    public function testB(): void
-    {
-        $this->assertTrue(true);
-    }
-
     public static function ok(): bool
     {
         return true;
+    }
+
+    public function testB(): void
+    {
+        $this->assertTrue(true);
     }
 }

--- a/tests/end-to-end/regression/GitHub/4037/Issue4037BTest.php
+++ b/tests/end-to-end/regression/GitHub/4037/Issue4037BTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+final class Issue4037BTest extends TestCase
+{
+    public function testB(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public static function ok(): bool
+    {
+        return true;
+    }
+}

--- a/tests/end-to-end/regression/GitHub/4037/phpunit.xml
+++ b/tests/end-to-end/regression/GitHub/4037/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.4/phpunit.xsd">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Hi, in order to be able to have a feedback for each test, but run them quickly, [Paratest](https://github.com/paratestphp/paratest) calls within a single process `PHPUnit\TextUI\Command::main(false)` [multiple times](https://github.com/paratestphp/paratest/blob/master/bin/phpunit-wrapper).

Starting for PHPUnit 9.0, if a test already loaded another test class, `PHPUnit\Runner\StandardTestSuiteLoader` fails to get a useful diff here:

https://github.com/sebastianbergmann/phpunit/blob/ec3adec334f7bbe8c61607bdacefbf5046a6df94/src/Runner/StandardTestSuiteLoader.php#L28-L36

hence throws a `ClassNotFoundException`, even though the class is perfectly already loaded.

The bug is present also in 8.5, but the workaround was to specify the class name alongside the class file, behavior suppressed in 9.0

Ping @andreasschroth