### PR TITLE
Fix test when the folder name isn't "phpunit"

### DIFF
--- a/tests/end-to-end/execution-order/depends-on-class.phpt
+++ b/tests/end-to-end/execution-order/depends-on-class.phpt
@@ -14,7 +14,7 @@ PHPUnit\TextUI\Command::main();
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime:       %s
-Configuration: %sphpunit%etests%e_files%econfiguration.depends-on-class.xml
+Configuration: %s%etests%e_files%econfiguration.depends-on-class.xml
 
 ....SFSSSSW                                                       11 / 11 (100%)
 
@@ -31,7 +31,7 @@ There was 1 failure:
 
 1) DependencyFailureTest::testOne
 
-%s%ephpunit%etests%e_files%eDependencyFailureTest.php:16
+%s%etests%e_files%eDependencyFailureTest.php:16
 
 --
 


### PR DESCRIPTION
```
/.../PHP-PHPUN-PM/tests/end-to-end/execution-order/depends-on-class.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 PHPUnit 9.3-gdfc9ae0 by Sebastian Bergmann and contributors.
 
 Runtime:       PHP 8.0.0-dev
-Configuration: %sphpunit%etests%e_files%econfiguration.depends-on-class.xml
+Configuration: /.../PHP-PHPUN-PM/tests/_files/configuration.depends-on-class.xml
 
 ....SFSSSSW                                                       11 / 11 (100%)
 
@@ @@
 
 1) DependencyFailureTest::testOne
 
-%s%ephpunit%etests%e_files%eDependencyFailureTest.php:16
+/.../PHP-PHPUN-PM/tests/_files/DependencyFailureTest.php:16
 
 --

/.../PHP-PHPUN-PM/tests/end-to-end/execution-order/depends-on-class.phpt:17
/.../PHP-PHPUN-PM/src/Framework/TestSuite.php:634
/.../PHP-PHPUN-PM/src/Framework/TestSuite.php:634
/.../PHP-PHPUN-PM/src/TextUI/TestRunner.php:670
/.../PHP-PHPUN-PM/src/TextUI/Command.php:108
/.../PHP-PHPUN-PM/src/TextUI/Command.php:68
```

From: https://revive.beccati.com/bamboo/browse/PHP-PHPUN-PM-2244/test/case/56483187