### PR TITLE
Fix: Run commands through PHP binary to ensure they are run on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,17 +141,17 @@ jobs:
 
       - name: Install lowest dependencies with composer
         if: matrix.dependencies == 'lowest'
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress --prefer-lowest
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress --prefer-lowest
 
       - name: Install highest dependencies with composer
         if: matrix.dependencies == 'highest'
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run sanity check
         run: bash ./build/scripts/sanity-check
 
       - name: Run tests with phpunit
-        run: ./phpunit --coverage-clover=coverage.xml
+        run: php ./phpunit --coverage-clover=coverage.xml
 
       - name: Send code coverage report to Codecov.io
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
           - highest
 
     steps:
+      - name: Configure git to avoid issues with line endings
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.autocrlf false
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -646,6 +646,10 @@ XML;
 
     public function testAssertFileIsNotReadable(): void
     {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            self::markTestSkipped('Cannot test this behaviour on Windows');
+        }
+
         $tempFile = \tempnam(
             \sys_get_temp_dir(),
             'unreadable'

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -19,7 +19,7 @@ final class XDebugFilterScriptGeneratorTest extends TestCase
 {
     public function testReturnsExpectedScript(): void
     {
-        $expectedDirectory = __DIR__ . \DIRECTORY_SEPARATOR;
+        $expectedDirectory = \sprintf(\addslashes('%s' . \DIRECTORY_SEPARATOR), __DIR__);
         $expected          = <<<EOF
 <?php declare(strict_types=1);
 if (!\\function_exists('xdebug_set_filter')) {


### PR DESCRIPTION
This PR

* [x] explicitly runs commands through PHP binary to ensure they are run on `windows-latest`
* [x] configures `git` to avoid issues with line endings when running tests on `windows-latest`
* [x] adds slashes
* [x] skips a test related to file permissions on Windows

Fixes #4333.