### PR TITLE
Fix test when readline ext is not available

### DIFF
--- a/tests/end-to-end/phpt/parse-ini-env-section.phpt
+++ b/tests/end-to-end/phpt/parse-ini-env-section.phpt
@@ -1,17 +1,17 @@
 --TEST--
 Can parse --INI-- and --ENV-- sections
 --INI--
-cli.prompt=PHPUNIT_PROMPT
+date.default_latitude=1.337
 dummy.key
 --ENV--
 PHPUNIT_ENV=phpunit-env-section
 --FILE--
 <?php
-echo ini_get('cli.prompt') . "\n";
-echo ini_get('dummy.key') . "\n";
-echo getenv('PHPUNIT_ENV') . "\n";
+var_dump(ini_get('date.default_latitude'));
+var_dump(ini_get('dummy.key'));
+var_dump(getenv('PHPUNIT_ENV'));
 ?>
 --EXPECT--
-PHPUNIT_PROMPT
-
-phpunit-env-section
+string(5) "1.337"
+bool(false)
+string(19) "phpunit-env-section"


### PR DESCRIPTION
```
/.../PHP-PHPUN-PM/tests/end-to-end/phpt/parse-ini-env-section.phpt
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'PHPUNIT_PROMPT\n
-\n
-phpunit-env-section'
+'phpunit-env-section'

/.../PHP-PHPUN-PM/tests/end-to-end/phpt/parse-ini-env-section.phpt:1
/.../PHP-PHPUN-PM/src/Framework/TestSuite.php:634
/.../PHP-PHPUN-PM/src/Framework/TestSuite.php:634
/.../PHP-PHPUN-PM/src/TextUI/TestRunner.php:670
/.../PHP-PHPUN-PM/src/TextUI/Command.php:108
/.../PHP-PHPUN-PM/src/TextUI/Command.php:68
```

From: https://revive.beccati.com/bamboo/browse/PHP-PHPUN-PM-2244/test/case/56483188