### PR TITLE
Fix: Remove duplicated configuration

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -85,7 +85,6 @@ return PhpCsFixer\Config::create()
         'line_ending' => true,
         'list_syntax' => ['syntax' => 'short'],
         'logical_operators' => true,
-        'lowercase_constants' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,


### PR DESCRIPTION
This PR

* [x] removes a duplicated configuration 

Related to #4338.

💁‍♂️ Running

```
$ /tools/php-cs-fixer describe lowercase_constants
```

yields

```
Description of lowercase_constants rule.
The PHP constants `true`, `false`, and `null` MUST be in lower case. DEPRECATED: use `constant_case` instead.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,4 +1,4 @@
    <?php
   -$a = FALSE;
   -$b = True;
   -$c = nuLL;
   +$a = false;
   +$b = true;
   +$c = null;

   ----------- end diff -----------

```

❓ Perhaps something went wrong when resolving conflicts?
