### PR TITLE
Fix: Do not run tests with PHP 8 and JIT on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,6 @@ jobs:
             compiler: jit
             dependencies: highest
 
-          - os: windows-latest
-            php-version: "8.0"
-            compiler: jit
-            dependencies: highest
-
     steps:
       - name: Configure git to avoid issues with line endings
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This PR

* [x] stops running tests on PHP 8 with JIT on `windows-latest`