### PR TITLE
Mark TestCase::$backupGlobals as nullable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -60,7 +60,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     private const LOCALE_CATEGORIES = [\LC_ALL, \LC_COLLATE, \LC_CTYPE, \LC_MONETARY, \LC_NUMERIC, \LC_TIME];
 
     /**
-     * @var bool
+     * @var null|bool
      */
     protected $backupGlobals;
 


### PR DESCRIPTION
`TestCase::$backupGlobals` is a nullable boolean: https://github.com/sebastianbergmann/phpunit/blob/a4baf33f0c2cffb6de207cd4ed95be3bb8193103/src/Framework/TestCase.php#L1200

Fixes https://github.com/sebastianbergmann/phpunit/issues/4307.