### PR TITLE
Infinite recursion when "--static-backup --strict-global-state" is used

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2306,6 +2306,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $excludeList->addClassNamePrefix('Symfony');
             $excludeList->addClassNamePrefix('Doctrine\Instantiator');
             $excludeList->addClassNamePrefix('Prophecy');
+            $excludeList->addStaticAttribute(ComparatorFactory::class, 'instance');
 
             foreach ($this->backupStaticAttributesExcludeList as $class => $attributes) {
                 foreach ($attributes as $attribute) {


### PR DESCRIPTION
To reproduce:
```bash
mkdir -p foo &&
pushd foo &&
cat <<PHP > SomeTest.php
<?php
class SomeTest extends \PHPUnit\Framework\TestCase {
    public function test_foo(): void { }
    public function test_bar(): void { }
}
PHP
composer require phpunit/phpunit:9.3.11 &&
vendor/bin/phpunit --static-backup --strict-global-state SomeTest.php &&
popd
```

Result:
```
PHPUnit 9.3.11 by Sebastian Bergmann and contributors.

RPHP Fatal error:  Nesting level too deep - recursive dependency? in /tmp/foo/vendor/phpunit/phpunit/src/Framework/TestCase.php on line 2369
```

I git-bisected the origin all the way to 9a7a667.
Sorry, not providing tests for this fix.