### PR TITLE
Update `mb_` functions in StringContainers Constraint to explicitly set "UTF-8" encoding

### DIFF
--- a/src/Framework/Constraint/StringContains.php
+++ b/src/Framework/Constraint/StringContains.php
@@ -42,7 +42,7 @@ final class StringContains extends Constraint
     public function toString(): string
     {
         if ($this->ignoreCase) {
-            $string = \mb_strtolower($this->string);
+            $string = \mb_strtolower($this->string, 'UTF-8');
         } else {
             $string = $this->string;
         }
@@ -70,7 +70,7 @@ final class StringContains extends Constraint
              * We must use the multi byte safe version so we can accurately compare non latin upper characters with
              * their lowercase equivalents.
              */
-            return \mb_stripos($other, $this->string) !== false;
+            return \mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
         }
 
         /*


### PR DESCRIPTION
Fixed #4098 .

There were only two `mb_` function calls, and they now explicitly get "UTF-8" as the encoding. `UTF-8` is used (as opposed to `utf-8` or `8bit`) to be consistent with `\PHPUnit\Util\Xml::convertToUtf8()`.

Thank you.