### PR TITLE
Enhancement: Use trait-string where possible

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -939,7 +939,8 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Framework/MockObject/MockBuilder.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion occurrences="4">
+      <code>$this-&gt;type</code>
       <code>$this-&gt;type</code>
       <code>$this-&gt;type</code>
       <code>$this-&gt;type</code>

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -249,6 +249,8 @@ final class Generator
      * of the trait mocked. Concrete methods to mock can be specified with the
      * `$mockedMethods` parameter.
      *
+     * @psalm-param trait-string $traitName
+     *
      * @throws RuntimeException
      */
     public function getMockForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = null, bool $cloneArguments = true): MockObject
@@ -286,6 +288,8 @@ final class Generator
 
     /**
      * Returns an object for the specified trait.
+     *
+     * @psalm-param trait-string $traitName
      *
      * @throws RuntimeException
      */

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1886,6 +1886,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      * Returns a mock object for the specified trait with all abstract methods
      * of the trait mocked. Concrete methods to mock can be specified with the
      * `$mockedMethods` parameter.
+     *
+     * @psalm-param trait-string $traitName
      */
     protected function getMockForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = [], bool $cloneArguments = false): MockObject
     {
@@ -1909,6 +1911,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
     /**
      * Returns an object for the specified trait.
+     *
+     * @psalm-param trait-string $traitName
      */
     protected function getObjectForTrait(string $traitName, array $arguments = [], string $traitClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true): object
     {


### PR DESCRIPTION
This PR

* [x] uses `trait-string` where possible

💁‍♂️ For reference, see https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#trait-string.