### PR TITLE
StandardTestSuiteLoader get_declared_classes check

### DIFF
--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -27,9 +27,9 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
     {
         $suiteClassName = \str_replace('.php', '', \basename($suiteClassFile));
 
-        if (!\class_exists($suiteClassName, false)) {
-            $loadedClasses = \get_declared_classes();
+        $loadedClasses = \get_declared_classes();
 
+        if (!\class_exists($suiteClassName, false)) {
             FileLoader::checkAndLoad($suiteClassFile);
 
             $loadedClasses = \array_values(

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -35,10 +35,10 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
             $loadedClasses = \array_values(
                 \array_diff(\get_declared_classes(), $loadedClasses)
             );
-        }
 
-        if (empty($loadedClasses)) {
-            throw ClassNotFoundException::byFilename($suiteClassName, $suiteClassFile);
+            if (empty($loadedClasses)) {
+                throw ClassNotFoundException::byFilename($suiteClassName, $suiteClassFile);
+            }
         }
 
         if (!\class_exists($suiteClassName, false)) {

--- a/tests/end-to-end/standardtestsuiteloader-issue-4192-1.phpt
+++ b/tests/end-to-end/standardtestsuiteloader-issue-4192-1.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit ../../_files/ConcreteTest.php
+--FILE--
+<?php declare(strict_types=1);
+require_once __DIR__.'/../../vendor/autoload.php';
+$cmd = new \PHPUnit\TextUI\Command();
+$cmd->run([
+    'phpunit',
+    (new \ReflectionClass(\ConcreteTest::class))->getFileName()
+], false);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+Configuration: %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)

--- a/tests/end-to-end/standardtestsuiteloader-issue-4192-2.phpt
+++ b/tests/end-to-end/standardtestsuiteloader-issue-4192-2.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit ../../_files/ConcreteTest.php
+--FILE--
+<?php declare(strict_types=1);
+require_once __DIR__.'/../../vendor/autoload.php';
+$cmd = new \PHPUnit\TextUI\Command();
+$cmd->run([
+    'phpunit',
+    realpath(__DIR__.'/../_files/ConcreteTest.php')
+], false);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+Configuration: %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)


### PR DESCRIPTION
| Branch? | master |
|---------|---|
| Version | 9 only |
| Bug fix | yes |
| New feature | no |
| Deprecations | no |

in `StandardTestSuiteLoader::load()`, if class exists, we still check for a `$loadedClasses`, but this variable `$loadedClasses` does not exists in this context.

```php
/* StandardTestSuiteLoader.php */
...
        // if class exists
        if (!\class_exists($suiteClassName, false)) {
           ...
        }
        // var $loadedClasses is not set, so this statement is always true.
        if (empty($loadedClasses)) {
           ...
        }
```