### PR TITLE
Performance improvement of StringContains

### DIFF
--- a/src/Framework/Constraint/StringContains.php
+++ b/src/Framework/Constraint/StringContains.php
@@ -66,9 +66,21 @@ final class StringContains extends Constraint
         }
 
         if ($this->ignoreCase) {
+            /*
+             * We must use the multi byte safe version so we can accurately compare non latin upper characters with
+             * their lowercase equivalents.
+             */
             return \mb_stripos($other, $this->string) !== false;
         }
 
-        return \mb_strpos($other, $this->string) !== false;
+        /*
+         * Use the non multi byte safe functions to see if the string is contained in $other.
+         *
+         * This function is very fast and we don't care about the character position in the string.
+         *
+         * Additionally, we want this method to be binary safe so we can check if some binary data is in other binary
+         * data.
+         */
+        return \strpos($other, $this->string) !== false;
     }
 }


### PR DESCRIPTION
I've created a faster version of StringContains, in particular for large haystacks. 

I noticed a 4.5x speed up for asserting 1,000x that a 2MB string contains an other string. 

We don't need the multi-byte ware function `mb_strpos` as it is approximately O(n^2) where `n` is the length of the haystack. 

* We don't care about the _character_ position of the substring. 
* In most encodings, the same characters will always be represented by the same bytes. This holds for ISO-8859-1 and friends, and UTF-8. 

In UTF-16 and UTF-32, it is _theoretically_ possible that same byte sequences map to different characters, but as all PHPUnit's own output is not compatible with this encoding I don't think it will cause any issues in practice as I don't think anyone is running PHPUnit with PHP's internal encoding set to UTF-16/UTF-32.

NB. There is the issue that UTF-8 allows the same _characters_ to be represented by different combinations of unicode code points (and thus bytes), but that wasn't supported by `mb_strpos` anyway as it doesn't normalize the string internally. 