### PR TITLE
Use template in param phpdoc

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -3117,7 +3117,7 @@ abstract class Assert
     /**
      * @psalm-template CallbackInput of mixed
      *
-     * @psalm-param callable(mixed $callback): bool $callback
+     * @psalm-param callable(CallbackInput $callback): bool $callback
      *
      * @psalm-return Callback<CallbackInput>
      */


### PR DESCRIPTION
It looks like Psalm is able to resolve it thanks to Callback.php, but
PHPStan isn't. To a human reading this phpdoc, it makes more sense to
see the template in both the param and return phpdoc anyway IMO.

This fixes the following PHPStan issue:

```
 ------ ----------------------------------------------------------------------- 
  Line   tests/Suggestion/Infrastructure/AlgoliaSuggestionIndexerTest.php       
 ------ ----------------------------------------------------------------------- 
  92     Unable to resolve the template type CallbackInput in call to method    
         static method PHPUnit\Framework\Assert::callback()                     
         💡 See:                                                                 
         https://phpstan.org/blog/solving-phpstan-error-unable-to-resolve-temp  
         late-type                                                              
 ------ ----------------------------------------------------------------------
 ```

I'm experiencing it on the following piece of code:


```
                    self::callback(static function (array $input) use ($expectedNumberOfQueryRules): bool {
                        self::assertCount($expectedNumberOfQueryRules, $input);                        return true;
                    })
```