### PR TITLE
Added tests for string equals file canonicalizing

### DIFF
--- a/tests/unit/Framework/Constraint/IsEqualCanonicalizingTest.php
+++ b/tests/unit/Framework/Constraint/IsEqualCanonicalizingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
+
+/**
+ * @small
+ */
+final class IsEqualCanonicalizingTest extends ConstraintTestCase
+{
+    public function testIsEqualCanonicalizingIfValuesAreIdentic(): void
+    {
+        $expected = 'Expected string';
+
+        $constraint = new IsEqualCanonicalizing($expected);
+
+        $this->assertTrue($constraint->evaluate($expected, '', true));
+        $this->assertCount(1, $constraint);
+    }
+
+    public function testIsEqualCanonicalizingIfValuesAreNotIdenticAndComparatorFactoryFindsNoSuitableComparator(): void
+    {
+        $constraint = new IsEqualCanonicalizing('Expected string');
+
+        $this->assertFalse($constraint->evaluate('Unexpected string', '', true));
+    }
+
+    public function testValuesAreConsideredEqualIfComparatorReturnsNull(): void
+    {
+        $expected = 'Expected';
+        $actual   = 'Faked to be identic to expected';
+
+        $this->setFakeComparator($expected, $actual, false);
+
+        $constraint = new IsEqualCanonicalizing($expected);
+
+        $this->assertTrue($constraint->evaluate($actual, '', true));
+    }
+
+    public function testValuesAreConsideredNotEqualIfComparatorThrowsException(): void
+    {
+        $expected = 'Expected';
+        $actual   = 'Faked to be identic to expected';
+
+        $this->setFakeComparator($expected, $actual, true);
+
+        $constraint = new IsEqualCanonicalizing($expected);
+
+        $this->assertFalse($constraint->evaluate($actual, '', true));
+    }
+
+    public function testExceptionIsThrownIfValuesAreNotEqual(): void
+    {
+        $constraint = new IsEqualCanonicalizing('Expected string');
+
+        try {
+            $constraint->evaluate('Unexpected string');
+
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals(
+                'Failed asserting that two strings are equal.',
+                $e->getMessage()
+            );
+        }
+    }
+
+    protected function setFakeComparator($expected, $actual, bool $throwException): void
+    {
+        $comparator = $this->createMock(Comparator::class);
+
+        $comparator->method('setFactory')->willReturn(null);
+
+        $comparator->expects($this->once())
+            ->method('accepts')
+            ->with($expected, $actual)
+            ->willReturn(true);
+
+        if ($throwException) {
+            $exception = new ComparisonFailure($expected, $actual, $expected, $actual);
+
+            $comparator->method('assertEquals')
+                ->will($this->throwException($exception));
+        } else {
+            $comparator->expects($this->once())
+                ->method('assertEquals')
+                ->with($expected, $actual);
+        }
+
+        ComparatorFactory::getInstance()->register($comparator);
+    }
+}

--- a/tests/unit/Framework/Constraint/StringEqualsFileCanonicalizingTest.php
+++ b/tests/unit/Framework/Constraint/StringEqualsFileCanonicalizingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\ExpectationFailedException;
+
+use function file_put_contents;
+
+/**
+ * @small
+ */
+final class StringEqualsFileCanonicalizingTest extends TestCase
+{
+    public function testFailsIfFileNotExists(): void
+    {
+        $filename = '/tmp/non-existent-file';
+
+        try {
+            $this->assertStringEqualsFileCanonicalizing($filename, 'expected');
+        } catch (ExpectationFailedException $exception) {
+            $expectedMessage = 'Failed asserting that file "/tmp/non-existent-file" exists.';
+
+            $this->assertEquals($expectedMessage, $exception->getMessage());
+        }
+    }
+
+    public function testFailsIfValuesDiffer()
+    {
+        $expected = 'Expected file contents';
+
+        $filename = tempnam(sys_get_temp_dir(), 'phpunit');
+
+        file_put_contents($filename, $expected);
+
+        $this->assertStringEqualsFileCanonicalizing($filename, $expected);
+    }
+}

--- a/tests/unit/Framework/Constraint/StringEqualsFileCanonicalizingTest.php
+++ b/tests/unit/Framework/Constraint/StringEqualsFileCanonicalizingTest.php
@@ -11,14 +11,9 @@ declare(strict_types=1);
  */
 namespace PHPUnit\Framework\Constraint;
 
-use SebastianBergmann\Comparator\Comparator;
-use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Comparator\Factory as ComparatorFactory;
-
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\ExpectationFailedException;
-
 use function file_put_contents;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @small
@@ -38,7 +33,7 @@ final class StringEqualsFileCanonicalizingTest extends TestCase
         }
     }
 
-    public function testFailsIfValuesDiffer()
+    public function testPassesIfValuesEquals(): void
     {
         $expected = 'Expected file contents';
 
@@ -47,5 +42,22 @@ final class StringEqualsFileCanonicalizingTest extends TestCase
         file_put_contents($filename, $expected);
 
         $this->assertStringEqualsFileCanonicalizing($filename, $expected);
+    }
+
+    public function testFailsIfValuesDiffer(): void
+    {
+        $expected = 'Expected file contents';
+
+        $filename = tempnam(sys_get_temp_dir(), 'phpunit');
+
+        file_put_contents($filename, 'Unexpected data');
+
+        try {
+            $this->assertStringEqualsFileCanonicalizing($filename, $expected);
+        } catch (ExpectationFailedException $exception) {
+            $expectedMessage = 'Failed asserting that two strings are equal.';
+
+            $this->assertEquals($expectedMessage, $exception->getMessage());
+        }
     }
 }


### PR DESCRIPTION
Closes #4053 

**Comments on the code:**
`assertStringEqualsFileCanonicalizing` consists of 2 parts: the assertion that the provided file exists and then the assertion that the file contant is actually equal to the expected variable.

The second assertion is performed with the `IsEqualCanonicalizing` constraint that missed tests as well. So it looked logical for me to create a separate test for `IsEqualCanonicalizing` constraint. I added this test to the current PR.