### PR TITLE
CI: remove double Dockerfile compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build Docker image
-        uses: ./.docker/lint-xml-configuration
-
       - name: Lint XML configuration files
         uses: ./.docker/lint-xml-configuration
         with:


### PR DESCRIPTION
As far as I can tell from the GA logs https://github.com/sebastianbergmann/phpunit/runs/905995415?check_suite_focus=true the Docker image is build on every step, so the first one is useless.

Ping @localheinz as original proposer in https://github.com/sebastianbergmann/phpunit/pull/3921