### PR TITLE
Fix mocking with anonymous classes

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -902,6 +902,15 @@ final class Generator
             $type = \implode('_', $type);
         }
 
+        // in case of an anonymous class we have to use an alias because of the special characters
+        if (\strpos($type, '@') !== false && \class_exists($type, false)) {
+            do {
+                $alias = 'anonymous_class_' . \md5($type) . '_' .
+                \substr(\md5((string) \mt_rand()), 0, 8);
+            } while (\class_exists($alias, false) || !\class_alias($type, $alias, false));
+            $type = $alias;
+        }
+
         if ($type[0] === '\\') {
             $type = \substr($type, 1);
         }

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -831,6 +831,16 @@ final class TestCaseTest extends TestCase
         $this->assertInstanceOf(MockObject::class, $mock);
     }
 
+    public function testCreateMockFromAnonymousClassName(): void
+    {
+        $anonymousClassName = \get_class(new class extends \Mockable {
+        });
+        $mock = $this->createMock($anonymousClassName);
+
+        $this->assertInstanceOf($anonymousClassName, $mock);
+        $this->assertInstanceOf(MockObject::class, $mock);
+    }
+
     public function testCreateMockMocksAllMethods(): void
     {
         $mock = $this->createMock(\Mockable::class);


### PR DESCRIPTION
A PHP Parse error is thrown when trying to mock an anonymous class.

I encountered this error by writing a test this way:
```php
public function testRunner()
{
    $mock = $this->createMock(new class {
        public function foo() {}
    });
    $mock->expects($this->once())->method('foo');

    $runner = new Runner();
    $runner->run(function () use ($mock) {
        $mock->foo();
    });
}
```
I recognize it's a bit convoluted (I have rewritten the test without using any mock then) but I hope this fix will help someone with a valid use case.