### PR TITLE
Fix: Disable caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,14 +103,6 @@ jobs:
           extensions: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
           ini-values: assert.exception=1, zend.assertions=1
 
-      - name: "Cache dependencies installed with composer"
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache
-          key: php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
-
       - name: Install lowest dependencies with composer
         if: matrix.dependencies == 'lowest'
         run: ./tools/composer update --no-ansi --no-interaction --no-progress --no-suggest --prefer-lowest


### PR DESCRIPTION
This PR

* [x] disables caching

Related to #4150.

💁‍♂ What puzzles me: the

- `backward-compatibility`
- `type-checker`

jobs fail, but the `tests` job passes. The obvious difference is caching. The commands for installing dependencies with `composer` are identical. For consistency, we should probably disable caching to expose the problem.