### PR TITLE
allow for case insensitive class names #4498

### DIFF
--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -15,7 +15,7 @@ use function basename;
 use function class_exists;
 use function get_declared_classes;
 use function sprintf;
-use function str_replace;
+use function stripos;
 use function strlen;
 use function substr;
 use PHPUnit\Framework\TestCase;
@@ -52,11 +52,11 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
         }
 
         if (!class_exists($suiteClassName, false)) {
+            // this block will handle namespaced classes
             $offset = 0 - strlen($suiteClassName);
 
             foreach ($loadedClasses as $loadedClass) {
-                if (substr($loadedClass, $offset) === $suiteClassName &&
-                    basename(str_replace('\\', '/', $loadedClass)) === $suiteClassName) {
+                if (stripos(substr($loadedClass, $offset - 1), '\\' . $suiteClassName) === 0) {
                     $suiteClassName = $loadedClass;
 
                     break;

--- a/tests/end-to-end/regression/GitHub/4498.phpt
+++ b/tests/end-to-end/regression/GitHub/4498.phpt
@@ -1,0 +1,19 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/4498
+--FILE--
+<?php declare(strict_types=1);
+
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/4498/Issue4498Test.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/GitHub/4498/Issue4498Test.php
+++ b/tests/end-to-end/regression/GitHub/4498/Issue4498Test.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\TestCase;
+
+class issue4498test extends TestCase
+{
+    public function testFoo(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Hey there :vulcan_salute:

this PR fixes #4498 by adding support for case insensitive namespaced class names when calling PHPUnit with the test case file name.

/Flo