### PR TITLE
Fix Undefined index: disableCodeCoverageIgnore

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -546,7 +546,7 @@ final class TestRunner extends BaseTestRunner
                 );
             }
 
-            if ($arguments['disableCodeCoverageIgnore']) {
+            if (isset($arguments['disableCodeCoverageIgnore']) && $arguments['disableCodeCoverageIgnore']) {
                 $codeCoverage->setDisableIgnoredLines(true);
             }
 


### PR DESCRIPTION
This will fix the `Notice: Undefined index: disableCodeCoverageIgnore in TestRunner.php:549` when you you have xDebug extension enabled and call without the `--disable-coverage-ignore` CLI argument

From: https://github.com/sebastianbergmann/phpunit/pull/4040#issuecomment-584516329