### PR TITLE
Enhancement: Enable magic_method_casing fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -89,6 +89,7 @@ return PhpCsFixer\Config::create()
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
+        'magic_method_casing' => true,
         'method_argument_space' => ['ensure_fully_multiline' => true],
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,


### PR DESCRIPTION
This PR

* [x] enables the `magic_method_casing` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**magic_method_casing** [`@Symfony`, `@PhpCsFixer`]
>
>Magic method definitions and calls must be using the correct casing.

❗ Currently has no effect, but why not enable it?