### PR TITLE
Ensure Warnings is always an array

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -121,6 +121,10 @@ final class TestRunner extends BaseTestRunner
      */
     public function run(Test $suite, array $arguments = [], bool $exit = true): TestResult
     {
+        if (!isset($arguments['warnings']) || !\is_array($arguments['warnings'])) {
+            $arguments['warnings'] = [];
+        }
+
         if (isset($arguments['configuration'])) {
             $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
         }


### PR DESCRIPTION
Hacking around with Laravel, I started writing tests and was greeted with a message that foreach was invalid. Clicked the traceback and saw this. Made this edit / hack and it works :shrug: .

Thanks for working on this library for so long

Running debian buster with php 7.3

sample repo https://github.com/Lewiscowles1986/larahack-2020-04-10/tree/ceb681afa87b7fa6a2f1d2418fba299e728f7c56