### PR TITLE
Fix: Create exporter only when needed

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1418,9 +1418,9 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
                 $buffer .= sprintf(' with data set "%s"', $this->dataName);
             }
 
-            $exporter = new Exporter;
-
             if ($includeData) {
+                $exporter = new Exporter;
+
                 $buffer .= sprintf(' (%s)', $exporter->shortenedRecursiveExport($this->data));
             }
         }


### PR DESCRIPTION
This pull request

* [x] creates an `Exporter` only when it is needed