### PR TITLE
Fix Psalm assertions on assertInstanceOf()

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1890,7 +1890,7 @@ abstract class Assert
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $expected
-     * @psalm-assert ExpectedType $actual
+     * @psalm-assert =ExpectedType $actual
      */
     public static function assertInstanceOf(string $expected, $actual, string $message = ''): void
     {

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1546,7 +1546,7 @@ if (!\function_exists('PHPUnit\Framework\assertInstanceOf')) {
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $expected
-     * @psalm-assert ExpectedType $actual
+     * @psalm-assert =ExpectedType $actual
      *
      * @see Assert::assertInstanceOf
      */


### PR DESCRIPTION
Hi, according to https://github.com/vimeo/psalm/issues/4473#issuecomment-721144447, the psalm assertions should be  `@psalm-assert =T` instead of `@psalm-assert T`.

The linked issue describes the problem in more detail.