### PR TITLE
Exclude internal tests from composer dist packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,16 @@
-/.docker    export-ignore
-/build      export-ignore
-/tools      export-ignore
-/tools/*    binary
+/.docker export-ignore
+/.github export-ignore
+/.psalm export-ignore
+/build export-ignore
+/tests export-ignore
+/tools export-ignore
+/tools/* binary
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs.dist export-ignore
+/build.xml export-ignore
+/phive.xml export-ignore
+/phpunit.xml export-ignore
 
 *.php diff=php
-


### PR DESCRIPTION
See discussion for example https://github.com/symfony/symfony/pull/33579

It was already done in phpunit in https://github.com/sebastianbergmann/phpunit/commit/d99e588e3cbab28db86f8da22e22c72d8cc38543 but reverted because it also removed the changelog and license file by mistake.