### PR TITLE
Enhancement: Enable phpdoc_no_alias_tag fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -192,6 +192,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
         'phpdoc_no_access' => true,
+        'phpdoc_no_alias_tag' => true,
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_order' => true,

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -750,7 +750,7 @@ final class Test
      *
      * Zend Framework (http://framework.zend.com/)
      *
-     * @link      http://github.com/zendframework/zf2 for the canonical source repository
+     * @see       http://github.com/zendframework/zf2 for the canonical source repository
      *
      * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
      * @license   http://framework.zend.com/license/new-bsd New BSD License


### PR DESCRIPTION
This PR

* [x] enables the `phpdoc_no_alias_tag` fixer
* [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/phpdoc/phpdoc_no_alias_tag.rst.