### PR TITLE
Add 'resource (closed)' type and assertions for closed resources

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1512,6 +1512,23 @@ abstract class Assert
     }
 
     /**
+     * Asserts that a variable is of type resource and is closed.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @psalm-assert resource $actual
+     */
+    public static function assertIsClosedResource($actual, string $message = ''): void
+    {
+        static::assertThat(
+            $actual,
+            new IsType(IsType::TYPE_CLOSED_RESOURCE),
+            $message
+        );
+    }
+
+    /**
      * Asserts that a variable is of type string.
      *
      * @throws ExpectationFailedException
@@ -1694,6 +1711,23 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_RESOURCE)),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that a variable is not of type resource.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @psalm-assert !resource $actual
+     */
+    public static function assertIsNotClosedResource($actual, string $message = ''): void
+    {
+        static::assertThat(
+            $actual,
+            new LogicalNot(new IsType(IsType::TYPE_CLOSED_RESOURCE)),
             $message
         );
     }

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1296,6 +1296,21 @@ function assertIsResource($actual, string $message = ''): void
 }
 
 /**
+ * Asserts that a variable is of type resource (closed).
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
+ * @psalm-assert resource $actual
+ *
+ * @see Assert::assertIsClosedResource
+ */
+function assertIsClosedResource($actual, string $message = ''): void
+{
+    Assert::assertIsClosedResource(...func_get_args());
+}
+
+/**
  * Asserts that a variable is of type string.
  *
  * @throws ExpectationFailedException
@@ -1458,6 +1473,21 @@ function assertIsNotObject($actual, string $message = ''): void
 function assertIsNotResource($actual, string $message = ''): void
 {
     Assert::assertIsNotResource(...func_get_args());
+}
+
+/**
+ * Asserts that a variable is not of type resource (closed).
+ *
+ * @throws ExpectationFailedException
+ * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+ *
+ * @psalm-assert !resource $actual
+ *
+ * @see Assert::assertIsNotClosedResource
+ */
+function assertIsNotClosedResource($actual, string $message = ''): void
+{
+    Assert::assertIsNotClosedResource(...func_get_args());
 }
 
 /**

--- a/src/Framework/Constraint/Type/IsType.php
+++ b/src/Framework/Constraint/Type/IsType.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use function get_resource_type;
+use function gettype;
 use function is_array;
 use function is_bool;
 use function is_callable;
@@ -18,11 +18,9 @@ use function is_int;
 use function is_iterable;
 use function is_numeric;
 use function is_object;
-use function is_resource;
 use function is_scalar;
 use function is_string;
 use function sprintf;
-use TypeError;
 
 /**
  * Constraint that asserts that the value it is evaluated for is of a
@@ -75,6 +73,11 @@ final class IsType extends Constraint
     /**
      * @var string
      */
+    public const TYPE_CLOSED_RESOURCE = 'resource (closed)';
+
+    /**
+     * @var string
+     */
     public const TYPE_STRING = 'string';
 
     /**
@@ -96,22 +99,23 @@ final class IsType extends Constraint
      * @var array<string,bool>
      */
     private const KNOWN_TYPES = [
-        'array'    => true,
-        'boolean'  => true,
-        'bool'     => true,
-        'double'   => true,
-        'float'    => true,
-        'integer'  => true,
-        'int'      => true,
-        'null'     => true,
-        'numeric'  => true,
-        'object'   => true,
-        'real'     => true,
-        'resource' => true,
-        'string'   => true,
-        'scalar'   => true,
-        'callable' => true,
-        'iterable' => true,
+        'array'             => true,
+        'boolean'           => true,
+        'bool'              => true,
+        'double'            => true,
+        'float'             => true,
+        'integer'           => true,
+        'int'               => true,
+        'null'              => true,
+        'numeric'           => true,
+        'object'            => true,
+        'real'              => true,
+        'resource'          => true,
+        'resource (closed)' => true,
+        'string'            => true,
+        'scalar'            => true,
+        'callable'          => true,
+        'iterable'          => true,
     ];
 
     /**
@@ -186,20 +190,12 @@ final class IsType extends Constraint
                 return is_object($other);
 
             case 'resource':
-                if (is_resource($other)) {
-                    return true;
-                }
+                $type = gettype($other);
 
-                try {
-                    $resource = @get_resource_type($other);
+                return $type === 'resource' || $type === 'resource (closed)';
 
-                    if (is_string($resource)) {
-                        return true;
-                    }
-                } catch (TypeError $e) {
-                }
-
-                return false;
+            case 'resource (closed)':
+                return gettype($other) === 'resource (closed)';
 
             case 'scalar':
                 return is_scalar($other);

--- a/tests/static-analysis/happy-path/assert-is-closed-resource.php
+++ b/tests/static-analysis/happy-path/assert-is-closed-resource.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\StaticAnalysis\HappyPath\AssertIsClosedResource;
+
+use PHPUnit\Framework\Assert;
+
+/**
+ * @param mixed $value
+ *
+ * @return resource
+ */
+function consume($value)
+{
+    Assert::assertIsClosedResource($value);
+
+    return $value;
+}

--- a/tests/static-analysis/happy-path/assert-is-not-closed-resource.php
+++ b/tests/static-analysis/happy-path/assert-is-not-closed-resource.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\StaticAnalysis\HappyPath\AssertIsNotClosedResource;
+
+use PHPUnit\Framework\Assert;
+
+/** @param int|resource $value */
+function consume($value): int
+{
+    Assert::assertIsNotClosedResource($value);
+
+    return $value;
+}

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -16,6 +16,7 @@ use const PHP_OS_FAMILY;
 use function acos;
 use function array_merge;
 use function chmod;
+use function fclose;
 use function file_get_contents;
 use function fopen;
 use function json_encode;
@@ -1980,6 +1981,23 @@ XML;
         $this->fail();
     }
 
+    public function testClosedResourceTypeCanBeAsserted(): void
+    {
+        $resource = fopen(__FILE__, 'r');
+        fclose($resource);
+
+        $this->assertIsClosedResource($resource);
+        $this->assertIsResource($resource);
+
+        try {
+            $this->assertIsClosedResource(null);
+        } catch (AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
     public function testStringTypeCanBeAsserted(): void
     {
         $this->assertIsString('');
@@ -2117,6 +2135,28 @@ XML;
 
         try {
             $this->assertIsNotResource(fopen(__FILE__, 'r'));
+        } catch (AssertionFailedError $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testNotClosedResourceTypeCanBeAsserted(): void
+    {
+        $this->assertIsNotClosedResource(null);
+
+        $resource = fopen(__FILE__, 'r');
+        fclose($resource);
+
+        try {
+            $this->assertIsNotClosedResource($resource);
+        } catch (AssertionFailedError $e) {
+            return;
+        }
+
+        try {
+            $this->assertIsNotResource($resource);
         } catch (AssertionFailedError $e) {
             return;
         }


### PR DESCRIPTION
Related #4276 

During the release of PHP 7.2 [`gettype()`](https://www.php.net/manual/en/function.gettype.php) was improved to be able to detect closed resources. The type `resource (closed)` was added to the return list. Previously it was very difficult to detect when a resource was closed because php's `is_resource()` function is not strict

[PHP's `is_resource()`:](https://www.php.net/manual/en/function.is-resource)
> is_resource() is not a strict type-checking method: it will return FALSE if var is a resource variable that has been closed.

*Notes*:
- I have built this with strictness in mind, a closed resource is still a resource.
- This is a BC change.

This PR adds assertions:
- `assertIsClosedResource()`
- `assertIsNotClosedResource()`