### PR TITLE
Enhancement: Build and test PHAR on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,37 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  build-and-test-phar:
+    name: Build and test PHAR
+
+    runs-on: ubuntu-latest
+
+    env:
+      PHP_EXTENSIONS: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
+      PHP_INI_VALUES: assert.exception=1, phar.readonly=0, zend.assertions=1
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: pcov
+          extensions: ${{ env.PHP_EXTENSIONS }}
+          ini-values: ${{ env.PHP_INI_VALUES }}
+
+      - name: Install java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: List ant targets
+        run: ant -p


### PR DESCRIPTION
This PR

* [x] builds and tests the PHAR on GitHub Actions

### Requires

* [ ] `ant` target to build scoped PHAR without version number and commit hash, e.g., `phpunit-scoped.phar`, so we can run `phpunit` tests with it
* [ ] `ant` target to build unscoped PHAR without version number and commit hash, e.g., `phpunit-unscoped.phar`, so we can run example tests with it
* [ ] example tests that can be used to to run tests with unscoped PHAR