### PR TITLE
Document fluent methods as such

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -53,6 +53,9 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         $this->configurableMethods = $configurableMethods;
     }
 
+    /**
+     * @return $this
+     */
     public function id($id): self
     {
         $this->invocationHandler->registerMatcher($id, $this->matcher);
@@ -60,6 +63,9 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function will(Stub $stub): Identity
     {
         $this->matcher->setStub($stub);
@@ -135,6 +141,9 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         return $this->will($stub);
     }
 
+    /**
+     * @return $this
+     */
     public function after($id): self
     {
         $this->matcher->setAfterMatchBuilderId($id);
@@ -144,6 +153,8 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
 
     /**
      * @throws RuntimeException
+     *
+     * @return $this
      */
     public function with(...$arguments): self
     {
@@ -158,6 +169,8 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
      * @param array ...$arguments
      *
      * @throws RuntimeException
+     *
+     * @return $this
      */
     public function withConsecutive(...$arguments): self
     {
@@ -170,6 +183,8 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
 
     /**
      * @throws RuntimeException
+     *
+     * @return $this
      */
     public function withAnyParameters(): self
     {
@@ -184,6 +199,8 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
      * @param Constraint|string $constraint
      *
      * @throws RuntimeException
+     *
+     * @return $this
      */
     public function method($constraint): self
     {

--- a/src/Framework/MockObject/Builder/ParametersMatch.php
+++ b/src/Framework/MockObject/Builder/ParametersMatch.php
@@ -9,8 +9,6 @@
  */
 namespace PHPUnit\Framework\MockObject\Builder;
 
-use PHPUnit\Framework\MockObject\Rule\AnyParameters;
-
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
@@ -44,7 +42,7 @@ interface ParametersMatch extends Match
      * $b->withAnyParameters();
      * </code>
      *
-     * @return AnyParameters
+     * @return ParametersMatch
      */
     public function withAnyParameters();
 }

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -188,6 +188,8 @@ final class MockBuilder
      * Specifies the subset of methods to mock. Default is to mock none of them.
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/pull/3687
+     *
+     * @return $this
      */
     public function setMethods(?array $methods = null): self
     {
@@ -206,6 +208,8 @@ final class MockBuilder
      * @param string[] $methods
      *
      * @throws RuntimeException
+     *
+     * @return $this
      */
     public function onlyMethods(array $methods): self
     {
@@ -250,6 +254,8 @@ final class MockBuilder
      * @param string[] $methods
      *
      * @throws RuntimeException
+     *
+     * @return $this
      */
     public function addMethods(array $methods): self
     {
@@ -303,6 +309,8 @@ final class MockBuilder
 
     /**
      * Specifies the arguments for the constructor.
+     *
+     * @return $this
      */
     public function setConstructorArgs(array $args): self
     {
@@ -313,6 +321,8 @@ final class MockBuilder
 
     /**
      * Specifies the name for the mock class.
+     *
+     * @return $this
      */
     public function setMockClassName(string $name): self
     {
@@ -323,6 +333,8 @@ final class MockBuilder
 
     /**
      * Disables the invocation of the original constructor.
+     *
+     * @return $this
      */
     public function disableOriginalConstructor(): self
     {
@@ -333,6 +345,8 @@ final class MockBuilder
 
     /**
      * Enables the invocation of the original constructor.
+     *
+     * @return $this
      */
     public function enableOriginalConstructor(): self
     {
@@ -343,6 +357,8 @@ final class MockBuilder
 
     /**
      * Disables the invocation of the original clone constructor.
+     *
+     * @return $this
      */
     public function disableOriginalClone(): self
     {
@@ -353,6 +369,8 @@ final class MockBuilder
 
     /**
      * Enables the invocation of the original clone constructor.
+     *
+     * @return $this
      */
     public function enableOriginalClone(): self
     {
@@ -363,6 +381,8 @@ final class MockBuilder
 
     /**
      * Disables the use of class autoloading while creating the mock object.
+     *
+     * @return $this
      */
     public function disableAutoload(): self
     {
@@ -373,6 +393,8 @@ final class MockBuilder
 
     /**
      * Enables the use of class autoloading while creating the mock object.
+     *
+     * @return $this
      */
     public function enableAutoload(): self
     {
@@ -383,6 +405,8 @@ final class MockBuilder
 
     /**
      * Disables the cloning of arguments passed to mocked methods.
+     *
+     * @return $this
      */
     public function disableArgumentCloning(): self
     {
@@ -393,6 +417,8 @@ final class MockBuilder
 
     /**
      * Enables the cloning of arguments passed to mocked methods.
+     *
+     * @return $this
      */
     public function enableArgumentCloning(): self
     {
@@ -403,6 +429,8 @@ final class MockBuilder
 
     /**
      * Enables the invocation of the original methods.
+     *
+     * @return $this
      */
     public function enableProxyingToOriginalMethods(): self
     {
@@ -413,6 +441,8 @@ final class MockBuilder
 
     /**
      * Disables the invocation of the original methods.
+     *
+     * @return $this
      */
     public function disableProxyingToOriginalMethods(): self
     {
@@ -424,6 +454,8 @@ final class MockBuilder
 
     /**
      * Sets the proxy target.
+     *
+     * @return $this
      */
     public function setProxyTarget(object $object): self
     {
@@ -432,6 +464,9 @@ final class MockBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function allowMockingUnknownTypes(): self
     {
         $this->allowMockingUnknownTypes = true;
@@ -439,6 +474,9 @@ final class MockBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function disallowMockingUnknownTypes(): self
     {
         $this->allowMockingUnknownTypes = false;
@@ -446,6 +484,9 @@ final class MockBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function enableAutoReturnValueGeneration(): self
     {
         $this->returnValueGeneration = true;
@@ -453,6 +494,9 @@ final class MockBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function disableAutoReturnValueGeneration(): self
     {
         $this->returnValueGeneration = false;


### PR DESCRIPTION
This will help static analyzers understand calls to these methods
better.

For example, it makes that kind of error go away:

```
ERROR: InvalidPropertyAssignmentValue - tests/Doctrine/Tests/DBAL/StatementTest.php:43:23 - $this->conn with declared type 'Doctrine\DBAL\Connection&PHPUnit\Framework\MockObject\MockObject' cannot be assigned type 'PHPUnit\Framework\MockObject\MockObject' (see https://psalm.dev/145)
        $this->conn = $this->getMockBuilder(Connection::class)
            ->setConstructorArgs([[], $driver])
            ->getMock()
```