### PR TITLE
Enhancement: Add error context on failing hook

### DIFF
--- a/src/Framework/Exception/Skipped/SkippedDueToErrorInHookMethodException.php
+++ b/src/Framework/Exception/Skipped/SkippedDueToErrorInHookMethodException.php
@@ -14,8 +14,13 @@ namespace PHPUnit\Framework;
  */
 final class SkippedDueToErrorInHookMethodException extends AssertionFailedError implements SkippedTest
 {
-    public function __construct()
+    public function __construct(string $errorMessage)
     {
-        parent::__construct('This test was skipped due to an error in a hook method');
+        parent::__construct(
+            sprintf(
+                'This test was skipped due to an error in a hook method, "%s"',
+                $errorMessage
+            )
+        );
     }
 }

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -467,7 +467,9 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                     } else {
                         $result->addFailure(
                             $test,
-                            new SkippedDueToErrorInHookMethodException,
+                            new SkippedDueToErrorInHookMethodException(
+                                trim(TestFailure::exceptionToString($t))
+                            ),
                             0
                         );
                     }

--- a/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
+++ b/tests/end-to-end/loggers/_files/raw_output_StatusTest.txt
@@ -91,7 +91,7 @@ Configuration: %stests%ebasic%econfiguration.basic.xml
 
  [36m↩[0m Two [36m %f [2mms[0m
    [36m┐[0m
-   [36m├[0m [36mThis test was skipped due to an error in a hook method[0m
+   [36m├[0m [36mThis test was skipped due to an error in a hook method, "Exception: forcing an Exception in setUpBeforeClass()"[0m
    [36m┴[0m
 
 [4mSet Up (PHPUnit\SelfTest\Basic\SetUp)[0m


### PR DESCRIPTION
When a test fails because of a Throwable the error was not helping to
locate the problem.