### PR TITLE
Cast to int for filterMin/Max in NameFilterIterator

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -159,12 +159,6 @@
       <code>$afterClassMethod</code>
     </PossiblyUndefinedVariable>
   </file>
-  <file src="src/Runner/Filter/NameFilterIterator.php">
-    <InvalidPropertyAssignmentValue occurrences="2">
-      <code>$matches[2]</code>
-      <code>$matches[3]</code>
-    </InvalidPropertyAssignmentValue>
-  </file>
   <file src="src/Runner/PhptTestCase.php">
     <PossiblyInvalidArgument occurrences="1">
       <code>$sections['FILEEOF']</code>

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -90,8 +90,8 @@ final class NameFilterIterator extends \RecursiveFilterIterator
                         $matches[1]
                     );
 
-                    $this->filterMin = $matches[2];
-                    $this->filterMax = $matches[3];
+                    $this->filterMin = (int) $matches[2];
+                    $this->filterMax = (int) $matches[3];
                 } else {
                     $filter = \sprintf(
                         '%s.*with data set #%s$',


### PR DESCRIPTION
A part of https://github.com/sebastianbergmann/phpunit/issues/4093, to [update Psalm baseline](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/#using-a-baseline-file).

```shell
./tools/psalm --config=.psalm/config.xml
```