### PR TITLE
use current directory for default cache path

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -156,9 +156,9 @@ final class TestRunner extends BaseTestRunner
                 if (isset($arguments['configuration'])) {
                     \assert($arguments['configuration'] instanceof Configuration);
 
-                    $cacheLocation = $arguments['configuration']->filename();
+                    $cacheLocation = \dirname($arguments['configuration']->filename());
                 } else {
-                    $cacheLocation = $_SERVER['PHP_SELF'];
+                    $cacheLocation = \getcwd();
                 }
 
                 $arguments['cacheResultFile'] = null;
@@ -166,7 +166,7 @@ final class TestRunner extends BaseTestRunner
                 $cacheResultFile = \realpath($cacheLocation);
 
                 if ($cacheResultFile !== false) {
-                    $arguments['cacheResultFile'] = \dirname($cacheResultFile);
+                    $arguments['cacheResultFile'] = $cacheResultFile;
                 }
             }
 


### PR DESCRIPTION
As phpunit command path seems a poor default:

- will result on vendor/bin/phpunit in most case
- will result on some global directory when global phpunit is used (phar) thus being used for "all" projects.

Open against master, but will be nice to have a better default in 8.x and 9.x

P.S. seems minor, as will only affects project without configuration file, as in most case path to configuration will be used.