### PR TITLE
Enhancement: Enable self_static_accessor fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -182,6 +182,7 @@ return PhpCsFixer\Config::create()
         'return_assignment' => true,
         'return_type_declaration' => ['space_before' => 'none'],
         'self_accessor' => true,
+        'self_static_accessor' => true,
         'semicolon_after_instruction' => true,
         'set_type_to_cast' => true,
         'short_scalar_cast' => true,

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -34,7 +34,7 @@ final class GlobalState
      */
     public static function getIncludedFilesAsString(): string
     {
-        return static::processIncludedFilesAsString(\get_included_files());
+        return self::processIncludedFilesAsString(\get_included_files());
     }
 
     /**

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -153,7 +153,7 @@ final class Test
      */
     public static function getMissingRequirements(string $className, string $methodName): array
     {
-        $required = static::getRequirements($className, $methodName);
+        $required = self::getRequirements($className, $methodName);
         $missing  = [];
         $hint     = null;
 


### PR DESCRIPTION
This PR

* [x] enables the `self_static_accessor`
* [x] runs `php-cs-fixer fixer`

Not related to #4311.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.3#usage:

> **self_static_accessor**
>
>Inside a `final` class or anonymous class `self` should be preferred to `static`.
