### PR TITLE
Enhancement: Enable php_unit_method_casing fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -214,6 +214,7 @@ return PhpCsFixer\Config::create()
         ],
         'ordered_traits' => true,
         'php_unit_set_up_tear_down_visibility' => true,
+        'php_unit_method_casing' => true,
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'this',
         ],

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -192,7 +192,7 @@ EOF
     /**
      * @ticket https://github.com/sebastianbergmann/phpunit/issues/3743
      */
-    public function test_EmptyIterator_is_handled_correctly(): void
+    public function testEmptyIteratorIsHandledCorrectly(): void
     {
         $constraint = new Count(0);
 

--- a/tests/unit/Framework/Constraint/IsEmptyTest.php
+++ b/tests/unit/Framework/Constraint/IsEmptyTest.php
@@ -73,7 +73,7 @@ EOF
     /**
      * @ticket https://github.com/sebastianbergmann/phpunit/issues/3743
      */
-    public function test_EmptyIterator_is_handled_correctly(): void
+    public function testEmptyIteratorIsHandledCorrectly(): void
     {
         $constraint = new IsEmpty;
 

--- a/tests/unit/Framework/Constraint/TraversableContainsEqualTest.php
+++ b/tests/unit/Framework/Constraint/TraversableContainsEqualTest.php
@@ -62,7 +62,7 @@ final class TraversableContainsEqualTest extends ConstraintTestCase
         $this->assertFalse($constraint->evaluate([$c], '', true));
     }
 
-    public function test_SplObjectStorage_ContainsObject(): void
+    public function testSplObjectStorageContainsObject(): void
     {
         $a      = new stdClass;
         $a->foo = 'bar';

--- a/tests/unit/Framework/Constraint/TraversableContainsIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/TraversableContainsIdenticalTest.php
@@ -63,7 +63,7 @@ final class TraversableContainsIdenticalTest extends ConstraintTestCase
         $this->assertFalse($constraint->evaluate([$c], '', true));
     }
 
-    public function test_SplObjectStorage_ContainsObject(): void
+    public function testSplObjectStorageContainsObject(): void
     {
         $a      = new stdClass;
         $a->foo = 'bar';

--- a/tests/unit/Framework/MockObject/InvocationHandlerTest.php
+++ b/tests/unit/Framework/MockObject/InvocationHandlerTest.php
@@ -15,7 +15,7 @@ use RuntimeException;
 
 class InvocationHandlerTest extends TestCase
 {
-    public function testExceptionThrownIn__ToStringIsDeferred(): void
+    public function testExceptionThrownInToStringIsDeferred(): void
     {
         $mock = $this->createMock(StringableClass::class);
         $mock->method('__toString')

--- a/tests/unit/TextUI/XmlConfigurationTest.php
+++ b/tests/unit/TextUI/XmlConfigurationTest.php
@@ -518,7 +518,7 @@ final class XmlConfigurationTest extends TestCase
         $this->assertTrue($phpunit->noInteraction());
     }
 
-    public function test_TestDox_configuration_is_parsed_correctly(): void
+    public function testTestDoxConfigurationIsParsedCorrectly(): void
     {
         $this->assertSame(
             CliTestDoxPrinter::class,
@@ -526,7 +526,7 @@ final class XmlConfigurationTest extends TestCase
         );
     }
 
-    public function test_Conflict_between_testdox_and_printerClass_is_detected(): void
+    public function testConflictBetweenTestdoxAndPrinterClassIsDetected(): void
     {
         $phpunit = $this->configuration('configuration_testdox_printerClass.xml')->phpunit();
 


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_method_casing` fixer
* [x] runs `tools/php-cs-fixer fix`

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5379.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/php_unit/php_unit_method_casing.rst.