### PR TITLE
Enhancement: Enable explicit_implicit_variable fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -66,6 +66,7 @@ return PhpCsFixer\Config::create()
         'dir_constant' => true,
         'elseif' => true,
         'encoding' => true,
+        'explicit_indirect_variable' => true,
         'full_opening_tag' => true,
         'function_declaration' => true,
         'header_comment' => ['header' => $header, 'separate' => 'none'],

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -3436,7 +3436,7 @@ abstract class Assert
                 $attribute = $reflector->getProperty($attributeName);
 
                 if (!$attribute || $attribute->isPublic()) {
-                    return $object->$attributeName;
+                    return $object->{$attributeName};
                 }
 
                 $attribute->setAccessible(true);

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1020,7 +1020,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
             if ($this->inIsolation) {
                 foreach ($hookMethods['beforeClass'] as $method) {
-                    $this->$method();
+                    $this->{$method}();
                 }
             }
 
@@ -1028,7 +1028,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
             $this->setDoesNotPerformAssertionsFromAnnotation();
 
             foreach ($hookMethods['before'] as $method) {
-                $this->$method();
+                $this->{$method}();
             }
 
             $this->assertPreConditions();
@@ -1075,12 +1075,12 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
         try {
             if ($hasMetRequirements) {
                 foreach ($hookMethods['after'] as $method) {
-                    $this->$method();
+                    $this->{$method}();
                 }
 
                 if ($this->inIsolation) {
                     foreach ($hookMethods['afterClass'] as $method) {
-                        $this->$method();
+                        $this->{$method}();
                     }
                 }
             }

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -301,7 +301,7 @@ final class TestResult implements Countable
         }
 
         foreach ($this->listeners as $listener) {
-            $listener->$notifyMethod($test, $t, $time);
+            $listener->{$notifyMethod}($test, $t, $time);
         }
 
         $this->lastTestFailed = true;
@@ -368,7 +368,7 @@ final class TestResult implements Countable
         }
 
         foreach ($this->listeners as $listener) {
-            $listener->$notifyMethod($test, $e, $time);
+            $listener->{$notifyMethod}($test, $e, $time);
         }
 
         $this->lastTestFailed = true;

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -773,7 +773,7 @@ class Command
                     }
 
                     if (isset($handler) && \is_callable([$this, $handler])) {
-                        $this->$handler($option[1]);
+                        $this->{$handler}($option[1]);
                     }
             }
         }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -693,9 +693,9 @@ final class Test
                     }
 
                     foreach ($methods as $method) {
-                        if ($inverse && !$method->$visibility()) {
+                        if ($inverse && !$method->{$visibility}()) {
                             $codeToCoverList[] = $method;
-                        } elseif (!$inverse && $method->$visibility()) {
+                        } elseif (!$inverse && $method->{$visibility}()) {
                             $codeToCoverList[] = $method;
                         }
                     }


### PR DESCRIPTION
This PR

* [x] enables the `explicit_implicit_variable` fixer
* [x] runs `php-cs-fixer`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**explicit_indirect_variable** [`@PhpCsFixer`]
>
>Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.