### PR TITLE
Enhancement: Enable and configure php_unit_test_case_static_method_calls_fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -211,6 +211,9 @@ return PhpCsFixer\Config::create()
             'order' => 'alpha',
         ],
         'ordered_traits' => true,
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'this',
+        ],
         'phpdoc_add_missing_param_annotation' => false,
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/tests/end-to-end/regression/GitHub/3093/Issue3093Test.php
+++ b/tests/end-to-end/regression/GitHub/3093/Issue3093Test.php
@@ -16,7 +16,7 @@ class Issue3093Test extends \PHPUnit\Framework\TestCase
 
     public function testFirstWithoutDependencies(): void
     {
-        self::assertTrue(true);
+        $this->assertTrue(true);
     }
 
     /**
@@ -25,6 +25,6 @@ class Issue3093Test extends \PHPUnit\Framework\TestCase
      */
     public function testSecondThatDependsOnFirstAndDataprovider($value): void
     {
-        self::assertTrue(true);
+        $this->assertTrue(true);
     }
 }

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -551,7 +551,7 @@ XML;
     public function testAssertDirectoryIsNotReadable(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {
-            self::markTestSkipped('Cannot test this behaviour on Windows');
+            $this->markTestSkipped('Cannot test this behaviour on Windows');
         }
 
         $dirName = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('unreadable_dir_', true);
@@ -581,7 +581,7 @@ XML;
     public function testAssertDirectoryIsNotWritable(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {
-            self::markTestSkipped('Cannot test this behaviour on Windows');
+            $this->markTestSkipped('Cannot test this behaviour on Windows');
         }
 
         $dirName = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('not_writable_dir_', true);
@@ -629,7 +629,7 @@ XML;
     public function testAssertFileIsNotReadable(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {
-            self::markTestSkipped('Cannot test this behaviour on Windows');
+            $this->markTestSkipped('Cannot test this behaviour on Windows');
         }
 
         $tempFile = tempnam(

--- a/tests/unit/Framework/Constraint/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/IsInstanceOfTest.php
@@ -23,7 +23,7 @@ final class IsInstanceOfTest extends ConstraintTestCase
     {
         $constraint = new IsInstanceOf(stdClass::class);
 
-        self::assertTrue($constraint->evaluate(new stdClass, '', true));
+        $this->assertTrue($constraint->evaluate(new stdClass, '', true));
     }
 
     public function testConstraintFailsOnString(): void
@@ -33,7 +33,7 @@ final class IsInstanceOfTest extends ConstraintTestCase
         try {
             $constraint->evaluate('stdClass');
         } catch (ExpectationFailedException $e) {
-            self::assertSame(
+            $this->assertSame(
                 <<<'EOT'
 Failed asserting that 'stdClass' is an instance of class "stdClass".
 
@@ -50,7 +50,7 @@ EOT
 
         $constraint = new IsInstanceOf(NotExistingClass::class);
 
-        self::assertSame(
+        $this->assertSame(
             'is instance of class "PHPUnit\Framework\Constraint\NotExistingClass"',
             $constraint->toString()
         );

--- a/tests/unit/Util/Annotation/RegistryTest.php
+++ b/tests/unit/Util/Annotation/RegistryTest.php
@@ -27,7 +27,7 @@ final class RegistryTest extends TestCase
     {
         $annotation = Registry::getInstance()->forClassName(self::class);
 
-        self::assertSame(
+        $this->assertSame(
             [
                 'small'  => [''],
                 'covers' => ['\PHPUnit\Util\Annotation\Registry'],
@@ -36,7 +36,7 @@ final class RegistryTest extends TestCase
             $annotation->symbolAnnotations()
         );
 
-        self::assertSame(
+        $this->assertSame(
             $annotation,
             Registry::getInstance()->forClassName(self::class),
             'Registry memoizes retrieved DocBlock instances'
@@ -50,7 +50,7 @@ final class RegistryTest extends TestCase
             'testTicketAnnotationSupportsNumericValue'
         );
 
-        self::assertSame(
+        $this->assertSame(
             [
                 'testdox' => ['Empty test for @ticket numeric annotation values'],
                 'ticket'  => ['3502'],
@@ -60,7 +60,7 @@ final class RegistryTest extends TestCase
             $annotation->symbolAnnotations()
         );
 
-        self::assertSame(
+        $this->assertSame(
             $annotation,
             Registry::getInstance()->forMethod(
                 NumericGroupAnnotationTest::class,

--- a/tests/unit/Util/TestClassTest.php
+++ b/tests/unit/Util/TestClassTest.php
@@ -1429,7 +1429,7 @@ final class TestClassTest extends TestCase
      */
     public function testGetGroupsFromAuthorAndTicketAnnotations(string $class, string $method, array $groups): void
     {
-        self::assertSame($groups, Test::getGroups($class, $method));
+        $this->assertSame($groups, Test::getGroups($class, $method));
     }
 
     public function getGroupsProvider(): array


### PR DESCRIPTION
This PR

* [x] enables and configures the `php_unit_test_case_static_method_calls` fixer
* [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst.