### PR TITLE
Enhancement: Enable phpdoc_line_span fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -191,6 +191,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
+        'phpdoc_line_span' => true,
         'phpdoc_no_access' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_line_span` fixer
* [ ] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/phpdoc_line_span.rst. Note that it can be configured to tweak its behaviour!