### PR TITLE
Remove whitespace terminology

### DIFF
--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -17,7 +17,7 @@ final class Color
     /**
      * @var array<string,string>
      */
-    private const WHITESPACE_MAP = [
+    private const EMPTYSPACE_MAP = [
         ' '  => '·',
         "\t" => '⇥',
     ];
@@ -25,7 +25,7 @@ final class Color
     /**
      * @var array<string,string>
      */
-    private const WHITESPACE_EOL_MAP = [
+    private const EMPTYSPACE_EOL_MAP = [
         ' '  => '·',
         "\t" => '⇥',
         "\n" => '↵',
@@ -121,9 +121,9 @@ final class Color
         return "\e[2m$buffer\e[22m";
     }
 
-    public static function visualizeWhitespace(string $buffer, bool $visualizeEOL = false): string
+    public static function visualizeEmptyspace(string $buffer, bool $visualizeEOL = false): string
     {
-        $replaceMap = $visualizeEOL ? self::WHITESPACE_EOL_MAP : self::WHITESPACE_MAP;
+        $replaceMap = $visualizeEOL ? self::EMPTYSPACE_EOL_MAP : self::EMPTYSPACE_MAP;
 
         return \preg_replace_callback('/\s+/', static function ($matches) use ($replaceMap) {
             return self::dim(\strtr($matches[0], $replaceMap));

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -223,9 +223,9 @@ class CliTestDoxPrinter extends TestDoxPrinter
                 $message[] = $line;
             } else {
                 if (\strpos($line, '-') === 0) {
-                    $line = Color::colorize('fg-red', Color::visualizeWhitespace($line, true));
+                    $line = Color::colorize('fg-red', Color::visualizeEmptyspace($line, true));
                 } elseif (\strpos($line, '+') === 0) {
-                    $line = Color::colorize('fg-green', Color::visualizeWhitespace($line, true));
+                    $line = Color::colorize('fg-green', Color::visualizeEmptyspace($line, true));
                 } elseif ($line === '@@ @@') {
                     $line = Color::colorize('fg-cyan', $line);
                 }

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -146,7 +146,7 @@ final class NamePrettifier
         if (\is_int($test->dataName())) {
             $data = Color::dim(' with data set ') . Color::colorize('fg-cyan', (string) $test->dataName());
         } else {
-            $data = Color::dim(' with ') . Color::colorize('fg-cyan', Color::visualizeWhitespace((string) $test->dataName()));
+            $data = Color::dim(' with ') . Color::colorize('fg-cyan', Color::visualizeEmptyspace((string) $test->dataName()));
         }
 
         return $data;
@@ -282,7 +282,7 @@ final class NamePrettifier
 
         if ($this->useColor) {
             $providedData = \array_map(static function ($value) {
-                return Color::colorize('fg-cyan', Color::visualizeWhitespace((string) $value, true));
+                return Color::colorize('fg-cyan', Color::visualizeEmptyspace((string) $value, true));
             }, $providedData);
         }
 

--- a/tests/_files/CoverageFunctionParenthesesEmptyspaceTest.php
+++ b/tests/_files/CoverageFunctionParenthesesEmptyspaceTest.php
@@ -9,14 +9,13 @@
  */
 use PHPUnit\Framework\TestCase;
 
-class CoverageMethodParenthesesWhitespaceTest extends TestCase
+class CoverageFunctionParenthesesEmptyspaceTest extends TestCase
 {
     /**
-     * @covers CoveredClass::publicMethod ( )
+     * @covers ::globalFunction ( )
      */
     public function testSomething(): void
     {
-        $o = new CoveredClass;
-        $o->publicMethod();
+        globalFunction();
     }
 }

--- a/tests/_files/CoverageMethodParenthesesEmptyspaceTest.php
+++ b/tests/_files/CoverageMethodParenthesesEmptyspaceTest.php
@@ -9,13 +9,14 @@
  */
 use PHPUnit\Framework\TestCase;
 
-class CoverageFunctionParenthesesWhitespaceTest extends TestCase
+class CoverageMethodParenthesesEmptyspaceTest extends TestCase
 {
     /**
-     * @covers ::globalFunction ( )
+     * @covers CoveredClass::publicMethod ( )
      */
     public function testSomething(): void
     {
-        globalFunction();
+        $o = new CoveredClass;
+        $o->publicMethod();
     }
 }

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -457,7 +457,7 @@ class RequirementsTest extends TestCase
      * @requires   PHP        ~5.6.22 || ~7.0.17
      * @requires   PHPUnit    ~5.6.22 || ~7.0.17
      */
-    public function testVersionConstraintRegexpIgnoresWhitespace(): void
+    public function testVersionConstraintRegexpIgnoresEmptyspace(): void
     {
     }
 

--- a/tests/_files/phpt-for-multiwhitelist-coverage.phpt
+++ b/tests/_files/phpt-for-multiwhitelist-coverage.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PHPT for testing coverage using multiple whitespace arguments
+PHPT for testing coverage using multiple emptyspace arguments
 --FILE--
 <?php declare(strict_types=1);
 require __DIR__ . '/../bootstrap.php';

--- a/tests/end-to-end/loggers/_files/raw_output_ColorTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_ColorTest.txt
@@ -14,10 +14,10 @@ Runtime:       %s
  [32m✔[0m Colorize path [36m%ephp%eunit%etest.phpt[0m after [36m%ephp%e[0m [32m %f [2mms[0m
  [32m✔[0m Colorize path [36m%e_d-i.r%et-e_s.t.phpt[0m after [36;2;4mempty[0m [32m %f [2mms[0m
  [32m✔[0m dim($m) and colorize('dim',$m) return different ANSI codes [32m %f [2mms[0m
- [32m✔[0m Visualize all whitespace characters in [36mno-spaces[0m [32m %f [2mms[0m
- [32m✔[0m Visualize all whitespace characters in [36;2m·[22mspace[2m···[22minvaders[2m·[0m [32m %f [2mms[0m
- [32m✔[0m Visualize all whitespace characters in [36;2m⇥[22mindent,[2m·[22mspace[2m·[22mand[2m·[22m\n[2m↵[22m\r[2m⟵[0m [32m %f [2mms[0m
- [32m✔[0m Visualize whitespace but ignore EOL [32m %f [2mms[0m
+ [32m✔[0m Visualize all emptyspace characters in [36mno-spaces[0m [32m %f [2mms[0m
+ [32m✔[0m Visualize all emptyspace characters in [36;2m·[22mspace[2m···[22minvaders[2m·[0m [32m %f [2mms[0m
+ [32m✔[0m Visualize all emptyspace characters in [36;2m⇥[22mindent,[2m·[22mspace[2m·[22mand[2m·[22m\n[2m↵[22m\r[2m⟵[0m [32m %f [2mms[0m
+ [32m✔[0m Visualize emptyspace but ignore EOL [32m %f [2mms[0m
  [32m✔[0m Prettify unnamed dataprovider[2m with data set [22m[36m0[0m [32m %f [2mms[0m
  [32m✔[0m Prettify unnamed dataprovider[2m with data set [22m[36m1[0m [32m %f [2mms[0m
  [32m✔[0m Prettify named dataprovider[2m with [22m[36mone[0m [32m %f [2mms[0m

--- a/tests/end-to-end/loggers/testdox.phpt
+++ b/tests/end-to-end/loggers/testdox.phpt
@@ -29,11 +29,11 @@ Basic ANSI color highlighting support
  ✔ Colorize path %ephp%eunit%etest.phpt after %ephp%e
  ✔ Colorize path %e_d-i.r%et-e_s.t.phpt after ''
  ✔ dim($m) and colorize('dim',$m) return different ANSI codes
- ✔ Visualize all whitespace characters in no-spaces
- ✔ Visualize all whitespace characters in  space   invaders
- ✔ Visualize all whitespace characters in 	indent, space and \n
+ ✔ Visualize all emptyspace characters in no-spaces
+ ✔ Visualize all emptyspace characters in  space   invaders
+ ✔ Visualize all emptyspace characters in 	indent, space and \n
 \r
- ✔ Visualize whitespace but ignore EOL
+ ✔ Visualize emptyspace but ignore EOL
  ✔ Prettify unnamed dataprovider with data set #0
  ✔ Prettify unnamed dataprovider with data set #1
  ✔ Prettify named dataprovider with data set "one"

--- a/tests/unit/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/unit/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -87,7 +87,7 @@ final class StringMatchesFormatDescriptionTest extends ConstraintTestCase
         $this->assertCount(1, $constraint);
     }
 
-    public function testConstraintStringMatchesWhitespace(): void
+    public function testConstraintStringMatchesEmptyspace(): void
     {
         $constraint = new StringMatchesFormatDescription('*%w*');
 

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -46,21 +46,21 @@ final class ColorTest extends TestCase
     }
 
     /**
-     * @testdox Visualize all whitespace characters in $actual
-     * @dataProvider whitespacedStringProvider
+     * @testdox Visualize all emptyspace characters in $actual
+     * @dataProvider emptyspacedStringProvider
      */
-    public function testVisibleWhitespace(string $actual, string $expected): void
+    public function testVisibleEmptyspace(string $actual, string $expected): void
     {
-        $this->assertSame($expected, Color::visualizeWhitespace($actual, true));
+        $this->assertSame($expected, Color::visualizeEmptyspace($actual, true));
     }
 
     /**
-     * @testdox Visualize whitespace but ignore EOL
+     * @testdox Visualize emptyspace but ignore EOL
      */
-    public function testVisibleWhitespaceWithoutEOL(): void
+    public function testVisibleEmptyspaceWithoutEOL(): void
     {
         $string = "line1\nline2\n";
-        $this->assertSame($string, Color::visualizeWhitespace($string, false));
+        $this->assertSame($string, Color::visualizeEmptyspace($string, false));
     }
 
     /**
@@ -138,7 +138,7 @@ final class ColorTest extends TestCase
         ];
     }
 
-    public function whitespacedStringProvider(): array
+    public function emptyspacedStringProvider(): array
     {
         return [
             ['no-spaces',

--- a/tests/unit/Util/TestClassTest.php
+++ b/tests/unit/Util/TestClassTest.php
@@ -595,7 +595,7 @@ final class TestClassTest extends TestCase
                 ],
             ],
             [
-                'testVersionConstraintRegexpIgnoresWhitespace',
+                'testVersionConstraintRegexpIgnoresEmptyspace',
                 [
                     'PHP' => [
                         'constraint' => '~5.6.22 || ~7.0.17',
@@ -1244,12 +1244,12 @@ final class TestClassTest extends TestCase
         );
     }
 
-    public function testFunctionParenthesesAreAllowedWithWhitespace(): void
+    public function testFunctionParenthesesAreAllowedWithEmptyspace(): void
     {
         $this->assertSame(
             [TEST_FILES_PATH . 'CoveredFunction.php' => \range(10, 12)],
             Test::getLinesToBeCovered(
-                'CoverageFunctionParenthesesWhitespaceTest',
+                'CoverageFunctionParenthesesEmptyspaceTest',
                 'testSomething'
             )
         );
@@ -1266,12 +1266,12 @@ final class TestClassTest extends TestCase
         );
     }
 
-    public function testMethodParenthesesAreAllowedWithWhitespace(): void
+    public function testMethodParenthesesAreAllowedWithEmptyspace(): void
     {
         $this->assertSame(
             [TEST_FILES_PATH . 'CoveredClass.php' => \range(29, 33)],
             Test::getLinesToBeCovered(
-                'CoverageMethodParenthesesWhitespaceTest',
+                'CoverageMethodParenthesesEmptyspaceTest',
                 'testSomething'
             )
         );


### PR DESCRIPTION
Following https://github.com/sebastianbergmann/phpunit/commit/8e9c76d33dab4095c9066072076f368193e4166d, `whitespace` might be considered as an offensive terminology and we should replace it with more appropriate word.