### PR TITLE
Enhancement: Enable phpdoc_summary fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -170,6 +170,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_summary' => true,
         'phpdoc_to_comment' => true,
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,

--- a/src/Framework/Constraint/Cardinality/IsEmpty.php
+++ b/src/Framework/Constraint/Cardinality/IsEmpty.php
@@ -42,7 +42,7 @@ final class IsEmpty extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -25,7 +25,7 @@ abstract class Constraint implements \Countable, SelfDescribing
     private $exporter;
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.
@@ -88,7 +88,7 @@ abstract class Constraint implements \Countable, SelfDescribing
     }
 
     /**
-     * Throws an exception for the given compared value and test description
+     * Throws an exception for the given compared value and test description.
      *
      * @param mixed             $other             evaluated value or object
      * @param string            $description       Additional information about the test
@@ -123,7 +123,7 @@ abstract class Constraint implements \Countable, SelfDescribing
     }
 
     /**
-     * Return additional failure description where needed
+     * Return additional failure description where needed.
      *
      * The function can be overridden to provide additional failure
      * information like a diff
@@ -136,7 +136,7 @@ abstract class Constraint implements \Countable, SelfDescribing
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.
@@ -155,7 +155,7 @@ abstract class Constraint implements \Countable, SelfDescribing
 
     /**
      * Returns a custom string representation of the constraint object when it
-     * appears in context of an $operator expression
+     * appears in context of an $operator expression.
      *
      * The purpose of this method is to provide meaningful descriptive string
      * in context of operators such as LogicalNot. Native PHPUnit constraints
@@ -175,7 +175,7 @@ abstract class Constraint implements \Countable, SelfDescribing
 
     /**
      * Returns the description of the failure when this constraint appears in
-     * context of an $operator expression
+     * context of an $operator expression.
      *
      * The purpose of this method is to provide meaningful failue description
      * in context of operators such as LogicalNot. Native PHPUnit constraints
@@ -203,7 +203,7 @@ abstract class Constraint implements \Countable, SelfDescribing
     /**
      * Reduces the sub-expression starting at $this by skipping degenerate
      * sub-expression and returns first descendant constraint that starts
-     * a non-reducible sub-expression
+     * a non-reducible sub-expression.
      *
      * Returns $this for terminal constraints and for operators that start
      * non-reducible sub-expression, or the nearest descendant of $this that

--- a/src/Framework/Constraint/Equality/IsEqual.php
+++ b/src/Framework/Constraint/Equality/IsEqual.php
@@ -53,7 +53,7 @@ final class IsEqual extends Constraint
     }
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.

--- a/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
+++ b/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
@@ -26,7 +26,7 @@ final class IsEqualCanonicalizing extends Constraint
     }
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.

--- a/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
+++ b/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
@@ -26,7 +26,7 @@ final class IsEqualIgnoringCase extends Constraint
     }
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.

--- a/src/Framework/Constraint/Equality/IsEqualWithDelta.php
+++ b/src/Framework/Constraint/Equality/IsEqualWithDelta.php
@@ -32,7 +32,7 @@ final class IsEqualWithDelta extends Constraint
     }
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.

--- a/src/Framework/Constraint/Exception/Exception.php
+++ b/src/Framework/Constraint/Exception/Exception.php
@@ -46,7 +46,7 @@ final class Exception extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Exception/ExceptionCode.php
+++ b/src/Framework/Constraint/Exception/ExceptionCode.php
@@ -41,7 +41,7 @@ final class ExceptionCode extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Exception/ExceptionMessage.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessage.php
@@ -46,7 +46,7 @@ final class ExceptionMessage extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Exception/ExceptionMessageRegularExpression.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessageRegularExpression.php
@@ -51,7 +51,7 @@ final class ExceptionMessageRegularExpression extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Filesystem/DirectoryExists.php
+++ b/src/Framework/Constraint/Filesystem/DirectoryExists.php
@@ -36,7 +36,7 @@ final class DirectoryExists extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Filesystem/FileExists.php
+++ b/src/Framework/Constraint/Filesystem/FileExists.php
@@ -36,7 +36,7 @@ final class FileExists extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Filesystem/IsReadable.php
+++ b/src/Framework/Constraint/Filesystem/IsReadable.php
@@ -36,7 +36,7 @@ final class IsReadable extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Filesystem/IsWritable.php
+++ b/src/Framework/Constraint/Filesystem/IsWritable.php
@@ -36,7 +36,7 @@ final class IsWritable extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/IsAnything.php
+++ b/src/Framework/Constraint/IsAnything.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 final class IsAnything extends Constraint
 {
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -41,7 +41,7 @@ final class IsIdentical extends Constraint
     }
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.
@@ -112,7 +112,7 @@ final class IsIdentical extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -65,7 +65,7 @@ final class JsonMatches extends Constraint
     }
 
     /**
-     * Throws an exception for the given compared value and test description
+     * Throws an exception for the given compared value and test description.
      *
      * @param mixed             $other             evaluated value or object
      * @param string            $description       Additional information about the test

--- a/src/Framework/Constraint/Object/ClassHasAttribute.php
+++ b/src/Framework/Constraint/Object/ClassHasAttribute.php
@@ -62,7 +62,7 @@ class ClassHasAttribute extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Operator/BinaryOperator.php
+++ b/src/Framework/Constraint/Operator/BinaryOperator.php
@@ -114,7 +114,7 @@ abstract class BinaryOperator extends Operator
     /**
      * Reduces the sub-expression starting at $this by skipping degenerate
      * sub-expression and returns first descendant constraint that starts
-     * a non-reducible sub-expression
+     * a non-reducible sub-expression.
      *
      * See Constraint::reduce() for more.
      */
@@ -128,7 +128,7 @@ abstract class BinaryOperator extends Operator
     }
 
     /**
-     * Returns string representation of given operand in context of this operator
+     * Returns string representation of given operand in context of this operator.
      *
      * @param Constraint $constraint operand constraint
      * @param int        $position   position of $constraint in this expression

--- a/src/Framework/Constraint/Operator/LogicalAnd.php
+++ b/src/Framework/Constraint/Operator/LogicalAnd.php
@@ -20,8 +20,9 @@ final class LogicalAnd extends BinaryOperator
     }
 
     /**
-     * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php.
+     * Returns this operator's precedence.
+     *
+     * @see https://www.php.net/manual/en/language.operators.precedence.php
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/LogicalAnd.php
+++ b/src/Framework/Constraint/Operator/LogicalAnd.php
@@ -21,7 +21,7 @@ final class LogicalAnd extends BinaryOperator
 
     /**
      * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php
+     * https://www.php.net/manual/en/language.operators.precedence.php.
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/LogicalNot.php
+++ b/src/Framework/Constraint/Operator/LogicalNot.php
@@ -78,7 +78,7 @@ final class LogicalNot extends UnaryOperator
 
     /**
      * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php
+     * https://www.php.net/manual/en/language.operators.precedence.php.
      */
     public function precedence(): int
     {
@@ -108,7 +108,7 @@ final class LogicalNot extends UnaryOperator
     /**
      * Reduces the sub-expression starting at $this by skipping degenerate
      * sub-expression and returns first descendant constraint that starts
-     * a non-reducible sub-expression
+     * a non-reducible sub-expression.
      *
      * See Constraint::reduce() for more.
      */

--- a/src/Framework/Constraint/Operator/LogicalNot.php
+++ b/src/Framework/Constraint/Operator/LogicalNot.php
@@ -77,8 +77,9 @@ final class LogicalNot extends UnaryOperator
     }
 
     /**
-     * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php.
+     * Returns this operator's precedence.
+     *
+     * @see https://www.php.net/manual/en/language.operators.precedence.php
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/LogicalOr.php
+++ b/src/Framework/Constraint/Operator/LogicalOr.php
@@ -20,8 +20,9 @@ final class LogicalOr extends BinaryOperator
     }
 
     /**
-     * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php.
+     * Returns this operator's precedence.
+     *
+     * @see https://www.php.net/manual/en/language.operators.precedence.php
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/LogicalOr.php
+++ b/src/Framework/Constraint/Operator/LogicalOr.php
@@ -21,7 +21,7 @@ final class LogicalOr extends BinaryOperator
 
     /**
      * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php
+     * https://www.php.net/manual/en/language.operators.precedence.php.
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/LogicalXor.php
+++ b/src/Framework/Constraint/Operator/LogicalXor.php
@@ -21,7 +21,7 @@ final class LogicalXor extends BinaryOperator
 
     /**
      * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php
+     * https://www.php.net/manual/en/language.operators.precedence.php.
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/LogicalXor.php
+++ b/src/Framework/Constraint/Operator/LogicalXor.php
@@ -20,8 +20,9 @@ final class LogicalXor extends BinaryOperator
     }
 
     /**
-     * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php.
+     * Returns this operator's precedence.
+     *
+     * @see https://www.php.net/manual/en/language.operators.precedence.php.
      */
     public function precedence(): int
     {

--- a/src/Framework/Constraint/Operator/Operator.php
+++ b/src/Framework/Constraint/Operator/Operator.php
@@ -18,7 +18,7 @@ abstract class Operator extends Constraint
 
     /**
      * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php
+     * https://www.php.net/manual/en/language.operators.precedence.php.
      */
     abstract public function precedence(): int;
 

--- a/src/Framework/Constraint/Operator/Operator.php
+++ b/src/Framework/Constraint/Operator/Operator.php
@@ -17,8 +17,9 @@ abstract class Operator extends Constraint
     abstract public function operator(): string;
 
     /**
-     * Returns this operator's precedence, as defined in
-     * https://www.php.net/manual/en/language.operators.precedence.php.
+     * Returns this operator's precedence.
+     *
+     * @see https://www.php.net/manual/en/language.operators.precedence.php
      */
     abstract public function precedence(): int;
 

--- a/src/Framework/Constraint/Operator/UnaryOperator.php
+++ b/src/Framework/Constraint/Operator/UnaryOperator.php
@@ -67,7 +67,7 @@ abstract class UnaryOperator extends Operator
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/String/IsJson.php
+++ b/src/Framework/Constraint/String/IsJson.php
@@ -44,7 +44,7 @@ final class IsJson extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Traversable/ArrayHasKey.php
+++ b/src/Framework/Constraint/Traversable/ArrayHasKey.php
@@ -64,7 +64,7 @@ final class ArrayHasKey extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Traversable/TraversableContains.php
+++ b/src/Framework/Constraint/Traversable/TraversableContains.php
@@ -36,7 +36,7 @@ abstract class TraversableContains extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
+++ b/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
@@ -44,7 +44,7 @@ final class TraversableContainsOnly extends Constraint
     }
 
     /**
-     * Evaluates the constraint for parameter $other
+     * Evaluates the constraint for parameter $other.
      *
      * If $returnResult is set to false (the default), an exception is thrown
      * in case of a failure. null is returned otherwise.

--- a/src/Framework/Constraint/Type/IsInstanceOf.php
+++ b/src/Framework/Constraint/Type/IsInstanceOf.php
@@ -51,7 +51,7 @@ final class IsInstanceOf extends Constraint
     }
 
     /**
-     * Returns the description of the failure
+     * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
      * cases. This method should return the second part of that sentence.

--- a/src/Framework/DataProviderTestSuite.php
+++ b/src/Framework/DataProviderTestSuite.php
@@ -48,7 +48,7 @@ final class DataProviderTestSuite extends TestSuite
     }
 
     /**
-     * Returns the size of the each test created using the data provider(s)
+     * Returns the size of the each test created using the data provider(s).
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -99,7 +99,7 @@ final class ExceptionWrapper extends Exception
     /**
      * Method to contain static originalException to exclude it from stacktrace to prevent the stacktrace contents,
      * which can be quite big, from being garbage-collected, thus blocking memory until shutdown.
-     * Approach works both for var_dump() and var_export() and print_r()
+     * Approach works both for var_dump() and var_export() and print_r().
      */
     private function originalException(\Throwable $exceptionToStore = null): ?\Throwable
     {

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -99,6 +99,7 @@ final class ExceptionWrapper extends Exception
     /**
      * Method to contain static originalException to exclude it from stacktrace to prevent the stacktrace contents,
      * which can be quite big, from being garbage-collected, thus blocking memory until shutdown.
+     *
      * Approach works both for var_dump() and var_export() and print_r().
      */
     private function originalException(\Throwable $exceptionToStore = null): ?\Throwable

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -148,7 +148,7 @@ final class Generator
     /**
      * Returns a mock object for the specified abstract class with all abstract
      * methods of the class mocked. Concrete methods to mock can be specified with
-     * the $mockedMethods parameter
+     * the $mockedMethods parameter.
      *
      * @psalm-template RealInstanceType of object
      * @psalm-param class-string<RealInstanceType> $originalClassName

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -147,8 +147,9 @@ final class Generator
 
     /**
      * Returns a mock object for the specified abstract class with all abstract
-     * methods of the class mocked. Concrete methods to mock can be specified with
-     * the $mockedMethods parameter.
+     * methods of the class mocked.
+     *
+     * Concrete methods to mock can be specified with the $mockedMethods parameter.
      *
      * @psalm-template RealInstanceType of object
      * @psalm-param class-string<RealInstanceType> $originalClassName

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -203,7 +203,7 @@ final class MockBuilder
     }
 
     /**
-     * Specifies the subset of methods to mock, requiring each to exist in the class
+     * Specifies the subset of methods to mock, requiring each to exist in the class.
      *
      * @param string[] $methods
      *
@@ -249,7 +249,7 @@ final class MockBuilder
     }
 
     /**
-     * Specifies methods that don't exist in the class which you want to mock
+     * Specifies methods that don't exist in the class which you want to mock.
      *
      * @param string[] $methods
      *

--- a/src/Framework/MockObject/Rule/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Rule/ConsecutiveParameters.php
@@ -85,7 +85,7 @@ final class ConsecutiveParameters implements ParametersRule
     }
 
     /**
-     * Verify a single invocation
+     * Verify a single invocation.
      *
      * @param int $callIndex
      *

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -471,7 +471,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Returns an array of TestFailure objects for the risky tests
+     * Returns an array of TestFailure objects for the risky tests.
      *
      * @return TestFailure[]
      */
@@ -481,7 +481,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Returns an array of TestFailure objects for the incomplete tests
+     * Returns an array of TestFailure objects for the incomplete tests.
      *
      * @return TestFailure[]
      */
@@ -507,7 +507,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Returns an array of TestFailure objects for the skipped tests
+     * Returns an array of TestFailure objects for the skipped tests.
      *
      * @return TestFailure[]
      */
@@ -525,7 +525,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Returns an array of TestFailure objects for the errors
+     * Returns an array of TestFailure objects for the errors.
      *
      * @return TestFailure[]
      */
@@ -543,7 +543,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Returns an array of TestFailure objects for the failures
+     * Returns an array of TestFailure objects for the failures.
      *
      * @return TestFailure[]
      */
@@ -561,7 +561,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Returns an array of TestFailure objects for the warnings
+     * Returns an array of TestFailure objects for the warnings.
      *
      * @return TestFailure[]
      */
@@ -1149,7 +1149,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Enables or disables the stopping for defects: error, failure, warning
+     * Enables or disables the stopping for defects: error, failure, warning.
      */
     public function stopOnDefect(bool $flag): void
     {
@@ -1183,7 +1183,7 @@ final class TestResult implements \Countable
     }
 
     /**
-     * Sets the default timeout for tests
+     * Sets the default timeout for tests.
      */
     public function setDefaultTimeLimit(int $timeout): void
     {

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -105,7 +105,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
     private $warnings = [];
 
     /**
-     * Constructs a new TestSuite:
+     * Constructs a new TestSuite:.
      *
      *   - PHPUnit\Framework\TestSuite() constructs an empty TestSuite.
      *
@@ -537,7 +537,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
     }
 
     /**
-     * Set tests groups of the test case
+     * Set tests groups of the test case.
      */
     public function setGroupDetails(array $groups): void
     {
@@ -692,7 +692,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
     }
 
     /**
-     * Set tests of the test suite
+     * Set tests of the test suite.
      *
      * @param Test[] $tests
      */

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -105,7 +105,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
     private $warnings = [];
 
     /**
-     * Constructs a new TestSuite:.
+     * Constructs a new TestSuite.
      *
      *   - PHPUnit\Framework\TestSuite() constructs an empty TestSuite.
      *

--- a/src/Runner/DefaultTestResultCache.php
+++ b/src/Runner/DefaultTestResultCache.php
@@ -23,7 +23,7 @@ final class DefaultTestResultCache implements \Serializable, TestResultCache
     public const DEFAULT_RESULT_CACHE_FILENAME = '.phpunit.result.cache';
 
     /**
-     * Provide extra protection against incomplete or corrupt caches
+     * Provide extra protection against incomplete or corrupt caches.
      *
      * @var int[]
      */
@@ -37,14 +37,14 @@ final class DefaultTestResultCache implements \Serializable, TestResultCache
     ];
 
     /**
-     * Path and filename for result cache file
+     * Path and filename for result cache file.
      *
      * @var string
      */
     private $cacheFilename;
 
     /**
-     * The list of defective tests
+     * The list of defective tests.
      *
      * <code>
      * // Mark a test skipped
@@ -56,7 +56,7 @@ final class DefaultTestResultCache implements \Serializable, TestResultCache
     private $defects = [];
 
     /**
-     * The list of execution duration of suites and tests (in seconds)
+     * The list of execution duration of suites and tests (in seconds).
      *
      * <code>
      * // Record running time for test

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -46,7 +46,7 @@ final class TestSuiteSorter
     public const ORDER_DURATION = 4;
 
     /**
-     * Order tests by @size annotation 'small', 'medium', 'large'
+     * Order tests by @size annotation 'small', 'medium', 'large'.
      *
      * @var int
      */
@@ -300,7 +300,7 @@ final class TestSuiteSorter
      * Comparator callback function to sort tests for "reach failure as fast as possible":
      * 1. sort tests by defect weight defined in self::DEFECT_SORT_WEIGHT
      * 2. when tests are equally defective, sort the fastest to the front
-     * 3. do not reorder successful tests
+     * 3. do not reorder successful tests.
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -333,7 +333,7 @@ final class TestSuiteSorter
     }
 
     /**
-     * Compares test size for sorting tests small->medium->large->unknown
+     * Compares test size for sorting tests small->medium->large->unknown.
      */
     private function cmpSize(Test $a, Test $b): int
     {

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -297,10 +297,11 @@ final class TestSuiteSorter
     }
 
     /**
-     * Comparator callback function to sort tests for "reach failure as fast as possible":
+     * Comparator callback function to sort tests for "reach failure as fast as possible".
+     *
      * 1. sort tests by defect weight defined in self::DEFECT_SORT_WEIGHT
      * 2. when tests are equally defective, sort the fastest to the front
-     * 3. do not reorder successful tests.
+     * 3. do not reorder successful tests
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -169,7 +169,7 @@ final class Help
     }
 
     /**
-     * Write the help file to the CLI, adapting width and colors to the console
+     * Write the help file to the CLI, adapting width and colors to the console.
      */
     public function writeToConsole(): void
     {

--- a/src/TextUI/XmlConfiguration/Loader.php
+++ b/src/TextUI/XmlConfiguration/Loader.php
@@ -661,9 +661,10 @@ final class Loader
     }
 
     /**
-     * if $value is 'false' or 'true', this returns the value that $value represents.
+     * If $value is 'false' or 'true', this returns the value that $value represents.
      * Otherwise, returns $default, which may be a string in rare cases.
-     * See PHPUnit\TextUI\XmlConfigurationTest::testPHPConfigurationIsReadCorrectly.
+     *
+     * @see \PHPUnit\TextUI\XmlConfigurationTest::testPHPConfigurationIsReadCorrectly
      *
      * @param bool|string $default
      *

--- a/src/TextUI/XmlConfiguration/Loader.php
+++ b/src/TextUI/XmlConfiguration/Loader.php
@@ -663,7 +663,7 @@ final class Loader
     /**
      * if $value is 'false' or 'true', this returns the value that $value represents.
      * Otherwise, returns $default, which may be a string in rare cases.
-     * See PHPUnit\TextUI\XmlConfigurationTest::testPHPConfigurationIsReadCorrectly
+     * See PHPUnit\TextUI\XmlConfigurationTest::testPHPConfigurationIsReadCorrectly.
      *
      * @param bool|string $default
      *

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -332,7 +332,7 @@ final class DocBlock
     }
 
     /**
-     * Parse annotation content to use constant/class constant values
+     * Parse annotation content to use constant/class constant values.
      *
      * Constants are specified using a starting '@'. For example: @ClassName::CONST_NAME
      *

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -15,9 +15,10 @@ namespace PHPUnit\Util;
 final class Filesystem
 {
     /**
-     * Maps class names to source file names:
+     * Maps class names to source file names.
+     *
      *   - PEAR CS:   Foo_Bar_Baz -> Foo/Bar/Baz.php
-     *   - Namespace: Foo\Bar\Baz -> Foo/Bar/Baz.php.
+     *   - Namespace: Foo\Bar\Baz -> Foo/Bar/Baz.php
      */
     public static function classNameToFilename(string $className): string
     {

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -17,7 +17,7 @@ final class Filesystem
     /**
      * Maps class names to source file names:
      *   - PEAR CS:   Foo_Bar_Baz -> Foo/Bar/Baz.php
-     *   - Namespace: Foo\Bar\Baz -> Foo/Bar/Baz.php
+     *   - Namespace: Foo\Bar\Baz -> Foo/Bar/Baz.php.
      */
     public static function classNameToFilename(string $className): string
     {

--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Exception;
 final class Json
 {
     /**
-     * Prettify json string
+     * Prettify json string.
      *
      * @throws \PHPUnit\Framework\Exception
      */

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -86,7 +86,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Sets the input string to be sent via STDIN
+     * Sets the input string to be sent via STDIN.
      */
     public function setStdin(string $stdin): void
     {
@@ -94,7 +94,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Returns the input string to be sent via STDIN
+     * Returns the input string to be sent via STDIN.
      */
     public function getStdin(): string
     {
@@ -102,7 +102,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Sets the string of arguments to pass to the php job
+     * Sets the string of arguments to pass to the php job.
      */
     public function setArgs(string $args): void
     {
@@ -110,7 +110,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Returns the string of arguments to pass to the php job
+     * Returns the string of arguments to pass to the php job.
      */
     public function getArgs(): string
     {
@@ -118,7 +118,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Sets the array of environment variables to start the child process with
+     * Sets the array of environment variables to start the child process with.
      *
      * @param array<string, string> $env
      */
@@ -128,7 +128,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Returns the array of environment variables to start the child process with
+     * Returns the array of environment variables to start the child process with.
      */
     public function getEnv(): array
     {
@@ -136,7 +136,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Sets the amount of seconds to wait before timing out
+     * Sets the amount of seconds to wait before timing out.
      */
     public function setTimeout(int $timeout): void
     {
@@ -144,7 +144,7 @@ abstract class AbstractPhpProcess
     }
 
     /**
-     * Returns the amount of seconds to wait before timing out
+     * Returns the amount of seconds to wait before timing out.
      */
     public function getTimeout(): int
     {

--- a/src/Util/PHP/DefaultPhpProcess.php
+++ b/src/Util/PHP/DefaultPhpProcess.php
@@ -43,7 +43,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
     }
 
     /**
-     * Returns an array of file handles to be used in place of pipes
+     * Returns an array of file handles to be used in place of pipes.
      */
     protected function getHandles(): array
     {
@@ -51,7 +51,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
     }
 
     /**
-     * Handles creating the child process and returning the STDOUT and STDERR
+     * Handles creating the child process and returning the STDOUT and STDERR.
      *
      * @throws Exception
      */

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -650,7 +650,7 @@ final class Test
 
     /**
      * Trims any extensions from version string that follows after
-     * the <major>.<minor>[.<patch>] format
+     * the <major>.<minor>[.<patch>] format.
      */
     private static function sanitizeVersionNumber(string $version)
     {

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -24,7 +24,7 @@ use SebastianBergmann\Timer\Timer;
 class CliTestDoxPrinter extends TestDoxPrinter
 {
     /**
-     * The default Testdox left margin for messages is a vertical line
+     * The default Testdox left margin for messages is a vertical line.
      */
     private const PREFIX_SIMPLE = [
         'default' => '│',
@@ -36,7 +36,7 @@ class CliTestDoxPrinter extends TestDoxPrinter
     ];
 
     /**
-     * Colored Testdox use box-drawing for a more textured map of the message
+     * Colored Testdox use box-drawing for a more textured map of the message.
      */
     private const PREFIX_DECORATED = [
         'default' => '│',

--- a/src/Util/Xml.php
+++ b/src/Util/Xml.php
@@ -149,7 +149,7 @@ final class Xml
     }
 
     /**
-     * Escapes a string for the use in XML documents
+     * Escapes a string for the use in XML documents.
      *
      * Any Unicode character is allowed, excluding the surrogate blocks, FFFE,
      * and FFFF (not even as character reference).

--- a/tests/basic/unit/SetUpBeforeClassTest.php
+++ b/tests/basic/unit/SetUpBeforeClassTest.php
@@ -12,7 +12,7 @@ namespace PHPUnit\SelfTest\Basic;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class SetUpBeforeClassTest
+ * Class SetUpBeforeClassTest.
  *
  * Behaviour to test:
  * - setUpBeforeClass() errors do reach the user

--- a/tests/basic/unit/SetUpTest.php
+++ b/tests/basic/unit/SetUpTest.php
@@ -12,7 +12,7 @@ namespace PHPUnit\SelfTest\Basic;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class SetUpBeforeClassTest
+ * Class SetUpBeforeClassTest.
  *
  * Behaviour to test:
  * - setUp() errors reacht he the user

--- a/tests/basic/unit/TearDownAfterClassTest.php
+++ b/tests/basic/unit/TearDownAfterClassTest.php
@@ -12,7 +12,7 @@ namespace PHPUnit\SelfTest\Basic;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class TearDownAfterClassTest
+ * Class TearDownAfterClassTest.
  *
  * Behaviour to test:
  * - tearDownAfterClass() errors do reach the user

--- a/tests/end-to-end/regression/GitHub/2158/Issue2158Test.php
+++ b/tests/end-to-end/regression/GitHub/2158/Issue2158Test.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 class Issue2158Test extends TestCase
 {
     /**
-     * Set constant in main process
+     * Set constant in main process.
      */
     public function testSomething(): void
     {
@@ -22,7 +22,7 @@ class Issue2158Test extends TestCase
 
     /**
      * Constant defined previously in main process constant should be available and
-     * no errors should be yielded by reload of included files
+     * no errors should be yielded by reload of included files.
      *
      * @runInSeparateProcess
      */

--- a/tests/unit/Framework/Constraint/BinaryOperatorTestCase.php
+++ b/tests/unit/Framework/Constraint/BinaryOperatorTestCase.php
@@ -14,12 +14,12 @@ use PHPUnit\Framework\ExpectationFailedException;
 abstract class BinaryOperatorTestCase extends OperatorTestCase
 {
     /**
-     * Shall return the name of the operator under test
+     * Shall return the name of the operator under test.
      */
     abstract public static function getOperatorName(): string;
 
     /**
-     * Shall return the precedence of the operator under test
+     * Shall return the precedence of the operator under test.
      */
     abstract public static function getOperatorPrecedence(): int;
 

--- a/tests/unit/Framework/Constraint/IsEqualTest.php
+++ b/tests/unit/Framework/Constraint/IsEqualTest.php
@@ -318,7 +318,7 @@ EOF
     }
 
     /**
-     * Removes spaces in front of newlines
+     * Removes spaces in front of newlines.
      *
      * @param string $string
      *

--- a/tests/unit/Framework/Constraint/IsTypeTest.php
+++ b/tests/unit/Framework/Constraint/IsTypeTest.php
@@ -127,7 +127,7 @@ EOF
     }
 
     /**
-     * Removes spaces in front of newlines
+     * Removes spaces in front of newlines.
      *
      * @param string $string
      *

--- a/tests/unit/Framework/Constraint/UnaryOperatorTestCase.php
+++ b/tests/unit/Framework/Constraint/UnaryOperatorTestCase.php
@@ -14,12 +14,12 @@ use PHPUnit\Framework\ExpectationFailedException;
 abstract class UnaryOperatorTestCase extends OperatorTestCase
 {
     /**
-     * Shall return the name of the operator under test
+     * Shall return the name of the operator under test.
      */
     abstract public static function getOperatorName(): string;
 
     /**
-     * Shall return the precedence of the operator under test
+     * Shall return the precedence of the operator under test.
      */
     abstract public static function getOperatorPrecedence(): int;
 

--- a/tests/unit/Framework/ConstraintTest.php
+++ b/tests/unit/Framework/ConstraintTest.php
@@ -1373,7 +1373,7 @@ EOF
     }
 
     /**
-     * Removes spaces in front of newlines
+     * Removes spaces in front of newlines.
      *
      * @param string $string
      *

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -813,7 +813,7 @@ final class MockObjectTest extends TestCase
     }
 
     /**
-     * See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81
+     * See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81.
      */
     public function testMockArgumentsPassedByReference(): void
     {
@@ -835,7 +835,7 @@ final class MockObjectTest extends TestCase
     }
 
     /**
-     * See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81
+     * See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81.
      */
     public function testMockArgumentsPassedByReference2(): void
     {

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -813,7 +813,7 @@ final class MockObjectTest extends TestCase
     }
 
     /**
-     * See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81.
+     * @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81
      */
     public function testMockArgumentsPassedByReference(): void
     {
@@ -835,7 +835,7 @@ final class MockObjectTest extends TestCase
     }
 
     /**
-     * See https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81.
+     * @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/81
      */
     public function testMockArgumentsPassedByReference2(): void
     {

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -332,7 +332,7 @@ EOF
     }
 
     /**
-     * Ensures the correct line ending is used for comparison
+     * Ensures the correct line ending is used for comparison.
      *
      * @param string $content
      *

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestSuite;
 final class TestSuiteSorterTest extends TestCase
 {
     /**
-     * Constants to improve clarity of @dataprovider
+     * Constants to improve clarity of @dataprovider.
      */
     private const IGNORE_DEPENDENCIES  = false;
 
@@ -302,7 +302,7 @@ final class TestSuiteSorterTest extends TestCase
      * - it has five tests 'testOne' ... 'testFive'
      * - 'testThree' @depends on both 'testOne' and 'testTwo'
      * - 'testFour' @depends on 'MultiDependencyTest::testThree' to test FQN @depends
-     * - 'testFive' has no dependencies
+     * - 'testFive' has no dependencies.
      */
     public function commonSorterOptionsProvider(): array
     {
@@ -366,7 +366,7 @@ final class TestSuiteSorterTest extends TestCase
      * - it has five tests 'testOne' ... 'testFive'
      * - 'testThree' @depends on both 'testOne' and 'testTwo'
      * - 'testFour' @depends on 'MultiDependencyTest::testThree' to test FQN @depends
-     * - 'testFive' has no dependencies
+     * - 'testFive' has no dependencies.
      */
     public function defectsSorterOptionsProvider(): array
     {

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -297,12 +297,14 @@ final class TestSuiteSorterTest extends TestCase
     }
 
     /**
-     * A @dataprovider for basic execution reordering options based on MultiDependencyTest
+     * A @dataprovider for basic execution reordering options based on MultiDependencyTest.
+     *
      * This class has the following relevant properties:
+     *
      * - it has five tests 'testOne' ... 'testFive'
      * - 'testThree' @depends on both 'testOne' and 'testTwo'
      * - 'testFour' @depends on 'MultiDependencyTest::testThree' to test FQN @depends
-     * - 'testFive' has no dependencies.
+     * - 'testFive' has no dependencies
      */
     public function commonSorterOptionsProvider(): array
     {
@@ -361,12 +363,14 @@ final class TestSuiteSorterTest extends TestCase
     }
 
     /**
-     * A @dataprovider for testing defects execution reordering options based on MultiDependencyTest
+     * A @dataprovider for testing defects execution reordering options based on MultiDependencyTest.
+     *
      * This class has the following relevant properties:
+     *
      * - it has five tests 'testOne' ... 'testFive'
      * - 'testThree' @depends on both 'testOne' and 'testTwo'
      * - 'testFour' @depends on 'MultiDependencyTest::testThree' to test FQN @depends
-     * - 'testFive' has no dependencies.
+     * - 'testFive' has no dependencies
      */
     public function defectsSorterOptionsProvider(): array
     {


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_summary` fixer
* [x] runs `php-cs-fixer`
* [x] sorts out a few issues manually

Slightly related to https://github.com/sebastianbergmann/phpunit/pull/3936.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.3#usage:

> **phpdoc_summary**
>
> PHPDoc summary should end in either a full stop, exclamation mark, or question mark.

