### PR TITLE
Implement --until-success CLI option

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -1206,6 +1206,14 @@ final class TestResult implements Countable
     }
 
     /**
+     * Returns number of defects.
+     */
+    public function defectCount(): int
+    {
+        return $this->warningCount() + $this->errorCount() + $this->failureCount();
+    }
+
+    /**
      * Returns whether the entire test was successful or not.
      */
     public function wasSuccessful(): bool

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -69,6 +69,11 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     protected $runTestInSeparateProcess = false;
 
     /**
+     * @var bool
+     */
+    protected $runTestsUntilSuccess = false;
+
+    /**
      * The name of the test suite.
      *
      * @var string
@@ -662,7 +667,13 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 $test->setRunTestInSeparateProcess($this->runTestInSeparateProcess);
             }
 
+            $defectsBefore = $result->defectCount();
             $test->run($result);
+            $defectsAfter = $result->defectCount();
+
+            if ($this->runTestsUntilSuccess && ($defectsAfter === $defectsBefore)) {
+                break;
+            }
         }
 
         foreach ($hookMethods['afterClass'] as $afterClassMethod) {
@@ -693,6 +704,11 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     public function setRunTestInSeparateProcess(bool $runTestInSeparateProcess): void
     {
         $this->runTestInSeparateProcess = $runTestInSeparateProcess;
+    }
+
+    public function setRunTestsUntilSuccess(bool $runTestsUntilSuccess): void
+    {
+        $this->runTestsUntilSuccess = $runTestsUntilSuccess;
     }
 
     public function setName(string $name): void

--- a/src/TextUI/CliArguments/Builder.php
+++ b/src/TextUI/CliArguments/Builder.php
@@ -114,6 +114,7 @@ final class Builder
         'testdox-xml=',
         'test-suffix=',
         'testsuite=',
+        'until-success',
         'verbose',
         'version',
         'whitelist=',
@@ -225,6 +226,7 @@ final class Builder
         $testSuite                                  = null;
         $unrecognizedOptions                        = [];
         $unrecognizedOrderBy                        = null;
+        $untilSuccess                               = null;
         $useDefaultConfiguration                    = null;
         $verbose                                    = null;
         $version                                    = null;
@@ -505,6 +507,11 @@ final class Builder
 
                 case '--repeat':
                     $repeat = (int) $option[1];
+
+                    break;
+
+                case '--until-success':
+                    $untilSuccess = true;
 
                     break;
 
@@ -875,6 +882,7 @@ final class Builder
             $testSuite,
             $unrecognizedOptions,
             $unrecognizedOrderBy,
+            $untilSuccess,
             $useDefaultConfiguration,
             $verbose,
             $version,

--- a/src/TextUI/CliArguments/Configuration.php
+++ b/src/TextUI/CliArguments/Configuration.php
@@ -455,6 +455,11 @@ final class Configuration
     /**
      * @var ?bool
      */
+    private $untilSuccess;
+
+    /**
+     * @var ?bool
+     */
     private $useDefaultConfiguration;
 
     /**
@@ -475,7 +480,7 @@ final class Configuration
     /**
      * @param null|int|string $columns
      */
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?string $loader, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $xdebugFilterFile)
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticAttributes, ?bool $beStrictAboutChangesToGlobalState, ?bool $beStrictAboutResourceUsageDuringSmallTests, ?string $bootstrap, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $disallowTodoAnnotatedTests, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?string $loader, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?string $printer, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, array $unrecognizedOptions, ?string $unrecognizedOrderBy, ?bool $untilSuccess, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $xdebugFilterFile)
     {
         $this->argument                                   = $argument;
         $this->atLeastVersion                             = $atLeastVersion;
@@ -564,6 +569,7 @@ final class Configuration
         $this->testSuite                                  = $testSuite;
         $this->unrecognizedOptions                        = $unrecognizedOptions;
         $this->unrecognizedOrderBy                        = $unrecognizedOrderBy;
+        $this->untilSuccess                               = $untilSuccess;
         $this->useDefaultConfiguration                    = $useDefaultConfiguration;
         $this->verbose                                    = $verbose;
         $this->version                                    = $version;
@@ -2086,6 +2092,23 @@ final class Configuration
         }
 
         return $this->version;
+    }
+
+    public function hasUntilSuccess(): bool
+    {
+        return $this->untilSuccess !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function untilSuccess(): bool
+    {
+        if ($this->untilSuccess === null) {
+            throw new Exception;
+        }
+
+        return $this->untilSuccess;
     }
 
     public function hasXdebugFilterFile(): bool

--- a/src/TextUI/CliArguments/Mapper.php
+++ b/src/TextUI/CliArguments/Mapper.php
@@ -204,6 +204,10 @@ final class Mapper
             $result['repeat'] = $arguments->repeat();
         }
 
+        if ($arguments->hasUntilSuccess()) {
+            $result['untilSuccess'] = $arguments->untilSuccess();
+        }
+
         if ($arguments->hasStderr()) {
             $result['stderr'] = $arguments->stderr();
         }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -110,6 +110,7 @@ final class Help
             ['spacer' => ''],
 
             ['arg'    => '--repeat <times>', 'desc' => 'Runs the test(s) repeatedly'],
+            ['arg'    => '--until-success', 'desc' => 'Combines with `repeat <n>` option, test executes until success, but maximum <n> times'],
             ['arg'    => '--teamcity', 'desc' => 'Report test execution progress in TeamCity format'],
             ['arg'    => '--testdox', 'desc' => 'Report test execution progress in TestDox format'],
             ['arg'    => '--testdox-group', 'desc' => 'Only include tests from the specified group(s)'],

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -224,6 +224,10 @@ final class TestRunner extends BaseTestRunner
             $suite = $_suite;
 
             unset($_suite);
+
+            if ($arguments['untilSuccess']) {
+                $suite->setRunTestsUntilSuccess(true);
+            }
         }
 
         $result = $this->createTestResult();
@@ -1137,6 +1141,7 @@ final class TestRunner extends BaseTestRunner
         $arguments['timeoutForMediumTests']                           = $arguments['timeoutForMediumTests'] ?? 10;
         $arguments['timeoutForSmallTests']                            = $arguments['timeoutForSmallTests'] ?? 1;
         $arguments['verbose']                                         = $arguments['verbose'] ?? false;
+        $arguments['untilSuccess']                                    = $arguments['untilSuccess'] ?? false;
     }
 
     private function processSuiteFilters(TestSuite $suite, array $arguments): void

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -97,6 +97,9 @@
   [32m--debug                    [0m Display debugging information
 
   [32m--repeat [36m<times>[0m           [0m Runs the test(s) repeatedly
+  [32m--until-success            [0m Combines with `repeat <n>` option, test
+                              executes until success, but maximum <n>
+                              times
   [32m--teamcity                 [0m Report test execution progress in
                               TeamCity format
   [32m--testdox                  [0m Report test execution progress in TestDox

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -78,6 +78,7 @@ Test Execution Options:
   --debug                     Display debugging information
 
   --repeat <times>            Runs the test(s) repeatedly
+  --until-success             Combines with `repeat <n>` option, test executes until success, but maximum <n> times
   --teamcity                  Report test execution progress in TeamCity format
   --testdox                   Report test execution progress in TestDox format
   --testdox-group             Only include tests from the specified group(s)

--- a/tests/end-to-end/execution-order/until-success.phpt
+++ b/tests/end-to-end/execution-order/until-success.phpt
@@ -1,0 +1,23 @@
+--TEST--
+phpunit --repeat 100 --until-success ../../_files/BankAccountTest.php
+--FILE--
+<?php declare(strict_types=1);
+$arguments = [
+    '--no-configuration',
+    '--repeat',
+    '100',
+    '--until-success',
+    \realpath(__DIR__ . '/../../_files/BankAccountTest.php'),
+];
+\array_splice($_SERVER['argv'], 1, count($arguments), $arguments);
+
+require __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+...
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)


### PR DESCRIPTION
`phpunit` has option `--repeat`, but sometimes we want something called `attempt` for unstable tests (tests run in parallel and sometimes fail, because of other tests)

`--until-success` option uses repeated testsuites provided by `--repeat` option and if testsuite successfully completed, doesnt' run another suites