### PR TITLE
Enhancement: Enable fully_qualified_strict_types fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -74,6 +74,7 @@ return PhpCsFixer\Config::create()
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,
         'full_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
         'function_declaration' => true,
         'header_comment' => ['header' => $header, 'separate' => 'none'],
         'increment_style' => [

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -73,7 +73,7 @@ final class ExceptionWrapper extends Exception
         $this->className = $className;
     }
 
-    public function setOriginalException(\Throwable $t): void
+    public function setOriginalException(Throwable $t): void
     {
         $this->originalException($t);
 

--- a/tests/_files/MyTestListener.php
+++ b/tests/_files/MyTestListener.php
@@ -31,7 +31,7 @@ final class MyTestListener implements TestListener
 
     private $startCount = 0;
 
-    public function addError(Test $test, \Throwable $t, float $time): void
+    public function addError(Test $test, Throwable $t, float $time): void
     {
         $this->errorCount++;
     }
@@ -46,17 +46,17 @@ final class MyTestListener implements TestListener
         $this->failureCount++;
     }
 
-    public function addIncompleteTest(Test $test, \Throwable $t, float $time): void
+    public function addIncompleteTest(Test $test, Throwable $t, float $time): void
     {
         $this->notImplementedCount++;
     }
 
-    public function addRiskyTest(Test $test, \Throwable $t, float $time): void
+    public function addRiskyTest(Test $test, Throwable $t, float $time): void
     {
         $this->riskyCount++;
     }
 
-    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
+    public function addSkippedTest(Test $test, Throwable $t, float $time): void
     {
         $this->skippedCount++;
     }

--- a/tests/_files/TestIteratorAggregate.php
+++ b/tests/_files/TestIteratorAggregate.php
@@ -11,7 +11,7 @@ class TestIteratorAggregate implements IteratorAggregate
 {
     private $traversable;
 
-    public function __construct(\Traversable $traversable)
+    public function __construct(Traversable $traversable)
     {
         $this->traversable = $traversable;
     }

--- a/tests/_files/TestIteratorAggregate2.php
+++ b/tests/_files/TestIteratorAggregate2.php
@@ -11,7 +11,7 @@ class TestIteratorAggregate2 implements IteratorAggregate
 {
     private $traversable;
 
-    public function __construct(\Traversable $traversable)
+    public function __construct(Traversable $traversable)
     {
         $this->traversable = $traversable;
     }

--- a/tests/end-to-end/regression/GitHub/3379/Issue3379TestListener.php
+++ b/tests/end-to-end/regression/GitHub/3379/Issue3379TestListener.php
@@ -16,7 +16,7 @@ class Issue3379TestListener implements TestListener
 {
     use TestListenerDefaultImplementation;
 
-    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
+    public function addSkippedTest(Test $test, Throwable $t, float $time): void
     {
         if ($test instanceof TestCase) {
             print 'Skipped test ' . $test->getName() . ', status: ' . $test->getStatus() . \PHP_EOL;


### PR DESCRIPTION
This PR

* [x] enables the `fully_qualified_strict_types` fixer
* [x] runs `php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**fully_qualified_strict_types** [`@PhpCsFixer`]
>
>Transforms imported FQCN parameters and return types in function arguments to short version.