### PR TITLE
Tentatively implements #4288

### DIFF
--- a/src/TextUI/XmlConfiguration/Migration/MigrationBuilder.php
+++ b/src/TextUI/XmlConfiguration/Migration/MigrationBuilder.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use function version_compare;
+
+final class MigrationBuilder {
+
+    private const availableMigrations = [
+        '9.2' => [
+            IntroduceCoverageElement::class,
+            MoveAttributesFromRootToCoverage::class,
+            MoveAttributesFromFilterWhitelistToCoverage::class,
+            MoveWhitelistDirectoriesToCoverage::class,
+            MoveWhitelistExcludesToCoverage::class,
+            RemoveEmptyFilter::class,
+            CoverageCloverToReport::class,
+            CoverageCrap4jToReport::class,
+            CoverageHtmlToReport::class,
+            CoveragePhpToReport::class,
+            CoverageTextToReport::class,
+            CoverageXmlToReport::class,
+            ConvertLogTypes::class
+        ]
+    ];
+
+    public function build(string $fromVersion): array
+    {
+        if (version_compare($fromVersion, '9.2', '<')) {
+            throw new MigrationBuilderException('Versions before 9.2 are not supported.');
+        }
+
+        $stack = [];
+
+        foreach(self::availableMigrations as $version => $migrations) {
+            if (version_compare($version, $fromVersion, '<')) {
+                continue;
+            }
+
+            foreach($migrations as $migration) {
+                $stack[] = new $migration;
+            }
+        }
+
+        return $stack;
+    }
+}

--- a/src/TextUI/XmlConfiguration/Migration/MigrationBuilderException.php
+++ b/src/TextUI/XmlConfiguration/Migration/MigrationBuilderException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use RuntimeException;
+
+class MigrationBuilderException extends RuntimeException implements \PHPUnit\Exception
+{
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/MigrationException.php
+++ b/src/TextUI/XmlConfiguration/Migration/MigrationException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use RuntimeException;
+
+class MigrationException extends RuntimeException implements \PHPUnit\Exception
+{
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/ConvertLogTypes.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/ConvertLogTypes.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class ConvertLogTypes implements Migration {
+
+    public function migrate(DOMDocument $document): void {
+
+        $logging = $document->getElementsByTagName('logging')->item(0);
+        if (!$logging instanceof DOMElement) {
+            return;
+        }
+        $types = [
+            'junit' => 'junit',
+            'teamcity' => 'teamcity',
+            'testdox-html' => 'testdoxHtml',
+            'testdox-text' => 'testdoxText',
+            'testdox-xml' => 'testdoxXml',
+            'plain' => 'text'
+        ];
+
+        $logNodes = [];
+        foreach($logging->getElementsByTagName('log') as $logNode) {
+            if (!isset($types[$logNode->getAttribute('type')])) {
+                continue;
+            }
+
+            $logNodes[] = $logNode;
+        }
+
+        foreach($logNodes as $oldNode) {
+            $newLogNode = $document->createElement($types[$oldNode->getAttribute('type')]);
+            $newLogNode->setAttribute('outputFile', $oldNode->getAttribute('target'));
+
+            $logging->replaceChild($newLogNode, $oldNode);
+        }
+
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCloverToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCloverToReport.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+class CoverageCloverToReport extends LogToReportMigration {
+
+    protected function forType(): string {
+        return 'coverage-clover';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement {
+        $clover = $logNode->ownerDocument->createElement('clover');
+        $clover->setAttribute('outputFile', $logNode->getAttribute('target'));
+
+        return $clover;
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCrap4jToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCrap4jToReport.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+class CoverageCrap4jToReport extends LogToReportMigration {
+
+    protected function forType(): string {
+        return 'coverage-crap4j';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement {
+        $crap4j = $logNode->ownerDocument->createElement('crap4j');
+        $crap4j->setAttribute('outputFile', $logNode->getAttribute('target'));
+
+        $this->migrateAttributes($logNode, $crap4j, ['threshold']);
+
+        return $crap4j;
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageHtmlToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageHtmlToReport.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+class CoverageHtmlToReport extends LogToReportMigration {
+
+    protected function forType(): string {
+        return 'coverage-html';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement {
+        $html = $logNode->ownerDocument->createElement('html');
+        $html->setAttribute('outputDirectory', $logNode->getAttribute('target'));
+
+        $this->migrateAttributes($logNode, $html, ['lowUpperBound', 'highLowerBound']);
+
+        return $html;
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoveragePhpToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoveragePhpToReport.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+class CoveragePhpToReport extends LogToReportMigration {
+
+    protected function forType(): string {
+        return 'coverage-php';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement {
+        $php = $logNode->ownerDocument->createElement('php');
+        $php->setAttribute('outputFile', $logNode->getAttribute('target'));
+
+        return $php;
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageTextToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageTextToReport.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+class CoverageTextToReport extends LogToReportMigration {
+
+    protected function forType(): string {
+        return 'coverage-text';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement {
+        $text = $logNode->ownerDocument->createElement('text');
+        $text->setAttribute('outputFile', $logNode->getAttribute('target'));
+
+        $this->migrateAttributes($logNode, $text, ['showUncoveredFiles', 'showOnlySummary']);
+
+        return $text;
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageXmlToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageXmlToReport.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+class CoverageXmlToReport extends LogToReportMigration {
+
+    protected function forType(): string {
+        return 'coverage-xml';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement {
+        $xml = $logNode->ownerDocument->createElement('xml');
+        $xml->setAttribute('outputDirectory', $logNode->getAttribute('target'));
+
+        return $xml;
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/IntroduceCoverageElement.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/IntroduceCoverageElement.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class IntroduceCoverageElement implements Migration
+{
+    /**
+     * @var DOMDocument
+     */
+    private $document;
+
+    /**
+     * @var DOMElement
+     */
+    private $coverage;
+
+    public function migrate(DOMDocument $document): void
+    {
+        $this->document = $document;
+        $this->coverage = $document->createElement('coverage');
+
+        $this->document->documentElement->insertBefore(
+            $this->coverage,
+            $this->document->documentElement->firstChild
+        );
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/LogToReportMigration.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/LogToReportMigration.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+
+abstract class LogToReportMigration implements Migration {
+
+    public function migrate(DOMDocument $document): void {
+        /** @var ?DOMElement $coverage */
+        $coverage = $document->getElementsByTagName('coverage')->item(0);
+        if (!$coverage instanceof DOMElement) {
+            throw new MigrationException('Unexpected state - No coverage element');
+        }
+
+        $logNode = $this->findLogNode($document);
+        if ($logNode === null) {
+            return;
+        }
+
+        $reportChild = $this->toReportFormat($logNode);
+
+        $report = $coverage->getElementsByTagName('report')->item(0);
+        if ($report === null) {
+            $report = $coverage->appendChild($document->createElement('report'));
+        }
+
+        $report->appendChild($reportChild);
+        $logNode->parentNode->removeChild($logNode);
+    }
+
+    private function findLogNode($document): ?DOMElement {
+        $logNode = (new DOMXPath($document))->query(
+            sprintf('//logging/log[@type="%s"]', $this->forType())
+        )->item(0);
+
+        if (!$logNode instanceof DOMElement) {
+            return null;
+        }
+
+        return $logNode;
+    }
+
+    protected function migrateAttributes(DOMElement $src, DOMElement $dest, array $attributes): void {
+        foreach($attributes as $attr) {
+            if (!$src->hasAttribute($attr)) {
+                continue;
+            }
+
+            $dest->setAttribute($attr, $src->getAttribute($attr));
+            $src->removeAttribute($attr);
+        }
+    }
+
+    abstract protected function forType(): string;
+    abstract protected function toReportFormat(DOMElement $logNode): DOMElement;
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/Migration.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/Migration.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+
+interface Migration
+{
+    public function migrate(DOMDocument $document): void;
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/MoveAttributesFromFilterWhitelistToCoverage.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/MoveAttributesFromFilterWhitelistToCoverage.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class MoveAttributesFromFilterWhitelistToCoverage implements Migration {
+    public function migrate(DOMDocument $document): void {
+        $whitelist = $document->getElementsByTagName('whitelist')->item(0);
+        if (!$whitelist) {
+            return;
+        }
+
+        /** @var ?DOMElement $coverage */
+        $coverage = $document->getElementsByTagName('coverage')->item(0);
+        if (!$coverage instanceof DOMElement) {
+            throw new MigrationException('Unexpected state - No coverage element');
+        }
+
+        $map = [
+            'addUncoveredFilesFromWhitelist' => 'includeUncoveredFiles',
+            'processUncoveredFilesFromWhitelist' => 'processUncoveredFiles'
+        ];
+
+        foreach($map as $old => $new) {
+            if (!$whitelist->hasAttribute($old)) {
+                continue;
+            }
+
+            $coverage->setAttribute($new, $whitelist->getAttribute($old));
+            $whitelist->removeAttribute($old);
+        }
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/MoveAttributesFromRootToCoverage.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/MoveAttributesFromRootToCoverage.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class MoveAttributesFromRootToCoverage implements Migration {
+
+    public function migrate(DOMDocument $document): void {
+        $map = [
+            'disableCodeCoverageIgnore' => 'disableCodeCoverageIgnore',
+            'ignoreDeprecatedCodeUnitsFromCodeCoverage' => 'ignoreDeprecatedCodeUnits'
+        ];
+
+        $root = $document->documentElement;
+
+        /** @var ?DOMElement $coverage */
+        $coverage = $document->getElementsByTagName('coverage')->item(0);
+        if (!$coverage instanceof DOMElement) {
+            throw new MigrationException('Unexpected state - No coverage element');
+        }
+
+        foreach($map as $old => $new) {
+            if (!$root->hasAttribute($old)) {
+                continue;
+            }
+
+            $coverage->setAttribute($new, $root->getAttribute($old));
+            $root->removeAttribute($old);
+        }
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistDirectoriesToCoverage.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistDirectoriesToCoverage.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class MoveWhitelistDirectoriesToCoverage implements Migration {
+
+    public function migrate(DOMDocument $document): void {
+        $whitelist = $document->getElementsByTagName('whitelist')->item(0);
+        if ($whitelist === null) {
+            return;
+        }
+
+        /** @var ?DOMElement $coverage */
+        $coverage = $document->getElementsByTagName('coverage')->item(0);
+        if (!$coverage instanceof DOMElement) {
+            throw new MigrationException('Unexpected state - No coverage element');
+        }
+
+        $include = $document->createElement('include');
+        $coverage->appendChild($include);
+
+        foreach($whitelist->childNodes as $child) {
+            if (!$child instanceof DOMElement || $child->nodeName !== 'directory') {
+                continue;
+            }
+
+            $include->appendChild($child);
+        }
+
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistExcludesToCoverage.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistExcludesToCoverage.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class MoveWhitelistExcludesToCoverage implements Migration {
+
+    public function migrate(DOMDocument $document): void {
+        $whitelist = $document->getElementsByTagName('whitelist')->item(0);
+        if ($whitelist === null) {
+            return;
+        }
+
+        $exclude = $whitelist->getElementsByTagName('exclude')->item(0);
+        if ($exclude === null) {
+            return;
+        }
+
+        /** @var ?DOMElement $coverage */
+        $coverage = $document->getElementsByTagName('coverage')->item(0);
+        if (!$coverage instanceof DOMElement) {
+            throw new MigrationException('Unexpected state - No coverage element');
+        }
+
+        $coverage->appendChild($exclude);
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/RemoveEmptyFilter.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/RemoveEmptyFilter.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class RemoveEmptyFilter implements Migration {
+
+    public function migrate(DOMDocument $document): void {
+        $whitelist = $document->getElementsByTagName('whitelist')->item(0);
+        if ($whitelist instanceof DOMElement) {
+            $this->ensureEmpty($whitelist);
+            $whitelist->parentNode->removeChild($whitelist);
+        }
+
+        $filter = $document->getElementsByTagName('filter')->item(0);
+        if ($filter instanceof DOMElement) {
+            $this->ensureEmpty($filter);
+            $filter->parentNode->removeChild($filter);
+        }
+    }
+
+    private function ensureEmpty(DOMElement $element) {
+        if ($element->attributes->length > 0) {
+            throw new MigrationException(sprintf('%s element has unexpected attributes', $element->nodeName));
+        }
+
+        if ($element->getElementsByTagName('*')->length > 0) {
+            throw new MigrationException(sprintf('%s element has unexpected children', $element->nodeName));
+        }
+    }
+
+}

--- a/tests/_files/Migration/phpunit-9.2.xml
+++ b/tests/_files/Migration/phpunit-9.2.xml
@@ -4,6 +4,7 @@
          cacheTokens="true"
          disableCodeCoverageIgnore="true"
          ignoreDeprecatedCodeUnitsFromCodeCoverage="true">
+    <!-- ... -->
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true"

--- a/tests/_files/Migration/phpunit-9.3.xml
+++ b/tests/_files/Migration/phpunit-9.3.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <!-- ... -->
 
     <coverage includeUncoveredFiles="true"
               processUncoveredFiles="true"

--- a/tests/unit/TextUI/MigrationTest.php
+++ b/tests/unit/TextUI/MigrationTest.php
@@ -18,9 +18,10 @@ final class MigrationTest extends TestCase
      */
     public function testMigratesPhpUnit92ConfigurationToPhpUnit93(): void
     {
+
         $this->assertStringEqualsFile(
             __DIR__ . '/../../_files/XmlConfigurationMigration/output-9.3.xml',
-            (new Migrator)->migrateFrom92To93(
+            (new Migrator)->migrate(
                 __DIR__ . '/../../_files/XmlConfigurationMigration/input-9.2.xml'
             )
         );


### PR DESCRIPTION
This should implement all the migration steps required to move from the 9.2 sample configuration xml to the 9.3 expected output format. As per discussion with @sebastianbergmann, the Migrator code is ready to easily deal with more migrations coming in the future and allows for adding code to migrate configuration files from before 9.2.

__Pending issues__:

* [x] There's an attribute `cacheTokens="true"` in the root element of the `input-9.2.xml`. It is missing in the `output-9.3.xml` but I was not convinced simply removing it would be the correct migration.

* [ ] The test for the migration is failing as the XML, while being semantically identical, is not from a formatting perspective so the string comparison based assertion fails. I don't see a point in matching the formatting to make the test happy but didn't want to simply change it. We should adjust the assertion.

* [ ] There is some minor code duplication (ensuring the newly created `<coverage>` node exists) in some of the migration classes. This could potentially be refactored to avoid it. Not sure if it's worth the effort.

* [ ] As stated before, no integration is included, e.g. nothing calls this migration code except for the test