### PR TITLE
Implement filtering tests based on XML input file

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -759,6 +759,16 @@
       <code>$this-&gt;filter</code>
     </PossiblyNullArgument>
   </file>
+  <file src="src/Runner/Filter/XmlTestsIterator.php">
+    <MissingThrowsDocblock occurrences="1">
+      <code>getName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="src/Runner/Hook/TestListenerAdapter.php">
+    <DeprecatedInterface occurrences="1">
+      <code>TestListenerAdapter</code>
+    </DeprecatedInterface>
+  </file>
   <file src="src/Runner/PhptTestCase.php">
     <InternalClass occurrences="2">
       <code>RawCodeCoverageData::fromXdebugWithoutPathCoverage([])</code>
@@ -889,7 +899,8 @@
       <code>$e</code>
     </InvalidArgument>
     <InvalidStringClass occurrences="1"/>
-    <MissingThrowsDocblock occurrences="11">
+    <MissingThrowsDocblock occurrences="12">
+      <code>addFilter</code>
       <code>addFilter</code>
       <code>addFilter</code>
       <code>addFilter</code>

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-simplexml": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
         "doctrine/instantiator": "^1.3.1",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
-        "ext-simplexml": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
         "doctrine/instantiator": "^1.3.1",

--- a/src/Runner/Filter/XmlTestsIterator.php
+++ b/src/Runner/Filter/XmlTestsIterator.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use Exception;
+use LibXMLError;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\PhptTestCase;
+use RecursiveFilterIterator;
+use RecursiveIterator;
+use SimpleXMLElement;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class XmlTestsIterator extends RecursiveFilterIterator
+{
+    /**
+     * The filter is used as a fast look for
+     * - the class name
+     * - the method name plus its optional data set description.
+     *
+     * Example: `filter[class name][method name + data set] = true;`
+     *
+     * The accept() method then can use a fast isset() to check if a test should
+     * be included or not.
+     *
+     * This works equally for phpt tests, except we hardcode the class name.
+     *
+     * @var array<string,array<string,true>>
+     */
+    private array $filter = [];
+
+    /**
+     * @throws Exception
+     */
+    public function __construct(RecursiveIterator $iterator, string $xmlFile)
+    {
+        parent::__construct($iterator);
+
+        $this->setFilter($xmlFile);
+    }
+
+    public function accept(): bool
+    {
+        $test = $this->getInnerIterator()->current();
+
+        if ($test instanceof TestSuite) {
+            return true;
+        }
+
+        /** @var TestCase $test */
+        $testClass = get_class($test);
+
+        if (!isset($this->filter[$testClass])) {
+            return false;
+        }
+
+        $name = $test->getName();
+
+        return isset($this->filter[$testClass][$name]);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function setFilter(string $xmlFile): void
+    {
+        $xml = $this->parseXmlFromFile($xmlFile);
+
+        // Regular PHPUnit tests
+        foreach ($xml->testCaseClass as $class) {
+            $className = $class['name']->__toString();
+
+            if (!isset($this->filter[$className])) {
+                $this->filter[$className] = [];
+            }
+
+            foreach ($class->children() as $method) {
+                $methodName = $method['name']->__toString();
+
+                $dataSet = $method['dataSet'];
+
+                if (null === $dataSet) {
+                    $this->filter[$className][$methodName] = true;
+
+                    continue;
+                }
+
+                $dataSet                         = $dataSet->__toString();
+                $name                            = "{$methodName} with data set {$dataSet}";
+                $this->filter[$className][$name] = true;
+            }
+        }
+
+        // Handle PHP tests
+        $this->filter[PhptTestCase::class] = [];
+
+        foreach ($xml->phptFile as $phptFile) {
+            $this->filter[PhptTestCase::class][$phptFile['path']->__toString()] = true;
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function parseXmlFromFile(string $xmlFile): SimpleXMLElement
+    {
+        $oldValue = libxml_use_internal_errors(true);
+        $xml      = simplexml_load_file($xmlFile);
+        libxml_use_internal_errors($oldValue);
+
+        if (false === $xml) {
+            $xmlError = libxml_get_last_error();
+
+            throw $this->xmlErrorToException($xmlError);
+        }
+
+        return $xml;
+    }
+
+    private function xmlErrorToException(LibXMLError $xmlError): Exception
+    {
+        return new Exception(
+            sprintf(
+                'Error parsing XML tests: %s in %s:%d:%d',
+                trim($xmlError->message),
+                $xmlError->file,
+                $xmlError->line,
+                $xmlError->column
+            )
+        );
+    }
+}

--- a/src/TextUI/CliArguments/Builder.php
+++ b/src/TextUI/CliArguments/Builder.php
@@ -116,6 +116,7 @@ final class Builder
         'testsuite=',
         'verbose',
         'version',
+        'tests-xml=',
     ];
 
     private const SHORT_OPTIONS = 'd:c:hv';
@@ -225,6 +226,7 @@ final class Builder
         $useDefaultConfiguration                    = null;
         $verbose                                    = null;
         $version                                    = null;
+        $testsXml                                   = null;
 
         if (isset($options[1][0])) {
             $argument = $options[1][0];
@@ -752,6 +754,11 @@ final class Builder
 
                     break;
 
+                case '--tests-xml':
+                    $testsXml = $option[1];
+
+                    break;
+
                 default:
                     $unrecognizedOptions[str_replace('--', '', $option[0])] = $option[1];
             }
@@ -862,7 +869,8 @@ final class Builder
             $useDefaultConfiguration,
             $verbose,
             $version,
-            $coverageFilter
+            $coverageFilter,
+            $testsXml
         );
     }
 }

--- a/src/TextUI/CliArguments/Configuration.php
+++ b/src/TextUI/CliArguments/Configuration.php
@@ -199,10 +199,12 @@ final class Configuration
 
     private ?bool $version = null;
 
+    private ?string $testsXml;
+
     /**
      * @param null|int|string $columns
      */
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter)
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $testsXml)
     {
         $this->argument                                   = $argument;
         $this->atLeastVersion                             = $atLeastVersion;
@@ -293,6 +295,7 @@ final class Configuration
         $this->useDefaultConfiguration                    = $useDefaultConfiguration;
         $this->verbose                                    = $verbose;
         $this->version                                    = $version;
+        $this->testsXml                                   = $testsXml;
     }
 
     public function hasArgument(): bool
@@ -1794,5 +1797,22 @@ final class Configuration
         }
 
         return $this->version;
+    }
+
+    public function hasTestsXml(): bool
+    {
+        return $this->testsXml !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testsXml(): string
+    {
+        if ($this->testsXml === null) {
+            throw new Exception;
+        }
+
+        return $this->testsXml;
     }
 }

--- a/src/TextUI/CliArguments/Mapper.php
+++ b/src/TextUI/CliArguments/Mapper.php
@@ -351,6 +351,10 @@ final class Mapper
             $result['randomOrderSeed'] = $arguments->randomOrderSeed();
         }
 
+        if ($arguments->hasTestsXml()) {
+            $result['testsXml'] = $arguments->testsXml();
+        }
+
         return $result;
     }
 }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -71,6 +71,7 @@ final class Help
             ['arg' => '--list-tests', 'desc' => 'List available tests'],
             ['arg' => '--list-tests-xml <file>', 'desc' => 'List available tests in XML format'],
             ['arg' => '--filter <pattern>', 'desc' => 'Filter which tests to run'],
+            ['arg' => '--tests-xml <file>', 'desc' => 'Filter which tests to run in XML format'],
             ['arg' => '--test-suffix <suffixes>', 'desc' => 'Only search for test in files with specified suffix(es). Default: Test.php,.phpt'],
         ],
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -114,6 +114,7 @@ final class TestRunner
     /**
      * @throws \PHPUnit\Runner\Exception
      * @throws \PHPUnit\TextUI\XmlConfiguration\Exception
+     * @throws \PHPUnit\Util\Xml\Exception
      * @throws Exception
      */
     public function run(TestSuite $suite, array $arguments = [], array $warnings = [], bool $exit = true): TestResult
@@ -1047,6 +1048,9 @@ final class TestRunner
         $arguments['verbose']                                         = $arguments['verbose'] ?? false;
     }
 
+    /**
+     * @throws \PHPUnit\Util\Xml\Exception
+     */
     private function processSuiteFilters(TestSuite $suite, array $arguments): void
     {
         if (!$arguments['filter'] &&
@@ -1108,7 +1112,7 @@ final class TestRunner
         if (!empty($arguments['testsXml'])) {
             $filterFactory->addFilter(
                 new ReflectionClass(XmlTestsIterator::class),
-                $arguments['testsXml']
+                XmlTestsIterator::createFilterFromXmlFile($arguments['testsXml']),
             );
         }
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -39,6 +39,7 @@ use PHPUnit\Runner\Filter\ExcludeGroupFilterIterator;
 use PHPUnit\Runner\Filter\Factory;
 use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
 use PHPUnit\Runner\Filter\NameFilterIterator;
+use PHPUnit\Runner\Filter\XmlTestsIterator;
 use PHPUnit\Runner\Hook;
 use PHPUnit\Runner\NullTestResultCache;
 use PHPUnit\Runner\ResultCacheExtension;
@@ -1052,7 +1053,8 @@ final class TestRunner
             empty($arguments['groups']) &&
             empty($arguments['excludeGroups']) &&
             empty($arguments['testsCovering']) &&
-            empty($arguments['testsUsing'])) {
+            empty($arguments['testsUsing']) &&
+            empty($arguments['testsXml'])) {
             return;
         }
 
@@ -1100,6 +1102,13 @@ final class TestRunner
             $filterFactory->addFilter(
                 new ReflectionClass(NameFilterIterator::class),
                 $arguments['filter']
+            );
+        }
+
+        if (!empty($arguments['testsXml'])) {
+            $filterFactory->addFilter(
+                new ReflectionClass(XmlTestsIterator::class),
+                $arguments['testsXml']
             );
         }
 

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -52,6 +52,7 @@
   [32m--list-tests               [0m List available tests
   [32m--list-tests-xml [36m<file>[0m    [0m List available tests in XML format
   [32m--filter [36m<pattern>[0m         [0m Filter which tests to run
+  [32m--tests-xml [36m<file>[0m         [0m Filter which tests to run in XML format
   [32m--test-suffix [36m<suffixes>[0m   [0m Only search for test in files with
                               specified suffix(es). Default:
                               Test.php,.phpt

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -42,6 +42,7 @@ Test Selection Options:
   --list-tests                List available tests
   --list-tests-xml <file>     List available tests in XML format
   --filter <pattern>          Filter which tests to run
+  --tests-xml <file>          Filter which tests to run in XML format
   --test-suffix <suffixes>    Only search for test in files with specified suffix(es). Default: Test.php,.phpt
 
 Test Execution Options:

--- a/tests/end-to-end/tests-xml-dataprovider.phpt
+++ b/tests/end-to-end/tests-xml-dataprovider.phpt
@@ -1,0 +1,48 @@
+--TEST--
+phpunit --list-tests-xml ../../_files/DataProviderTest.php
+--FILE--
+<?php declare(strict_types=1);
+$xml = tempnam(sys_get_temp_dir(), __FILE__);
+file_put_contents($xml, <<<XML
+<?xml version="1.0"?>
+<tests>
+  <!-- This class exists -->
+  <testCaseClass name="PHPUnit\TestFixture\DataProviderTest">
+    <testCaseMethod name="testAdd" groups="default" dataSet="#0"/>
+    <!-- This method does not exist -->
+    <testCaseMethod name="methodDoesNotExist"/>
+    <!-- name attribute missing -->
+    <testCaseMethod />
+  </testCaseClass>
+
+  <!-- name attribute missing -->
+  <testCaseClass>
+    <testCaseMethod name="testAdd" groups="default" dataSet="#0"/>
+  </testCaseClass>
+
+  <ignoredTag/>
+
+  <testCaseClass name="Class\Does\Not\Exist">
+    <testCaseMethod name="methodAlsoDoesNotExist"/>
+  </testCaseClass>
+</tests>
+XML
+);
+
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tests-xml';
+$_SERVER['argv'][3] = $xml;
+$_SERVER['argv'][4] = __DIR__ . '/../_files/DataProviderTest.php';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main(false);
+
+unlink($xml);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)


### PR DESCRIPTION
## Summary
Export via `--list-tests-xml` and cut and slice as wanted, to feed it back via `--tests-xml`. Works with PHPUnit tests as well as PHPT tests.

A cheap slicing script is provided for now at https://gist.github.com/mfn/256636242cbe8a51252ce28181a6b074

Example:
```
~/src/phpunit $ ./phpunit --list-tests-xml tests.xml
PHPUnit 9.4-g567e55e11 by Sebastian Bergmann and contributors.

Wrote list of tests that would have been run to tests.xml
```
```
~/src/phpunit $ ./phpunit_xml_slicer.php tests.xml 1/100 > partial_tests.xml
```
```
~/src/phpunit $ ./phpunit --tests-xml partial_tests.xml
PHPUnit 9.4-g567e55e11 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8
Configuration: /Users/neo/src/phpunit/phpunit.xml

.............................                                     29 / 29 (100%)

Time: 00:00.186, Memory: 22.00 MB

OK (29 tests, 29 assertions)
```
### Overview
- Add a new `--tests-xml <xml file>` argument to PHPUnit
- Implement new filter `\PHPUnit\Runner\Filter\XmlTestsIterator` which parses the XML and builds an internal data structure to identify what tests to `accept()`

I consider the state of the PR in a "functional state" and before finishing it I would seek feedback if I missed parts and guidance what kind of tests are best.

### Considerations
- ~The handling of using SimpleXML and parsing in `\PHPUnit\Runner\Filter\XmlTestsIterator::setFilter` is pretty crude. I barely worked with XML and PHP in the last decade. I saw `\PHPUnit\Util\Xml\Loader` but wasn't sure if it should be used, it was just added a few days ago. Also I liked the "simplicity" of `SimpleXml` to get this up and running.~
  => Replaced with ext-xml aka `DomDocument` and friends
- [x] I noticed that the filters (not just the new one I added) are instantiated _multiple_ times, thus the XML is parsed many more times. No idea what/if to do here
- I first wanted to name it `--filter-tests-xml`, seemed more apt. But I ran into a strange problem with `sebastian/cli-parser` I didn't really understand so I just gave it a different to get the ball rolling

<details>
<summary>Error when using --filter-tests-xml as option name</summary>

```
Testing started at 08:07 ...
/usr/local/bin/php /Users/user/src/phpunit/phpunit --configuration /Users/user/src/phpunit/phpunit.xml --teamcity
PHPUnit 9.4-g4719a8977 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.8
Configuration: /Users/user/src/phpunit/phpunit.xml


Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
-PHPUnit %s by Sebastian Bergmann and contributors.
+string(11) "-tests-xml="
+int(31)
+int(87)
+string(6) "filter"
+string(7) "filter="
 
-...                                                                 3 / 3 (100%)
+Fatal error: Uncaught RuntimeException: dafuq in /Users/user/src/phpunit/vendor/sebastian/cli-parser/src/exceptions/AmbiguousOptionException.php:19
+Stack trace:
+#0 /Users/user/src/phpunit/vendor/sebastian/cli-parser/src/Parser.php(165): SebastianBergmann\CliParser\AmbiguousOptionException->__construct('--filter')
+#1 /Users/user/src/phpunit/vendor/sebastian/cli-parser/src/Parser.php(81): SebastianBergmann\CliParser\Parser->parseLongOption('filter', Array, Array, Array)
+#2 /Users/user/src/phpunit/src/TextUI/CliArguments/Builder.php(128): SebastianBergmann\CliParser\Parser->parse(Array, 'd:c:hv', Array)
+#3 /Users/user/src/phpunit/src/TextUI/Command.php(223): PHPUnit\TextUI\CliArguments\Builder->fromParameters(Array, Array)
+#4 /Users/user/src/phpunit/src/TextUI/Command.php(115): PHPUnit\TextUI\Command->handleArguments(Array)
+#5 /Users/user/src/phpunit/src/TextUI/Command.php(100): PHPUnit\TextUI\Command->run(Array, true)
+#6 Standard input code(9): PHPUnit\TextUI\Command::main()
+#7 {main}
 
-Time: %s, Memory: %s
-
-OK (3 tests, 3 assertions)
+Next PHPUnit\TextUI\Exception: dafuq in /User in /Users/user/src/phpunit/src/TextUI/Command.php on line 102

 /Users/user/src/phpunit/tests/end-to-end/filter-class-isolation.phpt:14
 /Users/user/src/phpunit/src/Framework/TestSuite.php:665
 /Users/user/src/phpunit/src/Framework/TestSuite.php:665
 /Users/user/src/phpunit/src/TextUI/TestRunner.php:668
 /Users/user/src/phpunit/src/TextUI/Command.php:147
 /Users/user/src/phpunit/src/TextUI/Command.php:100
```
</details>


### TODO
- [x] Write tests; but what kind of? PHPT? Not sure where to put files / fixtures, so many already there. Guidance appreciated!
  => a phpt test has been added
- [x] XML parsing? Improve? Change to `DomDocument`?
  => Indeed, changed to DomDocument

### Links
- "Specify a list of tests to run"
  => https://github.com/sebastianbergmann/phpunit/issues/3387