### PR TITLE
Throw exception on non unique mocked method

### DIFF
--- a/src/Framework/MockObject/InvocationHandler.php
+++ b/src/Framework/MockObject/InvocationHandler.php
@@ -113,30 +113,11 @@ final class InvocationHandler
     public function invoke(Invocation $invocation)
     {
         $exception      = null;
-        $hasReturnValue = false;
         $returnValue    = null;
+        $match          = $this->findMatcher($invocation);
 
-        foreach ($this->matchers as $match) {
-            try {
-                if ($match->matches($invocation)) {
-                    $value = $match->invoked($invocation);
-
-                    if (!$hasReturnValue) {
-                        $returnValue    = $value;
-                        $hasReturnValue = true;
-                    }
-                }
-            } catch (\Exception $e) {
-                $exception = $e;
-            }
-        }
-
-        if ($exception !== null) {
-            throw $exception;
-        }
-
-        if ($hasReturnValue) {
-            return $returnValue;
+        if ($match !== null) {
+            return $match->invoked($invocation);
         }
 
         if (!$this->returnValueGeneration) {
@@ -184,6 +165,29 @@ final class InvocationHandler
         if ($this->deferredError) {
             throw $this->deferredError;
         }
+    }
+
+    private function findMatcher(Invocation $invocation): ?Matcher
+    {
+        $result = [];
+
+        foreach ($this->matchers as $matcher) {
+            if ($matcher->matches($invocation)) {
+                $result[] = $matcher;
+            }
+        }
+
+        if (\count($result) > 1) {
+            throw new ExpectationFailedException(
+                \sprintf(
+                    'Non unique mocked method invocation: %s::%s',
+                    $invocation->getClassName(),
+                    $invocation->getMethodName()
+                )
+            );
+        }
+
+        return \current($result) ?: null;
     }
 
     private function addMatcher(Matcher $matcher): void


### PR DESCRIPTION
This patch will make a mock throw an exception when multiple matchers
can be applied to a invoke. When allowing this, the results of tests are
not predictable.

In preparation on #4255 I found that a test case like the one below would never pass. Because the written test is just wrong. However, the mocking framework does allow this. But does not handle it properly. From now on an exception will be thrown. 

```
        $mock->expects($this->any())
            ->method($this->stringStartsWith('foo'))
            ->with('foo')
            ->willReturn('result');

        $mock->expects($this->any())
            ->method('foo')
            ->with('bar')
            ->willReturn('result');
```
refs #4255 