### PR TITLE
Allow DocBlock class to be called with built-in classes

### DIFF
--- a/tests/unit/Util/Annotation/RegistryTest.php
+++ b/tests/unit/Util/Annotation/RegistryTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Util\Annotation;
 
+use DateTime;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\NumericGroupAnnotationTest;
 use PHPUnit\Util\Exception;
@@ -68,6 +69,24 @@ final class RegistryTest extends TestCase
             ),
             'Registry memoizes retrieved DocBlock instances'
         );
+    }
+
+    public function testRegistryLookupForInternalClass(): void
+    {
+        $annotation = Registry::getInstance()->forClassName(DateTime::class);
+
+        self::assertSame([], $annotation->symbolAnnotations());
+        self::assertSame([], $annotation->getInlineAnnotations());
+        self::assertSame(['__OFFSET' => []], $annotation->requirements());
+    }
+
+    public function testRegistryLookupForInternalMethod(): void
+    {
+        $annotation = Registry::getInstance()->forMethod(DateTime::class, 'createFromFormat');
+
+        self::assertSame([], $annotation->symbolAnnotations());
+        self::assertSame([], $annotation->getInlineAnnotations());
+        self::assertSame(['__OFFSET' => []], $annotation->requirements());
     }
 
     public function testClassLookupForAClassThatDoesNotExistFails(): void


### PR DESCRIPTION
When being called on built-in classes like `DateTime` or `ReflectionClass`, the `DocBlock` parser fails with obscure type errors. This happens because the reflection methods `getStartLine()`, `getEndLine()` and `getFileName()` return `false` for those classes.

Since there are no doc blocks to parse on those classes, I'd expect the parser to behave the same way as for a userland class without any doc blocks. This is what I've tried to achieve with this PR.