### PR TITLE
Silence stream_get_contents() warnings in TestCaseClass.tpl and TestCaseMethod.tpl

### DIFF
--- a/src/Util/PHP/Template/TestCaseClass.tpl
+++ b/src/Util/PHP/Template/TestCaseClass.tpl
@@ -60,7 +60,7 @@ function __phpunit_run_isolated_test()
 
     ini_set('xdebug.scream', '0');
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
-    if ($stdout = stream_get_contents(STDOUT)) {
+    if ($stdout = @stream_get_contents(STDOUT)) {
         $output = $stdout . $output;
         $streamMetaData = stream_get_meta_data(STDOUT);
         if (!empty($streamMetaData['stream_type']) && 'STDIO' === $streamMetaData['stream_type']) {

--- a/src/Util/PHP/Template/TestCaseMethod.tpl
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl
@@ -63,7 +63,7 @@ function __phpunit_run_isolated_test()
 
     ini_set('xdebug.scream', '0');
     @rewind(STDOUT); /* @ as not every STDOUT target stream is rewindable */
-    if ($stdout = stream_get_contents(STDOUT)) {
+    if ($stdout = @stream_get_contents(STDOUT)) {
         $output = $stdout . $output;
         $streamMetaData = stream_get_meta_data(STDOUT);
         if (!empty($streamMetaData['stream_type']) && 'STDIO' === $streamMetaData['stream_type']) {


### PR DESCRIPTION
Although this problem is typically seen with PHPDBG, as per #3965, and not with regular PHP, it is not PHPDBG specific:
```
php -r 'stream_get_contents(STDOUT);' | cat
```
Will output the same error on PHP 7.4.11:
```
PHP Notice:  stream_get_contents(): read of 8192 bytes failed with errno=9 Bad file descriptor in Command line code on line 1
PHP Stack trace:
PHP   1. {main}() Command line code:0
PHP   2. stream_get_contents() Command line code:1
```
This problem [first appeared in PHP 7.4.0](https://3v4l.org/rIeW3).

Fixes #3965 
