### PR TITLE
Reimplement main aspect of assertEqualXMLStructure

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2253,14 +2253,20 @@ abstract class Assert
 
     public static function assertDOMTreesEqualStructurally(DOMElement $expectedElement, DOMElement $actualElement, bool $keepComments = false, string $message = ''): void
     {
-        $ed                     = new DOMDocument();
+        $ed = new DOMDocument();
+        $ed->appendChild($ed->importNode($expectedElement, true));
+        $xmlStr = $ed->C14N(false, $keepComments);
+
         $ed->preserveWhiteSpace = false;
-        $ed->loadXML($expectedElement->C14N(false, $keepComments));
+        $ed->loadXML($xmlStr);
         $ed->formatOutput = true;
 
-        $ad                     = new DOMDocument();
+        $ad = new DOMDocument();
+        $ad->appendChild($ad->importNode($actualElement, true));
+        $xmlStr = $ad->C14N(false, $keepComments);
+
         $ad->preserveWhiteSpace = false;
-        $ad->loadXML($actualElement->C14N(false, $keepComments));
+        $ad->loadXML($xmlStr);
         $ad->formatOutput = true;
 
         self::assertEquals($ed->documentElement, $ad->documentElement, $message);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2251,6 +2251,21 @@ abstract class Assert
         static::assertNotEquals($expected, $actual, $message);
     }
 
+    public static function assertDOMTreesEqualStructurally(DOMElement $expectedElement, DOMElement $actualElement, bool $keepComments = false, string $message = ''): void
+    {
+        $ed                     = new DOMDocument();
+        $ed->preserveWhiteSpace = false;
+        $ed->loadXML($expectedElement->C14N(false, $keepComments));
+        $ed->formatOutput = true;
+
+        $ad                     = new DOMDocument();
+        $ad->preserveWhiteSpace = false;
+        $ad->loadXML($actualElement->C14N(false, $keepComments));
+        $ad->formatOutput = true;
+
+        self::assertEquals($ed->documentElement, $ad->documentElement, $message);
+    }
+
     /**
      * Asserts that a hierarchy of DOMElements matches.
      *

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -2422,6 +2422,23 @@ if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlString')) {
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertDOMTreesEqualStructurally')) {
+    /**
+     * Asserts that two DOM trees are structurally identical.
+     *
+     * @throws AssertionFailedError
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertDOMTreesEqualStructurally
+     */
+    function assertDOMTreesEqualStructurally(DOMElement $expectedElement, DOMElement $actualElement, bool $keepComments = false, string $message = ''): void
+    {
+        Assert::assertDOMTreesEqualStructurally(...func_get_args());
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertEqualXMLStructure')) {
     /**
      * Asserts that a hierarchy of DOMElements matches.


### PR DESCRIPTION
As discussed in https://github.com/sebastianbergmann/phpunit/issues/4091, there is a valid use case for having an assertion ensuring two DOM sub trees are structurally identical.

This PR re-implements the main aspect of the original, deprecated `assertEqualXMLStructure`: The comparison of two XML trees for structural identicality. 

Two DOM trees are to be considered identical when, after canonicalization, the following holds true:

- The same child - parent relationship is maintained
- The same attributes are set on a node
- The attribute values are identical
- The textual content of nodes are identical

Looking at the options of the original, deprecated method, this appears to be stricter. The original method for instance ignored namespace defining attributes as well as textual content.

As I didn't see a use case for that, I did not reimplement that aspect. My implementation basically ignores any whitespace and, due to canonicalization, reorders attributes as needed so the order of attributes is not relevant.

The name `assertDOMTreesEqualStructurally` is subject to change, only pending a better naming suggestion. It should probably reflect the actual assertion better.
