### PR TITLE
Fix: Do not use set-env to set COMPOSER_CACHE_DIR environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,11 @@ jobs:
 
       - name: Determine composer cache directory on Linux
         if: matrix.os == 'ubuntu-latest'
-        run: echo "::set-env name=COMPOSER_CACHE_DIR::$(./tools/composer config cache-dir)"
+        run: echo "COMPOSER_CACHE_DIR=$(tools/composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Determine composer cache directory on Windows
         if: matrix.os == 'windows-latest'
-        run: ECHO "::set-env name=COMPOSER_CACHE_DIR::~\AppData\Local\Composer"
+        run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v2


### PR DESCRIPTION
This PR

* [x] stops using the disabled `set-env` command to set the `COMPOSER_CACHE_DIR` environment variable

💁‍♂️ For reference, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.