### PR TITLE
Ignore the .phive directory and not the phive.xml file for an export.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,11 @@
 /.docker        export-ignore
 /.editorconfig  export-ignore
 /.github        export-ignore
+/.phive         export-ignore
 /.psalm         export-ignore
 /.php_cs.dist   export-ignore
 /build          export-ignore
 /build.xml      export-ignore
-/phive.xml      export-ignore
 /phpunit.xml    export-ignore
 /tests          export-ignore
 /tools          export-ignore


### PR DESCRIPTION
While searching for an example about the use of the .gitattributes I found out that my composer install from PHPUnit has the .phive directory.

I see that it was moved in https://github.com/sebastianbergmann/phpunit/commit/442730038e7dd5bc375cdb875bce389a9c6846b9#diff-74378c63a5d351628d359c46d0d6759a so I suspected it is wanted to have it changed in the .gitattributes file.

Please tell me if its needed to be created on master and not on the 8.5 branch, then I will create a new PR to change that.