### PR TITLE
New inheritance constraints and assertions

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -44,8 +44,10 @@ use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\Count;
 use PHPUnit\Framework\Constraint\DirectoryExists;
+use PHPUnit\Framework\Constraint\ExtendsClass;
 use PHPUnit\Framework\Constraint\FileExists;
 use PHPUnit\Framework\Constraint\GreaterThan;
+use PHPUnit\Framework\Constraint\ImplementsInterface;
 use PHPUnit\Framework\Constraint\IsAnything;
 use PHPUnit\Framework\Constraint\IsEmpty;
 use PHPUnit\Framework\Constraint\IsEqual;
@@ -81,6 +83,7 @@ use PHPUnit\Framework\Constraint\StringStartsWith;
 use PHPUnit\Framework\Constraint\TraversableContainsEqual;
 use PHPUnit\Framework\Constraint\TraversableContainsIdentical;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
+use PHPUnit\Framework\Constraint\UsesTrait;
 use PHPUnit\Util\Type;
 use PHPUnit\Util\Xml;
 use PHPUnit\Util\Xml\Loader as XmlLoader;
@@ -1395,6 +1398,120 @@ abstract class Assert
     }
 
     /**
+     * Asserts that *$subject* implements *$interface*.
+     *
+     * @param string $interface name of the interface that is expected to be implemented
+     * @param mixed  $subject   an object or a class name that is being examined
+     * @param string $message   custom message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertImplementsInterface(string $interface, $subject, string $message = ''): void
+    {
+        static::assertThat(
+            $subject,
+            static::implementsInterface($interface),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that *$subject* does not implement *$interface*.
+     *
+     * @param string $interface name of the interface that is expected to be implemented
+     * @param mixed  $subject   an object or a class name that is being examined
+     * @param string $message   custom message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertNotImplementsInterface(string $interface, $subject, string $message = ''): void
+    {
+        static::assertThat(
+            $subject,
+            new LogicalNot(static::implementsInterface($interface)),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that *$subject* extends the class *$parent*.
+     *
+     * @param string $parent  name of the class that is supposed to be extended by *$subject*
+     * @param mixed  $subject an object or a class name that is being examined
+     * @param string $message custom message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertExtendsClass(string $parent, $subject, string $message = ''): void
+    {
+        static::assertThat(
+            $subject,
+            static::extendsClass($parent),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that *$subject* does not extend the class *$parent*.
+     *
+     * @param string $parent  name of the class that is expected to be extended by *$subject*
+     * @param mixed  $subject an object or a class name that is being examined
+     * @param string $message custom message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertNotExtendsClass(string $parent, $subject, string $message = ''): void
+    {
+        static::assertThat(
+            $subject,
+            new LogicalNot(static::extendsClass($parent)),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that *$subject* uses *$trait*.
+     *
+     * @param string $trait   name of the trait that is supposed to be included by *$subject*
+     * @param mixed  $subject an object or a class name that is being examined
+     * @param string $message custom message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertUsesTrait(string $trait, $subject, string $message = ''): void
+    {
+        static::assertThat(
+            $subject,
+            static::usesTrait($trait),
+            $message
+        );
+    }
+
+    /**
+     * Asserts that *$subject* does not use *$trait*.
+     *
+     * @param string $trait   name of the trait that is expected to be used by *$subject*
+     * @param mixed  $subject an object or a class name that is being examined
+     * @param string $message custom message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public static function assertNotUsesTrait(string $trait, $subject, string $message = ''): void
+    {
+        static::assertThat(
+            $subject,
+            new LogicalNot(static::usesTrait($trait)),
+            $message
+        );
+    }
+
+    /**
      * Asserts that a variable is of type array.
      *
      * @throws ExpectationFailedException
@@ -2119,7 +2236,7 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-     * @throws \PHPUnit\Util\Exception
+     * @throws \PHPUnit\Util\Xml\Exception
      */
     public static function assertXmlFileNotEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
@@ -2567,11 +2684,17 @@ abstract class Assert
         return new TraversableContainsIdentical($value);
     }
 
+    /**
+     * @throws Exception
+     */
     public static function containsOnly(string $type): TraversableContainsOnly
     {
         return new TraversableContainsOnly($type);
     }
 
+    /**
+     * @throws Exception
+     */
     public static function containsOnlyInstancesOf(string $className): TraversableContainsOnly
     {
         return new TraversableContainsOnly($className, false);
@@ -2668,6 +2791,33 @@ abstract class Assert
         return new IsInstanceOf($className);
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
+    public static function implementsInterface(string $interface): ImplementsInterface
+    {
+        return ImplementsInterface::fromInterfaceString($interface);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public static function extendsClass(string $parent): ExtendsClass
+    {
+        return ExtendsClass::fromClassString($parent);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public static function usesTrait(string $trait): UsesTrait
+    {
+        return UsesTrait::fromTraitString($trait);
+    }
+
+    /**
+     * @throws Exception
+     */
     public static function isType(string $type): IsType
     {
         return new IsType($type);
@@ -2785,6 +2935,7 @@ abstract class Assert
 
     /**
      * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
     public function assertObjectEquals(object $expected, object $actual, string $method = 'equals', string $message = ''): void
     {

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -21,8 +21,10 @@ use PHPUnit\Framework\Constraint\ClassHasStaticAttribute;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\Count;
 use PHPUnit\Framework\Constraint\DirectoryExists;
+use PHPUnit\Framework\Constraint\ExtendsClass;
 use PHPUnit\Framework\Constraint\FileExists;
 use PHPUnit\Framework\Constraint\GreaterThan;
+use PHPUnit\Framework\Constraint\ImplementsInterface;
 use PHPUnit\Framework\Constraint\IsAnything;
 use PHPUnit\Framework\Constraint\IsEmpty;
 use PHPUnit\Framework\Constraint\IsEqual;
@@ -55,6 +57,7 @@ use PHPUnit\Framework\Constraint\StringStartsWith;
 use PHPUnit\Framework\Constraint\TraversableContainsEqual;
 use PHPUnit\Framework\Constraint\TraversableContainsIdentical;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
+use PHPUnit\Framework\Constraint\UsesTrait;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount as AnyInvokedCountMatcher;
 use PHPUnit\Framework\MockObject\Rule\InvokedAtIndex as InvokedAtIndexMatcher;
 use PHPUnit\Framework\MockObject\Rule\InvokedAtLeastCount as InvokedAtLeastCountMatcher;
@@ -1514,6 +1517,108 @@ if (!function_exists('PHPUnit\Framework\assertNotInstanceOf')) {
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertImplementsInterface')) {
+    /**
+     * Asserts that subject implements specified interface.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertImplementsInterface
+     */
+    function assertImplementsInterface(string $interfaceName, $subject, string $message = ''): void
+    {
+        Assert::assertImplementsInterface(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertNotImplementsInterface')) {
+    /**
+     * Asserts that subject does not implement specified interface.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertNotImplementsInterface
+     */
+    function assertNotImplementsInterface(string $interfaceName, $subject, string $message = ''): void
+    {
+        Assert::assertNotImplementsInterface(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertExtendsClass')) {
+    /**
+     * Asserts that subject extends specified class.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertExtendsClass
+     */
+    function assertExtendsClass(string $className, $subject, string $message = ''): void
+    {
+        Assert::assertExtendsClass(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertNotExtendsClass')) {
+    /**
+     * Asserts that subject does not extend specified class.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertNotExtendsClass
+     */
+    function assertNotExtendsClass(string $className, $subject, string $message = ''): void
+    {
+        Assert::assertNotExtendsClass(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertUsesTrait')) {
+    /**
+     * Asserts that subject uses specified trait.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertUsesTrait
+     */
+    function assertUsesTrait(string $traitName, $subject, string $message = ''): void
+    {
+        Assert::assertUsesTrait(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertNotUsesTrait')) {
+    /**
+     * Asserts that subject does not use specified trait.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertNotUsesTrait
+     */
+    function assertNotUsesTrait(string $traitName, $subject, string $message = ''): void
+    {
+        Assert::assertNotUsesTrait(...func_get_args());
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertIsArray')) {
     /**
      * Asserts that a variable is of type array.
@@ -2803,6 +2908,27 @@ if (!function_exists('PHPUnit\Framework\isInstanceOf')) {
     function isInstanceOf(string $className): IsInstanceOf
     {
         return Assert::isInstanceOf(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\implementsInterface')) {
+    function implementsInterface(string $interfaceName): ImplementsInterface
+    {
+        return ImplementsInterface::fromInterfaceString($interfaceName);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\extendsClass')) {
+    function extendsClass(string $className): ImplementsInterface
+    {
+        return ExtendsClass::fromClassString($className);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\usesTrait')) {
+    function usesTrait(string $traitName): UsesTrait
+    {
+        return UsesTrait::fromTraitString($traitName);
     }
 }
 

--- a/src/Framework/Constraint/Inheritance/AbstractInheritanceConstraint.php
+++ b/src/Framework/Constraint/Inheritance/AbstractInheritanceConstraint.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+/**
+ * Abstract base class for inheritance constraints (ExtendsClass,
+ * ImplementsInterface, UsesTrait, etc.).
+ *
+ * @psalm-template Subclass of AbstractInheritanceConstraint
+ */
+abstract class AbstractInheritanceConstraint extends Constraint
+{
+    /**
+     * @var string
+     * @psalm-readonly
+     */
+    private $expected;
+
+    /**
+     * Initializes the constraint.
+     */
+    protected function __construct(string $expected)
+    {
+        $this->expected = $expected;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     */
+    final public function toString(): string
+    {
+        return sprintf('%s %s', $this->verb(), $this->expected);
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     *
+     * @param mixed $other value or object to evaluate
+     */
+    final public function matches($other): bool
+    {
+        if (is_object($other)) {
+            $other = get_class($other);
+        }
+
+        if (!is_string($other) || !$this->supportsActual($other)) {
+            return false;
+        }
+
+        return in_array($this->expected, $this->inheritance($other), true);
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     */
+    final public function failureDescription($other): string
+    {
+        return $this->short($other) . ' ' . $this->toString();
+    }
+
+    /**
+     * Returns short description of what we examine, e.g. ``'impements interface'``.
+     */
+    abstract protected function verb(bool $negated = false): string;
+
+    /**
+     * Returns an array of "inherited classes" -- eiher interfaces *$class*
+     * implements, parent classes it extends or traits it uses, depending on
+     * the actual implementation of this constraint.
+     */
+    abstract protected function inheritance(string $class): array;
+
+    /**
+     * Checks if *$string* may be used as an argument to ``inheritance()``.
+     */
+    abstract protected function supportsActual(string $string): bool;
+
+    /**
+     * Returns a custom string representation of the constraint object when it
+     * appears in context of an $operator expression.
+     *
+     * The purpose of this method is to provide meaningful descriptive string
+     * in context of operators such as LogicalNot. Native PHPUnit constraints
+     * are supported out of the box by LogicalNot, but externally developed
+     * ones had no way to provide correct strings in this context.
+     *
+     * The method shall return empty string, when it does not handle
+     * customization by itself.
+     *
+     * @param Operator $operator the $operator of the expression
+     * @param mixed    $role     role of $this constraint in the $operator expression
+     */
+    final protected function toStringInContext(Operator $operator, $role): string
+    {
+        if ($operator instanceof LogicalNot) {
+            return sprintf('%s %s', $this->verb(true), $this->expected);
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns the description of the failure when this constraint appears in
+     * context of an $operator expression.
+     *
+     * The purpose of this method is to provide meaningful failue description
+     * in context of operators such as LogicalNot. Native PHPUnit constraints
+     * are supported out of the box by LogicalNot, but externally developed
+     * ones had no way to provide correct messages in this context.
+     *
+     * The method shall return empty string, when it does not handle
+     * customization by itself.
+     *
+     * @param Operator $operator the $operator of the expression
+     * @param mixed    $role     role of $this constraint in the $operator expression
+     * @param mixed    $other    evaluated value or object
+     */
+    final protected function failureDescriptionInContext(Operator $operator, $role, $other): string
+    {
+        $string = $this->toStringInContext($operator, $role);
+
+        if ('' === $string) {
+            return '';
+        }
+
+        return $this->short($other) . ' ' . $string;
+    }
+
+    /**
+     * Returns short representation of $subject for failureDescription().
+     *
+     * @param mixed $subject
+     */
+    private function short($subject): string
+    {
+        if (is_object($subject)) {
+            $subject = 'object ' . get_class($subject);
+        } elseif (!is_string($subject) || !$this->supportsActual($subject)) {
+            $subject = $this->exporter()->export($subject);
+        }
+
+        return $subject;
+    }
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/src/Framework/Constraint/Inheritance/ExtendsClass.php
+++ b/src/Framework/Constraint/Inheritance/ExtendsClass.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\InvalidArgumentException;
+
+/**
+ * Constraint that accepts classes that extend given class.
+ *
+ * @extends AbstractInheritanceConstraint<ExtendsClass>
+ */
+final class ExtendsClass extends AbstractInheritanceConstraint
+{
+    /**
+     * @throws InvalidArgumentException
+     *
+     * @psalm-assert class-string $class
+     */
+    public static function fromClassString(string $class): self
+    {
+        if (!class_exists($class)) {
+            throw InvalidArgumentException::create(1, 'class-string');
+        }
+
+        return new self($class);
+    }
+
+    /**
+     * Returns short description of what we examine, e.g. ``'impements interface'``.
+     */
+    protected function verb(bool $negated = false): string
+    {
+        if ($negated) {
+            return 'does not extend class';
+        }
+
+        return 'extends class';
+    }
+
+    /**
+     * Returns an array of parent classes for $class.
+     */
+    protected function inheritance(string $class): array
+    {
+        return class_parents($class);
+    }
+
+    /**
+     * Checks if *$class* may be used as an argument to ``getInheritedClassesFor()``.
+     *
+     * @psalm-assert-if-true class-string $class
+     */
+    protected function supportsActual(string $class): bool
+    {
+        return class_exists($class);
+    }
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/src/Framework/Constraint/Inheritance/ImplementsInterface.php
+++ b/src/Framework/Constraint/Inheritance/ImplementsInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\InvalidArgumentException;
+
+/**
+ * Constraint that accepts classes that implement given interface.
+ *
+ * @extends AbstractInheritanceConstraint<ImplementsInterface>
+ */
+final class ImplementsInterface extends AbstractInheritanceConstraint
+{
+    /**
+     * @throws InvalidArgumentException
+     *
+     * @psalm-assert class-string $interface
+     */
+    public static function fromInterfaceString(string $interface): self
+    {
+        if (!interface_exists($interface)) {
+            throw InvalidArgumentException::create(1, 'interface-string');
+        }
+
+        return new self($interface);
+    }
+
+    /**
+     * Returns short description of what we examine, e.g. ``'impements interface'``.
+     */
+    protected function verb(bool $negated = false): string
+    {
+        if ($negated) {
+            return 'does not implement interface';
+        }
+
+        return 'implements interface';
+    }
+
+    /**
+     * Returns an array of interfaces $class implements.
+     */
+    protected function inheritance(string $class): array
+    {
+        return class_implements($class);
+    }
+
+    /**
+     * Checks if *$string* may be used as an argument to ``getInheritedClassesFor()``.
+     *
+     * @psalm-assert-if-true class-string $class
+     */
+    protected function supportsActual(string $class): bool
+    {
+        return class_exists($class) || interface_exists($class);
+    }
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/src/Framework/Constraint/Inheritance/UsesTrait.php
+++ b/src/Framework/Constraint/Inheritance/UsesTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\InvalidArgumentException;
+
+/**
+ * Constraint that accepts classes that extend given class.
+ *
+ * @extends AbstractInheritanceConstraint<UsesTrait>
+ */
+final class UsesTrait extends AbstractInheritanceConstraint
+{
+    /**
+     * @throws InvalidArgumentException
+     *
+     * @psalm-assert trait-string $trait
+     */
+    public static function fromTraitString(string $trait): self
+    {
+        if (!trait_exists($trait)) {
+            throw InvalidArgumentException::create(1, 'trait-string');
+        }
+
+        return new self($trait);
+    }
+
+    /**
+     * Returns short description of what we examine, e.g. ``'impements interface'``.
+     */
+    protected function verb(bool $negated = false): string
+    {
+        if ($negated) {
+            return 'does not use trait';
+        }
+
+        return 'uses trait';
+    }
+
+    /**
+     * Returns an array of traits $class uses.
+     */
+    protected function inheritance(string $class): array
+    {
+        return class_uses($class);
+    }
+
+    /**
+     * Checks if *$class* may be used as an argument to ``getInheritedClassesFor()``.
+     *
+     * @psalm-assert-if-true class-string|trait-string $class
+     */
+    protected function supportsActual(string $class): bool
+    {
+        return class_exists($class) || trait_exists($class);
+    }
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/tests/_files/ExampleClassNotUsingTrait.php
+++ b/tests/_files/ExampleClassNotUsingTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+/**
+ * Example class for testing purposes.
+ */
+final class ExampleClassNotUsingTrait
+{
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/tests/_files/ExampleClassUsingTrait.php
+++ b/tests/_files/ExampleClassUsingTrait.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+/**
+ * Example class for testing purposes.
+ */
+final class ExampleClassUsingTrait
+{
+    use ExampleTrait;
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/tests/_files/ExampleTraitUsingTrait.php
+++ b/tests/_files/ExampleTraitUsingTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+/**
+ * Example trait for testing purposes.
+ */
+trait ExampleTraitUsingTrait
+{
+    use ExampleTrait;
+}
+
+// vim: syntax=php sw=4 ts=4 et:

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -32,10 +32,17 @@ use ArrayIterator;
 use ArrayObject;
 use DateTime;
 use DateTimeZone;
+use Error;
+use ErrorException;
+use Iterator;
 use PHPUnit\TestFixture\Author;
 use PHPUnit\TestFixture\Book;
 use PHPUnit\TestFixture\ClassWithNonPublicAttributes;
 use PHPUnit\TestFixture\ClassWithToString;
+use PHPUnit\TestFixture\ExampleClassNotUsingTrait;
+use PHPUnit\TestFixture\ExampleClassUsingTrait;
+use PHPUnit\TestFixture\ExampleTrait;
+use PHPUnit\TestFixture\ExampleTraitUsingTrait;
 use PHPUnit\TestFixture\ObjectEquals\ValueObject;
 use PHPUnit\TestFixture\SampleArrayAccess;
 use PHPUnit\TestFixture\SampleClass;
@@ -44,6 +51,8 @@ use PHPUnit\Util\Xml\Exception as XmlException;
 use PHPUnit\Util\Xml\Loader as XmlLoader;
 use SplObjectStorage;
 use stdClass;
+use Throwable;
+use Traversable;
 
 /**
  * @small
@@ -55,6 +64,233 @@ final class AssertTest extends TestCase
         return [
             'error syntax in expected JSON' => ['{"Mascott"::}', '{"Mascott" : "Tux"}'],
             'error UTF-8 in actual JSON'    => ['{"Mascott" : "Tux"}', '{"Mascott" : :}'],
+        ];
+    }
+
+    //
+    // implementsInterface
+    //
+
+    public static function implementsInterfaceProvider(): array
+    {
+        $template = 'Failed asserting that %s does not implement interface %s.';
+
+        return [
+            [
+                'interface' => Throwable::class,
+                'subject'   => \Exception::class,
+                'message'   => sprintf($template, \Exception::class, Throwable::class),
+            ],
+            [
+                'interface' => Throwable::class,
+                'subject'   => new \Exception(),
+                'message'   => sprintf($template, 'object ' . \Exception::class, Throwable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => Iterator::class,
+                'message'   => sprintf($template, Iterator::class, Traversable::class),
+            ],
+        ];
+    }
+
+    public static function notImplementsInterfaceProvider(): array
+    {
+        $template = 'Failed asserting that %s implements interface %s.';
+
+        return [
+            [
+                'interface' => Traversable::class,
+                'subject'   => \Exception::class,
+                'message'   => sprintf($template, \Exception::class, Traversable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => new \Exception(),
+                'message'   => sprintf($template, 'object ' . \Exception::class, Traversable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => 'lorem ipsum',
+                'message'   => sprintf($template, "'lorem ipsum'", Traversable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => 123,
+                'message'   => sprintf($template, '123', Traversable::class),
+            ],
+        ];
+    }
+
+    public static function implementsInterfaceThrowsInvalidArgumentExceptionProvider(): array
+    {
+        $message = '/Argument #1 of \S+ must be an interface-string/';
+
+        return [
+            [
+                'argument' => 'non-interface string',
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => \Exception::class,
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => ExampleTrait::class,
+                'messsage' => $message,
+            ],
+        ];
+    }
+
+    //
+    // extendsClass
+    //
+
+    public static function extendsClassProvider(): array
+    {
+        $template = 'Failed asserting that %s does not extend class %s.';
+
+        return [
+            [
+                'class'   => \Exception::class,
+                'subject' => ErrorException::class,
+                'message' => sprintf($template, ErrorException::class, \Exception::class),
+            ],
+
+            [
+                'class'   => \Exception::class,
+                'subject' => new ErrorException(),
+                'message' => sprintf($template, 'object ' . ErrorException::class, \Exception::class),
+            ],
+        ];
+    }
+
+    public static function notExtendsClassProvider(): array
+    {
+        $template = 'Failed asserting that %s extends class %s.';
+
+        return [
+            [
+                'class'   => Error::class,
+                'subject' => ErrorException::class,
+                'message' => sprintf($template, ErrorException::class, Error::class),
+            ],
+            [
+                'class'   => Error::class,
+                'subject' => new ErrorException(),
+                'message' => sprintf($template, 'object ' . ErrorException::class, Error::class),
+            ],
+            [
+                'class'   => Error::class,
+                'subject' => 'lorem ipsum',
+                'message' => sprintf($template, "'lorem ipsum'", Error::class),
+            ],
+            [
+                'class'   => Error::class,
+                'subject' => 123,
+                'message' => sprintf($template, '123', Error::class),
+            ],
+        ];
+    }
+
+    public static function extendsClassThrowsInvalidArgumentExceptionProvider(): array
+    {
+        $message = '/Argument #1 of \S+ must be a class-string/';
+
+        return [
+            [
+                'argument' => 'non-class string',
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => Throwable::class,
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => ExampleTrait::class,
+                'messsage' => $message,
+            ],
+        ];
+    }
+
+    //
+    // usesTrait
+    //
+
+    public static function usesTraitProvider(): array
+    {
+        $template = 'Failed asserting that %s does not use trait %s.';
+
+        return [
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => ExampleClassUsingTrait::class,
+                'message' => sprintf($template, ExampleClassUsingTrait::class, ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => new ExampleClassUsingTrait(),
+                'message' => sprintf($template, 'object ' . ExampleClassUsingTrait::class, ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => ExampleTraitUsingTrait::class,
+                'message' => sprintf($template, ExampleTraitUsingTrait::class, ExampleTrait::class),
+            ],
+        ];
+    }
+
+    public static function notUsesTraitProvider(): array
+    {
+        $template = 'Failed asserting that %s uses trait %s.';
+
+        return [
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => ExampleClassNotUsingTrait::class,
+                'message' => sprintf($template, ExampleClassNotUsingTrait::class, ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => new ExampleClassNotUsingTrait(),
+                'message' => sprintf($template, 'object ' . ExampleClassNotUsingTrait::class, ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => 'lorem ipsum',
+                'message' => sprintf($template, "'lorem ipsum'", ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => 123,
+                'message' => sprintf($template, '123', ExampleTrait::class),
+            ],
+        ];
+    }
+
+    public static function usesTraitThrowsInvalidArgumentExceptionProvider(): array
+    {
+        $message = '/Argument #1 of \S+ must be a trait-string/';
+
+        return [
+            [
+                'argument' => 'non-trait string',
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => \Exception::class,
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => Throwable::class,
+                'messsage' => $message,
+            ],
         ];
     }
 
@@ -1824,6 +2060,227 @@ XML;
         $this->expectException(AssertionFailedError::class);
 
         $this->assertNotInstanceOf(stdClass::class, new stdClass);
+    }
+
+    /**
+     * @dataProvider implementsInterfaceProvider
+     *
+     * @param object|string $subject
+     */
+    public function testAssertImplementsInterfaceSucceeds(string $interface, $subject): void
+    {
+        self::assertImplementsInterface($interface, $subject);
+    }
+
+    /**
+     * @dataProvider notImplementsInterfaceProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertImplementsInterfaceFails(string $interface, $subject, string $message): void
+    {
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        self::assertImplementsInterface($interface, $subject);
+    }
+
+    /**
+     * @dataProvider notImplementsInterfaceProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertNotImplementsInterfaceSucceeds(string $interface, $subject): void
+    {
+        self::assertNotImplementsInterface($interface, $subject);
+    }
+
+    /**
+     * @dataProvider implementsInterfaceProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertNotImplementsInterfaceFails(string $interface, $subject, string $message): void
+    {
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        self::assertNotImplementsInterface($interface, $subject);
+    }
+
+    /**
+     * @dataProvider notImplementsInterfaceProvider
+     *
+     * @param mixed $subject
+     */
+    public function testImplementsInterfaceFails(string $interface, $subject): void
+    {
+        self::assertThat($subject, self::logicalNot(self::implementsInterface($interface)));
+    }
+
+    /**
+     * @dataProvider implementsInterfaceThrowsInvalidArgumentExceptionProvider
+     */
+    public function testImplementsInterfaceThrowsInvalidArgumentException(string $argument, string $message): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessageMatches($message);
+
+        self::implementsInterface($argument);
+    }
+
+    /**
+     * @dataProvider extendsClassProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertExtendsClassSucceeds(string $class, $subject): void
+    {
+        self::assertExtendsClass($class, $subject);
+    }
+
+    /**
+     * @dataProvider notExtendsClassProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertExtendsClassFails(string $class, $subject, string $message): void
+    {
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        self::assertExtendsClass($class, $subject);
+    }
+
+    /**
+     * @dataProvider notExtendsClassProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertNotExtendsClassSucceeds(string $class, $subject): void
+    {
+        self::assertNotExtendsClass($class, $subject);
+    }
+
+    /**
+     * @dataProvider extendsClassProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertNotExtendsClassFails(string $class, $subject, string $message): void
+    {
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        self::assertNotExtendsClass($class, $subject);
+    }
+
+    /**
+     * @dataProvider extendsClassProvider
+     *
+     * @param mixed $subject
+     */
+    public function testExtendsClass(string $class, $subject): void
+    {
+        self::assertThat($subject, self::extendsClass($class));
+    }
+
+    /**
+     * @dataProvider notExtendsClassProvider
+     *
+     * @param mixed $subject
+     */
+    public function testNotExtendsClass(string $class, $subject): void
+    {
+        self::assertThat($subject, self::logicalNot(self::extendsClass($class)));
+    }
+
+    /**
+     * @dataProvider extendsClassThrowsInvalidArgumentExceptionProvider
+     */
+    public function testExtendsClassThrowsInvalidArgumentException(string $argument, string $message): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessageMatches($message);
+
+        self::extendsClass($argument);
+    }
+
+    /**
+     * @dataProvider usesTraitProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertUsesTraitSucceeds(string $trait, $subject): void
+    {
+        self::assertUsesTrait($trait, $subject);
+    }
+
+    /**
+     * @dataProvider notUsesTraitProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertUsesTraitFails(string $trait, $subject, string $message): void
+    {
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        self::assertUsesTrait($trait, $subject);
+    }
+
+    /**
+     * @dataProvider notUsesTraitProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertNotUsesTraitSucceeds(string $trait, $subject): void
+    {
+        self::assertNotUsesTrait($trait, $subject);
+    }
+
+    /**
+     * @dataProvider usesTraitProvider
+     *
+     * @param mixed $subject
+     */
+    public function testAssertNotUsesTraitFails(string $trait, $subject, string $message): void
+    {
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        self::assertNotUsesTrait($trait, $subject);
+    }
+
+    /**
+     * @dataProvider usesTraitProvider
+     *
+     * @param mixed $subject
+     */
+    public function testUsesTrait(string $trait, $subject): void
+    {
+        self::assertThat($subject, self::usesTrait($trait));
+    }
+
+    /**
+     * @dataProvider notUsesTraitProvider
+     *
+     * @param mixed $subject
+     */
+    public function testNotUsesTrait(string $trait, $subject): void
+    {
+        self::assertThat($subject, self::logicalNot(self::usesTrait($trait)));
+    }
+
+    /**
+     * @dataProvider usesTraitThrowsInvalidArgumentExceptionProvider
+     */
+    public function testUsesTraitThrowsInvalidArgumentException(string $argument, string $message): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessageMatches($message);
+
+        self::usesTrait($argument);
     }
 
     public function testAssertStringMatchesFormatFileThrowsExceptionForInvalidArgument(): void

--- a/tests/unit/Framework/Constraint/ExtendsClassTest.php
+++ b/tests/unit/Framework/Constraint/ExtendsClassTest.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use Error;
+use ErrorException;
+use Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidArgumentException;
+use PHPUnit\TestFixture\ExampleTrait;
+use Throwable;
+
+/**
+ * @small
+ */
+final class ExtendsClassTest extends ConstraintTestCase
+{
+    public static function extendsClassProvider(): array
+    {
+        return [
+            // class extends class
+            [
+                'class'   => Exception::class,
+                'subject' => ErrorException::class,
+            ],
+
+            // object of class that extends class
+            [
+                'class'   => Exception::class,
+                'subject' => new ErrorException(),
+            ],
+        ];
+    }
+
+    public static function notExtendsClassProvider(): array
+    {
+        $template = 'Failed asserting that %s extends class %s.';
+
+        return [
+            [
+                'class'   => Error::class,
+                'subject' => ErrorException::class,
+                'message' => sprintf($template, ErrorException::class, Error::class),
+            ],
+            [
+                'class'   => Error::class,
+                'subject' => new ErrorException(),
+                'message' => sprintf($template, 'object ' . ErrorException::class, Error::class),
+            ],
+            [
+                'class'   => Error::class,
+                'subject' => 'lorem ipsum',
+                'message' => sprintf($template, "'lorem ipsum'", Error::class),
+            ],
+            [
+                'class'   => Error::class,
+                'subject' => 123,
+                'message' => sprintf($template, '123', Error::class),
+            ],
+        ];
+    }
+
+    public static function constraintThrowsInvalidArgumentExceptionProvider(): array
+    {
+        $message = '/Argument #1 of \S+ must be a class-string/';
+
+        return [
+            [
+                'argument' => 'non-class string',
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => Throwable::class,
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => ExampleTrait::class,
+                'messsage' => $message,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider extendsClassProvider
+     */
+    public function testConstraintSucceeds(string $class, $subject): void
+    {
+        $constraint = ExtendsClass::fromClassString($class);
+
+        self::assertTrue($constraint->evaluate($subject, '', true));
+    }
+
+    /**
+     * @dataProvider notExtendsClassProvider
+     */
+    public function testConstraintFails(string $class, $subject, string $message): void
+    {
+        $constraint = ExtendsClass::fromClassString($class);
+
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        $constraint->evaluate($subject);
+    }
+
+    /**
+     * @dataProvider constraintThrowsInvalidArgumentExceptionProvider
+     */
+    public function testConstraintThrowsInvalidArgumentException(string $argument, string $message): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessageMatches($message);
+
+        ExtendsClass::fromClassString($argument);
+    }
+
+    public function testFailureDescriptionOfCustomUnaryOperator(): void
+    {
+        $constraint = ExtendsClass::fromClassString(ErrorException::class);
+
+        $noop = $this->getMockBuilder(UnaryOperator::class)
+            ->setConstructorArgs([$constraint])
+            ->getMockForAbstractClass();
+
+        $noop->expects($this->any())
+            ->method('operator')
+            ->willReturn('noop');
+        $noop->expects($this->any())
+            ->method('precedence')
+            ->willReturn(1);
+
+        $regexp = '/Exception extends class ErrorException/';
+
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessageMatches($regexp);
+
+        $noop->evaluate(Exception::class);
+    }
+}

--- a/tests/unit/Framework/Constraint/ImplementsInterfaceTest.php
+++ b/tests/unit/Framework/Constraint/ImplementsInterfaceTest.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use Exception;
+use Iterator;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidArgumentException;
+use PHPUnit\TestFixture\ExampleTrait;
+use Throwable;
+use Traversable;
+
+/**
+ * @small
+ */
+final class ImplementsInterfaceTest extends ConstraintTestCase
+{
+    public static function implementsInterfaceProvider(): array
+    {
+        return [
+            // class implements interface
+            [
+                'interface' => Throwable::class,
+                'subject'   => Exception::class,
+            ],
+
+            // object of class that implements interface
+            [
+                'interface' => Throwable::class,
+                'subject'   => new Exception(),
+            ],
+
+            // interface that extends interface
+            [
+                'interface' => Traversable::class,
+                'subject'   => Iterator::class,
+            ],
+
+        ];
+    }
+
+    public static function notImplementsInterfaceProvider(): array
+    {
+        $template = 'Failed asserting that %s implements interface %s.';
+
+        return [
+            [
+                'interface' => Traversable::class,
+                'subject'   => Exception::class,
+                'message'   => sprintf($template, Exception::class, Traversable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => new Exception(),
+                'message'   => sprintf($template, 'object ' . Exception::class, Traversable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => 'lorem ipsum',
+                'message'   => sprintf($template, "'lorem ipsum'", Traversable::class),
+            ],
+            [
+                'interface' => Traversable::class,
+                'subject'   => 123,
+                'message'   => sprintf($template, '123', Traversable::class),
+            ],
+        ];
+    }
+
+    public static function constraintThrowsInvalidArgumentExceptionProvider(): array
+    {
+        $message = '/Argument #1 of \S+ must be an interface-string/';
+
+        return [
+            [
+                'argument' => 'non-interface string',
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => Exception::class,
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => ExampleTrait::class,
+                'messsage' => $message,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider implementsInterfaceProvider
+     */
+    public function testConstraintSucceeds(string $interface, $subject): void
+    {
+        $constraint = ImplementsInterface::fromInterfaceString($interface);
+
+        self::assertTrue($constraint->evaluate($subject, '', true));
+    }
+
+    /**
+     * @dataProvider notImplementsInterfaceProvider
+     */
+    public function testConstraintFails(string $interface, $subject, string $message): void
+    {
+        $constraint = ImplementsInterface::fromInterfaceString($interface);
+
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        $constraint->evaluate($subject);
+    }
+
+    /**
+     * @dataProvider constraintThrowsInvalidArgumentExceptionProvider
+     */
+    public function testConstraintThrowsInvalidArgumentException(string $argument, string $message): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessageMatches($message);
+
+        ImplementsInterface::fromInterfaceString($argument);
+    }
+
+    public function testFailureDescriptionOfCustomUnaryOperator(): void
+    {
+        $constraint = ImplementsInterface::fromInterfaceString(Throwable::class);
+
+        $noop = $this->getMockBuilder(UnaryOperator::class)
+            ->setConstructorArgs([$constraint])
+            ->getMockForAbstractClass();
+
+        $noop->expects($this->any())
+            ->method('operator')
+            ->willReturn('noop');
+        $noop->expects($this->any())
+            ->method('precedence')
+            ->willReturn(1);
+
+        $regexp = '/Iterator implements interface Throwable/';
+
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessageMatches($regexp);
+
+        $noop->evaluate(Iterator::class);
+    }
+}

--- a/tests/unit/Framework/Constraint/UsesTraitConstraintTest.php
+++ b/tests/unit/Framework/Constraint/UsesTraitConstraintTest.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use Exception;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidArgumentException;
+use PHPUnit\TestFixture\ExampleClassNotUsingTrait;
+use PHPUnit\TestFixture\ExampleClassUsingTrait;
+use PHPUnit\TestFixture\ExampleTrait;
+use PHPUnit\TestFixture\ExampleTraitUsingTrait;
+use Throwable;
+
+/**
+ * @small
+ */
+final class UsesTraitTest extends ConstraintTestCase
+{
+    public static function usesTraitProvider(): array
+    {
+        return [
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => ExampleClassUsingTrait::class,
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => new ExampleClassUsingTrait(),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => ExampleTraitUsingTrait::class,
+            ],
+        ];
+    }
+
+    public static function notUsesTraitProvider(): array
+    {
+        $template = 'Failed asserting that %s uses trait %s.';
+
+        return [
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => ExampleClassNotUsingTrait::class,
+                'message' => sprintf($template, ExampleClassNotUsingTrait::class, ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => new ExampleClassNotUsingTrait(),
+                'message' => sprintf($template, 'object ' . ExampleClassNotUsingTrait::class, ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => 'lorem ipsum',
+                'message' => sprintf($template, "'lorem ipsum'", ExampleTrait::class),
+            ],
+            [
+                'trait'   => ExampleTrait::class,
+                'subject' => 123,
+                'message' => sprintf($template, '123', ExampleTrait::class),
+            ],
+        ];
+    }
+
+    public static function constraintThrowsInvalidArgumentExceptionProvider(): array
+    {
+        $message = '/Argument #1 of \S+ must be a trait-string/';
+
+        return [
+            [
+                'argument' => 'non-trait string',
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => Exception::class,
+                'messsage' => $message,
+            ],
+
+            [
+                'argument' => Throwable::class,
+                'messsage' => $message,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider usesTraitProvider
+     */
+    public function testConstraintSucceeds(string $trait, $subject): void
+    {
+        $constraint = UsesTrait::fromTraitString($trait);
+
+        self::assertTrue($constraint->evaluate($subject, '', true));
+    }
+
+    /**
+     * @dataProvider notUsesTraitProvider
+     */
+    public function testConstraintFails(string $trait, $subject, string $message): void
+    {
+        $constraint = UsesTrait::fromTraitString($trait);
+
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessage($message);
+
+        $constraint->evaluate($subject);
+    }
+
+    /**
+     * @dataProvider constraintThrowsInvalidArgumentExceptionProvider
+     */
+    public function testConstraintThrowsInvalidArgumentException(string $argument, string $message): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessageMatches($message);
+
+        UsesTrait::fromTraitString($argument);
+    }
+
+    public function testFailureDescriptionOfCustomUnaryOperator(): void
+    {
+        $constraint = UsesTrait::fromTraitString(ExampleTrait::class);
+
+        $noop = $this->getMockBuilder(UnaryOperator::class)
+            ->setConstructorArgs([$constraint])
+            ->getMockForAbstractClass();
+
+        $noop->expects($this->any())
+            ->method('operator')
+            ->willReturn('noop');
+        $noop->expects($this->any())
+            ->method('precedence')
+            ->willReturn(1);
+
+        $regexp = '/Exception uses trait ' . preg_quote(ExampleTrait::class, '/') . '/';
+
+        self::expectException(ExpectationFailedException::class);
+        self::expectExceptionMessageMatches($regexp);
+
+        $noop->evaluate(Exception::class);
+    }
+}


### PR DESCRIPTION
I'd like to propose some new constraints and assertions for inheritance. They're inspired on ``isInstanceOf`` but are more specific. The new constraints are:

  - ``ImplementsInterface`` (whether the given class implements specific interface),
  - ``ExtendsClass`` (whether the given class extends specific class),
  - ``UsesTrait`` (whether the given class/trait uses specific trait) ,

and the accompanying assertions:

  - ``assertImplementsInterface``, ``assertNotImplementsInterface``,
  - ``assertExtendsClass``, ``assertNotExtendsClass``,
  - ``assertUsesTrait``, ``assertNotUsesTrait``.

I have also prepared some ``rst`` user docs for these functions (English), but not sure where to put them (shall they go to [phpunit-documentation-english](https://github.com/sebastianbergmann/phpunit-documentation-english)?).