### PR TITLE
Fix: Avoid use of empty()

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2825,7 +2825,7 @@ abstract class Assert
                 \sprintf(
                     '%s%sNumber of attributes on node "%s" does not match',
                     $message,
-                    !empty($message) ? "\n" : '',
+                    '' !== $message ? "\n" : '',
                     $expectedElement->tagName
                 )
             );
@@ -2841,7 +2841,7 @@ abstract class Assert
                         \sprintf(
                             '%s%sCould not find attribute "%s" on node "%s"',
                             $message,
-                            !empty($message) ? "\n" : '',
+                            '' !== $message ? "\n" : '',
                             $expectedAttribute->name,
                             $expectedElement->tagName
                         )
@@ -2859,7 +2859,7 @@ abstract class Assert
             \sprintf(
                 '%s%sNumber of child nodes of "%s" differs',
                 $message,
-                !empty($message) ? "\n" : '',
+                '' !== $message ? "\n" : '',
                 $expectedElement->tagName
             )
         );

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -111,7 +111,7 @@ abstract class Constraint implements Countable, SelfDescribing
             $failureDescription .= "\n" . $additionalFailureDescription;
         }
 
-        if (!empty($description)) {
+        if ('' !== $description) {
             $failureDescription = $description . "\n" . $failureDescription;
         }
 

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -215,7 +215,7 @@ final class Generator
                 }
             }
 
-            if (empty($methods)) {
+            if ([] === $methods) {
                 $methods = null;
             }
 
@@ -398,7 +398,7 @@ final class Generator
             $nameEnd      = $nameStart + \strlen($lastFunction[0]) - 1;
             $name         = \str_replace('(', '', $lastFunction[0]);
 
-            if (empty($methods) || \in_array($name, $methods, true)) {
+            if ([] === $methods || \in_array($name, $methods, true)) {
                 $args = \explode(
                     ',',
                     \str_replace(')', '', \substr($method, $nameEnd + 1))
@@ -723,7 +723,7 @@ final class Generator
         if (!$isClass && !$isInterface) {
             $prologue = 'class ' . $mockClassName['originalClassName'] . "\n{\n}\n\n";
 
-            if (!empty($mockClassName['namespaceName'])) {
+            if ('' !== $mockClassName['namespaceName']) {
                 $prologue = 'namespace ' . $mockClassName['namespaceName'] .
                             " {\n\n" . $prologue . "}\n\n" .
                             "namespace {\n\n";
@@ -988,7 +988,7 @@ final class Generator
             if (!\in_array($mockClassName['originalClassName'], $additionalInterfaces, true)) {
                 $buffer .= ', ';
 
-                if (!empty($mockClassName['namespaceName'])) {
+                if ('' !== $mockClassName['namespaceName']) {
                     $buffer .= $mockClassName['namespaceName'] . '\\';
                 }
 
@@ -998,7 +998,7 @@ final class Generator
             $buffer .= \sprintf(
                 '%s extends %s%s implements %s',
                 $mockClassName['className'],
-                !empty($mockClassName['namespaceName']) ? $mockClassName['namespaceName'] . '\\' : '',
+                '' !== $mockClassName['namespaceName'] ? $mockClassName['namespaceName'] . '\\' : '',
                 $mockClassName['originalClassName'],
                 $interfaces
             );

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -213,7 +213,7 @@ final class MockBuilder
      */
     public function onlyMethods(array $methods): self
     {
-        if (empty($methods)) {
+        if ([] === $methods) {
             $this->emptyMethodsArray = true;
 
             return $this;
@@ -259,7 +259,7 @@ final class MockBuilder
      */
     public function addMethods(array $methods): self
     {
-        if (empty($methods)) {
+        if ([] === $methods) {
             $this->emptyMethodsArray = true;
 
             return $this;

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -210,7 +210,7 @@ final class MockMethod
                 'arguments_decl'     => $this->argumentsForDeclaration,
                 'arguments_call'     => $this->argumentsForCall,
                 'return_declaration' => $this->returnType->getReturnTypeDeclaration(),
-                'arguments_count'    => !empty($this->argumentsForCall) ? \substr_count($this->argumentsForCall, ',') + 1 : 0,
+                'arguments_count'    => \is_string($this->argumentsForCall) && '' !== $this->argumentsForCall ? \substr_count($this->argumentsForCall, ',') + 1 : 0,
                 'class_name'         => $this->className,
                 'method_name'        => $this->methodName,
                 'modifier'           => $this->modifier,

--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -210,7 +210,7 @@ final class TestBuilder
     {
         $message = $t->getMessage();
 
-        if (empty(\trim($message))) {
+        if ('' === \trim($message)) {
             $message = '<no message>';
         }
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1036,7 +1036,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
             $this->verifyMockObjects();
             $this->assertPostConditions();
 
-            if (!empty($this->warnings)) {
+            if ([] !== $this->warnings) {
                 throw new Warning(
                     \implode(
                         "\n",
@@ -1327,7 +1327,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
      */
     public function usesDataProvider(): bool
     {
-        return !empty($this->data);
+        return \is_array($this->data) && [] !== $this->data;
     }
 
     /**
@@ -1353,20 +1353,22 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
      */
     public function getDataSetAsString(bool $includeData = true): string
     {
+        if (!$this->usesDataProvider()) {
+            return '';
+        }
+
         $buffer = '';
 
-        if (!empty($this->data)) {
-            if (\is_int($this->dataName)) {
-                $buffer .= \sprintf(' with data set #%d', $this->dataName);
-            } else {
-                $buffer .= \sprintf(' with data set "%s"', $this->dataName);
-            }
+        if (\is_int($this->dataName)) {
+            $buffer .= \sprintf(' with data set #%d', $this->dataName);
+        } else {
+            $buffer .= \sprintf(' with data set "%s"', $this->dataName);
+        }
 
-            $exporter = new Exporter;
+        $exporter = new Exporter;
 
-            if ($includeData) {
-                $buffer .= \sprintf(' (%s)', $exporter->shortenedRecursiveExport($this->data));
-            }
+        if ($includeData) {
+            $buffer .= \sprintf(' (%s)', $exporter->shortenedRecursiveExport($this->data));
         }
 
         return $buffer;
@@ -1662,7 +1664,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
                     ->disableOriginalClone()
                     ->disableArgumentCloning()
                     ->disallowMockingUnknownTypes()
-                    ->setMethods(empty($methods) ? null : $methods)
+                    ->setMethods([] === $methods ? null : $methods)
                     ->getMock();
     }
 
@@ -1959,7 +1961,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
             $this->name
         );
 
-        if (!empty($missingRequirements)) {
+        if ([] !== $missingRequirements) {
             $this->markTestSkipped(\implode(\PHP_EOL, $missingRequirements));
         }
     }
@@ -1998,7 +2000,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
     private function handleDependencies(): bool
     {
-        if (!empty($this->dependencies) && !$this->inIsolation) {
+        if ([] !== $this->dependencies && !$this->inIsolation) {
             $className  = \get_class($this);
             $passed     = $this->result->passed();
             $passedKeys = \array_keys($passed);
@@ -2017,7 +2019,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
                 $deepClone    = false;
                 $shallowClone = false;
 
-                if (empty($dependency)) {
+                if ('' === $dependency) {
                     $this->markSkippedForNotSpecifyingDependency();
 
                     return false;

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -48,7 +48,7 @@ final class TestFailure
                 $buffer .= $e->getDiff();
             }
 
-            if (!empty($buffer)) {
+            if ('' !== $buffer) {
                 $buffer = \trim($buffer) . "\n";
             }
 

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -1160,12 +1160,12 @@ final class TestResult implements Countable
      */
     public function wasSuccessful(): bool
     {
-        return $this->wasSuccessfulIgnoringWarnings() && empty($this->warnings);
+        return $this->wasSuccessfulIgnoringWarnings() && [] === $this->warnings;
     }
 
     public function wasSuccessfulIgnoringWarnings(): bool
     {
-        return empty($this->errors) && empty($this->failures);
+        return [] == $this->errors && [] === $this->failures;
     }
 
     public function wasSuccessfulAndNoTestIsRiskyOrSkippedOrIncomplete(): bool

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -195,7 +195,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
             $this->addTestMethod($theClass, $method);
         }
 
-        if (empty($this->tests)) {
+        if ([] === $this->tests) {
             $this->addTest(
                 new WarningTestCase(
                     \sprintf(
@@ -240,11 +240,11 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
             $this->tests[]  = $test;
             $this->numTests = -1;
 
-            if ($test instanceof self && empty($groups)) {
+            if ($test instanceof self && [] === $groups) {
                 $groups = $test->getGroups();
             }
 
-            if (empty($groups)) {
+            if ([] === $groups) {
                 $groups = ['default'];
             }
 
@@ -358,7 +358,7 @@ class TestSuite implements \IteratorAggregate, SelfDescribing, Test
         // AFTER a child class that inherited from it. To account for that case,
         // accumulate all discovered classes, so the parent class may be found in
         // a later invocation.
-        if (!empty($newClasses)) {
+        if ([] !== $newClasses) {
             // On the assumption that test classes are defined first in files,
             // process discovered classes in approximate LIFO order, so as to
             // avoid unnecessary reflection.

--- a/src/Runner/BaseTestRunner.php
+++ b/src/Runner/BaseTestRunner.php
@@ -83,7 +83,7 @@ abstract class BaseTestRunner
      */
     public function getTest(string $suiteClassName, string $suiteClassFile = '', $suffixes = ''): ?Test
     {
-        if (empty($suiteClassFile) && \is_dir($suiteClassName) && !\is_file($suiteClassName . '.php')) {
+        if ('' === $suiteClassFile && \is_dir($suiteClassName) && !\is_file($suiteClassName . '.php')) {
             /** @var string[] $files */
             $files = (new FileIteratorFacade)->getFilesAsArray(
                 $suiteClassName,

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -255,7 +255,7 @@ final class PhptTestCase implements SelfDescribing, Test
 
     public function hasOutput(): bool
     {
-        return !empty($this->output);
+        return '' !== $this->output;
     }
 
     /**
@@ -301,7 +301,7 @@ final class PhptTestCase implements SelfDescribing, Test
         foreach (\explode("\n", \trim($content)) as $e) {
             $e = \explode('=', \trim($e), 2);
 
-            if (!empty($e[0]) && isset($e[1])) {
+            if ('' !== $e[0] && isset($e[1])) {
                 $env[$e[0]] = $e[1];
             }
         }
@@ -426,7 +426,7 @@ final class PhptTestCase implements SelfDescribing, Test
                 continue;
             }
 
-            if (empty($section)) {
+            if ('' === $section) {
                 throw new Exception('Invalid PHPT file: empty section header');
             }
 
@@ -669,7 +669,7 @@ final class PhptTestCase implements SelfDescribing, Test
                 }
             }
 
-            if (!empty($line)) {
+            if ('' !== $line) {
                 $previousLine = $line;
             }
         }
@@ -690,7 +690,7 @@ final class PhptTestCase implements SelfDescribing, Test
     {
         $needle = \trim($needle);
 
-        if (empty($needle)) {
+        if ('' === $needle) {
             return [[
                 'file' => \realpath($this->filename),
                 'line' => 1,

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -27,11 +27,13 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
         $suiteClassName = \str_replace('.php', '', $suiteClassName);
         $filename       = null;
 
-        if (empty($suiteClassFile)) {
+        if ('' === $suiteClassFile) {
             $suiteClassFile = Filesystem::classNameToFilename(
                 $suiteClassName
             );
         }
+
+        $loadedClasses = [];
 
         if (!\class_exists($suiteClassName, false)) {
             $loadedClasses = \get_declared_classes();
@@ -43,7 +45,7 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
             );
         }
 
-        if (!empty($loadedClasses) && !\class_exists($suiteClassName, false)) {
+        if ([] !== $loadedClasses && !\class_exists($suiteClassName, false)) {
             $offset = 0 - \strlen($suiteClassName);
 
             foreach ($loadedClasses as $loadedClass) {
@@ -68,7 +70,7 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
             }
         }
 
-        if (!empty($loadedClasses) && !\class_exists($suiteClassName, false)) {
+        if ([] !== $loadedClasses && !\class_exists($suiteClassName, false)) {
             $testCaseClass = TestCase::class;
 
             foreach ($loadedClasses as $loadedClass) {

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -183,7 +183,7 @@ final class TestSuiteSorter
 
     private function sort(TestSuite $suite, int $order, bool $resolveDependencies, int $orderDefects): void
     {
-        if (empty($suite->tests())) {
+        if ([] === $suite->tests()) {
             return;
         }
 
@@ -378,13 +378,13 @@ final class TestSuiteSorter
                 $tests
             );
 
-            if (!$tests[$i]->hasDependencies() || empty(\array_intersect($this->getNormalizedDependencyNames($tests[$i]), $todoNames))) {
+            if (!$tests[$i]->hasDependencies() || [] === \array_intersect($this->getNormalizedDependencyNames($tests[$i]), $todoNames)) {
                 $newTestOrder = \array_merge($newTestOrder, \array_splice($tests, $i, 1));
                 $i            = 0;
             } else {
                 $i++;
             }
-        } while (!empty($tests) && ($i < \count($tests)));
+        } while ([] !== $tests && $i < \count($tests));
 
         return \array_merge($newTestOrder, $tests);
     }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -470,11 +470,11 @@ final class TestRunner extends BaseTestRunner
             if (isset($arguments['configuration'])) {
                 $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
 
-                if (!empty($filterConfiguration['whitelist'])) {
+                if ([] !== $filterConfiguration['whitelist']) {
                     $whitelistFromConfigurationFile = true;
                 }
 
-                if (!empty($filterConfiguration['whitelist'])) {
+                if ([] !== $filterConfiguration['whitelist']) {
                     foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
                         $this->codeCoverageFilter->addDirectoryToWhitelist(
                             $dir['path'],

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -415,13 +415,13 @@ final class DocBlock
             $leaf                            = \explode('::', \array_pop($dataProviderMethodNameNamespace));
             $dataProviderMethodName          = \array_pop($leaf);
 
-            if (empty($dataProviderMethodNameNamespace)) {
+            if ([] === $dataProviderMethodNameNamespace) {
                 $dataProviderMethodNameNamespace = '';
             } else {
                 $dataProviderMethodNameNamespace = \implode('\\', $dataProviderMethodNameNamespace) . '\\';
             }
 
-            if (empty($leaf)) {
+            if ([] === $leaf) {
                 $dataProviderClassName = $className;
             } else {
                 /** @psalm-var class-string $dataProviderClassName */

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -76,7 +76,7 @@ final class Color
             }
         }
 
-        if (empty($styles)) {
+        if ([] === $styles) {
             return $buffer;
         }
 

--- a/src/Util/Configuration.php
+++ b/src/Util/Configuration.php
@@ -371,7 +371,7 @@ final class Configuration
     {
         $configuration = $this->getPHPConfiguration();
 
-        if (!empty($configuration['include_path'])) {
+        if ([] !== $configuration['include_path']) {
             \ini_set(
                 'include_path',
                 \implode(\PATH_SEPARATOR, $configuration['include_path']) .
@@ -981,13 +981,13 @@ final class Configuration
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
             \assert($directoryNode instanceof DOMElement);
 
-            if (!empty($testSuiteFilter) && !\in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter, true)) {
+            if ([] !== $testSuiteFilter && !\in_array($directoryNode->parentNode->getAttribute('name'), $testSuiteFilter, true)) {
                 continue;
             }
 
             $directory = (string) $directoryNode->textContent;
 
-            if (empty($directory)) {
+            if ('' === $directory) {
                 continue;
             }
 
@@ -1008,13 +1008,13 @@ final class Configuration
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
             \assert($fileNode instanceof DOMElement);
 
-            if (!empty($testSuiteFilter) && !\in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter, true)) {
+            if ([] !== $testSuiteFilter && !\in_array($fileNode->parentNode->getAttribute('name'), $testSuiteFilter, true)) {
                 continue;
             }
 
             $file = (string) $fileNode->textContent;
 
-            if (empty($file)) {
+            if ('' === $file) {
                 continue;
             }
 

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -21,7 +21,7 @@ final class Getopt
      */
     public static function parse(array $args, string $short_options, array $long_options = null): array
     {
-        if (empty($args)) {
+        if ([] === $args) {
             return [[], []];
         }
 

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -358,7 +358,7 @@ final class JUnit extends Printer implements TestListener
             $testOutput = $test->hasOutput() ? $test->getActualOutput() : '';
         }
 
-        if (!empty($testOutput)) {
+        if ('' !== $testOutput) {
             $systemOut = $this->document->createElement(
                 'system-out',
                 Xml::prepareString($testOutput)

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -102,13 +102,13 @@ final class TeamCity extends ResultPrinter
             if ($comparisonFailure instanceof ComparisonFailure) {
                 $expectedString = $comparisonFailure->getExpectedAsString();
 
-                if ($expectedString === null || empty($expectedString)) {
+                if ($expectedString === null || '' === $expectedString) {
                     $expectedString = self::getPrimitiveValueAsString($comparisonFailure->getExpected());
                 }
 
                 $actualString = $comparisonFailure->getActualAsString();
 
-                if ($actualString === null || empty($actualString)) {
+                if ($actualString === null || '' === $actualString) {
                     $actualString = self::getPrimitiveValueAsString($comparisonFailure->getActual());
                 }
 
@@ -190,7 +190,7 @@ final class TeamCity extends ResultPrinter
 
         $suiteName = $suite->getName();
 
-        if (empty($suiteName)) {
+        if ('' === $suiteName) {
             return;
         }
 
@@ -219,7 +219,7 @@ final class TeamCity extends ResultPrinter
     {
         $suiteName = $suite->getName();
 
-        if (empty($suiteName)) {
+        if ('' === $suiteName) {
             return;
         }
 

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -248,7 +248,7 @@ abstract class AbstractPhpProcess
     {
         $time = 0;
 
-        if (!empty($stderr)) {
+        if ('' !== $stderr) {
             $result->addError(
                 $test,
                 new Exception(\trim($stderr)),
@@ -317,37 +317,37 @@ abstract class AbstractPhpProcess
                 $warnings       = $childResult->warnings();
                 $failures       = $childResult->failures();
 
-                if (!empty($notImplemented)) {
+                if ([] !== $notImplemented) {
                     $result->addError(
                         $test,
                         $this->getException($notImplemented[0]),
                         $time
                     );
-                } elseif (!empty($risky)) {
+                } elseif ([] !== $risky) {
                     $result->addError(
                         $test,
                         $this->getException($risky[0]),
                         $time
                     );
-                } elseif (!empty($skipped)) {
+                } elseif ([] !== $skipped) {
                     $result->addError(
                         $test,
                         $this->getException($skipped[0]),
                         $time
                     );
-                } elseif (!empty($errors)) {
+                } elseif ([] !== $errors) {
                     $result->addError(
                         $test,
                         $this->getException($errors[0]),
                         $time
                     );
-                } elseif (!empty($warnings)) {
+                } elseif ([] !== $warnings) {
                     $result->addWarning(
                         $test,
                         $this->getException($warnings[0]),
                         $time
                     );
-                } elseif (!empty($failures)) {
+                } elseif ([] !== $failures) {
                     $result->addFailure(
                         $test,
                         $this->getException($failures[0]),

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -219,7 +219,7 @@ class CliTestDoxPrinter extends TestDoxPrinter
         }
         $diff = \implode(\PHP_EOL, $diff);
 
-        if (!empty($message)) {
+        if ([] !== $message) {
             $message = $this->colorizeTextBox($style, \implode(\PHP_EOL, $message));
         }
 
@@ -331,7 +331,7 @@ class CliTestDoxPrinter extends TestDoxPrinter
 
     private function printNonSuccessfulTestsSummary(int $numberOfExecutedTests): void
     {
-        if (empty($this->nonSuccessfulTestResults)) {
+        if ([] === $this->nonSuccessfulTestResults) {
             return;
         }
 

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -65,11 +65,11 @@ final class NamePrettifier
             $className = \substr($className, \strlen('Test'));
         }
 
-        if (empty($className)) {
+        if ('' === $className) {
             $className = 'UnnamedTests';
         }
 
-        if (!empty($parts)) {
+        if ([] !== $parts) {
             $parts[]            = $className;
             $fullyQualifiedName = \implode('\\', $parts);
         } else {

--- a/src/Util/TestDox/ResultPrinter.php
+++ b/src/Util/TestDox/ResultPrinter.php
@@ -314,7 +314,7 @@ abstract class ResultPrinter extends Printer implements TestListener
             return false;
         }
 
-        if (!empty($this->groups)) {
+        if ([] !== $this->groups) {
             foreach ($test->getGroups() as $group) {
                 if (\in_array($group, $this->groups, true)) {
                     return true;
@@ -324,7 +324,7 @@ abstract class ResultPrinter extends Printer implements TestListener
             return false;
         }
 
-        if (!empty($this->excludeGroups)) {
+        if ([] !== $this->excludeGroups) {
             foreach ($test->getGroups() as $group) {
                 if (\in_array($group, $this->excludeGroups, true)) {
                     return false;

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -85,7 +85,7 @@ class TestDoxPrinter extends ResultPrinter
     public function setOriginalExecutionOrder(array $order): void
     {
         $this->originalExecutionOrder = $order;
-        $this->enableOutputBuffer     = !empty($order);
+        $this->enableOutputBuffer     = [] !== $order;
     }
 
     public function setShowProgressAnimation(bool $showProgress): void

--- a/src/Util/XmlTestListRenderer.php
+++ b/src/Util/XmlTestListRenderer.php
@@ -49,7 +49,7 @@ final class XmlTestListRenderer
                 $writer->writeAttribute('name', $test->getName(false));
                 $writer->writeAttribute('groups', \implode(',', $test->getGroups()));
 
-                if (!empty($test->getDataSetAsString(false))) {
+                if ('' !== $test->getDataSetAsString(false)) {
                     $writer->writeAttribute(
                         'dataSet',
                         \str_replace(


### PR DESCRIPTION
This PR

* [x] avoids the use of `empty()` where possible