### PR TITLE
Add tests for Assert::assertFileNotEqualsIgnoringCase()

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1421,6 +1421,21 @@ XML;
         );
     }
 
+    public function testAssertFileNotEqualsIgnoringCase(): void
+    {
+        $this->assertFileNotEqualsIgnoringCase(
+            TEST_FILES_PATH . 'foo.xml',
+            TEST_FILES_PATH . 'bar.xml'
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertFileNotEqualsIgnoringCase(
+            TEST_FILES_PATH . 'foo.xml',
+            TEST_FILES_PATH . 'fooUppercase.xml'
+        );
+    }
+
     public function testAssertStringStartsNotWithThrowsException2(): void
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Tests for #4052. This PR complements the test for `Assert::assertFileEqualsIgnoringCase`, which was fixed with #4050 and #4127.

This is against 8.5 branch, but I checked that there are no merge conflicts against 9.1 and master branches. 

Thank you!