### PR TITLE
Fix: Make tests failing on Windows portable or skip them

### DIFF
--- a/tests/end-to-end/abstract-test-class.phpt
+++ b/tests/end-to-end/abstract-test-class.phpt
@@ -8,4 +8,4 @@ $_SERVER['argv'][] = __DIR__ . '/../_files/AbstractTest.php';
 require __DIR__ . '/../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-Class 'AbstractTest' could not be found in '%s/tests/_files/AbstractTest.php'.
+Class 'AbstractTest' could not be found in '%sAbstractTest.php'.

--- a/tests/end-to-end/dataprovider-issue-2922.phpt
+++ b/tests/end-to-end/dataprovider-issue-2922.phpt
@@ -13,7 +13,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Warning:       Test case class not matching filename is deprecated
-               in %s/DataProviderIssue2922/SecondTest.php
+               in %sSecondTest.php
                Class name was 'SecondHelloWorldTest', expected 'SecondTest'
 
 .                                                                   1 / 1 (100%)

--- a/tests/end-to-end/filename-matches-class-name.phpt
+++ b/tests/end-to-end/filename-matches-class-name.phpt
@@ -14,7 +14,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Warning:       Test case class not matching filename is deprecated
-               in %s/OneClassPerFile/wrongClassName/WrongClassNameTest.php
+               in %sWrongClassNameTest.php
                Class name was 'WrongClassNameBar', expected 'WrongClassNameTest'
 
 .                                                                   1 / 1 (100%)

--- a/tests/end-to-end/regression/GitHub/2972.phpt
+++ b/tests/end-to-end/regression/GitHub/2972.phpt
@@ -12,7 +12,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Warning:       Test case class not matching filename is deprecated
-               in %s/unconventiallyNamedIssue2972Test.php
+               in %sunconventiallyNamedIssue2972Test.php
                Class name was 'Issue2972Test', expected 'unconventiallyNamedIssue2972Test'
 
 ..                                                                  2 / 2 (100%)

--- a/tests/end-to-end/test-suffix-multiple.phpt
+++ b/tests/end-to-end/test-suffix-multiple.phpt
@@ -14,10 +14,10 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Warning:       Test case class not matching filename is deprecated
-               in %s/BankAccountTest.test.php
+               in %sBankAccountTest.test.php
                Class name was 'BankAccountWithCustomExtensionTest', expected 'BankAccountTest'
 Warning:       Test case class not matching filename is deprecated
-               in %s/ConcreteTest.my.php
+               in %sConcreteTest.my.php
                Class name was 'ConcreteWithMyCustomExtensionTest', expected 'ConcreteTest'
 
 .....                                                               5 / 5 (100%)

--- a/tests/end-to-end/test-suffix-single.phpt
+++ b/tests/end-to-end/test-suffix-single.phpt
@@ -14,7 +14,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Warning:       Test case class not matching filename is deprecated
-               in %s/BankAccountTest.test.php
+               in %sBankAccountTest.test.php
                Class name was 'BankAccountWithCustomExtensionTest', expected 'BankAccountTest'
 
 ...                                                                 3 / 3 (100%)

--- a/tests/end-to-end/two-classes-per-file-invalid.phpt
+++ b/tests/end-to-end/two-classes-per-file-invalid.phpt
@@ -14,13 +14,13 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Warning:       Test case class not matching filename is deprecated
-               in %s/OneClassPerFile/failing/TwoClassesInvalidTest.php
+               in %sTwoClassesInvalidTest.php
                Class name was 'TwoClassesInvalid', expected 'TwoClassesInvalidTest'
 Warning:       Test case class not matching filename is deprecated
-               in %s/OneClassPerFile/failing/TwoClassesInvalidTest.php
+               in %sTwoClassesInvalidTest.php
                Class name was 'TwoClassesInvalid2', expected 'TwoClassesInvalidTest'
 Warning:       Multiple test case classes per file is deprecated
-               in %s/TwoClassesInvalidTest.php
+               in %sTwoClassesInvalidTest.php
 
 ..                                                                  2 / 2 (100%)
 

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -516,6 +516,10 @@ XML;
 
     public function testAssertDirectoryIsNotReadable(): void
     {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            self::markTestSkipped('Cannot test this behaviour on Windows');
+        }
+
         $dirName = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . \uniqid('unreadable_dir_', true);
         \mkdir($dirName, \octdec('0'));
         $this->assertDirectoryIsNotReadable($dirName);
@@ -541,6 +545,10 @@ XML;
 
     public function testAssertDirectoryIsNotWritable(): void
     {
+        if (\PHP_OS_FAMILY === 'Windows') {
+            self::markTestSkipped('Cannot test this behaviour on Windows');
+        }
+
         $dirName = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . \uniqid('unwritable_dir_', true);
         \mkdir($dirName, \octdec('444'));
         $this->assertDirectoryIsNotWritable($dirName);


### PR DESCRIPTION
This PR

* [x] skips two tests failing on `window-latest`
* [x] attempts to make a few tests failing on `window-latest` portable

Related to #4333.
Follows #4335.
