### PR TITLE
Support for Cobertura XML report format

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1701,6 +1701,7 @@
   <file src="src/TextUI/XmlConfiguration/CodeCoverage/CodeCoverage.php">
     <PossiblyUnusedMethod occurrences="7">
       <code>clover</code>
+      <code>cobertura</code>
       <code>crap4j</code>
       <code>html</code>
       <code>pathCoverage</code>
@@ -1728,6 +1729,11 @@
     </UnusedMethodCall>
   </file>
   <file src="src/TextUI/XmlConfiguration/CodeCoverage/Report/Clover.php">
+    <PossiblyUnusedMethod occurrences="1">
+      <code>target</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/TextUI/XmlConfiguration/CodeCoverage/Report/Cobertura.php">
     <PossiblyUnusedMethod occurrences="1">
       <code>target</code>
     </PossiblyUnusedMethod>
@@ -1870,6 +1876,11 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCloverToReport.php">
+    <PossiblyNullReference occurrences="1">
+      <code>createElement</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCoberturaToReport.php">
     <PossiblyNullReference occurrences="1">
       <code>createElement</code>
     </PossiblyNullReference>

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -1699,7 +1699,7 @@
     </UnusedParam>
   </file>
   <file src="src/TextUI/XmlConfiguration/CodeCoverage/CodeCoverage.php">
-    <PossiblyUnusedMethod occurrences="7">
+    <PossiblyUnusedMethod occurrences="8">
       <code>clover</code>
       <code>cobertura</code>
       <code>crap4j</code>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -287,6 +287,7 @@
     <xs:group name="coverageReportGroup">
         <xs:all>
             <xs:element name="clover" type="logToFileType" minOccurs="0"/>
+            <xs:element name="cobertura" type="logToFileType" minOccurs="0"/>
             <xs:element name="crap4j" type="coverageReportCrap4JType" minOccurs="0" />
             <xs:element name="html" type="coverageReportHtmlType" minOccurs="0" />
             <xs:element name="php" type="logToFileType" minOccurs="0" />

--- a/src/TextUI/CliArguments/Builder.php
+++ b/src/TextUI/CliArguments/Builder.php
@@ -42,6 +42,7 @@ final class Builder
         'warm-coverage-cache',
         'coverage-filter=',
         'coverage-clover=',
+        'coverage-cobertura=',
         'coverage-crap4j=',
         'coverage-html=',
         'coverage-php=',
@@ -151,6 +152,7 @@ final class Builder
         $warmCoverageCache                          = null;
         $coverageFilter                             = null;
         $coverageClover                             = null;
+        $coverageCobertura                          = null;
         $coverageCrap4J                             = null;
         $coverageHtml                               = null;
         $coveragePhp                                = null;
@@ -281,6 +283,11 @@ final class Builder
 
                 case '--coverage-clover':
                     $coverageClover = $option[1];
+
+                    break;
+
+                case '--coverage-cobertura':
+                    $coverageCobertura = $option[1];
 
                     break;
 
@@ -781,6 +788,7 @@ final class Builder
             $columns,
             $configuration,
             $coverageClover,
+            $coverageCobertura,
             $coverageCrap4J,
             $coverageHtml,
             $coveragePhp,

--- a/src/TextUI/CliArguments/Configuration.php
+++ b/src/TextUI/CliArguments/Configuration.php
@@ -95,6 +95,11 @@ final class Configuration
     /**
      * @var ?string
      */
+    private $coverageCobertura;
+
+    /**
+     * @var ?string
+     */
     private $coverageCrap4J;
 
     /**
@@ -460,7 +465,7 @@ final class Configuration
     /**
      * @param null|int|string $columns
      */
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?string $loader, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $xdebugFilterFile)
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?string $loader, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $xdebugFilterFile)
     {
         $this->argument                                   = $argument;
         $this->atLeastVersion                             = $atLeastVersion;
@@ -477,6 +482,7 @@ final class Configuration
         $this->configuration                              = $configuration;
         $this->coverageFilter                             = $coverageFilter;
         $this->coverageClover                             = $coverageClover;
+        $this->coverageCobertura                          = $coverageCobertura;
         $this->coverageCrap4J                             = $coverageCrap4J;
         $this->coverageHtml                               = $coverageHtml;
         $this->coveragePhp                                = $coveragePhp;
@@ -805,6 +811,23 @@ final class Configuration
         }
 
         return $this->coverageClover;
+    }
+
+    public function hasCoverageCobertura(): bool
+    {
+        return $this->coverageCobertura !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function coverageCobertura(): string
+    {
+        if ($this->coverageCobertura === null) {
+            throw new Exception;
+        }
+
+        return $this->coverageCobertura;
     }
 
     public function hasCoverageCrap4J(): bool

--- a/src/TextUI/CliArguments/Mapper.php
+++ b/src/TextUI/CliArguments/Mapper.php
@@ -68,6 +68,10 @@ final class Mapper
             $result['coverageClover'] = $arguments->coverageClover();
         }
 
+        if ($arguments->hasCoverageCobertura()) {
+            $result['coverageCobertura'] = $arguments->coverageCobertura();
+        }
+
         if ($arguments->hasCoverageCrap4J()) {
             $result['coverageCrap4J'] = $arguments->coverageCrap4J();
         }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -36,6 +36,7 @@ final class Help
 
         'Code Coverage Options' => [
             ['arg' => '--coverage-clover <file>', 'desc' => 'Generate code coverage report in Clover XML format'],
+            ['arg' => '--coverage-cobertura <file>', 'desc' => 'Generate code coverage report in Cobertura XML format'],
             ['arg' => '--coverage-crap4j <file>', 'desc' => 'Generate code coverage report in Crap4J XML format'],
             ['arg' => '--coverage-html <dir>', 'desc' => 'Generate code coverage report in HTML format'],
             ['arg' => '--coverage-php <file>', 'desc' => 'Export PHP_CodeCoverage object to file'],

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -69,6 +69,7 @@ use SebastianBergmann\CodeCoverage\Driver\Selector;
 use SebastianBergmann\CodeCoverage\Exception as CodeCoverageException;
 use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
 use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
+use SebastianBergmann\CodeCoverage\Report\Cobertura as CoberturaReport;
 use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jReport;
 use SebastianBergmann\CodeCoverage\Report\Html\Facade as HtmlReport;
 use SebastianBergmann\CodeCoverage\Report\PHP as PhpReport;
@@ -389,6 +390,10 @@ final class TestRunner extends BaseTestRunner
                 $codeCoverageReports++;
             }
 
+            if (isset($arguments['coverageCobertura'])) {
+                $codeCoverageReports++;
+            }
+
             if (isset($arguments['coverageCrap4J'])) {
                 $codeCoverageReports++;
             }
@@ -691,6 +696,21 @@ final class TestRunner extends BaseTestRunner
                 }
             }
 
+            if (isset($arguments['coverageCobertura'])) {
+                $this->codeCoverageGenerationStart('Cobertura XML');
+
+                try {
+                    $writer = new CoberturaReport;
+                    $writer->process($codeCoverage, $arguments['coverageCobertura']);
+
+                    $this->codeCoverageGenerationSucceeded();
+
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->codeCoverageGenerationFailed($e);
+                }
+            }
+
             if (isset($arguments['coverageCrap4J'])) {
                 $this->codeCoverageGenerationStart('Crap4J XML');
 
@@ -885,6 +905,10 @@ final class TestRunner extends BaseTestRunner
 
             if (!isset($arguments['coverageClover']) && $codeCoverageConfiguration->hasClover()) {
                 $arguments['coverageClover'] = $codeCoverageConfiguration->clover()->target()->path();
+            }
+
+            if (!isset($arguments['coverageCobertura']) && $codeCoverageConfiguration->hasCobertura()) {
+                $arguments['coverageCobertura'] = $codeCoverageConfiguration->cobertura()->target()->path();
             }
 
             if (!isset($arguments['coverageCrap4J']) && $codeCoverageConfiguration->hasCrap4j()) {

--- a/src/TextUI/XmlConfiguration/CodeCoverage/CodeCoverage.php
+++ b/src/TextUI/XmlConfiguration/CodeCoverage/CodeCoverage.php
@@ -12,6 +12,7 @@ namespace PHPUnit\TextUI\XmlConfiguration\CodeCoverage;
 use function count;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Filter\DirectoryCollection;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Clover;
+use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Cobertura;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Crap4j;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Html;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Php;
@@ -83,6 +84,11 @@ final class CodeCoverage
     private $clover;
 
     /**
+     * @var ?Cobertura
+     */
+    private $cobertura;
+
+    /**
      * @var ?Crap4j
      */
     private $crap4j;
@@ -107,7 +113,7 @@ final class CodeCoverage
      */
     private $xml;
 
-    public function __construct(?Directory $cacheDirectory, DirectoryCollection $directories, FileCollection $files, DirectoryCollection $excludeDirectories, FileCollection $excludeFiles, bool $pathCoverage, bool $includeUncoveredFiles, bool $processUncoveredFiles, bool $ignoreDeprecatedCodeUnits, bool $disableCodeCoverageIgnore, ?Clover $clover, ?Crap4j $crap4j, ?Html $html, ?Php $php, ?Text $text, ?Xml $xml)
+    public function __construct(?Directory $cacheDirectory, DirectoryCollection $directories, FileCollection $files, DirectoryCollection $excludeDirectories, FileCollection $excludeFiles, bool $pathCoverage, bool $includeUncoveredFiles, bool $processUncoveredFiles, bool $ignoreDeprecatedCodeUnits, bool $disableCodeCoverageIgnore, ?Clover $clover, ?Cobertura $cobertura, ?Crap4j $crap4j, ?Html $html, ?Php $php, ?Text $text, ?Xml $xml)
     {
         $this->cacheDirectory            = $cacheDirectory;
         $this->directories               = $directories;
@@ -120,6 +126,7 @@ final class CodeCoverage
         $this->ignoreDeprecatedCodeUnits = $ignoreDeprecatedCodeUnits;
         $this->disableCodeCoverageIgnore = $disableCodeCoverageIgnore;
         $this->clover                    = $clover;
+        $this->cobertura                 = $cobertura;
         $this->crap4j                    = $crap4j;
         $this->html                      = $html;
         $this->php                       = $php;
@@ -219,6 +226,28 @@ final class CodeCoverage
         }
 
         return $this->clover;
+    }
+
+    /**
+     * @psalm-assert-if-true !null $this->cobertura
+     */
+    public function hasCobertura(): bool
+    {
+        return $this->cobertura !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function cobertura(): Cobertura
+    {
+        if (!$this->hasCobertura()) {
+            throw new Exception(
+                'Code Coverage report "Cobertura XML" has not been configured'
+            );
+        }
+
+        return $this->cobertura;
     }
 
     /**

--- a/src/TextUI/XmlConfiguration/CodeCoverage/Report/Cobertura.php
+++ b/src/TextUI/XmlConfiguration/CodeCoverage/Report/Cobertura.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report;
+
+use PHPUnit\TextUI\XmlConfiguration\File;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ * @psalm-immutable
+ */
+final class Cobertura
+{
+    /**
+     * @var File
+     */
+    private $target;
+
+    public function __construct(File $target)
+    {
+        $this->target = $target;
+    }
+
+    public function target(): File
+    {
+        return $this->target;
+    }
+}

--- a/src/TextUI/XmlConfiguration/Loader.php
+++ b/src/TextUI/XmlConfiguration/Loader.php
@@ -35,6 +35,7 @@ use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\CodeCoverage;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Filter\Directory as FilterDirectory;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Filter\DirectoryCollection as FilterDirectoryCollection;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Clover;
+use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Cobertura;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Crap4j;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Html as CodeCoverageHtml;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Php as CodeCoveragePhp;
@@ -450,6 +451,20 @@ final class Loader
             );
         }
 
+        $cobertura = null;
+        $element   = $this->element($xpath, 'coverage/report/cobertura');
+
+        if ($element) {
+            $cobertura = new Cobertura(
+                new File(
+                    $this->toAbsolutePath(
+                        $filename,
+                        (string) $this->getStringAttribute($element, 'outputFile')
+                    )
+                )
+            );
+        }
+
         $crap4j  = null;
         $element = $this->element($xpath, 'coverage/report/crap4j');
 
@@ -537,6 +552,7 @@ final class Loader
             $ignoreDeprecatedCodeUnits,
             $disableCodeCoverageIgnore,
             $clover,
+            $cobertura,
             $crap4j,
             $html,
             $php,
@@ -583,12 +599,13 @@ final class Loader
             }
         }
 
-        $clover = null;
-        $crap4j = null;
-        $html   = null;
-        $php    = null;
-        $text   = null;
-        $xml    = null;
+        $clover    = null;
+        $cobertura = null;
+        $crap4j    = null;
+        $html      = null;
+        $php       = null;
+        $text      = null;
+        $xml       = null;
 
         foreach ($xpath->query('logging/log') as $log) {
             assert($log instanceof DOMElement);
@@ -605,6 +622,13 @@ final class Loader
             switch ($type) {
                 case 'coverage-clover':
                     $clover = new Clover(
+                        new File($target)
+                    );
+
+                    break;
+
+                case 'coverage-cobertura':
+                    $cobertura = new Cobertura(
                         new File($target)
                     );
 
@@ -664,6 +688,7 @@ final class Loader
             $ignoreDeprecatedCodeUnits,
             $disableCodeCoverageIgnore,
             $clover,
+            $cobertura,
             $crap4j,
             $html,
             $php,

--- a/src/TextUI/XmlConfiguration/Migration/MigrationBuilder.php
+++ b/src/TextUI/XmlConfiguration/Migration/MigrationBuilder.php
@@ -32,6 +32,7 @@ final class MigrationBuilder
             MoveWhitelistExcludesToCoverage::class,
             RemoveEmptyFilter::class,
             CoverageCloverToReport::class,
+            CoverageCoberturaToReport::class,
             CoverageCrap4jToReport::class,
             CoverageHtmlToReport::class,
             CoveragePhpToReport::class,

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCoberturaToReport.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/CoverageCoberturaToReport.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMElement;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class CoverageCoberturaToReport extends LogToReportMigration
+{
+    protected function forType(): string
+    {
+        return 'coverage-cobertura';
+    }
+
+    protected function toReportFormat(DOMElement $logNode): DOMElement
+    {
+        $cobertura = $logNode->ownerDocument->createElement('cobertura');
+        $cobertura->setAttribute('outputFile', $logNode->getAttribute('target'));
+
+        return $cobertura;
+    }
+}

--- a/tests/_files/configuration_codecoverage.xml
+++ b/tests/_files/configuration_codecoverage.xml
@@ -21,6 +21,7 @@
 
         <report>
             <clover outputFile="clover.xml"/>
+            <cobertura outputFile="cobertura.xml"/>
             <crap4j outputFile="crap4j.xml" threshold="30"/>
             <html outputDirectory="coverage" lowUpperBound="50" highLowerBound="90"/>
             <php outputFile="coverage.php"/>

--- a/tests/_files/configuration_legacy_codecoverage.xml
+++ b/tests/_files/configuration_legacy_codecoverage.xml
@@ -18,6 +18,7 @@
 
     <logging>
         <log type="coverage-clover" target="clover.xml"/>
+        <log type="coverage-cobertura" target="cobertura.xml"/>
         <log type="coverage-crap4j" target="crap4j.xml" threshold="50"/>
         <log type="coverage-html" target="coverage" lowUpperBound="50" highLowerBound="90"/>
         <log type="coverage-php" target="coverage.php"/>

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -5,6 +5,8 @@
 [33mCode Coverage Options:[0m
   [32m--coverage-clover [36m<file>[0m   [0m Generate code coverage report in Clover
                               XML format
+  [32m--coverage-cobertura [36m<file>[0m[0m Generate code coverage report in
+                              Cobertura XML format
   [32m--coverage-crap4j [36m<file>[0m   [0m Generate code coverage report in Crap4J
                               XML format
   [32m--coverage-html [36m<dir>[0m      [0m Generate code coverage report in HTML

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -7,6 +7,7 @@ Usage:
 Code Coverage Options:
 
   --coverage-clover <file>    Generate code coverage report in Clover XML format
+  --coverage-cobertura <file> Generate code coverage report in Cobertura XML format
   --coverage-crap4j <file>    Generate code coverage report in Crap4J XML format
   --coverage-html <dir>       Generate code coverage report in HTML format
   --coverage-php <file>       Export PHP_CodeCoverage object to file

--- a/tests/unit/TextUI/XmlConfigurationTest.php
+++ b/tests/unit/TextUI/XmlConfigurationTest.php
@@ -193,6 +193,9 @@ final class XmlConfigurationTest extends TestCase
         $this->assertTrue($codeCoverage->hasClover());
         $this->assertSame(TEST_FILES_PATH . 'clover.xml', $codeCoverage->clover()->target()->path());
 
+        $this->assertTrue($codeCoverage->hasCobertura());
+        $this->assertSame(TEST_FILES_PATH . 'cobertura.xml', $codeCoverage->cobertura()->target()->path());
+
         $this->assertTrue($codeCoverage->hasCrap4j());
         $this->assertSame(TEST_FILES_PATH . 'crap4j.xml', $codeCoverage->crap4j()->target()->path());
 
@@ -250,6 +253,9 @@ final class XmlConfigurationTest extends TestCase
 
         $this->assertTrue($codeCoverage->hasClover());
         $this->assertSame(TEST_FILES_PATH . 'clover.xml', $codeCoverage->clover()->target()->path());
+
+        $this->assertTrue($codeCoverage->hasCobertura());
+        $this->assertSame(TEST_FILES_PATH . 'cobertura.xml', $codeCoverage->cobertura()->target()->path());
 
         $this->assertTrue($codeCoverage->hasCrap4j());
         $this->assertSame(TEST_FILES_PATH . 'crap4j.xml', $codeCoverage->crap4j()->target()->path());

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -101,6 +101,7 @@ EOF;
             null,
             null,
             null,
+            null,
             null
         );
 


### PR DESCRIPTION
Cobertura options to for once https://github.com/sebastianbergmann/php-code-coverage/pull/812 gets merged in.

There is 1 type check failing that I don't understand. It references a method that hasn't been changed with this patch so I am unclear as to why it is failing now and doesn't on master. I haven't used psalm before though so maybe I am just missing something.