### PR TITLE
Enhancement: Enable and configure operator_linebreak fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -152,6 +152,10 @@ return PhpCsFixer\Config::create()
         'non_printable_character' => true,
         'normalize_index_brace' => true,
         'object_operator_without_whitespace' => true,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'end',
+        ],
         'ordered_class_elements' => [
             'order' => [
                 'use_trait',

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -331,14 +331,14 @@ final class DocBlock
 
     public function isHookToBeExecutedBeforeClass(): bool
     {
-        return $this->isMethod
-            && false !== strpos($this->docComment, '@beforeClass');
+        return $this->isMethod &&
+            false !== strpos($this->docComment, '@beforeClass');
     }
 
     public function isHookToBeExecutedAfterClass(): bool
     {
-        return $this->isMethod
-            && false !== strpos($this->docComment, '@afterClass');
+        return $this->isMethod &&
+            false !== strpos($this->docComment, '@afterClass');
     }
 
     public function isToBeExecutedBeforeTest(): bool


### PR DESCRIPTION
This PR

* [x] enables and configures the `operator_linebreak` fixer
* [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.1/doc/rules/operator/operator_linebreak.rst.