### PR TITLE
Add option to exit with exit code 1 when no tests are executed

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -228,6 +228,7 @@
         <xs:attribute name="stopOnIncomplete" type="xs:boolean" default="false"/>
         <xs:attribute name="stopOnRisky" type="xs:boolean" default="false"/>
         <xs:attribute name="stopOnSkipped" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnEmptyTestSuite" type="xs:boolean" default="false"/>
         <xs:attribute name="failOnIncomplete" type="xs:boolean" default="false"/>
         <xs:attribute name="failOnRisky" type="xs:boolean" default="false"/>
         <xs:attribute name="failOnSkipped" type="xs:boolean" default="false"/>

--- a/src/TextUI/CliArguments/Builder.php
+++ b/src/TextUI/CliArguments/Builder.php
@@ -91,6 +91,7 @@ final class Builder
         'stop-on-incomplete',
         'stop-on-risky',
         'stop-on-skipped',
+        'fail-on-empty-test-suite',
         'fail-on-warning',
         'fail-on-risky',
         'strict-coverage',
@@ -162,6 +163,7 @@ final class Builder
         $executionOrderDefects                      = null;
         $extensions                                 = [];
         $unavailableExtensions                      = [];
+        $failOnEmptyTestSuite                       = null;
         $failOnIncomplete                           = null;
         $failOnRisky                                = null;
         $failOnSkipped                              = null;
@@ -496,6 +498,11 @@ final class Builder
 
                     break;
 
+                case '--fail-on-empty-test-suite':
+                    $failOnEmptyTestSuite = true;
+
+                    break;
+
                 case '--fail-on-incomplete':
                     $failOnIncomplete = true;
 
@@ -764,6 +771,7 @@ final class Builder
             $executionOrderDefects,
             $extensions,
             $unavailableExtensions,
+            $failOnEmptyTestSuite,
             $failOnIncomplete,
             $failOnRisky,
             $failOnSkipped,

--- a/src/TextUI/CliArguments/Configuration.php
+++ b/src/TextUI/CliArguments/Configuration.php
@@ -185,6 +185,11 @@ final class Configuration
     /**
      * @var ?bool
      */
+    private $failOnEmptyTestSuite;
+
+    /**
+     * @var ?bool
+     */
     private $failOnIncomplete;
 
     /**
@@ -435,7 +440,7 @@ final class Configuration
     /**
      * @param null|int|string $columns
      */
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?array $groups, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?string $loader, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $xdebugFilterFile)
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?array $groups, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?string $loader, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $xdebugFilterFile)
     {
         $this->argument                                   = $argument;
         $this->atLeastVersion                             = $atLeastVersion;
@@ -470,6 +475,7 @@ final class Configuration
         $this->executionOrderDefects                      = $executionOrderDefects;
         $this->extensions                                 = $extensions;
         $this->unavailableExtensions                      = $unavailableExtensions;
+        $this->failOnEmptyTestSuite                       = $failOnEmptyTestSuite;
         $this->failOnIncomplete                           = $failOnIncomplete;
         $this->failOnRisky                                = $failOnRisky;
         $this->failOnSkipped                              = $failOnSkipped;
@@ -954,6 +960,20 @@ final class Configuration
         }
 
         return $this->executionOrderDefects;
+    }
+
+    public function hasFailOnEmptyTestSuite(): bool
+    {
+        return $this->failOnEmptyTestSuite !== null;
+    }
+
+    public function failOnEmptyTestSuite(): bool
+    {
+        if ($this->failOnEmptyTestSuite === null) {
+            throw new Exception;
+        }
+
+        return $this->failOnEmptyTestSuite;
     }
 
     public function hasFailOnIncomplete(): bool

--- a/src/TextUI/CliArguments/Mapper.php
+++ b/src/TextUI/CliArguments/Mapper.php
@@ -209,6 +209,10 @@ final class Mapper
             $result['stopOnSkipped'] = $arguments->stopOnSkipped();
         }
 
+        if ($arguments->hasFailOnEmptyTestSuite()) {
+            $result['failOnEmptyTestSuite'] = $arguments->failOnEmptyTestSuite();
+        }
+
         if ($arguments->hasFailOnIncomplete()) {
             $result['failOnIncomplete'] = $arguments->failOnIncomplete();
         }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -15,6 +15,7 @@ use const PHP_VERSION;
 use function array_diff;
 use function assert;
 use function class_exists;
+use function count;
 use function dirname;
 use function file_put_contents;
 use function htmlspecialchars;
@@ -804,6 +805,10 @@ final class TestRunner extends BaseTestRunner
         }
 
         if ($exit) {
+            if (isset($arguments['failOnEmptyTestSuite']) && $arguments['failOnEmptyTestSuite'] === true && count($result) === 0) {
+                exit(self::FAILURE_EXIT);
+            }
+
             if ($result->wasSuccessfulIgnoringWarnings()) {
                 if ($arguments['failOnRisky'] && !$result->allHarmless()) {
                     exit(self::FAILURE_EXIT);
@@ -959,6 +964,7 @@ final class TestRunner extends BaseTestRunner
             $arguments['stopOnIncomplete']                                = $arguments['stopOnIncomplete'] ?? $phpunitConfiguration->stopOnIncomplete();
             $arguments['stopOnRisky']                                     = $arguments['stopOnRisky'] ?? $phpunitConfiguration->stopOnRisky();
             $arguments['stopOnSkipped']                                   = $arguments['stopOnSkipped'] ?? $phpunitConfiguration->stopOnSkipped();
+            $arguments['failOnEmptyTestSuite']                            = $arguments['failOnEmptyTestSuite'] ?? $phpunitConfiguration->failOnEmptyTestSuite();
             $arguments['failOnIncomplete']                                = $arguments['failOnIncomplete'] ?? $phpunitConfiguration->failOnIncomplete();
             $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? $phpunitConfiguration->failOnRisky();
             $arguments['failOnSkipped']                                   = $arguments['failOnSkipped'] ?? $phpunitConfiguration->failOnSkipped();

--- a/src/TextUI/XmlConfiguration/Loader.php
+++ b/src/TextUI/XmlConfiguration/Loader.php
@@ -1027,6 +1027,7 @@ final class Loader
             $this->getBooleanAttribute($document->documentElement, 'forceCoversAnnotation', false),
             $bootstrap,
             $this->getBooleanAttribute($document->documentElement, 'processIsolation', false),
+            $this->getBooleanAttribute($document->documentElement, 'failOnEmptyTestSuite', false),
             $this->getBooleanAttribute($document->documentElement, 'failOnIncomplete', false),
             $this->getBooleanAttribute($document->documentElement, 'failOnRisky', false),
             $this->getBooleanAttribute($document->documentElement, 'failOnSkipped', false),

--- a/src/TextUI/XmlConfiguration/PHPUnit/PHPUnit.php
+++ b/src/TextUI/XmlConfiguration/PHPUnit/PHPUnit.php
@@ -93,6 +93,11 @@ final class PHPUnit
     /**
      * @var bool
      */
+    private $failOnEmptyTestSuite;
+
+    /**
+     * @var bool
+     */
     private $failOnIncomplete;
 
     /**
@@ -269,7 +274,7 @@ final class PHPUnit
      */
     private $conflictBetweenPrinterClassAndTestdox;
 
-    public function __construct(bool $cacheResult, ?string $cacheResultFile, $columns, string $colors, bool $stderr, bool $noInteraction, bool $verbose, bool $reverseDefectList, bool $convertDeprecationsToExceptions, bool $convertErrorsToExceptions, bool $convertNoticesToExceptions, bool $convertWarningsToExceptions, bool $forceCoversAnnotation, ?string $bootstrap, bool $processIsolation, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, ?string $extensionsDirectory, ?string $testSuiteLoaderClass, ?string $testSuiteLoaderFile, ?string $printerClass, ?string $printerFile, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutResourceUsageDuringSmallTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutTodoAnnotatedTests, bool $beStrictAboutCoversAnnotation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticAttributes, bool $registerMockObjectsFromTestArgumentsRecursively, bool $conflictBetweenPrinterClassAndTestdox)
+    public function __construct(bool $cacheResult, ?string $cacheResultFile, $columns, string $colors, bool $stderr, bool $noInteraction, bool $verbose, bool $reverseDefectList, bool $convertDeprecationsToExceptions, bool $convertErrorsToExceptions, bool $convertNoticesToExceptions, bool $convertWarningsToExceptions, bool $forceCoversAnnotation, ?string $bootstrap, bool $processIsolation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, ?string $extensionsDirectory, ?string $testSuiteLoaderClass, ?string $testSuiteLoaderFile, ?string $printerClass, ?string $printerFile, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutResourceUsageDuringSmallTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutTodoAnnotatedTests, bool $beStrictAboutCoversAnnotation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticAttributes, bool $registerMockObjectsFromTestArgumentsRecursively, bool $conflictBetweenPrinterClassAndTestdox)
     {
         $this->cacheResult                                     = $cacheResult;
         $this->cacheResultFile                                 = $cacheResultFile;
@@ -286,6 +291,7 @@ final class PHPUnit
         $this->forceCoversAnnotation                           = $forceCoversAnnotation;
         $this->bootstrap                                       = $bootstrap;
         $this->processIsolation                                = $processIsolation;
+        $this->failOnEmptyTestSuite                            = $failOnEmptyTestSuite;
         $this->failOnIncomplete                                = $failOnIncomplete;
         $this->failOnRisky                                     = $failOnRisky;
         $this->failOnSkipped                                   = $failOnSkipped;
@@ -420,6 +426,11 @@ final class PHPUnit
     public function processIsolation(): bool
     {
         return $this->processIsolation;
+    }
+
+    public function failOnEmptyTestSuite(): bool
+    {
+        return $this->failOnEmptyTestSuite;
     }
 
     public function failOnIncomplete(): bool

--- a/tests/unit/TextUI/XmlConfigurationTest.php
+++ b/tests/unit/TextUI/XmlConfigurationTest.php
@@ -127,6 +127,7 @@ final class XmlConfigurationTest extends TestCase
             'stopOnIncomplete'                                => ['stopOnIncomplete', 'true', true],
             'stopOnRisky'                                     => ['stopOnRisky', 'true', true],
             'stopOnSkipped'                                   => ['stopOnSkipped', 'true', true],
+            'failOnEmptyTestSuite'                            => ['failOnEmptyTestSuite', 'true', true],
             'failOnWarning'                                   => ['failOnWarning', 'true', true],
             'failOnRisky'                                     => ['failOnRisky', 'true', true],
             'processIsolation'                                => ['processIsolation', 'true', true],
@@ -648,6 +649,7 @@ final class XmlConfigurationTest extends TestCase
         $this->assertSame(60, $phpunit->timeoutForLargeTests());
         $this->assertFalse($phpunit->beStrictAboutResourceUsageDuringSmallTests());
         $this->assertFalse($phpunit->beStrictAboutTodoAnnotatedTests());
+        $this->assertFalse($phpunit->failOnEmptyTestSuite());
         $this->assertFalse($phpunit->failOnIncomplete());
         $this->assertFalse($phpunit->failOnRisky());
         $this->assertFalse($phpunit->failOnSkipped());


### PR DESCRIPTION
This PR

* [x] adds a `failOnEmptyTestSuite` option which - when set - will fail a test run when no tests were found

Fixes #4313.

💁‍♂️ I have tried adding an end-to-end test, but I'm unsure how to assert the exit code from a `.phpt` test. Is that even possible?

### Disabled

![Screen Shot 2020-06-23 at 21 28 56](https://user-images.githubusercontent.com/605483/85450009-a5d3d080-b598-11ea-8c55-7e66e6755924.png)

### Enabled

![Screen Shot 2020-06-23 at 21 29 21](https://user-images.githubusercontent.com/605483/85450025-a8cec100-b598-11ea-87af-b86b86c50711.png)

