### PR TITLE
Add missing deprecation warnings

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -3128,6 +3128,8 @@ abstract class Assert
      */
     public static function contains($value, bool $checkForObjectIdentity = true, bool $checkForNonObjectIdentity = false): TraversableContains
     {
+        self::createWarning('contains() is deprecated and will be removed in PHPUnit 9. Use containsEqual() or containsIdentical() instead.');
+
         return new TraversableContains($value, $checkForObjectIdentity, $checkForNonObjectIdentity);
     }
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -506,6 +506,8 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
      */
     public function expectExceptionMessageRegExp(string $regularExpression): void
     {
+        $this->addWarning('expectExceptionMessageRegExp() is deprecated and will be removed in PHPUnit 9. Use expectExceptionMessageMatches() instead.');
+
         $this->expectExceptionMessageMatches($regularExpression);
     }
 
@@ -538,7 +540,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
     public function expectDeprecationMessageMatches(string $regularExpression): void
     {
-        $this->expectExceptionMessageRegExp($regularExpression);
+        $this->expectExceptionMessageMatches($regularExpression);
     }
 
     public function expectNotice(): void
@@ -553,7 +555,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
     public function expectNoticeMessageMatches(string $regularExpression): void
     {
-        $this->expectExceptionMessageRegExp($regularExpression);
+        $this->expectExceptionMessageMatches($regularExpression);
     }
 
     public function expectWarning(): void
@@ -568,7 +570,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
     public function expectWarningMessageMatches(string $regularExpression): void
     {
-        $this->expectExceptionMessageRegExp($regularExpression);
+        $this->expectExceptionMessageMatches($regularExpression);
     }
 
     public function expectError(): void
@@ -583,7 +585,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
     public function expectErrorMessageMatches(string $regularExpression): void
     {
-        $this->expectExceptionMessageRegExp($regularExpression);
+        $this->expectExceptionMessageMatches($regularExpression);
     }
 
     public function getStatus(): int
@@ -795,6 +797,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
      */
     public function setUseErrorHandler(bool $useErrorHandler): void
     {
+        $this->addWarning('setUseErrorHandler() is deprecated and will be removed in PHPUnit 9.');
     }
 
     /**
@@ -1925,7 +1928,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
                 if ($expectedException['message'] !== '') {
                     $this->expectExceptionMessage($expectedException['message']);
                 } elseif ($expectedException['message_regex'] !== '') {
-                    $this->expectExceptionMessageRegExp($expectedException['message_regex']);
+                    $this->expectExceptionMessageMatches($expectedException['message_regex']);
                 }
             }
         } catch (UtilException $e) {

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1203,11 +1203,6 @@ XML;
         );
     }
 
-    public function testAssertThatContains(): void
-    {
-        $this->assertThat(['foo'], $this->contains('foo'));
-    }
-
     public function testAssertThatStringContains(): void
     {
         $this->assertThat('barfoobar', $this->stringContains('foo'));

--- a/tests/unit/Framework/Constraint/ExceptionMessageRegExpTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionMessageRegExpTest.php
@@ -19,7 +19,7 @@ final class ExceptionMessageRegExpTest extends TestCase
     public function testRegexMessage(): void
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/^A polymorphic \w+ message/');
+        $this->expectExceptionMessageMatches('/^A polymorphic \w+ message/');
 
         throw new \Exception('A polymorphic exception message');
     }
@@ -27,7 +27,7 @@ final class ExceptionMessageRegExpTest extends TestCase
     public function testRegexMessageExtreme(): void
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('/^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$/i');
+        $this->expectExceptionMessageMatches('/^a poly[a-z]+ [a-zA-Z0-9_]+ me(s){2}age$/i');
 
         throw new \Exception('A polymorphic exception message');
     }
@@ -41,7 +41,7 @@ final class ExceptionMessageRegExpTest extends TestCase
         \ini_set('xdebug.scream', '1');
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessageRegExp('#Screaming preg_match#');
+        $this->expectExceptionMessageMatches('#Screaming preg_match#');
 
         throw new \Exception('Screaming preg_match');
     }

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -333,7 +333,7 @@ final class TestCaseTest extends TestCase
     {
         $test = new \ThrowExceptionTestCase('test');
         $test->expectException(\RuntimeException::class);
-        $test->expectExceptionMessageRegExp('/runtime .*? occurred/');
+        $test->expectExceptionMessageMatches('/runtime .*? occurred/');
 
         $result = $test->run();
 
@@ -347,7 +347,7 @@ final class TestCaseTest extends TestCase
 
         $test = new \ThrowExceptionTestCase('test');
 
-        $test->expectExceptionMessageRegExp($messageRegExp);
+        $test->expectExceptionMessageMatches($messageRegExp);
 
         $this->assertSame($messageRegExp, $test->getExpectedExceptionMessageRegExp());
     }
@@ -356,7 +356,7 @@ final class TestCaseTest extends TestCase
     {
         $test = new \ThrowExceptionTestCase('test');
         $test->expectException(\RuntimeException::class);
-        $test->expectExceptionMessageRegExp('/logic .*? occurred/');
+        $test->expectExceptionMessageMatches('/logic .*? occurred/');
 
         $result = $test->run();
 
@@ -372,7 +372,7 @@ final class TestCaseTest extends TestCase
     {
         $test = new \ThrowExceptionTestCase('test');
         $test->expectException(\RuntimeException::class);
-        $test->expectExceptionMessageRegExp('#runtime .*? occurred/');
+        $test->expectExceptionMessageMatches('#runtime .*? occurred/');
 
         $test->run();
 

--- a/tests/unit/Util/TestClassTest.php
+++ b/tests/unit/Util/TestClassTest.php
@@ -1085,7 +1085,7 @@ final class TestClassTest extends TestCase
         ), VariousDocblockDefinedDataProvider::class);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/^The data set for the @testWith annotation cannot be parsed:/');
+        $this->expectExceptionMessageMatches('/^The data set for the @testWith annotation cannot be parsed:/');
 
         $docBlock->getProvidedData();
     }
@@ -1098,7 +1098,7 @@ final class TestClassTest extends TestCase
         ), VariousDocblockDefinedDataProvider::class);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/^The data set for the @testWith annotation cannot be parsed:/');
+        $this->expectExceptionMessageMatches('/^The data set for the @testWith annotation cannot be parsed:/');
 
         $docBlock->getProvidedData();
     }


### PR DESCRIPTION
When switching the tests to PHPUnit 9, a few errors occurred because some methods were removed in PHPUni 9 that did not yet give a deprecation warning in PHPUnit 8.

**What I have changed:**

- Assert::contains()
  - added deprecation warning
  - removed testAssertThatContains() (seems to be the normal behavior for deprecated code)
- TestCase:: expectExceptionMessageRegExp()
  - added deprecation warning
  - replaced calls in tests with expectExceptionMessageMatches() to supress warnigs in test runs
- TestCase::setUseErrorHandler()
  - added deprecation warning