### PR TITLE
Improvements when expecting exception objects

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1195,7 +1195,7 @@
       <code>$beStrictAboutChangesToGlobalState</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyUnusedMethod occurrences="71">
+    <PossiblyUnusedMethod occurrences="74">
       <code>any</code>
       <code>never</code>
       <code>atLeast</code>

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -500,7 +500,7 @@ class TestCaseTest extends TestCase
     public function testExpectExceptionObjectWithEqualException(): void
     {
         $exception = new RuntimeException(
-            'Cannot compute at this time',
+            'Cannot compute at this time.',
             9000
         );
 
@@ -514,10 +514,10 @@ class TestCaseTest extends TestCase
         $this->assertTrue($result->wasSuccessful());
     }
 
-    public function testExpectExceptionObjectAllowsAccessingExpectedExceptionDetails(): void
+    public function testExpectExceptionObjectAllowsAccessingExpectedException(): void
     {
         $exception = new RuntimeException(
-            'Cannot compute at this time',
+            'Cannot compute at this time.',
             9000
         );
 
@@ -525,9 +525,7 @@ class TestCaseTest extends TestCase
 
         $test->expectExceptionObject($exception);
 
-        $this->assertSame(get_class($exception), $test->getExpectedException());
-        $this->assertSame($exception->getCode(), $test->getExpectedExceptionCode());
-        $this->assertSame($exception->getMessage(), $test->getExpectedExceptionMessage());
+        $this->assertSame($exception, $test->getExpectedExceptionObject());
     }
 
     public function testNoException(): void


### PR DESCRIPTION
This PR changes how exception objects are expected, instead of getting exception values (class, message and code) the instance itself gets tested, which means any additional value on the exception might hold will also be tested