### PR TITLE
Change parameter "int $position" to "mixed $role" in Constraint::**InContext() methods

### DIFF
--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -166,9 +166,9 @@ abstract class Constraint implements \Countable, SelfDescribing
      * customization by itself.
      *
      * @param Operator $operator the $operator of the expression
-     * @param int      $position position in $operator expression
+     * @param mixed    $role     role of $this constraint in the $operator expression
      */
-    protected function toStringInContext(Operator $operator, int $position): string
+    protected function toStringInContext(Operator $operator, $role): string
     {
         return '';
     }
@@ -186,12 +186,12 @@ abstract class Constraint implements \Countable, SelfDescribing
      * customization by itself.
      *
      * @param Operator $operator the $operator of the expression
-     * @param int      $position position in $operator expression
+     * @param mixed    $role     role of $this constraint in the $operator expression
      * @param mixed    $other    evaluated value or object
      */
-    protected function failureDescriptionInContext(Operator $operator, int $position, $other): string
+    protected function failureDescriptionInContext(Operator $operator, $role, $other): string
     {
-        $string = $this->toStringInContext($operator, $position);
+        $string = $this->toStringInContext($operator, $role);
 
         if ($string === '') {
             return '';

--- a/tests/unit/Framework/Constraint/ConstraintTest.php
+++ b/tests/unit/Framework/Constraint/ConstraintTest.php
@@ -56,14 +56,14 @@ final class ConstraintTest extends ConstraintTestCase
                 return parent::failureDescription($other);
             }
 
-            final protected function toStringInContext(Operator $operator, int $position): string
+            final protected function toStringInContext(Operator $operator, $role): string
             {
-                return parent::toStringInContext($operator, $position);
+                return parent::toStringInContext($operator, $role);
             }
 
-            final protected function failureDescriptionInContext(Operator $operator, int $position, $other): string
+            final protected function failureDescriptionInContext(Operator $operator, $role, $other): string
             {
-                return parent::failureDescriptionInContext($operator, $position, $other);
+                return parent::failureDescriptionInContext($operator, $role, $other);
             }
 
             final public function exposedMatches($other): bool
@@ -96,14 +96,14 @@ final class ConstraintTest extends ConstraintTestCase
                 return $this->failureDescription($other);
             }
 
-            final public function exposedToStringInContext(Operator $operator, int $position): string
+            final public function exposedToStringInContext(Operator $operator, $role): string
             {
-                return $this->toStringInContext($operator, $position);
+                return $this->toStringInContext($operator, $role);
             }
 
-            final public function exposedFailureDescriptionInContext(Operator $operator, int $position, $other): string
+            final public function exposedFailureDescriptionInContext(Operator $operator, $role, $other): string
             {
-                return $this->failureDescriptionInContext($operator, $position, $other);
+                return $this->failureDescriptionInContext($operator, $role, $other);
             }
         };
     }


### PR DESCRIPTION
Decided to make this parameter more generic, so the caller can pass virtually anything. ``UnarConstraint`` and ``BinaryConstraint`` passes argument position as a ``$role``. Future expressions can pass operand names, for example, if they use named operands instead of positional ones.