### PR TITLE
Mark all methods that never return as such

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -3460,6 +3460,8 @@ abstract class Assert
      * Mark the test as incomplete.
      *
      * @throws IncompleteTestError
+     *
+     * @psalm-return never-return
      */
     public static function markTestIncomplete(string $message = ''): void
     {
@@ -3471,6 +3473,8 @@ abstract class Assert
      *
      * @throws SkippedTestError
      * @throws SyntheticSkippedError
+     *
+     * @psalm-return never-return
      */
     public static function markTestSkipped(string $message = ''): void
     {

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -95,6 +95,8 @@ abstract class Constraint implements Countable, SelfDescribing
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @psalm-return never-return
      */
     protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
     {

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -74,6 +74,8 @@ final class JsonMatches extends Constraint
      * @throws ExpectationFailedException
      * @throws \PHPUnit\Framework\Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @psalm-return never-return
      */
     protected function fail($other, $description, ComparisonFailure $comparisonFailure = null): void
     {

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -668,6 +668,8 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
      * @param string $message
      *
      * @throws SkippedTestSuiteError
+     *
+     * @psalm-return never-return
      */
     public function markTestSuiteSkipped($message = ''): void
     {

--- a/src/Framework/WarningTestCase.php
+++ b/src/Framework/WarningTestCase.php
@@ -63,6 +63,8 @@ final class WarningTestCase extends TestCase
 
     /**
      * @throws Exception
+     *
+     * @psalm-return never-return
      */
     protected function runTest(): void
     {


### PR DESCRIPTION
This should allow static analyzers to understand better why methods
calling these methods also never return.