### PR TITLE
Deprecate TestSuiteLoader

### DIFF
--- a/ChangeLog-9.1.md
+++ b/ChangeLog-9.1.md
@@ -4,5 +4,8 @@ All notable changes of the PHPUnit 9.1 release series are documented in this fil
 
 ## [9.1.0] - 2020-04-10
 
-[9.1.0]: https://github.com/sebastianbergmann/phpunit/compare/9.0...master
+### Removed
 
+* Implemented [#4039](https://github.com/sebastianbergmann/phpunit/issues/4039): Deprecate custom test suite loader
+
+[9.1.0]: https://github.com/sebastianbergmann/phpunit/compare/9.0...master

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -15,6 +15,8 @@ use PHPUnit\Util\FileLoader;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ *
+ * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
  */
 final class StandardTestSuiteLoader implements TestSuiteLoader
 {

--- a/src/Runner/TestSuiteLoader.php
+++ b/src/Runner/TestSuiteLoader.php
@@ -13,6 +13,8 @@ use ReflectionClass;
 
 /**
  * An interface to define how a test suite should be loaded.
+ *
+ * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
  */
 interface TestSuiteLoader
 {

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -912,6 +912,8 @@ class Command
 
     /**
      * Handles the loading of the PHPUnit\Runner\TestSuiteLoader implementation.
+     *
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
      */
     protected function handleLoader(string $loaderClass, string $loaderFile = ''): ?TestSuiteLoader
     {

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -808,7 +808,8 @@ class Command
         }
 
         if ($this->arguments['loader'] !== null) {
-            $this->arguments['loader'] = $this->handleLoader($this->arguments['loader']);
+            $this->arguments['warnings'][] = 'Usage of custom test suite loader is deprecated';
+            $this->arguments['loader']     = $this->handleLoader($this->arguments['loader']);
         }
 
         if (isset($this->arguments['configuration']) &&
@@ -875,6 +876,8 @@ class Command
             }
 
             if ($phpunitConfiguration->hasTestSuiteLoaderClass()) {
+                $this->arguments['warnings'][] = 'Usage of custom test suite loader is deprecated';
+
                 $file = $phpunitConfiguration->hasTestSuiteLoaderFile() ? $phpunitConfiguration->testSuiteLoaderFile() : '';
 
                 $this->arguments['loader'] = $this->handleLoader(

--- a/src/TextUI/Configuration/PHPUnit/PHPUnit.php
+++ b/src/TextUI/Configuration/PHPUnit/PHPUnit.php
@@ -157,11 +157,15 @@ final class PHPUnit
 
     /**
      * @var ?string
+     *
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
      */
     private $testSuiteLoaderClass;
 
     /**
      * @var ?string
+     *
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
      */
     private $testSuiteLoaderFile;
 
@@ -501,6 +505,9 @@ final class PHPUnit
         return (string) $this->extensionsDirectory;
     }
 
+    /**
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
+     */
     public function hasTestSuiteLoaderClass(): bool
     {
         return $this->testSuiteLoaderClass !== null;
@@ -508,6 +515,8 @@ final class PHPUnit
 
     /**
      * @throws Exception
+     *
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
      */
     public function testSuiteLoaderClass(): string
     {
@@ -518,6 +527,9 @@ final class PHPUnit
         return (string) $this->testSuiteLoaderClass;
     }
 
+    /**
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
+     */
     public function hasTestSuiteLoaderFile(): bool
     {
         return $this->testSuiteLoaderFile !== null;
@@ -525,6 +537,8 @@ final class PHPUnit
 
     /**
      * @throws Exception
+     *
+     * @deprecated see https://github.com/sebastianbergmann/phpunit/issues/4039
      */
     public function testSuiteLoaderFile(): string
     {

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -91,7 +91,7 @@ final class Help
             ['arg'    => '--debug', 'desc' => 'Display debugging information'],
             ['spacer' => ''],
 
-            ['arg'    => '--loader <loader>', 'desc' => 'TestSuiteLoader implementation to use'],
+            ['arg'    => '--loader <loader>', 'desc' => 'TestSuiteLoader implementation to use. Deprecated, see https://github.com/sebastianbergmann/phpunit/issues/4039'],
             ['arg'    => '--repeat <times>', 'desc' => 'Runs the test(s) repeatedly'],
             ['arg'    => '--teamcity', 'desc' => 'Report test execution progress in TeamCity format'],
             ['arg'    => '--testdox', 'desc' => 'Report test execution progress in TestDox format'],

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -337,6 +337,10 @@ final class TestRunner extends BaseTestRunner
             }
         }
 
+        foreach ($arguments['warnings'] as $warning) {
+            $this->writeMessage('Warning', $warning);
+        }
+
         if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
             $this->writeMessage(
                 'Random seed',

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -87,7 +87,9 @@
   [32m-v|--verbose               [0m Output more verbose information
   [32m--debug                    [0m Display debugging information
 
-  [32m--loader [36m<loader>[0m          [0m TestSuiteLoader implementation to use
+  [32m--loader [36m<loader>[0m          [0m TestSuiteLoader implementation to use.
+                              Deprecated, see
+                              https://github.com/sebastianbergmann/phpunit/issues/4039
   [32m--repeat [36m<times>[0m           [0m Runs the test(s) repeatedly
   [32m--teamcity                 [0m Report test execution progress in
                               TeamCity format

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -69,7 +69,7 @@ Test Execution Options:
   -v|--verbose                Output more verbose information
   --debug                     Display debugging information
 
-  --loader <loader>           TestSuiteLoader implementation to use
+  --loader <loader>           TestSuiteLoader implementation to use. Deprecated, see https://github.com/sebastianbergmann/phpunit/issues/4039
   --repeat <times>            Runs the test(s) repeatedly
   --teamcity                  Report test execution progress in TeamCity format
   --testdox                   Report test execution progress in TestDox format

--- a/tests/end-to-end/regression/GitHub/1265.phpt
+++ b/tests/end-to-end/regression/GitHub/1265.phpt
@@ -11,6 +11,8 @@ PHPUnit\TextUI\Command::main();
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
+Warning:       Usage of custom test suite loader is deprecated
+
 .                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %s


### PR DESCRIPTION
This pull request will deprecate `TestSuiteLoader`, `StandardTestSuiteLoader` and the `testSuiteLoaderClass` and `testSuiteLoaderFile` configuration settings.

See #4039 