### PR TITLE
Enhancement: Enable explicit_string_variable fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -67,6 +67,7 @@ return PhpCsFixer\Config::create()
         'elseif' => true,
         'encoding' => true,
         'explicit_indirect_variable' => true,
+        'explicit_string_variable' => true,
         'full_opening_tag' => true,
         'function_declaration' => true,
         'header_comment' => ['header' => $header, 'separate' => 'none'],

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -183,7 +183,7 @@
       <code>$className</code>
     </ArgumentTypeCoercion>
     <PossiblyUndefinedVariable occurrences="1">
-      <code>$afterClassMethod</code>
+      <code>${afterClassMethod}</code>
     </PossiblyUndefinedVariable>
   </file>
   <file src="src/Runner/PhptTestCase.php">

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -193,7 +193,7 @@ final class MockMethod
         $deprecation = $this->deprecation;
 
         if (null !== $this->deprecation) {
-            $deprecation         = "The $this->className::$this->methodName method is deprecated ($this->deprecation).";
+            $deprecation         = "The {$this->className}::{$this->methodName} method is deprecated ({$this->deprecation}).";
             $deprecationTemplate = $this->getTemplate('deprecation.tpl');
 
             $deprecationTemplate->setVar([

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -606,7 +606,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
                 }
             }
         } catch (\Throwable $t) {
-            $message = "Exception in {$this->name}::$afterClassMethod" . \PHP_EOL . $t->getMessage();
+            $message = "Exception in {$this->name}::${afterClassMethod}" . \PHP_EOL . $t->getMessage();
             $error   = new SyntheticError($message, 0, $t->getFile(), $t->getLine(), $t->getTrace());
 
             $placeholderTest = clone $test;

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -447,7 +447,7 @@ final class PhptTestCase implements SelfDescribing, Test
         foreach ($unsupportedSections as $section) {
             if (isset($sections[$section])) {
                 throw new Exception(
-                    "PHPUnit does not support PHPT $section sections"
+                    "PHPUnit does not support PHPT ${section} sections"
                 );
             }
         }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -1325,7 +1325,7 @@ class Command
                     break;
 
                 default:
-                    $this->exitWithErrorMessage("unrecognized --order-by option: $order");
+                    $this->exitWithErrorMessage("unrecognized --order-by option: ${order}");
             }
         }
     }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -182,7 +182,7 @@ final class Help
     private function writePlaintext(): void
     {
         foreach (self::HELP_TEXT as $section => $options) {
-            print "$section:" . \PHP_EOL;
+            print "${section}:" . \PHP_EOL;
 
             if ($section !== 'Usage') {
                 print \PHP_EOL;
@@ -210,7 +210,7 @@ final class Help
     private function writeWithColor(): void
     {
         foreach (self::HELP_TEXT as $section => $options) {
-            print Color::colorize('fg-yellow', "$section:") . \PHP_EOL;
+            print Color::colorize('fg-yellow', "${section}:") . \PHP_EOL;
 
             foreach ($options as $option) {
                 if (isset($option['spacer'])) {

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -118,7 +118,7 @@ final class Color
             return $buffer;
         }
 
-        return "\e[2m$buffer\e[22m";
+        return "\e[2m${buffer}\e[22m";
     }
 
     public static function visualizeWhitespace(string $buffer, bool $visualizeEOL = false): string

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -94,7 +94,7 @@ final class Getopt
 
             if ($arg[$i] === ':' || ($spec = \strstr($short_options, $opt)) === false) {
                 throw new Exception(
-                    "unrecognized option -- $opt"
+                    "unrecognized option -- ${opt}"
                 );
             }
 
@@ -109,7 +109,7 @@ final class Getopt
                     /* @noinspection ComparisonOperandsOrderInspection */
                     if (false === $opt_arg = \current($args)) {
                         throw new Exception(
-                            "option requires an argument -- $opt"
+                            "option requires an argument -- ${opt}"
                         );
                     }
 
@@ -148,7 +148,7 @@ final class Getopt
 
             if ($opt_rest !== '' && $i + 1 < $count && $opt[0] !== '=' && \strpos($long_options[$i + 1], $opt) === 0) {
                 throw new Exception(
-                    "option --$opt is ambiguous"
+                    "option --${opt} is ambiguous"
                 );
             }
 
@@ -158,7 +158,7 @@ final class Getopt
                     /* @noinspection ComparisonOperandsOrderInspection */
                     if (false === $opt_arg = \current($args)) {
                         throw new Exception(
-                            "option --$opt requires an argument"
+                            "option --${opt} requires an argument"
                         );
                     }
 
@@ -166,7 +166,7 @@ final class Getopt
                 }
             } elseif ($opt_arg) {
                 throw new Exception(
-                    "option --$opt doesn't allow an argument"
+                    "option --${opt} doesn't allow an argument"
                 );
             }
 
@@ -176,6 +176,6 @@ final class Getopt
             return;
         }
 
-        throw new Exception("unrecognized option --$opt");
+        throw new Exception("unrecognized option --${opt}");
     }
 }

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -198,13 +198,13 @@ final class TeamCity extends ResultPrinter
 
         if (\class_exists($suiteName, false)) {
             $fileName                   = self::getFileName($suiteName);
-            $parameters['locationHint'] = "php_qn://$fileName::\\$suiteName";
+            $parameters['locationHint'] = "php_qn://${fileName}::\\${suiteName}";
         } else {
             $split = \explode('::', $suiteName);
 
             if (\count($split) === 2 && \class_exists($split[0]) && \method_exists($split[0], $split[1])) {
                 $fileName                   = self::getFileName($split[0]);
-                $parameters['locationHint'] = "php_qn://$fileName::\\$suiteName";
+                $parameters['locationHint'] = "php_qn://${fileName}::\\${suiteName}";
                 $parameters['name']         = $split[1];
             }
         }
@@ -248,7 +248,7 @@ final class TeamCity extends ResultPrinter
         if ($test instanceof TestCase) {
             $className              = \get_class($test);
             $fileName               = self::getFileName($className);
-            $params['locationHint'] = "php_qn://$fileName::\\$className::$testName";
+            $params['locationHint'] = "php_qn://${fileName}::\\${className}::${testName}";
         }
 
         $this->printEvent('testStarted', $params);
@@ -276,7 +276,7 @@ final class TeamCity extends ResultPrinter
 
     private function printEvent(string $eventName, array $params = []): void
     {
-        $this->write("\n##teamcity[$eventName");
+        $this->write("\n##teamcity[${eventName}");
 
         if ($this->flowId) {
             $params['flowId'] = $this->flowId;
@@ -284,7 +284,7 @@ final class TeamCity extends ResultPrinter
 
         foreach ($params as $key => $value) {
             $escapedValue = self::escapeValue((string) $value);
-            $this->write(" $key='$escapedValue'");
+            $this->write(" ${key}='${escapedValue}'");
         }
 
         $this->write("]\n");

--- a/src/Util/XdebugFilterScriptGenerator.php
+++ b/src/Util/XdebugFilterScriptGenerator.php
@@ -40,7 +40,7 @@ if (!\\function_exists('xdebug_set_filter')) {
     \\XDEBUG_FILTER_CODE_COVERAGE,
     \\XDEBUG_PATH_WHITELIST,
     [
-$files
+${files}
     ]
 );
 

--- a/tests/_files/ExceptionStackTest.php
+++ b/tests/_files/ExceptionStackTest.php
@@ -19,7 +19,7 @@ class ExceptionStackTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $message = $e->getMessage() . $e->getComparisonFailure()->getDiff();
 
-            throw new PHPUnit\Framework\Exception("Child exception\n$message", 101, $e);
+            throw new PHPUnit\Framework\Exception("Child exception\n${message}", 101, $e);
         }
     }
 

--- a/tests/end-to-end/cli/_files/MyCommand.php
+++ b/tests/end-to-end/cli/_files/MyCommand.php
@@ -19,6 +19,6 @@ class MyCommand extends Command
 
     public function myHandler($value): void
     {
-        print __METHOD__ . " $value\n";
+        print __METHOD__ . " ${value}\n";
     }
 }

--- a/tests/unit/Framework/Assert/FunctionsTest.php
+++ b/tests/unit/Framework/Assert/FunctionsTest.php
@@ -34,7 +34,7 @@ final class FunctionsTest extends TestCase
         Assert::assertContains(
             $methodName,
             self::$globalAssertionFunctions,
-            "Mapping for Assert::$methodName is missing in Functions.php"
+            "Mapping for Assert::${methodName} is missing in Functions.php"
         );
     }
 

--- a/tests/unit/Framework/Constraint/DirectoryExistsTest.php
+++ b/tests/unit/Framework/Constraint/DirectoryExistsTest.php
@@ -54,7 +54,7 @@ final class DirectoryExistsTest extends ConstraintTestCase
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
                 <<<PHP
-Failed asserting that directory "$directory" exists.
+Failed asserting that directory "${directory}" exists.
 
 PHP
                 ,

--- a/tests/unit/Framework/Constraint/IsEqualTest.php
+++ b/tests/unit/Framework/Constraint/IsEqualTest.php
@@ -55,7 +55,7 @@ EOF
             $constraint->evaluate($actual, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                "custom message\n$message",
+                "custom message\n${message}",
                 $this->trimnl(TestFailure::exceptionToString($e))
             );
 
@@ -297,17 +297,17 @@ Failed asserting that two objects are equal.
 --- Expected
 +++ Actual
 @@ @@
--SplObjectStorage Object &$storage1hash (
--    '$ahash' => Array &0 (
--        'obj' => stdClass Object &$ahash (
+-SplObjectStorage Object &${storage1hash} (
+-    '${ahash}' => Array &0 (
+-        'obj' => stdClass Object &${ahash} (
 -            'foo' => 'bar'
 -        )
 -        'inf' => null
 -    )
--    '$bhash' => Array &1 (
-+SplObjectStorage Object &$storage2hash (
-+    '$bhash' => Array &0 (
-         'obj' => stdClass Object &$bhash ()
+-    '${bhash}' => Array &1 (
++SplObjectStorage Object &${storage2hash} (
++    '${bhash}' => Array &0 (
+         'obj' => stdClass Object &${bhash} ()
          'inf' => null
      )
  )

--- a/tests/unit/Framework/Constraint/LogicalAndTest.php
+++ b/tests/unit/Framework/Constraint/LogicalAndTest.php
@@ -124,7 +124,7 @@ final class LogicalAndTest extends ConstraintTestCase
             $toString = $this->stringify($constraints);
 
             $expectedDescription = <<<EOF
-Failed asserting that '$other' $toString.
+Failed asserting that '${other}' ${toString}.
 
 EOF;
 
@@ -159,8 +159,8 @@ EOF;
             $toString = $this->stringify($constraints);
 
             $expectedDescription = <<<EOF
-$customDescription
-Failed asserting that '$other' $toString.
+${customDescription}
+Failed asserting that '${other}' ${toString}.
 
 EOF;
 

--- a/tests/unit/Framework/Constraint/LogicalOrTest.php
+++ b/tests/unit/Framework/Constraint/LogicalOrTest.php
@@ -117,7 +117,7 @@ final class LogicalOrTest extends ConstraintTestCase
             $toString = $this->stringify($constraints);
 
             $expectedDescription = <<<EOF
-Failed asserting that '$other' $toString.
+Failed asserting that '${other}' ${toString}.
 
 EOF;
 
@@ -152,8 +152,8 @@ EOF;
             $toString = $this->stringify($constraints);
 
             $expectedDescription = <<<EOF
-$customDescription
-Failed asserting that '$other' $toString.
+${customDescription}
+Failed asserting that '${other}' ${toString}.
 
 EOF;
 

--- a/tests/unit/Framework/ConstraintTest.php
+++ b/tests/unit/Framework/ConstraintTest.php
@@ -89,7 +89,7 @@ EOF
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
                 <<<EOF
-Failed asserting that file "$file" does not exist.
+Failed asserting that file "${file}" does not exist.
 
 EOF
                 ,
@@ -116,7 +116,7 @@ EOF
             $this->assertEquals(
                 <<<EOF
 custom message
-Failed asserting that file "$file" does not exist.
+Failed asserting that file "${file}" does not exist.
 
 EOF
                 ,
@@ -1414,7 +1414,7 @@ EOF
             $this->assertEquals(
                 <<<EOF
 Failed asserting that exception of type "DummyException" matches expected exception "FoobarException". Message was: "Test" at
-$stackTrace.
+${stackTrace}.
 
 EOF
                 ,

--- a/tests/unit/Util/ConfigurationTest.php
+++ b/tests/unit/Util/ConfigurationTest.php
@@ -103,7 +103,7 @@ final class ConfigurationTest extends TestCase
     public function testShouldParseXmlConfigurationRootAttributes(string $optionName, string $optionValue, $expected): void
     {
         $tmpFilename = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'phpunit.' . $optionName . \uniqid() . '.xml';
-        $xml         = "<phpunit $optionName='$optionValue'></phpunit>" . \PHP_EOL;
+        $xml         = "<phpunit ${optionName}='${optionValue}'></phpunit>" . \PHP_EOL;
         \file_put_contents($tmpFilename, $xml);
 
         $configurationInstance = Configuration::getInstance($tmpFilename);
@@ -448,7 +448,7 @@ final class ConfigurationTest extends TestCase
         if ($backupFoo === false) {
             \putenv('foo');     // delete variable from environment
         } else {
-            \putenv("foo=$backupFoo");
+            \putenv("foo=${backupFoo}");
         }
     }
 

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -30,9 +30,9 @@ if (!\\function_exists('xdebug_set_filter')) {
     \\XDEBUG_FILTER_CODE_COVERAGE,
     \\XDEBUG_PATH_WHITELIST,
     [
-        '$expectedDirectory',
-        '$expectedDirectory',
-        '$expectedDirectory',
+        '${expectedDirectory}',
+        '${expectedDirectory}',
+        '${expectedDirectory}',
         'src/foo.php',
         'src/bar.php'
     ]

--- a/tests/unit/Util/XmlTest.php
+++ b/tests/unit/Util/XmlTest.php
@@ -25,7 +25,7 @@ final class XmlTest extends TestCase
         $e = null;
 
         $escapedString = Xml::prepareString($char);
-        $xml           = "<?xml version='1.0' encoding='UTF-8' ?><tag>$escapedString</tag>";
+        $xml           = "<?xml version='1.0' encoding='UTF-8' ?><tag>${escapedString}</tag>";
         $dom           = new \DOMDocument('1.0', 'UTF-8');
 
         try {


### PR DESCRIPTION
This PR

* [x] enables the `explicit_string_variable` fixer
* [x] runs `php-cs-fixer`
* [x] regenerates the baseline for `psalm`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**explicit_string_variable** [`@PhpCsFixer`]
>
>Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.