### PR TITLE
Restore spy functionality

### DIFF
--- a/src/Framework/MockObject/Rule/InvocationOrder.php
+++ b/src/Framework/MockObject/Rule/InvocationOrder.php
@@ -29,6 +29,15 @@ abstract class InvocationOrder implements SelfDescribing, Verifiable
         return count($this->invocations);
     }
 
+    /**
+     * @return BaseInvocation[]
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function getInvocations(): array
+    {
+        return $this->invocations;
+    }
+
     public function hasBeenInvoked(): bool
     {
         return count($this->invocations) > 0;

--- a/tests/unit/Framework/MockObject/Matcher/SpyTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/SpyTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @small
+ */
+final class SpyTest extends TestCase
+{
+    public function testIntegration(): void
+    {
+        $mock = $this->getMockBuilder(stdClass::class)
+                     ->setMethods(['foo'])
+                     ->getMock();
+
+        $mock->expects($spy = $this->any())
+             ->method('foo');
+
+        $mock->foo([
+            'attachments' => [
+                'attachment1',
+                'attachment2',
+            ],
+        ]);
+
+        $invocationParams = $spy->getInvocations()[0]->getParameters();
+        $this->assertContains('attachment2', $invocationParams[0]['attachments']);
+    }
+}


### PR DESCRIPTION
Although I understand the reluctance to let people rely on an internal class, many people have come to rely on this functionality already.

- I can't upgrade test suites for some of my clients because the feature is completely gone.
- I have an online course where people keep complaining that spies no longer work in PHPUnit.
- I see numerous comments about this being needed: on this repo, on blog posts, etc.

It's a really easy win with nothing but a getter. The underlying `Invocation` class is a value object, so there's no risk in exposing it.