### PR TITLE
Enhancement: Enable strict_param fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -206,6 +206,7 @@ return PhpCsFixer\Config::create()
         'single_line_after_imports' => true,
         'single_quote' => true,
         'standardize_not_equals' => true,
+        'strict_param' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/src/Framework/Exception/InvalidArgumentException.php
+++ b/src/Framework/Exception/InvalidArgumentException.php
@@ -24,7 +24,7 @@ final class InvalidArgumentException extends Exception
                 $argument,
                 $stack[1]['class'],
                 $stack[1]['function'],
-                \in_array(\lcfirst($type)[0], ['a', 'e', 'i', 'o', 'u']) ? 'an' : 'a',
+                \in_array(\lcfirst($type)[0], ['a', 'e', 'i', 'o', 'u'], true) ? 'an' : 'a',
                 $type
             )
         );

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -981,7 +981,7 @@ final class Configuration
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
             \assert($directoryNode instanceof DOMElement);
 
-            if (!empty($testSuiteFilter) && !\in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
+            if (!empty($testSuiteFilter) && !\in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter, true)) {
                 continue;
             }
 
@@ -1008,7 +1008,7 @@ final class Configuration
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
             \assert($fileNode instanceof DOMElement);
 
-            if (!empty($testSuiteFilter) && !\in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter)) {
+            if (!empty($testSuiteFilter) && !\in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter, true)) {
                 continue;
             }
 

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -56,7 +56,7 @@ final class GlobalState
             $file = $files[$i];
 
             if (!empty($GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST']) &&
-                \in_array($file, $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'])) {
+                \in_array($file, $GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST'], true)) {
                 continue;
             }
 

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -165,7 +165,7 @@ final class NamePrettifier
 
         $string = (string) \preg_replace('#\d+$#', '', $name, -1, $count);
 
-        if (\in_array($string, $this->strings)) {
+        if (\in_array($string, $this->strings, true)) {
             $name = $string;
         } elseif ($count === 0) {
             $this->strings[] = $string;

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -316,7 +316,7 @@ abstract class ResultPrinter extends Printer implements TestListener
 
         if (!empty($this->groups)) {
             foreach ($test->getGroups() as $group) {
-                if (\in_array($group, $this->groups)) {
+                if (\in_array($group, $this->groups, true)) {
                     return true;
                 }
             }
@@ -326,7 +326,7 @@ abstract class ResultPrinter extends Printer implements TestListener
 
         if (!empty($this->excludeGroups)) {
             foreach ($test->getGroups() as $group) {
-                if (\in_array($group, $this->excludeGroups)) {
+                if (\in_array($group, $this->excludeGroups, true)) {
                     return false;
                 }
             }

--- a/src/Util/VersionComparisonOperator.php
+++ b/src/Util/VersionComparisonOperator.php
@@ -42,7 +42,7 @@ final class VersionComparisonOperator
      */
     private function ensureOperatorIsValid(string $operator): void
     {
-        if (!\in_array($operator, ['<', 'lt', '<=', 'le', '>', 'gt', '>=', 'ge', '==', '=', 'eq', '!=', '<>', 'ne'])) {
+        if (!\in_array($operator, ['<', 'lt', '<=', 'le', '>', 'gt', '>=', 'ge', '==', '=', 'eq', '!=', '<>', 'ne'], true)) {
             throw new Exception(
                 \sprintf(
                     '"%s" is not a valid version_compare() operator',


### PR DESCRIPTION
This PR

* [x] enables the `strict_param` fixer
* [x] runs `php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

>**strict_param** [`@PhpCsFixer:risky`]
>
>Functions should be used with `$strict` param set to `true`.
>
>Risky rule: risky when the fixed function is overridden or if the code relies on non-strict usage.