### PR TITLE
Enhancement: Enable heredoc_to_nowdoc fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -77,6 +77,7 @@ return PhpCsFixer\Config::create()
         'fully_qualified_strict_types' => true,
         'function_declaration' => true,
         'header_comment' => ['header' => $header, 'separate' => 'none'],
+        'heredoc_to_nowdoc' => true,
         'increment_style' => [
             'style' => PhpCsFixer\Fixer\Operator\IncrementStyleFixer::STYLE_POST,
         ],

--- a/src/Util/ConfigurationGenerator.php
+++ b/src/Util/ConfigurationGenerator.php
@@ -17,7 +17,7 @@ final class ConfigurationGenerator
     /**
      * @var string
      */
-    private const TEMPLATE = <<<EOT
+    private const TEMPLATE = <<<'EOT'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/{phpunit_version}/phpunit.xsd"

--- a/src/Util/TestDox/HtmlResultPrinter.php
+++ b/src/Util/TestDox/HtmlResultPrinter.php
@@ -17,7 +17,7 @@ final class HtmlResultPrinter extends ResultPrinter
     /**
      * @var string
      */
-    private const PAGE_HEADER = <<<EOT
+    private const PAGE_HEADER = <<<'EOT'
 <!doctype html>
 <html lang="en">
     <head>
@@ -53,7 +53,7 @@ EOT;
     /**
      * @var string
      */
-    private const CLASS_HEADER = <<<EOT
+    private const CLASS_HEADER = <<<'EOT'
 
         <h2 id="%s">%s</h2>
         <ul>
@@ -63,14 +63,14 @@ EOT;
     /**
      * @var string
      */
-    private const CLASS_FOOTER = <<<EOT
+    private const CLASS_FOOTER = <<<'EOT'
         </ul>
 EOT;
 
     /**
      * @var string
      */
-    private const PAGE_FOOTER = <<<EOT
+    private const PAGE_FOOTER = <<<'EOT'
 
     </body>
 </html>

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -411,14 +411,14 @@ final class AssertTest extends TestCase
      */
     public function testAssertXmlStringEqualsXmlString3(): void
     {
-        $expected = <<<XML
+        $expected = <<<'XML'
 <?xml version="1.0"?>
 <root>
     <node />
 </root>
 XML;
 
-        $actual = <<<XML
+        $actual = <<<'XML'
 <?xml version="1.0"?>
 <root>
 <node />

--- a/tests/unit/Framework/Constraint/ArrayHasKeyTest.php
+++ b/tests/unit/Framework/Constraint/ArrayHasKeyTest.php
@@ -29,7 +29,7 @@ final class ArrayHasKeyTest extends ConstraintTestCase
             $constraint->evaluate([]);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an array has the key 0.
 
 EOF
@@ -73,7 +73,7 @@ EOF
             $constraint->evaluate(0, '');
         } catch (ExpectationFailedException  $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an array has the key 0.
 
 EOF

--- a/tests/unit/Framework/Constraint/ClassHasAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ClassHasAttributeTest.php
@@ -32,7 +32,7 @@ final class ClassHasAttributeTest extends ConstraintTestCase
             $constraint->evaluate(\stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that class "stdClass" has attribute "privateAttribute".
 
 EOF
@@ -56,7 +56,7 @@ EOF
             $constraint->evaluate(\stdClass::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that class "stdClass" has attribute "privateAttribute".
 

--- a/tests/unit/Framework/Constraint/ClassHasStaticAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ClassHasStaticAttributeTest.php
@@ -30,7 +30,7 @@ final class ClassHasStaticAttributeTest extends ConstraintTestCase
             $constraint->evaluate(\stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that class "stdClass" has static attribute "privateStaticAttribute".
 
 EOF
@@ -52,7 +52,7 @@ EOF
             $constraint->evaluate(\stdClass::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that class "stdClass" has static attribute "foo".
 

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -169,7 +169,7 @@ final class CountTest extends ConstraintTestCase
             $this->assertNull($countConstraint->evaluate(1));
         } catch (ExpectationFailedException  $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that actual size 0 matches expected size 1.
 
 EOF

--- a/tests/unit/Framework/Constraint/ExceptionCodeTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionCodeTest.php
@@ -25,7 +25,7 @@ class ExceptionCodeTest extends TestCase
             $exceptionCode->evaluate($other);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 456 is equal to expected exception code 123.
 
 EOF

--- a/tests/unit/Framework/Constraint/FileExistsTest.php
+++ b/tests/unit/Framework/Constraint/FileExistsTest.php
@@ -29,7 +29,7 @@ final class FileExistsTest extends ConstraintTestCase
             $constraint->evaluate('foo');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that file "foo" exists.
 
 EOF
@@ -51,7 +51,7 @@ EOF
             $constraint->evaluate('foo', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that file "foo" exists.
 

--- a/tests/unit/Framework/Constraint/GreaterThanTest.php
+++ b/tests/unit/Framework/Constraint/GreaterThanTest.php
@@ -30,7 +30,7 @@ final class GreaterThanTest extends ConstraintTestCase
             $constraint->evaluate(0);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 0 is greater than 1.
 
 EOF
@@ -52,7 +52,7 @@ EOF
             $constraint->evaluate(0, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 0 is greater than 1.
 

--- a/tests/unit/Framework/Constraint/IsEmptyTest.php
+++ b/tests/unit/Framework/Constraint/IsEmptyTest.php
@@ -32,7 +32,7 @@ final class IsEmptyTest extends ConstraintTestCase
             $constraint->evaluate(['foo']);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an array is empty.
 
 EOF

--- a/tests/unit/Framework/Constraint/IsEqualTest.php
+++ b/tests/unit/Framework/Constraint/IsEqualTest.php
@@ -30,7 +30,7 @@ final class IsEqualTest extends ConstraintTestCase
             $constraint->evaluate(0);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 0 matches expected 1.
 
 EOF
@@ -113,17 +113,17 @@ EOF
         $dom2->loadXML('<root><foo/></root>');
 
         return [
-            [1, 0, <<<EOF
+            [1, 0, <<<'EOF'
 Failed asserting that 0 matches expected 1.
 
 EOF
             ],
-            [1.1, 0, <<<EOF
+            [1.1, 0, <<<'EOF'
 Failed asserting that 0 matches expected 1.1.
 
 EOF
             ],
-            ['a', 'b', <<<EOF
+            ['a', 'b', <<<'EOF'
 Failed asserting that two strings are equal.
 --- Expected
 +++ Actual
@@ -133,38 +133,38 @@ Failed asserting that two strings are equal.
 
 EOF
             ],
-            ["a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk", "a\np\nc\nd\ne\nf\ng\nh\ni\nw\nk", <<<EOF
+            ["a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk", "a\np\nc\nd\ne\nf\ng\nh\ni\nw\nk", <<<'EOF'
 Failed asserting that two strings are equal.
 --- Expected
 +++ Actual
 @@ @@
- 'a\\n
--b\\n
-+p\\n
- c\\n
- d\\n
- e\\n
+ 'a\n
+-b\n
++p\n
+ c\n
+ d\n
+ e\n
 @@ @@
- g\\n
- h\\n
- i\\n
--j\\n
-+w\\n
+ g\n
+ h\n
+ i\n
+-j\n
++w\n
  k'
 
 EOF
             ],
-            [1, [0], <<<EOF
+            [1, [0], <<<'EOF'
 Array (...) does not match expected type "integer".
 
 EOF
             ],
-            [[0], 1, <<<EOF
+            [[0], 1, <<<'EOF'
 1 does not match expected type "array".
 
 EOF
             ],
-            [[0], [1], <<<EOF
+            [[0], [1], <<<'EOF'
 Failed asserting that two arrays are equal.
 --- Expected
 +++ Actual
@@ -176,7 +176,7 @@ Failed asserting that two arrays are equal.
 
 EOF
             ],
-            [[true], ['true'], <<<EOF
+            [[true], ['true'], <<<'EOF'
 Failed asserting that two arrays are equal.
 --- Expected
 +++ Actual
@@ -188,7 +188,7 @@ Failed asserting that two arrays are equal.
 
 EOF
             ],
-            [[0, [1], [2], 3], [0, [4], [2], 3], <<<EOF
+            [[0, [1], [2], 3], [0, [4], [2], 3], <<<'EOF'
 Failed asserting that two arrays are equal.
 --- Expected
 +++ Actual
@@ -205,17 +205,17 @@ Failed asserting that two arrays are equal.
 
 EOF
             ],
-            [$a, [0], <<<EOF
+            [$a, [0], <<<'EOF'
 Array (...) does not match expected type "object".
 
 EOF
             ],
-            [[0], $a, <<<EOF
+            [[0], $a, <<<'EOF'
 stdClass Object (...) does not match expected type "array".
 
 EOF
             ],
-            [$a, $b, <<<EOF
+            [$a, $b, <<<'EOF'
 Failed asserting that two objects are equal.
 --- Expected
 +++ Actual
@@ -226,7 +226,7 @@ Failed asserting that two objects are equal.
 
 EOF
             ],
-            [$c, $d, <<<EOF
+            [$c, $d, <<<'EOF'
 Failed asserting that two objects are equal.
 --- Expected
 +++ Actual
@@ -246,18 +246,18 @@ Failed asserting that two objects are equal.
 @@ @@
      )
      'related' => stdClass Object (
-         'foo' => 'a\\n
--        b\\n
-+        p\\n
-         c\\n
-         d\\n
-         e\\n
+         'foo' => 'a\n
+-        b\n
++        p\n
+         c\n
+         d\n
+         e\n
 @@ @@
-         g\\n
-         h\\n
-         i\\n
--        j\\n
-+        w\\n
+         g\n
+         h\n
+         i\n
+-        j\n
++        w\n
          k'
      )
      'self' => stdClass Object (...)
@@ -266,7 +266,7 @@ Failed asserting that two objects are equal.
 
 EOF
             ],
-            [$dom1, $dom2, <<<EOF
+            [$dom1, $dom2, <<<'EOF'
 Failed asserting that two DOM documents are equal.
 --- Expected
 +++ Actual
@@ -282,7 +282,7 @@ EOF
             [
                 new \DateTime('2013-03-29 04:13:35', new \DateTimeZone('America/New_York')),
                 new \DateTime('2013-03-29 04:13:35', new \DateTimeZone('America/Chicago')),
-                <<<EOF
+                <<<'EOF'
 Failed asserting that two DateTime objects are equal.
 --- Expected
 +++ Actual

--- a/tests/unit/Framework/Constraint/IsIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/IsIdenticalTest.php
@@ -33,7 +33,7 @@ final class IsIdenticalTest extends ConstraintTestCase
             $constraint->evaluate($b);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that two variables reference the same object.
 
 EOF
@@ -58,7 +58,7 @@ EOF
             $constraint->evaluate($b, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that two variables reference the same object.
 
@@ -81,7 +81,7 @@ EOF
             $constraint->evaluate('b', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that two strings are identical.
 --- Expected
@@ -112,7 +112,7 @@ EOF
             $constraint->evaluate($actual, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that two arrays are identical.
 --- Expected
@@ -166,7 +166,7 @@ EOF
             $constraint->evaluate($actual, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that two arrays are identical.
 --- Expected

--- a/tests/unit/Framework/Constraint/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/IsInstanceOfTest.php
@@ -32,7 +32,7 @@ final class IsInstanceOfTest extends ConstraintTestCase
             $constraint->evaluate('stdClass');
         } catch (ExpectationFailedException $e) {
             self::assertSame(
-                <<<EOT
+                <<<'EOT'
 Failed asserting that 'stdClass' is an instance of class "stdClass".
 
 EOT

--- a/tests/unit/Framework/Constraint/IsJsonTest.php
+++ b/tests/unit/Framework/Constraint/IsJsonTest.php
@@ -54,7 +54,7 @@ final class IsJsonTest extends ConstraintTestCase
             $isJson->evaluate('');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an empty string is valid JSON.
 
 EOF

--- a/tests/unit/Framework/Constraint/IsNullTest.php
+++ b/tests/unit/Framework/Constraint/IsNullTest.php
@@ -30,7 +30,7 @@ final class IsNullTest extends ConstraintTestCase
             $constraint->evaluate(0);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 0 is null.
 
 EOF
@@ -52,7 +52,7 @@ EOF
             $constraint->evaluate(0, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 0 is null.
 

--- a/tests/unit/Framework/Constraint/IsReadableTest.php
+++ b/tests/unit/Framework/Constraint/IsReadableTest.php
@@ -29,7 +29,7 @@ final class IsReadableTest extends ConstraintTestCase
             $constraint->evaluate('foo');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that "foo" is readable.
 
 EOF

--- a/tests/unit/Framework/Constraint/IsTypeTest.php
+++ b/tests/unit/Framework/Constraint/IsTypeTest.php
@@ -31,7 +31,7 @@ final class IsTypeTest extends ConstraintTestCase
             $constraint->evaluate(new \stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertStringMatchesFormat(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that stdClass Object &%x () is of type "string".
 
 EOF
@@ -53,7 +53,7 @@ EOF
             $constraint->evaluate(new \stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertStringMatchesFormat(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that stdClass Object &%x () is of type "string".
 

--- a/tests/unit/Framework/Constraint/IsWritableTest.php
+++ b/tests/unit/Framework/Constraint/IsWritableTest.php
@@ -29,7 +29,7 @@ final class IsWritableTest extends ConstraintTestCase
             $constraint->evaluate('foo');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that "foo" is writable.
 
 EOF

--- a/tests/unit/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/unit/Framework/Constraint/JsonMatchesTest.php
@@ -105,7 +105,7 @@ final class JsonMatchesTest extends ConstraintTestCase
             $this->fail(\sprintf('Expected %s to be thrown.', ExpectationFailedException::class));
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that '{"Mascott"::}' matches JSON string "{"Mascott"::}".
 
 EOF
@@ -124,7 +124,7 @@ EOF
             $this->fail(\sprintf('Expected %s to be thrown.', ExpectationFailedException::class));
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that '{"Mascott":"Tux"}' matches JSON string "{"Mascott"::}".
 
 EOF
@@ -142,7 +142,7 @@ EOF
             $constraint->evaluate('{"obj": {}, "val": 2}', '', false);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that '{"obj": {}, "val": 2}' matches JSON string "{"obj": {}, "val": 1}".
 --- Expected
 +++ Actual
@@ -168,7 +168,7 @@ EOF
             $constraint->evaluate('{"obj": {"y": 2, "x": 1}, "val": 2}', '', false);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that '{"obj": {"y": 2, "x": 1}, "val": 2}' matches JSON string "{"obj": {"x": 1, "y": 2}, "val": 1}".
 --- Expected
 +++ Actual

--- a/tests/unit/Framework/Constraint/LessThanTest.php
+++ b/tests/unit/Framework/Constraint/LessThanTest.php
@@ -30,7 +30,7 @@ final class LessThanTest extends ConstraintTestCase
             $constraint->evaluate(1);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 1 is less than 1.
 
 EOF
@@ -52,7 +52,7 @@ EOF
             $constraint->evaluate(1, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 1 is less than 1.
 

--- a/tests/unit/Framework/Constraint/ObjectHasAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ObjectHasAttributeTest.php
@@ -30,7 +30,7 @@ final class ObjectHasAttributeTest extends ConstraintTestCase
             $constraint->evaluate(new \stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that object of class "stdClass" has attribute "privateAttribute".
 
 EOF
@@ -52,7 +52,7 @@ EOF
             $constraint->evaluate(new \stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that object of class "stdClass" has attribute "privateAttribute".
 

--- a/tests/unit/Framework/Constraint/RegularExpressionTest.php
+++ b/tests/unit/Framework/Constraint/RegularExpressionTest.php
@@ -30,7 +30,7 @@ final class RegularExpressionTest extends ConstraintTestCase
             $constraint->evaluate('barbazbar');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'barbazbar' matches PCRE pattern "/foo/".
 
 EOF
@@ -52,7 +52,7 @@ EOF
             $constraint->evaluate('barbazbar', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'barbazbar' matches PCRE pattern "/foo/".
 

--- a/tests/unit/Framework/Constraint/SameSizeTest.php
+++ b/tests/unit/Framework/Constraint/SameSizeTest.php
@@ -49,7 +49,7 @@ final class SameSizeTest extends ConstraintTestCase
             $constraint->evaluate([1, 2]);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that actual size 2 matches expected size 5.
 
 EOF

--- a/tests/unit/Framework/Constraint/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/StringContainsTest.php
@@ -30,7 +30,7 @@ final class StringContainsTest extends ConstraintTestCase
             $constraint->evaluate('barbazbar');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'barbazbar' contains "foo".
 
 EOF
@@ -82,7 +82,7 @@ EOF
             $constraint->evaluate('barbazbar', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'barbazbar' contains "foo".
 

--- a/tests/unit/Framework/Constraint/StringEndsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringEndsWithTest.php
@@ -67,7 +67,7 @@ final class StringEndsWithTest extends ConstraintTestCase
             $constraint->evaluate('error');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'error' ends with "suffix".
 
 EOF
@@ -89,7 +89,7 @@ EOF
             $constraint->evaluate('error', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'error' ends with "suffix".
 

--- a/tests/unit/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/unit/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -264,7 +264,7 @@ final class StringMatchesFormatDescriptionTest extends ConstraintTestCase
             $constraint->evaluate("*\nbar\n*");
             $this->fail('Expected ExpectationFailedException, but it was not thrown.');
         } catch (ExpectationFailedException $e) {
-            $expected = <<<EOD
+            $expected = <<<'EOD'
 Failed asserting that string matches format description.
 --- Expected
 +++ Actual

--- a/tests/unit/Framework/Constraint/StringStartsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringStartsWithTest.php
@@ -74,7 +74,7 @@ final class StringStartsWithTest extends ConstraintTestCase
             $constraint->evaluate('error');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'error' starts with "prefix".
 
 EOF
@@ -96,7 +96,7 @@ EOF
             $constraint->evaluate('error', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'error' starts with "prefix".
 

--- a/tests/unit/Framework/Constraint/TraversableContainsTest.php
+++ b/tests/unit/Framework/Constraint/TraversableContainsTest.php
@@ -69,7 +69,7 @@ final class TraversableContainsTest extends ConstraintTestCase
             $constraint->evaluate(['bar']);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an array contains 'foo'.
 
 EOF
@@ -111,7 +111,7 @@ EOF
             $constraint->evaluate(['bar'], 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that an array contains 'foo'.
 
@@ -161,7 +161,7 @@ EOF
             $constraint->evaluate(new \SplObjectStorage);
         } catch (ExpectationFailedException $e) {
             $this->assertStringMatchesFormat(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that a traversable contains stdClass Object &%x ().
 
 EOF
@@ -184,7 +184,7 @@ EOF
             $constraint->evaluate(new \SplObjectStorage, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertStringMatchesFormat(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that a traversable contains stdClass Object &%x ().
 

--- a/tests/unit/Framework/ConstraintTest.php
+++ b/tests/unit/Framework/ConstraintTest.php
@@ -33,7 +33,7 @@ final class ConstraintTest extends TestCase
             $constraint->evaluate([0 => 1]);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an array does not have the key 0.
 
 EOF
@@ -57,7 +57,7 @@ EOF
             $constraint->evaluate([0], 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that an array does not have the key 0.
 
@@ -143,7 +143,7 @@ EOF
             $constraint->evaluate(2);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 2 is not greater than 1.
 
 EOF
@@ -167,7 +167,7 @@ EOF
             $constraint->evaluate(2, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 2 is not greater than 1.
 
@@ -195,7 +195,7 @@ EOF
             $constraint->evaluate(0);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 0 is equal to 1 or is greater than 1.
 
 EOF
@@ -217,7 +217,7 @@ EOF
             $constraint->evaluate(0, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 0 is equal to 1 or is greater than 1.
 
@@ -246,7 +246,7 @@ EOF
             $constraint->evaluate(1);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that not( 1 is equal to 1 or is greater than 1 ).
 
 EOF
@@ -270,7 +270,7 @@ EOF
             $constraint->evaluate(1, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that not( 1 is equal to 1 or is greater than 1 ).
 
@@ -309,7 +309,7 @@ EOF
             $constraint->evaluate(null);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that null is not anything.
 
 EOF
@@ -338,7 +338,7 @@ EOF
             $constraint->evaluate(1);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 1 is not equal to 1.
 
 EOF
@@ -362,7 +362,7 @@ EOF
             $constraint->evaluate(1, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 1 is not equal to 1.
 
@@ -395,7 +395,7 @@ EOF
             $constraint->evaluate($a);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that two variables don't reference the same object.
 
 EOF
@@ -421,7 +421,7 @@ EOF
             $constraint->evaluate($a, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that two variables don't reference the same object.
 
@@ -446,7 +446,7 @@ EOF
             $constraint->evaluate('a', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that two strings are not identical.
 
@@ -479,7 +479,7 @@ EOF
             $constraint->evaluate(new \stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that stdClass Object () is an instance of class "Exception".
 
 EOF
@@ -501,7 +501,7 @@ EOF
             $constraint->evaluate(new \stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that stdClass Object () is an instance of class "Exception".
 
@@ -531,7 +531,7 @@ EOF
             $constraint->evaluate(new \stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that stdClass Object () is not an instance of class "stdClass".
 
 EOF
@@ -555,7 +555,7 @@ EOF
             $constraint->evaluate(new \stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that stdClass Object () is not an instance of class "stdClass".
 
@@ -585,7 +585,7 @@ EOF
             $constraint->evaluate('');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that '' is not of type "string".
 
 EOF
@@ -609,7 +609,7 @@ EOF
             $constraint->evaluate('', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that '' is not of type "string".
 
@@ -639,7 +639,7 @@ EOF
             $constraint->evaluate(null);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that null is not null.
 
 EOF
@@ -663,7 +663,7 @@ EOF
             $constraint->evaluate(null, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that null is not null.
 
@@ -693,7 +693,7 @@ EOF
             $constraint->evaluate(0);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 0 is not less than 1.
 
 EOF
@@ -717,7 +717,7 @@ EOF
             $constraint->evaluate(0, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 0 is not less than 1.
 
@@ -745,7 +745,7 @@ EOF
             $constraint->evaluate(2);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 2 is equal to 1 or is less than 1.
 
 EOF
@@ -767,7 +767,7 @@ EOF
             $constraint->evaluate(2, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 2 is equal to 1 or is less than 1.
 
@@ -797,7 +797,7 @@ EOF
             $constraint->evaluate(1);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that not( 1 is equal to 1 or is less than 1 ).
 
 EOF
@@ -821,7 +821,7 @@ EOF
             $constraint->evaluate(1, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that not( 1 is equal to 1 or is less than 1 ).
 
@@ -851,7 +851,7 @@ EOF
             $constraint->evaluate(\ClassWithNonPublicAttributes::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that class "ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
 
 EOF
@@ -875,7 +875,7 @@ EOF
             $constraint->evaluate(\ClassWithNonPublicAttributes::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that class "ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
 
@@ -905,7 +905,7 @@ EOF
             $constraint->evaluate(\ClassWithNonPublicAttributes::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that class "ClassWithNonPublicAttributes" does not have static attribute "privateStaticAttribute".
 
 EOF
@@ -929,7 +929,7 @@ EOF
             $constraint->evaluate(\ClassWithNonPublicAttributes::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that class "ClassWithNonPublicAttributes" does not have static attribute "privateStaticAttribute".
 
@@ -959,7 +959,7 @@ EOF
             $constraint->evaluate(new \ClassWithNonPublicAttributes);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that object of class "ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
 
 EOF
@@ -983,7 +983,7 @@ EOF
             $constraint->evaluate(new \ClassWithNonPublicAttributes, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that object of class "ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
 
@@ -1016,7 +1016,7 @@ EOF
             $constraint->evaluate('barfoobar');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'barfoobar' does not match PCRE pattern "/foo/".
 
 EOF
@@ -1043,7 +1043,7 @@ EOF
             $constraint->evaluate('barfoobar', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'barfoobar' does not match PCRE pattern "/foo/".
 
@@ -1073,7 +1073,7 @@ EOF
             $constraint->evaluate('prefixfoo');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'prefixfoo' starts not with "prefix".
 
 EOF
@@ -1097,7 +1097,7 @@ EOF
             $constraint->evaluate('prefixfoo', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'prefixfoo' starts not with "prefix".
 
@@ -1127,7 +1127,7 @@ EOF
             $constraint->evaluate('barfoobar');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'barfoobar' does not contain "foo".
 
 EOF
@@ -1185,7 +1185,7 @@ EOF
             $constraint->evaluate('barfoobar', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'barfoobar' does not contain "foo".
 
@@ -1215,7 +1215,7 @@ EOF
             $constraint->evaluate('foosuffix');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that 'foosuffix' ends not with "suffix".
 
 EOF
@@ -1239,7 +1239,7 @@ EOF
             $constraint->evaluate('foosuffix', 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that 'foosuffix' ends not with "suffix".
 
@@ -1269,7 +1269,7 @@ EOF
             $constraint->evaluate(['foo']);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that an array does not contain 'foo'.
 
 EOF
@@ -1293,7 +1293,7 @@ EOF
             $constraint->evaluate(['foo'], 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 custom message
 Failed asserting that an array does not contain 'foo'.
 
@@ -1340,7 +1340,7 @@ EOF
             $constraint->evaluate([1, 2]);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that actual size 2 matches expected size 5.
 
 EOF
@@ -1364,7 +1364,7 @@ EOF
             $constraint->evaluate([1, 2]);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that actual size 2 does not match expected size 2.
 
 EOF
@@ -1388,7 +1388,7 @@ EOF
             $constraint->evaluate([3, 4]);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                <<<'EOF'
 Failed asserting that actual size 2 does not match expected size 2.
 
 EOF

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Util\PHP\AbstractPhpProcess;
  */
 final class PhptTestCaseTest extends TestCase
 {
-    private const EXPECT_CONTENT = <<<EOF
+    private const EXPECT_CONTENT = <<<'EOF'
 --TEST--
 EXPECT test
 --FILE--
@@ -26,7 +26,7 @@ EXPECT test
 Hello PHPUnit!
 EOF;
 
-    private const EXPECTF_CONTENT = <<<EOF
+    private const EXPECTF_CONTENT = <<<'EOF'
 --TEST--
 EXPECTF test
 --FILE--
@@ -35,7 +35,7 @@ EXPECTF test
 Hello %s!
 EOF;
 
-    private const EXPECTREGEX_CONTENT = <<<EOF
+    private const EXPECTREGEX_CONTENT = <<<'EOF'
 --TEST--
 EXPECTREGEX test
 --FILE--
@@ -44,7 +44,7 @@ EXPECTREGEX test
 Hello [HPU]{4}[nit]{3}!
 EOF;
 
-    private const FILE_SECTION = <<<EOF
+    private const FILE_SECTION = <<<'EOF'
 <?php echo "Hello PHPUnit!"; ?>
 
 EOF;
@@ -115,7 +115,7 @@ EOF;
     public function testRenderFileSection(): void
     {
         $this->setPhpContent($this->ensureCorrectEndOfLine(
-            <<<EOF
+            <<<'EOF'
 --TEST--
 Something to decribe it
 --FILE--
@@ -223,7 +223,7 @@ EOF
     public function testShouldSkipTestWhenFileSectionIsMissing(): void
     {
         $this->setPhpContent(
-            <<<EOF
+            <<<'EOF'
 --TEST--
 Something to describe it
 --EXPECT--
@@ -260,7 +260,7 @@ EOF
     public function testShouldSkipTestWhenSectionHeaderIsMalformed(): void
     {
         $this->setPhpContent(
-            <<<EOF
+            <<<'EOF'
 ----
 --TEST--
 This is not going to work out


### PR DESCRIPTION
This PR

* [x] enables the `heredoc_to_nowdoc` fixer
* [x] runs `php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**heredoc_to_nowdoc** [`@PhpCsFixer`]
>
>Convert heredoc to nowdoc where possible.