### PR TITLE
Make InvocationMocker part of the public API

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -26,9 +26,6 @@ use PHPUnit\Framework\MockObject\Stub\ReturnStub;
 use PHPUnit\Framework\MockObject\Stub\ReturnValueMap;
 use PHPUnit\Framework\MockObject\Stub\Stub;
 
-/**
- * @internal This class is not covered by the backward compatibility promise for PHPUnit
- */
 final class InvocationMocker implements InvocationStubber, MethodNameMatch
 {
     /**


### PR DESCRIPTION
The `InvocationMocker` interface is exposed to the userland via `MockObject::expects()`:
https://github.com/sebastianbergmann/phpunit/blob/7f664ffd558ba68031963f63d3e23a951ba441fc/src/Framework/MockObject/MockObject.php#L24

According to #3236, the `@internal` annotation should be removed.

Fixes #4309.