### PR TITLE
add some common patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,26 @@
 # PhpStorm
 /.idea
 
+# Various IDEs and editors
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+*.swp
+*.bkp
+*.bak
+*~
+.~lock.*
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
 # Composer
 /vendor
 /composer.lock


### PR DESCRIPTION
Use .gitignore to exclude files generated by Eclipse, VisualStudio Code, vim, and some common editors.