### PR TITLE
Enhancement: Enable no_useless_sprintf fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -147,6 +147,7 @@ return PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1757,7 +1757,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         $this->result->addFailure(
             $this,
             new SkippedTestError(
-                sprintf('This method has an invalid @depends annotation.')
+                'This method has an invalid @depends annotation.'
             ),
             0
         );


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_sprintf` fixer
* [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/function_notation/no_useless_sprintf.rst.