### PR TITLE
Add InvocationResolver and use in ReturnValueMap

### DIFF
--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -50,6 +50,7 @@ use PHPUnit\Framework\Constraint\TraversableContainsEqual;
 use PHPUnit\Framework\Constraint\TraversableContainsIdentical;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\InvocationResolver;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount as AnyInvokedCountMatcher;
 use PHPUnit\Framework\MockObject\Rule\InvokedAtIndex as InvokedAtIndexMatcher;
 use PHPUnit\Framework\MockObject\Rule\InvokedAtLeastCount as InvokedAtLeastCountMatcher;
@@ -2561,7 +2562,7 @@ function returnValue($value): ReturnStub
 
 function returnValueMap(array $valueMap): ReturnValueMapStub
 {
-    return new ReturnValueMapStub($valueMap);
+    return new ReturnValueMapStub($valueMap, new InvocationResolver(true));
 }
 
 function returnArgument(int $argumentIndex): ReturnArgumentStub

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -97,7 +97,7 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
 
     public function willReturnMap(array $valueMap): self
     {
-        $stub = new ReturnValueMap($valueMap);
+        $stub = new ReturnValueMap($valueMap, $this->invocationHandler->getInvocationResolver());
 
         return $this->will($stub);
     }

--- a/src/Framework/MockObject/Exception/InvocationNotExpectedException.php
+++ b/src/Framework/MockObject/Exception/InvocationNotExpectedException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use function sprintf;
+
+final class InvocationNotExpectedException extends \PHPUnit\Framework\Exception implements Exception
+{
+    public function __construct(Invocation $invocation)
+    {
+        parent::__construct(
+            sprintf(
+                'Return value inference disabled and no expectation set up for %s::%s()',
+                $invocation->getClassName(),
+                $invocation->getMethodName()
+            )
+        );
+    }
+}

--- a/src/Framework/MockObject/InvocationResolver.php
+++ b/src/Framework/MockObject/InvocationResolver.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+class InvocationResolver
+{
+    /**
+     * @var bool
+     */
+    private $returnValueGeneration;
+
+    public function __construct(bool $returnValueGeneration)
+    {
+        $this->returnValueGeneration = $returnValueGeneration;
+    }
+
+    /**
+     * @return mixed
+     * @throws RuntimeException
+     *
+     */
+    public function defaultResult(Invocation $invocation)
+    {
+        if (!$this->returnValueGeneration) {
+            throw new InvocationNotExpectedException($invocation);
+        }
+
+        return $invocation->generateReturnValue();
+    }
+}

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -206,6 +206,8 @@ final class Matcher
             );
         }
 
+        // TODO: maybe better to implement `Stub::matches(Invocation)` and run here?
+
         return true;
     }
 

--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Framework\MockObject\Stub;
 
 use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\InvocationResolver;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -21,9 +22,15 @@ final class ReturnValueMap implements Stub
      */
     private $valueMap;
 
-    public function __construct(array $valueMap)
+    /**
+     * @var InvocationResolver
+     */
+    private $invocationResolver;
+
+    public function __construct(array $valueMap, InvocationResolver $invocationResolver)
     {
-        $this->valueMap = $valueMap;
+        $this->valueMap           = $valueMap;
+        $this->invocationResolver = $invocationResolver;
     }
 
     public function invoke(Invocation $invocation)
@@ -41,6 +48,8 @@ final class ReturnValueMap implements Stub
                 return $return;
             }
         }
+
+        return $this->invocationResolver->defaultResult($invocation);
     }
 
     public function toString(): string

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Error\Error;
 use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\Error\Warning as WarningError;
 use PHPUnit\Framework\MockObject\Generator as MockGenerator;
+use PHPUnit\Framework\MockObject\InvocationResolver;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount as AnyInvokedCountMatcher;
@@ -352,7 +353,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
     public static function returnValueMap(array $valueMap): ReturnValueMapStub
     {
-        return new ReturnValueMapStub($valueMap);
+        return new ReturnValueMapStub($valueMap, new InvocationResolver(true));
     }
 
     public static function returnArgument(int $argumentIndex): ReturnArgumentStub


### PR DESCRIPTION
I'd like to use strict mode in my tests: if a mock called method, that I didn't mock (or didn't think of, or method was added after the test was written), test should fail. For that I use MockBuilder::disableAutoReturnValueGeneration.
But ReturnValueMap breaks this constraint - if arguments list didn't match to any of mocked, method just silently returns null. With this PR I'm trying to fix it.