### PR TITLE
Make ReturnValueMap fail when invoked arguments did not match the mocked ones

### DIFF
--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -80,6 +80,7 @@ final class ReturnValueMap implements Stub
         // just first map, if exists
         if ($map = $this->valueMap[0] ?? null) {
             \array_pop($map);
+
             return $map;
         }
 

--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -75,7 +75,7 @@ final class ReturnValueMap implements Stub
         );
     }
 
-    private function getExpectedArguments(): array
+    private function getExpectedArguments(): ?array
     {
         // just first map, if exists
         if ($map = $this->valueMap[0] ?? null) {
@@ -84,6 +84,6 @@ final class ReturnValueMap implements Stub
             return $map;
         }
 
-        return [];
+        return null;
     }
 }

--- a/src/Framework/MockObject/Stub/ReturnValueMap.php
+++ b/src/Framework/MockObject/Stub/ReturnValueMap.php
@@ -73,6 +73,7 @@ final class ReturnValueMap implements Stub
     private function getExpectedArguments(): array
     {
         $expectedArguments = [];
+
         foreach ($this->valueMap as $map) {
             \array_pop($map);
             $expectedArguments[] = $map;

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -258,7 +258,9 @@ final class MockObjectTest extends TestCase
         );
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('method arguments did not match to any of mocked');
+        $this->expectExceptionMessage(
+            'Arguments passed to AnInterface::doSomething were not expected by ReturnValueMap'
+        );
         $mock->doSomething('foo', 'bar');
     }
 

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -231,7 +231,6 @@ final class MockObjectTest extends TestCase
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertNull($mock->doSomething('foo', 'bar'));
 
         $mock = $this->getMockBuilder(AnInterface::class)
                      ->getMock();
@@ -242,7 +241,25 @@ final class MockObjectTest extends TestCase
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
-        $this->assertNull($mock->doSomething('foo', 'bar'));
+    }
+
+    public function testReturnValueMapNotMatchedThrowsException(): void
+    {
+        $mock = $this->createConfiguredMock(
+            AnInterface::class,
+            [
+                'doSomething' => self::returnValueMap(
+                    [
+                        ['a', 'b', 'c', 'd'],
+                        ['e', 'f', 'g', 'h'],
+                    ]
+                ),
+            ]
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('method arguments did not match to any of mocked');
+        $mock->doSomething('foo', 'bar');
     }
 
     public function testStubbedReturnArgument(): void


### PR DESCRIPTION
When a method is stubbed with `ReturnValueMap`, and actual invoked arguments did not match to any of mocked ones' lists, method silently returns `void`.
IMHO, this is an issue, since user might expect different behavior, but test still may pass. The assumption is that user expects only stubbed argument lists, i.e. defined in `ReturnValueMap`.
This PR makes `ReturnValueMap::invoke` throw exception in such cases.