### PR TITLE
Fix: Use on_multiline instead of deprecated ensure_fully_multiline option for method_argument_space fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -90,7 +90,9 @@ return PhpCsFixer\Config::create()
         'lowercase_static_reference' => true,
         'magic_constant_casing' => true,
         'magic_method_casing' => true,
-        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+        ],
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,


### PR DESCRIPTION
This PR

* [x] uses the `on_multiline` option instead of the deprecated `ensure_fully_multiline` option for the `method_argument_space` fixer

💁‍♂️ For reference, see 

- https://github.com/ergebnis/php-cs-fixer-config/pull/319
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/doc/rules/function_notation/method_argument_space.rst

![CleanShot 2020-12-25 at 23 42 31](https://user-images.githubusercontent.com/605483/103142830-f9230900-470a-11eb-99d5-294cf978f0d2.png)
