### PR TITLE
Add InvokedWithArgsCount rule

### DIFF
--- a/src/Framework/MockObject/Rule/InvokedWithArgsCount.php
+++ b/src/Framework/MockObject/Rule/InvokedWithArgsCount.php
@@ -66,9 +66,9 @@ class InvokedWithArgsCount extends InvocationOrder
     {
         parent::invoked($invocation);
 
-        $count = $this->incrementInvocationWithArgsCount($invocation);
+        $this->incrementInvocationWithArgsCount($invocation);
 
-        if ($count > $this->expectedCount) {
+        if ($this->currentCount > $this->expectedCount) {
             $message = $invocation->toString() . ' ';
 
             switch ($this->expectedCount) {
@@ -101,15 +101,13 @@ class InvokedWithArgsCount extends InvocationOrder
      */
     public function verify(): void
     {
-        $count = $this->currentCount;
-
-        if ($count !== $this->expectedCount) {
+        if ($this->currentCount !== $this->expectedCount) {
             throw new ExpectationFailedException(
                 sprintf(
                     'Method was expected to be called %d times with ' . $this->argValuesToString() .
                     ', actually called %d times.',
                     $this->expectedCount,
-                    $count
+                    $this->currentCount
                 )
             );
         }
@@ -120,15 +118,13 @@ class InvokedWithArgsCount extends InvocationOrder
         return true;
     }
 
-    private function incrementInvocationWithArgsCount(BaseInvocation $invocation)
+    private function incrementInvocationWithArgsCount(BaseInvocation $invocation): void
     {
         if (count($this->argValues) > 0) {
             $parameters = $invocation->getParameters();
             // Figure out if it matches the arguments
             if ($parameters === $this->argValues) {
                 $this->currentCount++;
-
-                return true;
             }
             // Figure out if we have some constraints to check
             if (count($parameters) === count($this->argValues)) {
@@ -146,20 +142,14 @@ class InvokedWithArgsCount extends InvocationOrder
 
                 if ($matchingParams === count($this->argValues)) {
                     $this->currentCount++;
-
-                    return true;
                 }
             }
         } elseif (count($invocation->getParameters()) === 0) {
             $this->currentCount++;
-
-            return true;
         }
-
-        return false;
     }
 
-    private function argValuesToString()
+    private function argValuesToString(): string
     {
         $argValuesString = '[';
 

--- a/src/Framework/MockObject/Rule/InvokedWithArgsCount.php
+++ b/src/Framework/MockObject/Rule/InvokedWithArgsCount.php
@@ -138,7 +138,7 @@ class InvokedWithArgsCount extends InvocationOrder
                     if ($this->argValues[$index] === $parameters[$index] ||
                             $this->argValues[$index] instanceof IsAnything ||
                             ($this->argValues[$index] instanceof Constraint &&
-                            $this->argValues[$index]->match($parameters[$index]))
+                            $this->argValues[$index]->evaluate($parameters[$index]))
                         ) {
                         $matchingParams++;
                     }

--- a/src/Framework/MockObject/Rule/InvokedWithArgsCount.php
+++ b/src/Framework/MockObject/Rule/InvokedWithArgsCount.php
@@ -1,0 +1,178 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Rule;
+
+use function sprintf;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsAnything;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
+use ReflectionClass;
+
+/**
+ * Invocation matcher which checks if a method has been invoked a certain amount
+ * of times WITH A SPECIFIC SET OF ARGUMENT VALUES.
+ * If the number of invocations exceeds the value it will immediately throw an
+ * exception,
+ * If the number is less it will later be checked in verify() and also throw an
+ * exception.
+ *
+ * @author Mark Blakley <mblakley@datto.com>
+ */
+class InvokedWithArgsCount extends InvocationOrder
+{
+    /**
+     * @var int
+     */
+    private $currentCount;
+
+    /**
+     * @var int
+     */
+    private $expectedCount;
+
+    /**
+     * @var array
+     */
+    private $argValues;
+
+    /**
+     * @param int   $expectedCount
+     * @param array $argValues
+     */
+    public function __construct($expectedCount, $argValues)
+    {
+        $this->expectedCount = $expectedCount;
+        $this->argValues     = $argValues;
+        $this->currentCount  = 0;
+    }
+
+    public function toString(): string
+    {
+        return 'invoked ' . $this->currentCount . ' time(s) with arguments ' . $this->argValuesToString();
+    }
+
+    /**
+     * @throws ExpectationFailedException
+     */
+    public function invokedDo(BaseInvocation $invocation): void
+    {
+        parent::invoked($invocation);
+
+        $count = $this->incrementInvocationWithArgsCount($invocation);
+
+        if ($count > $this->expectedCount) {
+            $message = $invocation->toString() . ' ';
+
+            switch ($this->expectedCount) {
+                case 0:
+                    $message .= 'was not expected to be called with arguments ' . $this->argValuesToString() . '.';
+
+                    break;
+
+                case 1:
+                    $message .= 'was not expected to be called more than once with arguments ' . $this->argValuesToString() . '.';
+
+                    break;
+
+                default:
+                    $message .= sprintf(
+                        'was not expected to be called more than %d times with arguments ' . $this->argValuesToString() . '.',
+                        $this->expectedCount
+                    );
+            }
+
+            throw new ExpectationFailedException($message);
+        }
+    }
+
+    /**
+     * Verifies that the current expectation is valid. If everything is OK the
+     * code should just return, if not it must throw an exception.
+     *
+     * @throws ExpectationFailedException
+     */
+    public function verify(): void
+    {
+        $count = $this->currentCount;
+
+        if ($count !== $this->expectedCount) {
+            throw new ExpectationFailedException(
+                sprintf(
+                    'Method was expected to be called %d times with ' . $this->argValuesToString() .
+                    ', actually called %d times.',
+                    $this->expectedCount,
+                    $count
+                )
+            );
+        }
+    }
+
+    public function matches(BaseInvocation $invocation): bool
+    {
+        return true;
+    }
+
+    private function incrementInvocationWithArgsCount(BaseInvocation $invocation)
+    {
+        if (count($this->argValues) > 0) {
+            $parameters = $invocation->getParameters();
+            // Figure out if it matches the arguments
+            if ($parameters === $this->argValues) {
+                $this->currentCount++;
+
+                return true;
+            }
+            // Figure out if we have some constraints to check
+            if (count($parameters) === count($this->argValues)) {
+                $matchingParams = 0;
+
+                for ($index = 0; $index < count($this->argValues); $index++) {
+                    if ($this->argValues[$index] === $parameters[$index] ||
+                            $this->argValues[$index] instanceof IsAnything ||
+                            ($this->argValues[$index] instanceof Constraint &&
+                            $this->argValues[$index]->match($parameters[$index]))
+                        ) {
+                        $matchingParams++;
+                    }
+                }
+
+                if ($matchingParams === count($this->argValues)) {
+                    $this->currentCount++;
+
+                    return true;
+                }
+            }
+        } elseif (count($invocation->getParameters()) === 0) {
+            $this->currentCount++;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function argValuesToString()
+    {
+        $argValuesString = '[';
+
+        foreach ($this->argValues as $argValue) {
+            if ($argValue instanceof Constraint) {
+                $argValuesString .= (new ReflectionClass($argValue))->getShortName() . ',';
+            } elseif (is_array($argValue)) {
+                $argValuesString .= '[' . implode(',', $argValue) . '],';
+            } else {
+                $argValuesString .= '\'' . $argValue . '\',';
+            }
+        }
+
+        return rtrim($argValuesString, ',') . ']';
+    }
+}


### PR DESCRIPTION
If you have a single function that you call with multiple different arguments, but you only care that the function got called with a specific argument, there doesn’t seem to be an easy way to set an expectation on it.  Example:
```
$this->myObject->expects($this->once())->method('notice')->with('A specific argument');
```
In this example, myObject->notice would be called multiple times with other arguments, but in the test I only care that it was called with this one specific argument value.  It doesn't seem to be possible to configure a mock object to check the expectations correctly in this case unless you enumerate all of the argument values that are passed in and use returnValueMap.

My solution to this was to set both the expectation and the expected argument in the same call, and also add a check for how many times the specified method is called with the specified arguments.  Example of my new class in use:
```
$this->myObject->expects(new InvokedWithArgsCount(1, ['A specific argument'])->method('notice');
```

I also allow other rules, to allow applying different levels of checks on different arguments:
```
$this->myObject->expects(new InvokedWithArgsCount(1, ['A specific argument', $this->anything()])->method('notice');
```