### PR TITLE
Add renamed methods to 8.5

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1486,6 +1486,17 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        static::assertThat($filename, new LogicalNot(new FileExists), $message);
+    }
+
+    /**
+     * Asserts that a file does not exist.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertFileNotExists(string $filename, string $message = ''): void
     {
         static::assertThat($filename, new LogicalNot(new FileExists), $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1394,6 +1394,17 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertIsNotWritable(string $filename, string $message = ''): void
+    {
+        static::assertThat($filename, new LogicalNot(new IsWritable), $message);
+    }
+
+    /**
+     * Asserts that a file/dir exists and is not writable.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertNotIsWritable(string $filename, string $message = ''): void
     {
         static::assertThat($filename, new LogicalNot(new IsWritable), $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1566,6 +1566,18 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertFileIsNotReadable(string $file, string $message = ''): void
+    {
+        self::assertFileExists($file, $message);
+        self::assertIsNotReadable($file, $message);
+    }
+
+    /**
+     * Asserts that a file exists and is not readable.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertFileNotIsReadable(string $file, string $message = ''): void
     {
         self::assertFileExists($file, $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1497,6 +1497,18 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertDirectoryIsNotWritable(string $directory, string $message = ''): void
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertIsNotWritable($directory, $message);
+    }
+
+    /**
+     * Asserts that a directory exists and is not writable.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertDirectoryNotIsWritable(string $directory, string $message = ''): void
     {
         self::assertDirectoryExists($directory, $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1602,6 +1602,18 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertFileIsNotWritable(string $file, string $message = ''): void
+    {
+        self::assertFileExists($file, $message);
+        self::assertIsNotWritable($file, $message);
+    }
+
+    /**
+     * Asserts that a file exists and is not writable.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertFileNotIsWritable(string $file, string $message = ''): void
     {
         self::assertFileExists($file, $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1361,6 +1361,17 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertIsNotReadable(string $filename, string $message = ''): void
+    {
+        static::assertThat($filename, new LogicalNot(new IsReadable), $message);
+    }
+
+    /**
+     * Asserts that a file/dir exists and is not readable.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertNotIsReadable(string $filename, string $message = ''): void
     {
         static::assertThat($filename, new LogicalNot(new IsReadable), $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2493,6 +2493,23 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        static::assertThat(
+            $string,
+            new LogicalNot(
+                new RegularExpression($pattern)
+            ),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that a string does not match a given regular expression.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertNotRegExp(string $pattern, string $string, string $message = ''): void
     {
         static::assertThat(

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1461,6 +1461,18 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertDirectoryIsNotReadable(string $directory, string $message = ''): void
+    {
+        self::assertDirectoryExists($directory, $message);
+        self::assertIsNotReadable($directory, $message);
+    }
+
+    /**
+     * Asserts that a directory exists and is not readable.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertDirectoryNotIsReadable(string $directory, string $message = ''): void
     {
         self::assertDirectoryExists($directory, $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1405,6 +1405,17 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
+    {
+        static::assertThat($directory, new LogicalNot(new DirectoryExists), $message);
+    }
+
+    /**
+     * Asserts that a directory does not exist.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertDirectoryNotExists(string $directory, string $message = ''): void
     {
         static::assertThat($directory, new LogicalNot(new DirectoryExists), $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2471,6 +2471,17 @@ abstract class Assert
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        static::assertThat($string, new RegularExpression($pattern), $message);
+    }
+
+    /**
+     * Asserts that a string matches a given regular expression.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     public static function assertRegExp(string $pattern, string $string, string $message = ''): void
     {
         static::assertThat($string, new RegularExpression($pattern), $message);

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1116,6 +1116,19 @@ function assertFileIsReadable(string $file, string $message = ''): void
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertFileIsNotReadable
+ */
+function assertFileIsNotReadable(string $file, string $message = ''): void
+{
+    Assert::assertFileIsNotReadable(...\func_get_args());
+}
+
+/**
+ * Asserts that a file exists and is not readable.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertFileNotIsReadable
  */
 function assertFileNotIsReadable(string $file, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1038,6 +1038,19 @@ function assertDirectoryIsWritable(string $directory, string $message = ''): voi
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertDirectoryIsNotWritable
+ */
+function assertDirectoryIsNotWritable(string $directory, string $message = ''): void
+{
+    Assert::assertDirectoryIsNotWritable(...\func_get_args());
+}
+
+/**
+ * Asserts that a directory exists and is not writable.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertDirectoryNotIsWritable
  */
 function assertDirectoryNotIsWritable(string $directory, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1872,6 +1872,19 @@ function assertAttributeNotInternalType(string $expected, string $attributeName,
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertMatchesRegularExpression
+ */
+function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+{
+    Assert::assertMatchesRegularExpression(...\func_get_args());
+}
+
+/**
+ * Asserts that a string matches a given regular expression.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertRegExp
  */
 function assertRegExp(string $pattern, string $string, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1155,6 +1155,19 @@ function assertFileIsWritable(string $file, string $message = ''): void
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertFileIsNotWritable
+ */
+function assertFileIsNotWritable(string $file, string $message = ''): void
+{
+    Assert::assertFileIsNotWritable(...\func_get_args());
+}
+
+/**
+ * Asserts that a file exists and is not writable.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertFileNotIsWritable
  */
 function assertFileNotIsWritable(string $file, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -934,6 +934,19 @@ function assertDirectoryExists(string $directory, string $message = ''): void
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertDirectoryDoesNotExist
+ */
+function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
+{
+    Assert::assertDirectoryDoesNotExist(...\func_get_args());
+}
+
+/**
+ * Asserts that a directory does not exist.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertDirectoryNotExists
  */
 function assertDirectoryNotExists(string $directory, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1898,6 +1898,19 @@ function assertRegExp(string $pattern, string $string, string $message = ''): vo
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertDoesNotMatchRegularExpression
+ */
+function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
+{
+    Assert::assertDoesNotMatchRegularExpression(...\func_get_args());
+}
+
+/**
+ * Asserts that a string does not match a given regular expression.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertNotRegExp
  */
 function assertNotRegExp(string $pattern, string $string, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1025,6 +1025,19 @@ function assertFileExists(string $filename, string $message = ''): void
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertFileDoesNotExist
+ */
+function assertFileDoesNotExist(string $filename, string $message = ''): void
+{
+    Assert::assertFileDoesNotExist(...\func_get_args());
+}
+
+/**
+ * Asserts that a file does not exist.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertFileNotExists
  */
 function assertFileNotExists(string $filename, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -921,6 +921,19 @@ function assertIsWritable(string $filename, string $message = ''): void
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertIsNotWritable
+ */
+function assertIsNotWritable(string $filename, string $message = ''): void
+{
+    Assert::assertIsNotWritable(...\func_get_args());
+}
+
+/**
+ * Asserts that a file/dir exists and is not writable.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertNotIsWritable
  */
 function assertNotIsWritable(string $filename, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -882,6 +882,19 @@ function assertIsReadable(string $filename, string $message = ''): void
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertIsNotReadable
+ */
+function assertIsNotReadable(string $filename, string $message = ''): void
+{
+    Assert::assertIsNotReadable(...\func_get_args());
+}
+
+/**
+ * Asserts that a file/dir exists and is not readable.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertNotIsReadable
  */
 function assertNotIsReadable(string $filename, string $message = ''): void

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -999,6 +999,19 @@ function assertDirectoryIsReadable(string $directory, string $message = ''): voi
  * @throws ExpectationFailedException
  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
  *
+ * @see Assert::assertDirectoryIsNotReadable
+ */
+function assertDirectoryIsNotReadable(string $directory, string $message = ''): void
+{
+    Assert::assertDirectoryIsNotReadable(...\func_get_args());
+}
+
+/**
+ * Asserts that a directory exists and is not readable.
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
  * @see Assert::assertDirectoryNotIsReadable
  */
 function assertDirectoryNotIsReadable(string $directory, string $message = ''): void


### PR DESCRIPTION
Renamed versions of these Assert methods were added in 9.1 and the old names were deprecated. 

Code that uses the old/deprecated Assert methods gets deprecation warnings emitted when running phpunit 9.1.

But currently if you want to have unit test code that works for both 8.5 and 9.1 you have to use the old/deprecated Assert methods - because the new method names do not exist in 8.5. But that means you get deprecation warnings when you run the code in 9.1.

This PR adds the new method names to 8.5 - it is simple paste in, there is no difficulty in providing these. This should make life easier for people who are trying to make their unit test code compatible with v9, and with deprecations that are coming in v10, but still need to also run v8 for PHP  7.2 until the end of 2020.

The code comes from 9.1:
assertDirectoryDoesNotExist https://github.com/sebastianbergmann/phpunit/commit/fd47f79220f2ba84f8a0b26fd1b11b9b03fabd6c
assertFileDoesNotExist https://github.com/sebastianbergmann/phpunit/commit/6674297520d1485f696c7fa311e1c65e8d479545
assertMatchesRegularExpression https://github.com/sebastianbergmann/phpunit/commit/247d79ce66a59d94fb550e11b23312d36ea068a7
assertDoesNotMatchRegularExpression https://github.com/sebastianbergmann/phpunit/commit/6721b5092417a9098bc8dff7704aa21e6be0a0bc
assertIsNotReadable https://github.com/sebastianbergmann/phpunit/commit/57cd3b17d604ac7f0ebc8cd223d72f82c74d18bd
assertIsNotWritable https://github.com/sebastianbergmann/phpunit/commit/1a6cb97644b0671acdae7f30812404468da9925e
assertDirectoryIsNotReadable https://github.com/sebastianbergmann/phpunit/commit/4789ddddec84846f747726bc917c3ecd3c028827
assertDirectoryIsNotWritable https://github.com/sebastianbergmann/phpunit/commit/485f8f89f6bd8e2fbefaf51d2febd8b62a728adc
assertFileIsNotReadable https://github.com/sebastianbergmann/phpunit/commit/542943f5c140c1f5b2e0c811e239a053e8fa8e2a
assertFileIsNotWritable https://github.com/sebastianbergmann/phpunit/commit/7b82e38e964f8eaffd317b1af367eeec038869a6

And covers the additions noted in the 9.1 release notes:
* [#4061](https://github.com/sebastianbergmann/phpunit/issues/4061): Implement `assertIsNotReadable()` as alternative for `assertNotIsReadable()` with a more readable name
* [#4064](https://github.com/sebastianbergmann/phpunit/issues/4064): Implement `assertIsNotWritable()` as alternative for `assertNotIsWritable()` with a more readable name
* [#4067](https://github.com/sebastianbergmann/phpunit/issues/4067): Implement `assertDirectoryDoesNotExist()` as alternative for `assertDirectoryNotExists()` with a more readable name
* [#4070](https://github.com/sebastianbergmann/phpunit/issues/4070): Implement `assertDirectoryIsNotReadable()` as alternative for `assertDirectoryNotIsReadable()` with a more readable name
* [#4073](https://github.com/sebastianbergmann/phpunit/issues/4073): Implement `assertDirectoryIsNotWritable()` as alternative for `assertDirectoryNotIsWritable()` with a more readable name
* [#4076](https://github.com/sebastianbergmann/phpunit/issues/4076): Implement `assertFileDoesNotExist()` as alternative for `assertFileNotExists()` with a more readable name
* [#4079](https://github.com/sebastianbergmann/phpunit/issues/4079): Implement `assertFileIsNotReadable()` as alternative for `assertFileNotIsReadable()` with a more readable name
* [#4082](https://github.com/sebastianbergmann/phpunit/issues/4082): Implement `assertFileIsNotWritable()` as alternative for `assertFileNotIsWritable()` with a more readable name
* [#4085](https://github.com/sebastianbergmann/phpunit/issues/4085): Implement `assertMatchesRegularExpression()` as alternative for `assertRegExp()` with a more readable name
* [#4088](https://github.com/sebastianbergmann/phpunit/issues/4088): Implement `assertDoesNotMatchRegularExpression()` as alternative for `assertNotRegExp()` with a more readable name


