### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order throws annotations

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -230,6 +230,7 @@ return PhpCsFixer\Config::create()
             'annotations' => [
                 'covers',
                 'dataProvider',
+                'throws',
                 'uses',
             ],
         ],

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -94,9 +94,9 @@ abstract class Assert
      * @param int|string        $key
      * @param array|ArrayAccess $array
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertArrayHasKey($key, $array, string $message = ''): void
     {
@@ -125,9 +125,9 @@ abstract class Assert
      * @param int|string        $key
      * @param array|ArrayAccess $array
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertArrayNotHasKey($key, $array, string $message = ''): void
     {
@@ -155,9 +155,9 @@ abstract class Assert
     /**
      * Asserts that a haystack contains a needle.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertContains($needle, iterable $haystack, string $message = ''): void
     {
@@ -176,9 +176,9 @@ abstract class Assert
     /**
      * Asserts that a haystack does not contain a needle.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertNotContains($needle, iterable $haystack, string $message = ''): void
     {
@@ -199,8 +199,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of a given type.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
     {
@@ -221,8 +221,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only instances of a given class name.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertContainsOnlyInstancesOf(string $className, iterable $haystack, string $message = ''): void
     {
@@ -239,8 +239,8 @@ abstract class Assert
     /**
      * Asserts that a haystack does not contain only values of a given type.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNotContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
     {
@@ -265,9 +265,9 @@ abstract class Assert
      *
      * @param Countable|iterable $haystack
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertCount(int $expectedCount, $haystack, string $message = ''): void
     {
@@ -287,9 +287,9 @@ abstract class Assert
      *
      * @param Countable|iterable $haystack
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertNotCount(int $expectedCount, $haystack, string $message = ''): void
     {
@@ -307,8 +307,8 @@ abstract class Assert
     /**
      * Asserts that two variables are equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertEquals($expected, $actual, string $message = ''): void
     {
@@ -320,8 +320,8 @@ abstract class Assert
     /**
      * Asserts that two variables are equal (canonicalizing).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertEqualsCanonicalizing($expected, $actual, string $message = ''): void
     {
@@ -333,8 +333,8 @@ abstract class Assert
     /**
      * Asserts that two variables are equal (ignoring case).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertEqualsIgnoringCase($expected, $actual, string $message = ''): void
     {
@@ -346,8 +346,8 @@ abstract class Assert
     /**
      * Asserts that two variables are equal (with delta).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertEqualsWithDelta($expected, $actual, float $delta, string $message = ''): void
     {
@@ -362,8 +362,8 @@ abstract class Assert
     /**
      * Asserts that two variables are not equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNotEquals($expected, $actual, string $message = ''): void
     {
@@ -377,8 +377,8 @@ abstract class Assert
     /**
      * Asserts that two variables are not equal (canonicalizing).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNotEqualsCanonicalizing($expected, $actual, string $message = ''): void
     {
@@ -392,8 +392,8 @@ abstract class Assert
     /**
      * Asserts that two variables are not equal (ignoring case).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNotEqualsIgnoringCase($expected, $actual, string $message = ''): void
     {
@@ -407,8 +407,8 @@ abstract class Assert
     /**
      * Asserts that two variables are not equal (with delta).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNotEqualsWithDelta($expected, $actual, float $delta, string $message = ''): void
     {
@@ -437,8 +437,8 @@ abstract class Assert
     /**
      * Asserts that a variable is empty.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert empty $actual
      */
@@ -450,8 +450,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not empty.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !empty $actual
      */
@@ -463,8 +463,8 @@ abstract class Assert
     /**
      * Asserts that a value is greater than another value.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertGreaterThan($expected, $actual, string $message = ''): void
     {
@@ -474,8 +474,8 @@ abstract class Assert
     /**
      * Asserts that a value is greater than or equal to another value.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertGreaterThanOrEqual($expected, $actual, string $message = ''): void
     {
@@ -489,8 +489,8 @@ abstract class Assert
     /**
      * Asserts that a value is smaller than another value.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertLessThan($expected, $actual, string $message = ''): void
     {
@@ -500,8 +500,8 @@ abstract class Assert
     /**
      * Asserts that a value is smaller than or equal to another value.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertLessThanOrEqual($expected, $actual, string $message = ''): void
     {
@@ -512,8 +512,8 @@ abstract class Assert
      * Asserts that the contents of one file is equal to the contents of another
      * file.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileEquals(string $expected, string $actual, string $message = ''): void
     {
@@ -529,8 +529,8 @@ abstract class Assert
      * Asserts that the contents of one file is equal to the contents of another
      * file (canonicalizing).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileEqualsCanonicalizing(string $expected, string $actual, string $message = ''): void
     {
@@ -548,8 +548,8 @@ abstract class Assert
      * Asserts that the contents of one file is equal to the contents of another
      * file (ignoring case).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileEqualsIgnoringCase(string $expected, string $actual, string $message = ''): void
     {
@@ -565,8 +565,8 @@ abstract class Assert
      * Asserts that the contents of one file is not equal to the contents of
      * another file.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileNotEquals(string $expected, string $actual, string $message = ''): void
     {
@@ -584,8 +584,8 @@ abstract class Assert
      * Asserts that the contents of one file is not equal to the contents of another
      * file (canonicalizing).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileNotEqualsCanonicalizing(string $expected, string $actual, string $message = ''): void
     {
@@ -603,8 +603,8 @@ abstract class Assert
      * Asserts that the contents of one file is not equal to the contents of another
      * file (ignoring case).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileNotEqualsIgnoringCase(string $expected, string $actual, string $message = ''): void
     {
@@ -622,8 +622,8 @@ abstract class Assert
      * Asserts that the contents of a string is equal
      * to the contents of a file.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringEqualsFile(string $expectedFile, string $actualString, string $message = ''): void
     {
@@ -638,8 +638,8 @@ abstract class Assert
      * Asserts that the contents of a string is equal
      * to the contents of a file (canonicalizing).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringEqualsFileCanonicalizing(string $expectedFile, string $actualString, string $message = ''): void
     {
@@ -654,8 +654,8 @@ abstract class Assert
      * Asserts that the contents of a string is equal
      * to the contents of a file (ignoring case).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringEqualsFileIgnoringCase(string $expectedFile, string $actualString, string $message = ''): void
     {
@@ -670,8 +670,8 @@ abstract class Assert
      * Asserts that the contents of a string is not equal
      * to the contents of a file.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotEqualsFile(string $expectedFile, string $actualString, string $message = ''): void
     {
@@ -688,8 +688,8 @@ abstract class Assert
      * Asserts that the contents of a string is not equal
      * to the contents of a file (canonicalizing).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotEqualsFileCanonicalizing(string $expectedFile, string $actualString, string $message = ''): void
     {
@@ -706,8 +706,8 @@ abstract class Assert
      * Asserts that the contents of a string is not equal
      * to the contents of a file (ignoring case).
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotEqualsFileIgnoringCase(string $expectedFile, string $actualString, string $message = ''): void
     {
@@ -723,8 +723,8 @@ abstract class Assert
     /**
      * Asserts that a file/dir is readable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertIsReadable(string $filename, string $message = ''): void
     {
@@ -734,8 +734,8 @@ abstract class Assert
     /**
      * Asserts that a file/dir exists and is not readable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertIsNotReadable(string $filename, string $message = ''): void
     {
@@ -745,8 +745,8 @@ abstract class Assert
     /**
      * Asserts that a file/dir exists and is writable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertIsWritable(string $filename, string $message = ''): void
     {
@@ -756,8 +756,8 @@ abstract class Assert
     /**
      * Asserts that a file/dir exists and is not writable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertIsNotWritable(string $filename, string $message = ''): void
     {
@@ -767,8 +767,8 @@ abstract class Assert
     /**
      * Asserts that a directory exists.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDirectoryExists(string $directory, string $message = ''): void
     {
@@ -778,8 +778,8 @@ abstract class Assert
     /**
      * Asserts that a directory does not exist.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
     {
@@ -789,8 +789,8 @@ abstract class Assert
     /**
      * Asserts that a directory exists and is readable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDirectoryIsReadable(string $directory, string $message = ''): void
     {
@@ -801,8 +801,8 @@ abstract class Assert
     /**
      * Asserts that a directory exists and is not readable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDirectoryIsNotReadable(string $directory, string $message = ''): void
     {
@@ -813,8 +813,8 @@ abstract class Assert
     /**
      * Asserts that a directory exists and is writable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDirectoryIsWritable(string $directory, string $message = ''): void
     {
@@ -825,8 +825,8 @@ abstract class Assert
     /**
      * Asserts that a directory exists and is not writable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDirectoryIsNotWritable(string $directory, string $message = ''): void
     {
@@ -837,8 +837,8 @@ abstract class Assert
     /**
      * Asserts that a file exists.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileExists(string $filename, string $message = ''): void
     {
@@ -848,8 +848,8 @@ abstract class Assert
     /**
      * Asserts that a file does not exist.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileDoesNotExist(string $filename, string $message = ''): void
     {
@@ -859,8 +859,8 @@ abstract class Assert
     /**
      * Asserts that a file exists and is readable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileIsReadable(string $file, string $message = ''): void
     {
@@ -871,8 +871,8 @@ abstract class Assert
     /**
      * Asserts that a file exists and is not readable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileIsNotReadable(string $file, string $message = ''): void
     {
@@ -883,8 +883,8 @@ abstract class Assert
     /**
      * Asserts that a file exists and is writable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileIsWritable(string $file, string $message = ''): void
     {
@@ -895,8 +895,8 @@ abstract class Assert
     /**
      * Asserts that a file exists and is not writable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFileIsNotWritable(string $file, string $message = ''): void
     {
@@ -907,8 +907,8 @@ abstract class Assert
     /**
      * Asserts that a condition is true.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert true $condition
      */
@@ -920,8 +920,8 @@ abstract class Assert
     /**
      * Asserts that a condition is not true.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !true $condition
      */
@@ -933,8 +933,8 @@ abstract class Assert
     /**
      * Asserts that a condition is false.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert false $condition
      */
@@ -946,8 +946,8 @@ abstract class Assert
     /**
      * Asserts that a condition is not false.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !false $condition
      */
@@ -959,8 +959,8 @@ abstract class Assert
     /**
      * Asserts that a variable is null.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert null $actual
      */
@@ -972,8 +972,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not null.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !null $actual
      */
@@ -985,8 +985,8 @@ abstract class Assert
     /**
      * Asserts that a variable is finite.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertFinite($actual, string $message = ''): void
     {
@@ -996,8 +996,8 @@ abstract class Assert
     /**
      * Asserts that a variable is infinite.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertInfinite($actual, string $message = ''): void
     {
@@ -1007,8 +1007,8 @@ abstract class Assert
     /**
      * Asserts that a variable is nan.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNan($actual, string $message = ''): void
     {
@@ -1018,9 +1018,9 @@ abstract class Assert
     /**
      * Asserts that a class has a specified attribute.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertClassHasAttribute(string $attributeName, string $className, string $message = ''): void
     {
@@ -1038,9 +1038,9 @@ abstract class Assert
     /**
      * Asserts that a class does not have a specified attribute.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertClassNotHasAttribute(string $attributeName, string $className, string $message = ''): void
     {
@@ -1064,9 +1064,9 @@ abstract class Assert
     /**
      * Asserts that a class has a specified static attribute.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertClassHasStaticAttribute(string $attributeName, string $className, string $message = ''): void
     {
@@ -1088,9 +1088,9 @@ abstract class Assert
     /**
      * Asserts that a class does not have a specified static attribute.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertClassNotHasStaticAttribute(string $attributeName, string $className, string $message = ''): void
     {
@@ -1116,9 +1116,9 @@ abstract class Assert
      *
      * @param object $object
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertObjectHasAttribute(string $attributeName, $object, string $message = ''): void
     {
@@ -1142,9 +1142,9 @@ abstract class Assert
      *
      * @param object $object
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertObjectNotHasAttribute(string $attributeName, $object, string $message = ''): void
     {
@@ -1170,8 +1170,8 @@ abstract class Assert
      * Used on objects, it asserts that two variables reference
      * the same object.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-template ExpectedType
      * @psalm-param ExpectedType $expected
@@ -1191,8 +1191,8 @@ abstract class Assert
      * Used on objects, it asserts that two variables do not reference
      * the same object.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertNotSame($expected, $actual, string $message = ''): void
     {
@@ -1212,9 +1212,9 @@ abstract class Assert
     /**
      * Asserts that a variable is of a given type.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $expected
@@ -1236,9 +1236,9 @@ abstract class Assert
     /**
      * Asserts that a variable is not of a given type.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      *
      * @psalm-template ExpectedType of object
      * @psalm-param class-string<ExpectedType> $expected
@@ -1262,8 +1262,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type array.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert array $actual
      */
@@ -1279,8 +1279,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type bool.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert bool $actual
      */
@@ -1296,8 +1296,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type float.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert float $actual
      */
@@ -1313,8 +1313,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type int.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert int $actual
      */
@@ -1330,8 +1330,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type numeric.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert numeric $actual
      */
@@ -1347,8 +1347,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type object.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert object $actual
      */
@@ -1364,8 +1364,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type resource.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert resource $actual
      */
@@ -1381,8 +1381,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type resource and is closed.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert resource $actual
      */
@@ -1398,8 +1398,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type string.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert string $actual
      */
@@ -1415,8 +1415,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type scalar.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert scalar $actual
      */
@@ -1432,8 +1432,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type callable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert callable $actual
      */
@@ -1449,8 +1449,8 @@ abstract class Assert
     /**
      * Asserts that a variable is of type iterable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert iterable $actual
      */
@@ -1466,8 +1466,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type array.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !array $actual
      */
@@ -1483,8 +1483,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type bool.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !bool $actual
      */
@@ -1500,8 +1500,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type float.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !float $actual
      */
@@ -1517,8 +1517,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type int.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !int $actual
      */
@@ -1534,8 +1534,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type numeric.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !numeric $actual
      */
@@ -1551,8 +1551,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type object.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !object $actual
      */
@@ -1568,8 +1568,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type resource.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !resource $actual
      */
@@ -1585,8 +1585,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type resource.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !resource $actual
      */
@@ -1602,8 +1602,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type string.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !string $actual
      */
@@ -1619,8 +1619,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type scalar.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !scalar $actual
      */
@@ -1636,8 +1636,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type callable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !callable $actual
      */
@@ -1653,8 +1653,8 @@ abstract class Assert
     /**
      * Asserts that a variable is not of type iterable.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-assert !iterable $actual
      */
@@ -1670,8 +1670,8 @@ abstract class Assert
     /**
      * Asserts that a string matches a given regular expression.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
     {
@@ -1681,8 +1681,8 @@ abstract class Assert
     /**
      * Asserts that a string does not match a given regular expression.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
     {
@@ -1702,9 +1702,9 @@ abstract class Assert
      * @param Countable|iterable $expected
      * @param Countable|iterable $actual
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertSameSize($expected, $actual, string $message = ''): void
     {
@@ -1730,9 +1730,9 @@ abstract class Assert
      * @param Countable|iterable $expected
      * @param Countable|iterable $actual
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertNotSameSize($expected, $actual, string $message = ''): void
     {
@@ -1756,8 +1756,8 @@ abstract class Assert
     /**
      * Asserts that a string matches a given format string.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringMatchesFormat(string $format, string $string, string $message = ''): void
     {
@@ -1767,8 +1767,8 @@ abstract class Assert
     /**
      * Asserts that a string does not match a given format string.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotMatchesFormat(string $format, string $string, string $message = ''): void
     {
@@ -1784,8 +1784,8 @@ abstract class Assert
     /**
      * Asserts that a string matches a given format file.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringMatchesFormatFile(string $formatFile, string $string, string $message = ''): void
     {
@@ -1803,8 +1803,8 @@ abstract class Assert
     /**
      * Asserts that a string does not match a given format string.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotMatchesFormatFile(string $formatFile, string $string, string $message = ''): void
     {
@@ -1824,8 +1824,8 @@ abstract class Assert
     /**
      * Asserts that a string starts with a given prefix.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringStartsWith(string $prefix, string $string, string $message = ''): void
     {
@@ -1838,8 +1838,8 @@ abstract class Assert
      * @param string $prefix
      * @param string $string
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringStartsNotWith($prefix, $string, string $message = ''): void
     {
@@ -1853,8 +1853,8 @@ abstract class Assert
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringContainsString(string $needle, string $haystack, string $message = ''): void
     {
@@ -1864,8 +1864,8 @@ abstract class Assert
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringContainsStringIgnoringCase(string $needle, string $haystack, string $message = ''): void
     {
@@ -1875,8 +1875,8 @@ abstract class Assert
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotContainsString(string $needle, string $haystack, string $message = ''): void
     {
@@ -1886,8 +1886,8 @@ abstract class Assert
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringNotContainsStringIgnoringCase(string $needle, string $haystack, string $message = ''): void
     {
@@ -1899,8 +1899,8 @@ abstract class Assert
     /**
      * Asserts that a string ends with a given suffix.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringEndsWith(string $suffix, string $string, string $message = ''): void
     {
@@ -1910,8 +1910,8 @@ abstract class Assert
     /**
      * Asserts that a string ends not with a given suffix.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertStringEndsNotWith(string $suffix, string $string, string $message = ''): void
     {
@@ -1927,9 +1927,9 @@ abstract class Assert
     /**
      * Asserts that two XML files are equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     public static function assertXmlFileEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
@@ -1942,9 +1942,9 @@ abstract class Assert
     /**
      * Asserts that two XML files are not equal.
      *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws \PHPUnit\Util\Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertXmlFileNotEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
@@ -1957,9 +1957,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are equal.
      *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertXmlStringEqualsXmlFile(string $expectedFile, string $actualXml, string $message = ''): void
     {
@@ -1972,9 +1972,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are not equal.
      *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertXmlStringNotEqualsXmlFile(string $expectedFile, string $actualXml, string $message = ''): void
     {
@@ -1987,9 +1987,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are equal.
      *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertXmlStringEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
     {
@@ -2002,9 +2002,9 @@ abstract class Assert
     /**
      * Asserts that two XML documents are not equal.
      *
-     * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertXmlStringNotEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
     {
@@ -2017,8 +2017,8 @@ abstract class Assert
     /**
      * Evaluates a PHPUnit\Framework\Constraint matcher object.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertThat($value, Constraint $constraint, string $message = ''): void
     {
@@ -2030,8 +2030,8 @@ abstract class Assert
     /**
      * Asserts that a string is a valid JSON string.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJson(string $actualJson, string $message = ''): void
     {
@@ -2041,8 +2041,8 @@ abstract class Assert
     /**
      * Asserts that two given JSON encoded objects or arrays are equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJsonStringEqualsJsonString(string $expectedJson, string $actualJson, string $message = ''): void
     {
@@ -2058,8 +2058,8 @@ abstract class Assert
      * @param string $expectedJson
      * @param string $actualJson
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJsonStringNotEqualsJsonString($expectedJson, $actualJson, string $message = ''): void
     {
@@ -2078,8 +2078,8 @@ abstract class Assert
     /**
      * Asserts that the generated JSON encoded object and the content of the given file are equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJsonStringEqualsJsonFile(string $expectedFile, string $actualJson, string $message = ''): void
     {
@@ -2095,8 +2095,8 @@ abstract class Assert
     /**
      * Asserts that the generated JSON encoded object and the content of the given file are not equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJsonStringNotEqualsJsonFile(string $expectedFile, string $actualJson, string $message = ''): void
     {
@@ -2118,8 +2118,8 @@ abstract class Assert
     /**
      * Asserts that two JSON files are equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJsonFileEqualsJsonFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
@@ -2145,8 +2145,8 @@ abstract class Assert
     /**
      * Asserts that two JSON files are not equal.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public static function assertJsonFileNotEqualsJsonFile(string $expectedFile, string $actualFile, string $message = ''): void
     {

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -33,8 +33,8 @@ abstract class Constraint implements Countable, SelfDescribing
      * a boolean value instead: true in case of success, false in case of a
      * failure.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
@@ -93,8 +93,8 @@ abstract class Constraint implements Countable, SelfDescribing
      * @param string            $description       Additional information about the test
      * @param ComparisonFailure $comparisonFailure
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-return never-return
      */

--- a/src/Framework/Constraint/Exception/ExceptionMessageRegularExpression.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessageRegularExpression.php
@@ -36,8 +36,8 @@ final class ExceptionMessageRegularExpression extends Constraint
      *
      * @param \PHPUnit\Framework\Exception $other
      *
-     * @throws Exception
      * @throws \PHPUnit\Framework\Exception
+     * @throws Exception
      */
     protected function matches($other): bool
     {

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -51,8 +51,8 @@ final class IsIdentical extends Constraint
      * a boolean value instead: true in case of success, false in case of a
      * failure.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -70,9 +70,9 @@ final class JsonMatches extends Constraint
      * @param string            $description       Additional information about the test
      * @param ComparisonFailure $comparisonFailure
      *
-     * @throws ExpectationFailedException
      * @throws \PHPUnit\Framework\Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      *
      * @psalm-return never-return
      */

--- a/src/Framework/Constraint/Object/ObjectEquals.php
+++ b/src/Framework/Constraint/Object/ObjectEquals.php
@@ -42,11 +42,11 @@ final class ObjectEquals extends Constraint
 
     /**
      * @throws ActualValueIsNotAnObjectException
-     * @throws ComparisonMethodDoesNotExistException
+     * @throws ComparisonMethodDoesNotAcceptParameterTypeException
      * @throws ComparisonMethodDoesNotDeclareBoolReturnTypeException
      * @throws ComparisonMethodDoesNotDeclareExactlyOneParameterException
      * @throws ComparisonMethodDoesNotDeclareParameterTypeException
-     * @throws ComparisonMethodDoesNotAcceptParameterTypeException
+     * @throws ComparisonMethodDoesNotExistException
      */
     protected function matches($other): bool
     {

--- a/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
+++ b/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
@@ -52,8 +52,8 @@ final class TraversableContainsOnly extends Constraint
      *
      * @param mixed|Traversable $other
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -165,9 +165,9 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
     /**
      * @param mixed[] $arguments
      *
+     * @throws \PHPUnit\Framework\Exception
      * @throws MethodNameNotConfiguredException
      * @throws MethodParametersAlreadyConfiguredException
-     * @throws \PHPUnit\Framework\Exception
      *
      * @return $this
      */
@@ -183,9 +183,9 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
     /**
      * @param array ...$arguments
      *
+     * @throws \PHPUnit\Framework\Exception
      * @throws MethodNameNotConfiguredException
      * @throws MethodParametersAlreadyConfiguredException
-     * @throws \PHPUnit\Framework\Exception
      *
      * @return $this
      */
@@ -216,9 +216,9 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
     /**
      * @param Constraint|string $constraint
      *
-     * @throws MethodNameAlreadyConfiguredException
-     * @throws MethodCannotBeConfiguredException
      * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws MethodCannotBeConfiguredException
+     * @throws MethodNameAlreadyConfiguredException
      *
      * @return $this
      */

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -88,15 +88,15 @@ final class Generator
      *
      * @param null|array $methods
      *
-     * @throws ClassIsFinalException
-     * @throws ClassAlreadyExistsException
-     * @throws ReflectionException
-     * @throws UnknownTypeException
-     * @throws InvalidMethodNameException
-     * @throws DuplicateMethodException
-     * @throws OriginalConstructorInvocationRequiredException
-     * @throws RuntimeException
      * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws ClassAlreadyExistsException
+     * @throws ClassIsFinalException
+     * @throws DuplicateMethodException
+     * @throws InvalidMethodNameException
+     * @throws OriginalConstructorInvocationRequiredException
+     * @throws ReflectionException
+     * @throws RuntimeException
+     * @throws UnknownTypeException
      */
     public function getMock(string $type, $methods = [], array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, bool $cloneArguments = true, bool $callOriginalMethods = false, object $proxyTarget = null, bool $allowMockingUnknownTypes = true, bool $returnValueGeneration = true): MockObject
     {
@@ -178,16 +178,16 @@ final class Generator
      * @psalm-param class-string<RealInstanceType> $originalClassName
      * @psalm-return MockObject&RealInstanceType
      *
-     * @throws RuntimeException
-     * @throws ReflectionException
-     * @throws ClassIsFinalException
-     * @throws ClassAlreadyExistsException
-     * @throws UnknownTypeException
-     * @throws UnknownClassException
-     * @throws InvalidMethodNameException
-     * @throws DuplicateMethodException
-     * @throws OriginalConstructorInvocationRequiredException
      * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws ClassAlreadyExistsException
+     * @throws ClassIsFinalException
+     * @throws DuplicateMethodException
+     * @throws InvalidMethodNameException
+     * @throws OriginalConstructorInvocationRequiredException
+     * @throws ReflectionException
+     * @throws RuntimeException
+     * @throws UnknownClassException
+     * @throws UnknownTypeException
      */
     public function getMockForAbstractClass(string $originalClassName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = null, bool $cloneArguments = true): MockObject
     {
@@ -239,17 +239,17 @@ final class Generator
      *
      * @psalm-param trait-string $traitName
      *
-     * @throws RuntimeException
-     * @throws ReflectionException
-     * @throws UnknownTraitException
-     * @throws ClassIsFinalException
-     * @throws ClassAlreadyExistsException
-     * @throws UnknownTypeException
-     * @throws UnknownClassException
-     * @throws InvalidMethodNameException
-     * @throws DuplicateMethodException
-     * @throws OriginalConstructorInvocationRequiredException
      * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws ClassAlreadyExistsException
+     * @throws ClassIsFinalException
+     * @throws DuplicateMethodException
+     * @throws InvalidMethodNameException
+     * @throws OriginalConstructorInvocationRequiredException
+     * @throws ReflectionException
+     * @throws RuntimeException
+     * @throws UnknownClassException
+     * @throws UnknownTraitException
+     * @throws UnknownTypeException
      */
     public function getMockForTrait(string $traitName, array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $callAutoload = true, array $mockedMethods = null, bool $cloneArguments = true): MockObject
     {
@@ -284,8 +284,8 @@ final class Generator
      *
      * @psalm-param trait-string $traitName
      *
-     * @throws RuntimeException
      * @throws ReflectionException
+     * @throws RuntimeException
      * @throws UnknownTraitException
      */
     public function getObjectForTrait(string $traitName, string $traitClassName = '', bool $callAutoload = true, bool $callOriginalConstructor = false, array $arguments = []): object
@@ -323,9 +323,9 @@ final class Generator
     }
 
     /**
-     * @throws RuntimeException
-     * @throws ReflectionException
      * @throws ClassIsFinalException
+     * @throws ReflectionException
+     * @throws RuntimeException
      */
     public function generate(string $type, array $methods = null, string $mockClassName = '', bool $callOriginalClone = true, bool $callAutoload = true, bool $cloneArguments = true, bool $callOriginalMethods = false): MockClass
     {
@@ -580,8 +580,8 @@ final class Generator
     }
 
     /**
-     * @throws RuntimeException
      * @throws ReflectionException
+     * @throws RuntimeException
      */
     private function getObject(MockType $mockClass, $type = '', bool $callOriginalConstructor = false, bool $callAutoload = false, array $arguments = [], bool $callOriginalMethods = false, object $proxyTarget = null, bool $returnValueGeneration = true)
     {
@@ -645,9 +645,9 @@ final class Generator
     }
 
     /**
-     * @throws RuntimeException
-     * @throws ReflectionException
      * @throws ClassIsFinalException
+     * @throws ReflectionException
+     * @throws RuntimeException
      */
     private function generateMock(string $type, ?array $explicitMethods, string $mockClassName, bool $callOriginalClone, bool $callAutoload, bool $cloneArguments, bool $callOriginalMethods): MockClass
     {

--- a/src/Framework/MockObject/InvocationHandler.php
+++ b/src/Framework/MockObject/InvocationHandler.php
@@ -101,8 +101,8 @@ final class InvocationHandler
     }
 
     /**
-     * @throws RuntimeException
      * @throws Exception
+     * @throws RuntimeException
      */
     public function invoke(Invocation $invocation)
     {

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -88,10 +88,10 @@ final class Matcher
     }
 
     /**
-     * @throws MethodNameNotConfiguredException
-     * @throws MatchBuilderNotFoundException
-     * @throws RuntimeException
      * @throws ExpectationFailedException
+     * @throws MatchBuilderNotFoundException
+     * @throws MethodNameNotConfiguredException
+     * @throws RuntimeException
      */
     public function invoked(Invocation $invocation)
     {
@@ -141,11 +141,11 @@ final class Matcher
     }
 
     /**
-     * @throws RuntimeException
-     * @throws MethodNameNotConfiguredException
-     * @throws MatchBuilderNotFoundException
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     * @throws MatchBuilderNotFoundException
+     * @throws MethodNameNotConfiguredException
+     * @throws RuntimeException
      */
     public function matches(Invocation $invocation): bool
     {
@@ -193,9 +193,9 @@ final class Matcher
     }
 
     /**
-     * @throws MethodNameNotConfiguredException
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     * @throws MethodNameNotConfiguredException
      */
     public function verify(): void
     {

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -68,15 +68,15 @@ final class MockBuilder
     /**
      * Creates a mock object using a fluent interface.
      *
-     * @throws UnknownTypeException
-     * @throws InvalidMethodNameException
-     * @throws DuplicateMethodException
-     * @throws ClassIsFinalException
-     * @throws ClassAlreadyExistsException
-     * @throws OriginalConstructorInvocationRequiredException
-     * @throws RuntimeException
-     * @throws ReflectionException
      * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws ClassAlreadyExistsException
+     * @throws ClassIsFinalException
+     * @throws DuplicateMethodException
+     * @throws InvalidMethodNameException
+     * @throws OriginalConstructorInvocationRequiredException
+     * @throws ReflectionException
+     * @throws RuntimeException
+     * @throws UnknownTypeException
      *
      * @psalm-return MockObject&MockedType
      */
@@ -108,8 +108,8 @@ final class MockBuilder
      * @psalm-return MockObject&MockedType
      *
      * @throws \PHPUnit\Framework\Exception
-     * @throws RuntimeException
      * @throws ReflectionException
+     * @throws RuntimeException
      */
     public function getMockForAbstractClass(): MockObject
     {

--- a/src/Framework/MockObject/Rule/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Rule/ConsecutiveParameters.php
@@ -60,8 +60,8 @@ final class ConsecutiveParameters implements ParametersRule
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function apply(BaseInvocation $invocation): void
     {
@@ -87,8 +87,8 @@ final class ConsecutiveParameters implements ParametersRule
      *
      * @param int $callIndex
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     private function verifyInvocation(BaseInvocation $invocation, $callIndex): void
     {

--- a/src/Framework/MockObject/Rule/Parameters.php
+++ b/src/Framework/MockObject/Rule/Parameters.php
@@ -89,8 +89,8 @@ final class Parameters implements ParametersRule
      * does the rule will get the invoked() method called which should check
      * if an expectation is met.
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function verify(): void
     {
@@ -98,8 +98,8 @@ final class Parameters implements ParametersRule
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     private function doVerify(): bool
     {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -558,11 +558,11 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      * Runs the test case and collects the results in a TestResult object.
      * If no TestResult object is passed a new one will be created.
      *
-     * @throws CodeCoverageException
-     * @throws UtilException
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
      * @throws \SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws CodeCoverageException
+     * @throws UtilException
      */
     public function run(TestResult $result = null): TestResult
     {
@@ -1212,10 +1212,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * Override to run the test and assert its state.
      *
+     * @throws \SebastianBergmann\ObjectEnumerator\InvalidArgumentException
      * @throws AssertionFailedError
      * @throws Exception
      * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\ObjectEnumerator\InvalidArgumentException
      * @throws Throwable
      */
     protected function runTest()
@@ -1644,9 +1644,9 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @throws Warning
      * @throws SkippedTestError
      * @throws SyntheticSkippedError
+     * @throws Warning
      */
     private function checkRequirements(): void
     {
@@ -1863,8 +1863,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @throws RiskyTestError
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws RiskyTestError
      */
     private function restoreGlobalState(): void
     {
@@ -1940,8 +1940,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @throws RiskyTestError
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws RiskyTestError
      */
     private function compareGlobalStateSnapshots(Snapshot $before, Snapshot $after): void
     {

--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -38,10 +38,10 @@ use Throwable;
 final class TestRunner
 {
     /**
-     * @throws CodeCoverageException
-     * @throws UnintentionallyCoveredCodeException
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws CodeCoverageException
+     * @throws UnintentionallyCoveredCodeException
      */
     public function run(TestCase $test, TestResult $result): void
     {

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -102,10 +102,10 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
     /**
      * Runs a test and collects its result in a TestResult instance.
      *
-     * @throws Exception
      * @throws \SebastianBergmann\CodeCoverage\InvalidArgumentException
      * @throws \SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
      */
     public function run(TestResult $result = null): TestResult
     {
@@ -343,9 +343,9 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
     }
 
     /**
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws Exception
+     * @throws ExpectationFailedException
      */
     private function assertPhptExpectation(array $sections, string $output): void
     {

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -105,8 +105,8 @@ final class TestSuiteSorter
     }
 
     /**
-     * @throws Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
      */
     public function reorderTestsInSuite(Test $suite, int $order, bool $resolveDependencies, int $orderDefects, bool $isRootTestSuite = true): void
     {

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -824,8 +824,8 @@ final class TestRunner extends BaseTestRunner
     }
 
     /**
-     * @throws Exception
      * @throws \PHPUnit\TextUI\XmlConfiguration\Exception
+     * @throws Exception
      */
     private function handleConfiguration(array &$arguments): void
     {

--- a/src/TextUI/XmlConfiguration/Migration/Migrator.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrator.php
@@ -20,9 +20,9 @@ use PHPUnit\Util\Xml\SchemaDetector;
 final class Migrator
 {
     /**
+     * @throws Exception
      * @throws MigrationBuilderException
      * @throws MigrationException
-     * @throws Exception
      * @throws XmlException
      */
     public function migrate(string $filename): string

--- a/tests/end-to-end/regression/GitHub/2137/Issue2137Test.php
+++ b/tests/end-to-end/regression/GitHub/2137/Issue2137Test.php
@@ -12,9 +12,9 @@ class Issue2137Test extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider provideBrandService
      *
-     * @throws Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
      */
     public function testBrandService($provided, $expected): void
     {
@@ -32,9 +32,9 @@ class Issue2137Test extends PHPUnit\Framework\TestCase
     /**
      * @dataProvider provideBrandService
      *
-     * @throws Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
      */
     public function testSomethingElseInvalid($provided, $expected): void
     {

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -263,8 +263,8 @@ final class AssertTest extends TestCase
     /**
      * @dataProvider equalProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertEqualsSucceeds($a, $b): void
     {
@@ -274,8 +274,8 @@ final class AssertTest extends TestCase
     /**
      * @dataProvider notEqualProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertEqualsFails($a, $b): void
     {
@@ -287,8 +287,8 @@ final class AssertTest extends TestCase
     /**
      * @dataProvider notEqualProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertNotEqualsSucceeds($a, $b): void
     {
@@ -299,8 +299,8 @@ final class AssertTest extends TestCase
      * @testdox assertNotEquals($a, $b) with delta $delta, canoicalize $canonicalize, ignoreCase $ignoreCase
      * @dataProvider equalProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertNotEqualsFails($a, $b): void
     {
@@ -313,8 +313,8 @@ final class AssertTest extends TestCase
      * @testdox assertNotSame($a, $b) fails
      * @dataProvider sameProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertSameSucceeds($a, $b): void
     {
@@ -325,8 +325,8 @@ final class AssertTest extends TestCase
      * @testdox assertNotSame($a, $b)
      * @dataProvider notSameProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertSameFails($a, $b): void
     {
@@ -339,8 +339,8 @@ final class AssertTest extends TestCase
      * @testdox assertSame($a, $b) fails
      * @dataProvider notSameProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertNotSameSucceeds($a, $b): void
     {
@@ -351,8 +351,8 @@ final class AssertTest extends TestCase
      * @testdox assertSame($a, $b)
      * @dataProvider sameProvider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertNotSameFails($a, $b): void
     {
@@ -1706,8 +1706,8 @@ XML;
     /**
      * @dataProvider validInvalidJsonDataprovider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertJsonStringEqualsJsonStringErrorRaised($expected, $actual): void
     {
@@ -1729,8 +1729,8 @@ XML;
      * @testdox Assert JSON string equals equals JSON string raised $_dataName
      * @dataProvider validInvalidJsonDataprovider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testAssertJsonStringNotEqualsJsonStringErrorRaised($expected, $actual): void
     {

--- a/tests/unit/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/unit/Framework/Constraint/JsonMatchesTest.php
@@ -56,8 +56,8 @@ final class JsonMatchesTest extends ConstraintTestCase
     /**
      * @dataProvider evaluateDataprovider
      *
-     * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testEvaluate($expected, $jsonOther, $jsonValue): void
     {
@@ -69,10 +69,10 @@ final class JsonMatchesTest extends ConstraintTestCase
     /**
      * @dataProvider evaluateThrowsExpectationFailedExceptionWhenJsonIsValidButDoesNotMatchDataprovider
      *
-     * @throws ExpectationFailedException
      * @throws \PHPUnit\Framework\AssertionFailedError
      * @throws \PHPUnit\Framework\Exception
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
      */
     public function testEvaluateThrowsExpectationFailedExceptionWhenJsonIsValidButDoesNotMatch($jsonOther, $jsonValue): void
     {

--- a/tests/unit/Util/RegularExpressionTest.php
+++ b/tests/unit/Util/RegularExpressionTest.php
@@ -40,8 +40,8 @@ final class RegularExpressionTest extends TestCase
      * @testdox Valid regex $pattern on $subject returns $return
      * @dataProvider validRegexpProvider
      *
-     * @throws Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws Exception
      */
     public function testValidRegex($pattern, $subject, $return): void
     {
@@ -52,8 +52,8 @@ final class RegularExpressionTest extends TestCase
      * @testdox Invalid regex $pattern on $subject
      * @dataProvider invalidRegexpProvider
      *
-     * @throws Exception
      * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws Exception
      */
     public function testInvalidRegex($pattern, $subject): void
     {

--- a/tests/unit/Util/TestClassTest.php
+++ b/tests/unit/Util/TestClassTest.php
@@ -66,9 +66,9 @@ final class TestClassTest extends TestCase
      * @testdox Test::getRequirements() for $test
      * @dataProvider requirementsProvider
      *
-     * @throws Warning
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Warning
      */
     public function testGetRequirements($test, $result): void
     {
@@ -512,10 +512,10 @@ final class TestClassTest extends TestCase
      * @testdox Test::getRequirements() with constraints for $test
      * @dataProvider requirementsWithVersionConstraintsProvider
      *
-     * @throws Exception
-     * @throws Warning
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     * @throws Warning
      */
     public function testGetRequirementsWithVersionConstraints($test, array $result): void
     {
@@ -704,9 +704,9 @@ final class TestClassTest extends TestCase
      * @testdox Test::getMissingRequirements() for $test
      * @dataProvider missingRequirementsProvider
      *
-     * @throws Warning
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Warning
      */
     public function testGetMissingRequirements($test, $result): void
     {
@@ -1208,9 +1208,9 @@ final class TestClassTest extends TestCase
     /**
      * @dataProvider getLinesToBeCoveredProvider
      *
-     * @throws CodeCoverageException
      * @throws \PHPUnit\Framework\ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws CodeCoverageException
      */
     public function testGetLinesToBeCovered($test, $lines): void
     {


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@throws` annotations
* [x] runs `tools/php-cs-fixer fix`

Follows 29f420d0b.
