### PR TITLE
Canonicalize JSON values in failure message

### DIFF
--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -78,13 +78,13 @@ final class JsonMatches extends Constraint
     protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
     {
         if ($comparisonFailure === null) {
-            [$error] = Json::canonicalize($other);
+            [$error, $recodedOther] = Json::canonicalize($other);
 
             if ($error) {
                 parent::fail($other, $description);
             }
 
-            [$error] = Json::canonicalize($this->value);
+            [$error, $recodedValue] = Json::canonicalize($this->value);
 
             if ($error) {
                 parent::fail($other, $description);
@@ -93,8 +93,8 @@ final class JsonMatches extends Constraint
             $comparisonFailure = new ComparisonFailure(
                 \json_decode($this->value),
                 \json_decode($other),
-                Json::prettify($this->value),
-                Json::prettify($other),
+                Json::prettify($recodedValue),
+                Json::prettify($recodedOther),
                 false,
                 'Failed asserting that two json values are equal.'
             );

--- a/tests/unit/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/unit/Framework/Constraint/JsonMatchesTest.php
@@ -82,8 +82,12 @@ final class JsonMatchesTest extends ConstraintTestCase
         } catch (ExpectationFailedException $expectedException) {
             $comparisonFailure = $expectedException->getComparisonFailure();
             $this->assertNotNull($comparisonFailure);
-            $this->assertSame(Json::prettify($jsonOther), $comparisonFailure->getActualAsString());
-            $this->assertSame(Json::prettify($jsonValue), $comparisonFailure->getExpectedAsString());
+
+            [$error, $jsonOtherCanonicalized] = Json::canonicalize($jsonOther);
+            [$error, $jsonValueCanonicalized] = Json::canonicalize($jsonValue);
+
+            $this->assertSame(Json::prettify($jsonOtherCanonicalized), $comparisonFailure->getActualAsString());
+            $this->assertSame(Json::prettify($jsonValueCanonicalized), $comparisonFailure->getExpectedAsString());
             $this->assertSame('Failed asserting that two json values are equal.', $comparisonFailure->getMessage());
         }
     }


### PR DESCRIPTION
This PR

* [x] uses canonicalized JSON values in failure messages

💁‍♂ This makes it easier to spot the actual difference when dealing with JSON structures that have a few more fields.