### PR TITLE
Add InvocationResolver and use in ReturnValueMap

### DIFF
--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -55,6 +55,7 @@ use PHPUnit\Framework\Constraint\StringStartsWith;
 use PHPUnit\Framework\Constraint\TraversableContainsEqual;
 use PHPUnit\Framework\Constraint\TraversableContainsIdentical;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
+use PHPUnit\Framework\MockObject\InvocationResolver;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount as AnyInvokedCountMatcher;
 use PHPUnit\Framework\MockObject\Rule\InvokedAtIndex as InvokedAtIndexMatcher;
 use PHPUnit\Framework\MockObject\Rule\InvokedAtLeastCount as InvokedAtLeastCountMatcher;
@@ -2276,7 +2277,7 @@ function returnValue($value): ReturnStub
 
 function returnValueMap(array $valueMap): ReturnValueMapStub
 {
-    return new ReturnValueMapStub($valueMap);
+    return new ReturnValueMapStub($valueMap, new InvocationResolver(true));
 }
 
 function returnArgument(int $argumentIndex): ReturnArgumentStub

--- a/src/Framework/InvocationResolver.php
+++ b/src/Framework/InvocationResolver.php
@@ -26,7 +26,7 @@ class InvocationResolver // TODO: rename?
      *
      * @return mixed
      */
-    public function invocationDefaultResult(Invocation $invocation)
+    public function defaultResult(Invocation $invocation)
     {
         if (!$this->returnValueGeneration) {
             throw new InvocationNotExpectedException($invocation);

--- a/src/Framework/InvocationResolver.php
+++ b/src/Framework/InvocationResolver.php
@@ -22,9 +22,9 @@ class InvocationResolver // TODO: rename?
     }
 
     /**
-     * @param Invocation $invocation
-     * @return mixed
      * @throws RuntimeException
+     *
+     * @return mixed
      */
     public function invocationDefaultResult(Invocation $invocation)
     {

--- a/src/Framework/InvocationResolver.php
+++ b/src/Framework/InvocationResolver.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+class InvocationResolver // TODO: rename?
+{
+    /**
+     * @var bool
+     */
+    private $returnValueGeneration;
+
+    public function __construct(bool $returnValueGeneration)
+    {
+        $this->returnValueGeneration = $returnValueGeneration;
+    }
+
+    /**
+     * @param Invocation $invocation
+     * @return mixed
+     * @throws RuntimeException
+     */
+    public function invocationDefaultResult(Invocation $invocation)
+    {
+        if (!$this->returnValueGeneration) {
+            throw new InvocationNotExpectedException($invocation);
+        }
+
+        return $invocation->generateReturnValue();
+    }
+}

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -108,7 +108,7 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
 
     public function willReturnMap(array $valueMap): self
     {
-        $stub = new ReturnValueMap($valueMap);
+        $stub = new ReturnValueMap($valueMap, $this->invocationHandler->getInvocationResolver());
 
         return $this->will($stub);
     }

--- a/src/Framework/MockObject/Exception/InvocationNotExpectedException.php
+++ b/src/Framework/MockObject/Exception/InvocationNotExpectedException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use function sprintf;
+
+final class InvocationNotExpectedException extends \PHPUnit\Framework\Exception implements Exception // TODO: rename?
+{
+    public function __construct(Invocation $invocation)
+    {
+        parent::__construct(
+            sprintf(
+                'Return value inference disabled and no expectation set up for %s::%s()',
+                $invocation->getClassName(),
+                $invocation->getMethodName()
+            )
+        );
+    }
+}

--- a/src/Framework/MockObject/InvocationHandler.php
+++ b/src/Framework/MockObject/InvocationHandler.php
@@ -36,14 +36,14 @@ final class InvocationHandler
     private $configurableMethods;
 
     /**
-     * @var Throwable
-     */
-    private $deferredError;
-
-    /**
      * @var InvocationResolver
      */
     private $invocationResolver;
+
+    /**
+     * @var Throwable
+     */
+    private $deferredError;
 
     public function __construct(array $configurableMethods, bool $returnValueGeneration)
     {
@@ -142,7 +142,7 @@ final class InvocationHandler
         }
 
         try {
-            return $this->invocationResolver->invocationDefaultResult($invocation);
+            return $this->invocationResolver->defaultResult($invocation);
         } catch (InvocationNotExpectedException $exception) {
             if (strtolower($invocation->getMethodName()) === '__tostring') {
                 $this->deferredError = $exception;

--- a/src/Framework/MockObject/InvocationHandler.php
+++ b/src/Framework/MockObject/InvocationHandler.php
@@ -148,9 +148,9 @@ final class InvocationHandler
                 $this->deferredError = $exception;
 
                 return '';
-            } else {
-                throw $exception;
             }
+
+            throw $exception;
         }
     }
 

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -210,6 +210,8 @@ final class Matcher
             );
         }
 
+        // TODO: maybe better to implement `Stub::matches(Invocation)` and run here?
+
         return true;
     }
 

--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -13,6 +13,7 @@ use function array_pop;
 use function count;
 use function is_array;
 use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\InvocationResolver;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -24,9 +25,15 @@ final class ReturnValueMap implements Stub
      */
     private $valueMap;
 
-    public function __construct(array $valueMap)
+    /**
+     * @var InvocationResolver
+     */
+    private $invocationResolver;
+
+    public function __construct(array $valueMap, InvocationResolver $invocationResolver)
     {
-        $this->valueMap = $valueMap;
+        $this->valueMap           = $valueMap;
+        $this->invocationResolver = $invocationResolver;
     }
 
     public function invoke(Invocation $invocation)
@@ -44,6 +51,8 @@ final class ReturnValueMap implements Stub
                 return $return;
             }
         }
+
+        return $this->invocationResolver->invocationDefaultResult($invocation);
     }
 
     public function toString(): string

--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -52,7 +52,7 @@ final class ReturnValueMap implements Stub
             }
         }
 
-        return $this->invocationResolver->invocationDefaultResult($invocation);
+        return $this->invocationResolver->defaultResult($invocation);
     }
 
     public function toString(): string

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -72,6 +72,7 @@ use PHPUnit\Framework\Error\Error;
 use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\Error\Warning as WarningError;
 use PHPUnit\Framework\MockObject\Generator as MockGenerator;
+use PHPUnit\Framework\MockObject\InvocationResolver;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount as AnyInvokedCountMatcher;
@@ -424,7 +425,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
     public static function returnValueMap(array $valueMap): ReturnValueMapStub
     {
-        return new ReturnValueMapStub($valueMap);
+        return new ReturnValueMapStub($valueMap, new InvocationResolver(true));
     }
 
     public static function returnArgument(int $argumentIndex): ReturnArgumentStub

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -228,7 +228,21 @@ final class MockObjectTest extends TestCase
         $this->assertEquals('something', $mock->doSomething());
     }
 
-    public function testStubbedReturnValueMap(): void
+    /**
+     * @return array[]
+     */
+    public function returnValueGenerationProvider(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnValueGenerationProvider
+     */
+    public function testReturnValueMap(bool $returnValueGeneration): void
     {
         $map = [
             ['a', 'b', 'c', 'd'],
@@ -245,32 +259,30 @@ final class MockObjectTest extends TestCase
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
         $this->assertNull($mock->doSomething('foo', 'bar'));
 
-        $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+        if ($returnValueGeneration) {
+            $mock = $this->getMockBuilder(AnInterface::class) // TODO: call enableAutoReturnValueGeneration?
+                         ->getMock();
+        } else {
+            $mock = $this->getMockBuilder(AnInterface::class)
+                         ->disableAutoReturnValueGeneration()
+                         ->getMock();
+        }
 
         $mock->method('doSomething')
              ->willReturnMap($map);
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertNull($mock->doSomething('foo', 'bar'));
-    }
 
-    public function testStubbedNotReturnValueMap(): void
-    {
-        $mock = $this->getMockBuilder(AnInterface::class)
-                     ->disableAutoReturnValueGeneration()
-                     ->getMock();
-
-        $mock->method('doSomething')
-             ->willReturnMap([['a', 'b']]);
-
-        $this->expectException(InvocationNotExpectedException::class);
-        $this->expectExceptionMessage(
-            'Return value inference disabled and no expectation set up for PHPUnit\TestFixture\AnInterface::doSomething()'
-        );
-
-        $mock->doSomething('c');
+        if ($returnValueGeneration) {
+            $this->assertNull($mock->doSomething('foo', 'bar'));
+        } else {
+            $this->expectException(InvocationNotExpectedException::class);
+            $this->expectExceptionMessage(
+                'Return value inference disabled and no expectation set up for PHPUnit\TestFixture\AnInterface::doSomething()'
+            );
+            $mock->doSomething('foo', 'bar');
+        }
     }
 
     public function testStubbedReturnArgument(): void

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  */
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\InvocationNotExpectedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\AbstractTrait;
@@ -253,6 +254,23 @@ final class MockObjectTest extends TestCase
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
         $this->assertNull($mock->doSomething('foo', 'bar'));
+    }
+
+    public function testStubbedNotReturnValueMap(): void
+    {
+        $mock = $this->getMockBuilder(AnInterface::class)
+                     ->disableAutoReturnValueGeneration()
+                     ->getMock();
+
+        $mock->method('doSomething')
+             ->willReturnMap([['a', 'b']]);
+
+        $this->expectException(InvocationNotExpectedException::class);
+        $this->expectExceptionMessage(
+            'Return value inference disabled and no expectation set up for PHPUnit\TestFixture\AnInterface::doSomething()'
+        );
+
+        $mock->doSomething('c');
     }
 
     public function testStubbedReturnArgument(): void
@@ -1056,7 +1074,7 @@ final class MockObjectTest extends TestCase
             ->disableAutoReturnValueGeneration()
             ->getMock();
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvocationNotExpectedException::class);
         $this->expectExceptionMessage(
             'Return value inference disabled and no expectation set up for PHPUnit\TestFixture\SomeClass::doSomethingElse()'
         );
@@ -1076,7 +1094,7 @@ final class MockObjectTest extends TestCase
         try {
             $mock->__phpunit_verify();
             $this->fail('Exception expected');
-        } catch (RuntimeException $e) {
+        } catch (InvocationNotExpectedException $e) {
             $this->assertSame(
                 'Return value inference disabled and no expectation set up for PHPUnit\TestFixture\StringableClass::__toString()',
                 $e->getMessage()

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -242,7 +242,7 @@ final class MockObjectTest extends TestCase
     /**
      * @dataProvider returnValueGenerationProvider
      */
-    public function testReturnValueMap(bool $returnValueGeneration): void
+    public function testStubbedReturnValueMap(bool $returnValueGeneration): void
     {
         $map = [
             ['a', 'b', 'c', 'd'],


### PR DESCRIPTION
I'd like to use strict mode in my tests: if a mock called method, that I didn't mock (or didn't think of, or method was added after the test was written), test should fail. For that I use `MockBuilder::disableAutoReturnValueGeneration`.
But `ReturnValueMap` breaks this constraint - if arguments list didn't match to any of mocked, method just silently returns `null`. With this PR I'm trying to fix it.