### PR TITLE
some properties in TestCase may be null

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -167,7 +167,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     protected $providedTests = [];
 
     /**
-     * @var bool
+     * @var ?bool
      */
     private $runClassInSeparateProcess;
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -152,7 +152,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     protected $backupStaticAttributesBlacklist = [];
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $runTestInSeparateProcess;
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -135,7 +135,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     protected $backupGlobalsBlacklist = [];
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $backupStaticAttributes;
 


### PR DESCRIPTION
Psalm warned me about `ERROR: PropertyNotSetInConstructor - tests/XxxTest.php:14:13 - Property Xxx\Tests\XxxTest::$backupStaticAttributes is not defined in constructor of Xxx\Tests\XxxTest and in any methods called in the constructor (see https://psalm.dev/074)
`.

Same issue with runClassInSeparateProcess and runTestInSeparateProcess. Notice that inside the class they are often compared against null, so I changed the annotation so they allow null, instead of setting a default!