### PR TITLE
Support Xdebug 3

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -53,6 +53,7 @@ final class PhptTestCase implements SelfDescribing, Test
         'report_zend_debug=0',
         'safe_mode=0',
         'xdebug.default_enable=0',
+        'xdebug.mode=off',
     ];
 
     /**

--- a/tests/_files/FatalTest.php
+++ b/tests/_files/FatalTest.php
@@ -13,7 +13,7 @@ class FatalTest extends TestCase
 {
     public function testFatalError(): void
     {
-        if (\extension_loaded('xdebug')) {
+        if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '<')) {
             \xdebug_disable();
         }
 

--- a/tests/end-to-end/regression/GitHub/873/Issue873Test.php
+++ b/tests/end-to-end/regression/GitHub/873/Issue873Test.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-if (\extension_loaded('xdebug')) {
+if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', '<')) {
     \xdebug_disable();
 }
 


### PR DESCRIPTION
This makes PHPUnit's (end-to-end) test suite run with the current development version of Xdebug.