### PR TITLE
Simplify array access

### DIFF
--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -71,7 +71,7 @@ final class Getopt
             }
 
             if ($arg[0] !== '-' || (strlen($arg) > 1 && $arg[1] === '-' && !$long_options)) {
-                $non_opts[] = $args[$i];
+                $non_opts[] = $arg;
 
                 continue;
             }


### PR DESCRIPTION
Psalm doesn't know whether or not `$i` is `null` (it's not smart enough to understand that `false !== $arg = current($args)` implies `$args` is non-empty).

But, regardless, the array access is not necessary there.