### PR TITLE
Enhancement: Enable native_function_type_declaration_casing fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -96,6 +96,7 @@ return PhpCsFixer\Config::create()
         'native_constant_invocation' => true,
         'native_function_casing' => true,
         'native_function_invocation' => true,
+        'native_function_type_declaration_casing' => true,
         'new_with_braces' => false,
         'no_alias_functions' => true,
         'no_alternative_syntax' => true,


### PR DESCRIPTION
This PR

* [x] enables the `native_function_type_declaration_casing` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**native_function_type_declaration_casing** [`@Symfony`, `@PhpCsFixer`]
>
>Native type hints for functions should use the correct case.

❗ Currently has no effect, but why not enable it?
