### PR TITLE
Enhancement: Enable increment_style fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -75,6 +75,9 @@ return PhpCsFixer\Config::create()
         'full_opening_tag' => true,
         'function_declaration' => true,
         'header_comment' => ['header' => $header, 'separate' => 'none'],
+        'increment_style' => [
+            'style' => PhpCsFixer\Fixer\Operator\IncrementStyleFixer::STYLE_POST,
+        ],
         'indentation_type' => true,
         'is_null' => true,
         'line_ending' => true,

--- a/src/Framework/Constraint/Count.php
+++ b/src/Framework/Constraint/Count.php
@@ -98,7 +98,7 @@ class Count extends Constraint
     protected function getCountOfGenerator(Generator $generator): int
     {
         for ($count = 0; $generator->valid(); $generator->next()) {
-            ++$count;
+            $count++;
         }
 
         return $count;

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -545,7 +545,7 @@ final class DocBlock
         if (\preg_match_all('/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m', $docBlock, $matches)) {
             $numMatches = \count($matches[0]);
 
-            for ($i = 0; $i < $numMatches; ++$i) {
+            for ($i = 0; $i < $numMatches; $i++) {
                 $annotations[$matches['name'][$i]][] = (string) $matches['value'][$i];
             }
         }

--- a/tests/unit/Framework/Constraint/LogicalXorTest.php
+++ b/tests/unit/Framework/Constraint/LogicalXorTest.php
@@ -34,7 +34,7 @@ final class LogicalXorTest extends TestCase
                 ->with($this->identicalTo($other))
                 ->willReturn($count % 2 === 1);
 
-            ++$count;
+            $count++;
 
             return $constraint;
         }, \array_fill(0, $count, null));


### PR DESCRIPTION
This PR

* [x] enables the `increment_style` fixer
* [x] runs `php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**increment_style** [`@Symfony`, `@PhpCsFixer`]
>
>Pre- or post-increment and decrement operators should be used if possible.
>
>Configuration options:
>
>* `style` (`'post'`, `'pre'`): whether to use pre- or post-increment and decrement operators; defaults to `'pre'`
