### PR TITLE
Fix global assert wrapper

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.14.1@9822043ca46d6682b76097bfa97d7c450eef9e90">
+<files psalm-version="3.14.2@3538fe1955d47f6ee926c0769d71af6db08aa488">
   <file src="src/Framework/Assert.php">
     <ArgumentTypeCoercion occurrences="2">
       <code>$expectedElement-&gt;childNodes-&gt;item($i)</code>
@@ -156,16 +156,7 @@
       <code>$expected</code>
       <code>$expected</code>
     </PossiblyInvalidArgument>
-    <PossiblyUnusedMethod occurrences="10">
-      <code>assertCount</code>
-      <code>assertNotCount</code>
-      <code>assertSameSize</code>
-      <code>assertNotSameSize</code>
-      <code>assertXmlStringEqualsXmlFile</code>
-      <code>assertXmlStringNotEqualsXmlFile</code>
-      <code>assertXmlStringEqualsXmlString</code>
-      <code>assertXmlStringNotEqualsXmlString</code>
-      <code>assertEqualXMLStructure</code>
+    <PossiblyUnusedMethod occurrences="1">
       <code>getCount</code>
     </PossiblyUnusedMethod>
     <RedundantCondition occurrences="1">
@@ -177,7 +168,7 @@
       <code>InvokedAtIndexMatcher</code>
       <code>new InvokedAtIndexMatcher($index)</code>
     </DeprecatedClass>
-    <DeprecatedMethod occurrences="10">
+    <DeprecatedMethod occurrences="11">
       <code>Assert::assertNotIsReadable(...func_get_args())</code>
       <code>Assert::assertNotIsWritable(...func_get_args())</code>
       <code>Assert::assertDirectoryNotExists(...func_get_args())</code>
@@ -188,6 +179,7 @@
       <code>Assert::assertFileNotIsWritable(...func_get_args())</code>
       <code>Assert::assertRegExp(...func_get_args())</code>
       <code>Assert::assertNotRegExp(...func_get_args())</code>
+      <code>Assert::assertEqualXMLStructure(...func_get_args())</code>
     </DeprecatedMethod>
     <MissingParamType occurrences="85">
       <code>$needle</code>
@@ -294,25 +286,7 @@
       <code>Assert::directoryExists(...func_get_args())</code>
       <code>Assert::fileExists(...func_get_args())</code>
     </TooManyArguments>
-    <UndefinedClass occurrences="2">
-      <code>DOMElement</code>
-      <code>DOMElement</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="12">
-      <code>Countable|iterable</code>
-      <code>Countable|iterable</code>
-      <code>Countable|iterable</code>
-      <code>Countable|iterable</code>
-      <code>Countable|iterable</code>
-      <code>Countable|iterable</code>
-      <code>DOMDocument|string</code>
-      <code>DOMDocument|string</code>
-      <code>DOMDocument|string</code>
-      <code>DOMDocument|string</code>
-      <code>DOMDocument|string</code>
-      <code>DOMDocument|string</code>
-    </UndefinedDocblockClass>
-    <UnusedParam occurrences="274">
+    <UnusedParam occurrences="302">
       <code>$key</code>
       <code>$array</code>
       <code>$message</code>
@@ -337,6 +311,12 @@
       <code>$type</code>
       <code>$haystack</code>
       <code>$isNativeType</code>
+      <code>$message</code>
+      <code>$expectedCount</code>
+      <code>$haystack</code>
+      <code>$message</code>
+      <code>$expectedCount</code>
+      <code>$haystack</code>
       <code>$message</code>
       <code>$message</code>
       <code>$message</code>
@@ -508,6 +488,12 @@
       <code>$pattern</code>
       <code>$string</code>
       <code>$message</code>
+      <code>$expected</code>
+      <code>$actual</code>
+      <code>$message</code>
+      <code>$expected</code>
+      <code>$actual</code>
+      <code>$message</code>
       <code>$format</code>
       <code>$string</code>
       <code>$message</code>
@@ -549,6 +535,22 @@
       <code>$message</code>
       <code>$expectedFile</code>
       <code>$actualFile</code>
+      <code>$message</code>
+      <code>$expectedFile</code>
+      <code>$actualXml</code>
+      <code>$message</code>
+      <code>$expectedFile</code>
+      <code>$actualXml</code>
+      <code>$message</code>
+      <code>$expectedXml</code>
+      <code>$actualXml</code>
+      <code>$message</code>
+      <code>$expectedXml</code>
+      <code>$actualXml</code>
+      <code>$message</code>
+      <code>$expectedElement</code>
+      <code>$actualElement</code>
+      <code>$checkAttributes</code>
       <code>$message</code>
       <code>$constraint</code>
       <code>$message</code>
@@ -2130,17 +2132,15 @@
     <DeprecatedInterface occurrences="1">
       <code>JUnit</code>
     </DeprecatedInterface>
-    <DocblockTypeContradiction occurrences="3">
-      <code>$this-&gt;currentTestCase === null</code>
+    <DocblockTypeContradiction occurrences="2">
       <code>$this-&gt;currentTestCase === null</code>
       <code>$this-&gt;currentTestCase === null</code>
     </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;testSuiteTimes</code>
     </InvalidPropertyAssignmentValue>
-    <MissingThrowsDocblock occurrences="5">
+    <MissingThrowsDocblock occurrences="4">
       <code>parent::__construct($out)</code>
-      <code>Filter::getFilteredStacktrace($t)</code>
       <code>Filter::getFilteredStacktrace($t)</code>
     </MissingThrowsDocblock>
     <PossiblyNullPropertyAssignmentValue occurrences="1">

--- a/build/scripts/generate-global-assert-wrappers.php
+++ b/build/scripts/generate-global-assert-wrappers.php
@@ -21,6 +21,9 @@ $buffer = '<?php declare(strict_types=1);
 namespace PHPUnit\Framework;
 
 use ArrayAccess;
+use Countable;
+use DOMDocument;
+use DOMElement;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount as AnyInvokedCountMatcher;

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -11,6 +11,9 @@ namespace PHPUnit\Framework;
 
 use function func_get_args;
 use ArrayAccess;
+use Countable;
+use DOMDocument;
+use DOMElement;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;


### PR DESCRIPTION
#4418 fixes ArrayAccess, but It's not just ArrayAccess that has problems.
The same applies to the following global classes.

* [Countable](https://github.com/sebastianbergmann/phpunit/blob/9.3.6/src/Framework/Assert/Functions.php#L186)
* [DOMDocument](https://github.com/sebastianbergmann/phpunit/blob/9.3.6/src/Framework/Assert/Functions.php#L1828)
* [DOMElement](https://github.com/sebastianbergmann/phpunit/blob/9.3.6/src/Framework/Assert/Functions.php#L1903)
