### PR TITLE
Add compatibility with the InternalIterator change

### DIFF
--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -144,6 +144,11 @@ final class CountTest extends ConstraintTestCase
         $this->assertEquals(null, $generator->current());
     }
 
+    /**
+     * Since PHP8, Traversable cannot be implemented directly.
+     *
+     * @requires PHP < 8.0
+     */
     public function testCountTraversable(): void
     {
         $countConstraint = new Count(5);


### PR DESCRIPTION
There are no bundled classes extending `InternalIterator`, but now `Traversable` cannot be implemented directly and `DatePeriod` implements `IteratorAggregate`, so testing for it becomes moot.