### PR TITLE
Fix loading same-name namespaced classes

### DIFF
--- a/src/Runner/TestSuiteLoader.php
+++ b/src/Runner/TestSuiteLoader.php
@@ -46,16 +46,15 @@ final class TestSuiteLoader
     public function load(string $suiteClassFile): ReflectionClass
     {
         $suiteClassName = $this->classNameFromFileName($suiteClassFile);
-        $loadedClasses  = self::$declaredClasses;
 
         if (!class_exists($suiteClassName, false)) {
             include_once $suiteClassFile;
 
             $loadedClasses = array_values(
-                array_diff(get_declared_classes(), $loadedClasses)
+                array_diff(get_declared_classes(), array_merge(self::$declaredClasses, self::$loadedClasses))
             );
 
-            self::$loadedClasses += $loadedClasses;
+            self::$loadedClasses = array_merge($loadedClasses, self::$loadedClasses);
 
             if (empty(self::$loadedClasses)) {
                 throw $this->exceptionFor($suiteClassName, $suiteClassFile);

--- a/tests/_files/SameClassNames/NamespaceOne/MyTest.php
+++ b/tests/_files/SameClassNames/NamespaceOne/MyTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace NamespaceOne;
+
+use PHPUnit\Framework\TestCase;
+
+class MyTest extends TestCase
+{
+    public function test1of3(): void
+    {
+    }
+}

--- a/tests/_files/SameClassNames/NamespaceTwo/MyTest.php
+++ b/tests/_files/SameClassNames/NamespaceTwo/MyTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace NamespaceTwo;
+
+use PHPUnit\Framework\TestCase;
+
+class MyTest extends TestCase
+{
+    public function test2of3(): void
+    {
+    }
+
+    public function test3of3(): void
+    {
+    }
+}

--- a/tests/unit/Framework/TestSuiteTest.php
+++ b/tests/unit/Framework/TestSuiteTest.php
@@ -264,6 +264,24 @@ final class TestSuiteTest extends TestCase
         $this->assertCount(2, $result);
     }
 
+    public function testCorrectlyLoadSameNameClasses(): void
+    {
+        $suite = new TestSuite(
+            'CorrectlyLoadSameNameClasses'
+        );
+
+        $dir = TEST_FILES_PATH . DIRECTORY_SEPARATOR . 'SameClassNames' . DIRECTORY_SEPARATOR;
+
+        $suite->addTestFile($dir . 'NamespaceOne' . DIRECTORY_SEPARATOR . 'MyTest.php');
+        $suite->addTestFile($dir . 'NamespaceTwo' . DIRECTORY_SEPARATOR . 'MyTest.php');
+
+        $result = new TestResult;
+
+        $suite->run($result);
+
+        $this->assertCount(3, $result);
+    }
+
     /**
      * @testdox Handles exceptions in tearDownAfterClass()
      */


### PR DESCRIPTION
Hi, I've found this issue while preparing paratest to PHPUnit 10, se https://github.com/paratestphp/paratest/pull/575

This PR prioritize again in `\PHPUnit\Runner\TestSuiteLoader` (like the old StandardTestSuiteLoaded did) the newly discovered classes over the old ones, so same-name namespaced classes are loaded correctly.