### PR TITLE
Enhancement: Enable no_spaces_around_offset fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -118,6 +118,7 @@ return PhpCsFixer\Config::create()
         'no_short_echo_tag' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_after_function_name' => true,
+        'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => [


### PR DESCRIPTION
This PR

* [x] enables the `no_spaces_around_offset` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**no_spaces_around_offset** [`@Symfony`, `@PhpCsFixer`]
>
>There MUST NOT be spaces around offset braces.
>
>Configuration options:
>
>* `positions` (a subset of `['inside', 'outside']`): whether spacing should be fixed inside and/or outside the offset braces; defaults to `['inside', 'outside']`

❗ Currently has no effect, but why not enable it?