### PR TITLE
Enhance Exclude Migration to support multiple occurrences

### DIFF
--- a/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistExcludesToCoverage.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistExcludesToCoverage.php
@@ -30,6 +30,7 @@ final class MoveWhitelistExcludesToCoverage implements Migration
         }
 
         $excludeNodes = SnapshotNodeList::fromNodeList($whitelist->getElementsByTagName('exclude'));
+
         if ($excludeNodes->count() === 0) {
             return;
         }
@@ -50,7 +51,6 @@ final class MoveWhitelistExcludesToCoverage implements Migration
 
         foreach ($excludeNodes as $excludeNode) {
             assert($excludeNode instanceof DOMElement);
-
 
             foreach (SnapshotNodeList::fromNodeList($excludeNode->childNodes) as $child) {
                 if (!$child instanceof DOMElement || !in_array($child->nodeName, ['directory', 'file'], true)) {

--- a/src/TextUI/XmlConfiguration/Migration/SnapshotNodeList.php
+++ b/src/TextUI/XmlConfiguration/Migration/SnapshotNodeList.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+namespace TextUI\XmlConfiguration\Migration;
+
+use ArrayIterator;
+use Countable;
+use DOMNode;
+use DOMNodeList;
+use IteratorAggregate;
+
+class SnapshotNodeList implements IteratorAggregate, Countable {
+
+    /** @var DOMNode[] */
+    private $nodes = [];
+
+    public static function fromNodeList(DOMNodeList  $list): SnapshotNodeList {
+        $snapshot = new self();
+        foreach($list as $node) {
+            $snapshot->nodes[] = $node;
+        }
+
+        return $snapshot;
+    }
+
+    public function count(): int {
+        return count($this->nodes);
+    }
+
+    public function getIterator() {
+        return new ArrayIterator($this->nodes);
+    }
+
+}

--- a/src/TextUI/XmlConfiguration/Migration/SnapshotNodeList.php
+++ b/src/TextUI/XmlConfiguration/Migration/SnapshotNodeList.php
@@ -1,4 +1,12 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace TextUI\XmlConfiguration\Migration;
 
 use ArrayIterator;
@@ -7,26 +15,29 @@ use DOMNode;
 use DOMNodeList;
 use IteratorAggregate;
 
-class SnapshotNodeList implements IteratorAggregate, Countable {
-
+class SnapshotNodeList implements Countable, IteratorAggregate
+{
     /** @var DOMNode[] */
     private $nodes = [];
 
-    public static function fromNodeList(DOMNodeList  $list): SnapshotNodeList {
+    public static function fromNodeList(DOMNodeList  $list): self
+    {
         $snapshot = new self();
-        foreach($list as $node) {
+
+        foreach ($list as $node) {
             $snapshot->nodes[] = $node;
         }
 
         return $snapshot;
     }
 
-    public function count(): int {
+    public function count(): int
+    {
         return count($this->nodes);
     }
 
-    public function getIterator() {
+    public function getIterator()
+    {
         return new ArrayIterator($this->nodes);
     }
-
 }

--- a/tests/_files/XmlConfigurationMigration/input-9.2.xml
+++ b/tests/_files/XmlConfigurationMigration/input-9.2.xml
@@ -14,6 +14,10 @@
                 <directory suffix=".php">src/generated</directory>
                 <file>src/autoload.php</file>
             </exclude>
+            <exclude>
+                <directory suffix=".php">src/other</directory>
+                <file>src/some.php</file>
+            </exclude>
         </whitelist>
     </filter>
 

--- a/tests/_files/XmlConfigurationMigration/output-9.3.xml
+++ b/tests/_files/XmlConfigurationMigration/output-9.3.xml
@@ -13,6 +13,8 @@
         <exclude>
             <directory suffix=".php">src/generated</directory>
             <file>src/autoload.php</file>
+            <directory suffix=".php">src/other</directory>
+            <file>src/some.php</file>
         </exclude>
 
         <report>


### PR DESCRIPTION
Closes #4419

This also introduces a SnapshotNodeList helper since we can't use live
lists as we are modifying the DOM tree while iterating