### PR TITLE
Tests for assertDirectoryIsNotReadable and assertDirectoryIsNotWritable

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -514,6 +514,22 @@ XML;
         $this->assertDirectoryIsReadable(__DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting');
     }
 
+    public function testAssertDirectoryIsNotReadable(): void
+    {
+        $dirName = TEST_FILES_PATH . \uniqid('unreadable_dir_', true);
+        \mkdir($dirName, \octdec('0'));
+        $this->assertDirectoryIsNotReadable($dirName);
+
+        \chmod($dirName, \octdec('444'));
+
+        try {
+            $this->assertDirectoryIsNotReadable($dirName);
+        } catch (AssertionFailedError $e) {
+        }
+
+        \rmdir($dirName);
+    }
+
     public function testAssertDirectoryIsWritable(): void
     {
         $this->assertDirectoryIsWritable(__DIR__);

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -539,6 +539,22 @@ XML;
         $this->assertDirectoryIsWritable(__DIR__ . \DIRECTORY_SEPARATOR . 'NotExisting');
     }
 
+    public function testAssertDirectoryIsNotWritable(): void
+    {
+        $dirName = TEST_FILES_PATH . \uniqid('unwritable_dir_', true);
+        \mkdir($dirName, \octdec('444'));
+        $this->assertDirectoryIsNotWritable($dirName);
+
+        \chmod($dirName, \octdec('755'));
+
+        try {
+            $this->assertDirectoryIsNotWritable($dirName);
+        } catch (AssertionFailedError $e) {
+        }
+
+        \rmdir($dirName);
+    }
+
     public function testAssertFileExists(): void
     {
         $this->assertFileExists(__FILE__);


### PR DESCRIPTION
Hi there,
Related to issues: #4057 and #4058.

They create temporary directories to pass the _exists_ condition, and a `chmod` toggle to check truthness of the assertion, followed by an assertion failure after running `chmod`. I can work on further changes if necessary. 

Thank you :)