### PR TITLE
Tests for Assert::assertString(Not)EqualsFileIgnoringCase

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1327,6 +1327,21 @@ XML;
         );
     }
 
+    public function testAssertStringNotEqualsFileIgnoringCase(): void
+    {
+        $this->assertStringNotEqualsFileIgnoringCase(
+            TEST_FILES_PATH . 'foo.xml',
+            \file_get_contents(TEST_FILES_PATH . 'bar.xml')
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertStringNotEqualsFileIgnoringCase(
+            TEST_FILES_PATH . 'foo.xml',
+            \file_get_contents(TEST_FILES_PATH . 'fooUppercase.xml')
+        );
+    }
+
     public function testAssertFileEqualsIgnoringCase(): void
     {
         $this->assertFileEqualsIgnoringCase(

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1297,6 +1297,21 @@ XML;
         );
     }
 
+    public function testAssertStringEqualsFileIgnoringCase(): void
+    {
+        $this->assertStringEqualsFileIgnoringCase(
+            TEST_FILES_PATH . 'foo.xml',
+            \file_get_contents(TEST_FILES_PATH . 'fooUppercase.xml')
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertStringEqualsFileIgnoringCase(
+            TEST_FILES_PATH . 'foo.xml',
+            \file_get_contents(TEST_FILES_PATH . 'bar.xml')
+        );
+    }
+
     public function testAssertStringNotEqualsFile(): void
     {
         $this->assertStringNotEqualsFile(


### PR DESCRIPTION
Hi Sebastian,
Sending my first PR to PHPUnit; fingers crossed :)

Adds tests for `Assert::assertStringEqualsFileIgnoringCase` and `Assert::assertStringNotEqualsFileIgnoringCase`. They are mentioned in issues #4054 and #4056. 

The tests themselves use the new `fooUppercase` fixture file that was added recently. If there are any changes necessary, I'd be happy to work on them. Thanks a lot for your time.