### PR TITLE
Enhancement: Enable php_unit_set_up_tear_down_visibility fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -211,6 +211,7 @@ return PhpCsFixer\Config::create()
             'order' => 'alpha',
         ],
         'ordered_traits' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'this',
         ],

--- a/tests/basic/unit/fixtures/SetUpBeforeClassTest.php
+++ b/tests/basic/unit/fixtures/SetUpBeforeClassTest.php
@@ -32,7 +32,7 @@ class SetUpBeforeClassTest extends TestCase
         throw new Exception('forcing an Exception in setUpBeforeClass()');
     }
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         throw new Exception('setUp() should never have been run');
     }

--- a/tests/basic/unit/fixtures/SetUpTest.php
+++ b/tests/basic/unit/fixtures/SetUpTest.php
@@ -25,7 +25,7 @@ use RuntimeException;
  */
 class SetUpTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         throw new RuntimeException('throw exception in setUp');
     }


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_set_up_tear_down_visibility` fixer
* [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.17/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.rst.