### PR TITLE
Add support for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "prefer-stable": true,
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.3",
+        "php": "^7.3||^8.0",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
This will allow this library to be installed on PHP8 as well. Since all tests are ran on CI against PHP 8, I think this should be releasable.