### PR TITLE
Fix: Remove useless DocBlocks

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -87,7 +87,6 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         return $this->will($stub);
     }
 
-    /** {@inheritDoc} */
     public function willReturnReference(&$reference): self
     {
         $stub = new ReturnReference($reference);
@@ -109,7 +108,6 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         return $this->will($stub);
     }
 
-    /** {@inheritDoc} */
     public function willReturnCallback($callback): self
     {
         $stub = new ReturnCallback($callback);


### PR DESCRIPTION
This PR

* [x] removes useless DocBlocks

💁‍♂️ I intended to enable the `phpdoc_inline_tag` fixer, but figured we could do without these DocBlocks instead.