### PR TITLE
Enhancement: Enable single_space_after_construct fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -221,6 +221,7 @@ return PhpCsFixer\Config::create()
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
         'single_quote' => true,
+        'single_space_after_construct' => true,
         'standardize_not_equals' => true,
         'strict_param' => true,
         'ternary_to_null_coalescing' => true,

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -302,7 +302,7 @@ abstract class AbstractPhpProcess
                 $test->addToAssertionCount($childResult['numAssertions']);
 
                 $childResult = $childResult['result'];
-                assert($childResult instanceof  TestResult);
+                assert($childResult instanceof TestResult);
 
                 if ($result->collectsCodeCoverageInformation()) {
                     $result->codeCoverage()->merge(


### PR DESCRIPTION
This PR

* [x] enables the `single_space_after_construct` fixer
* [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/language_construct/single_space_after_construct.rst.