### PR TITLE
Mark TestCase::$backupStaticAttributes and TestCase::$runTestInSeparateProcess as nullable

### DIFF
--- a/src/Framework/IncompleteTestCase.php
+++ b/src/Framework/IncompleteTestCase.php
@@ -20,12 +20,12 @@ final class IncompleteTestCase extends TestCase
     protected $backupGlobals = false;
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $backupStaticAttributes = false;
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $runTestInSeparateProcess = false;
 

--- a/src/Framework/SkippedTestCase.php
+++ b/src/Framework/SkippedTestCase.php
@@ -20,12 +20,12 @@ final class SkippedTestCase extends TestCase
     protected $backupGlobals = false;
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $backupStaticAttributes = false;
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $runTestInSeparateProcess = false;
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -70,7 +70,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     protected $backupGlobalsBlacklist = [];
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $backupStaticAttributes;
 
@@ -80,7 +80,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     protected $backupStaticAttributesBlacklist = [];
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $runTestInSeparateProcess;
 

--- a/src/Framework/WarningTestCase.php
+++ b/src/Framework/WarningTestCase.php
@@ -20,12 +20,12 @@ final class WarningTestCase extends TestCase
     protected $backupGlobals = false;
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $backupStaticAttributes = false;
 
     /**
-     * @var bool
+     * @var ?bool
      */
     protected $runTestInSeparateProcess = false;
 


### PR DESCRIPTION
Similarly to the changes made in https://github.com/sebastianbergmann/phpunit/pull/4308, `TestCase::$backupStaticAttributes` and `TestCase::$runTestInSeparateProcess` should be marked as nullable:
1. https://github.com/sebastianbergmann/phpunit/blob/c651a94c1ead15c83de97581bb154ee5e7ae4630/src/Framework/TestCase.php#L1210
2. https://github.com/sebastianbergmann/phpunit/blob/c651a94c1ead15c83de97581bb154ee5e7ae4630/src/Framework/TestCase.php#L1220

Otherwise, Psalm reports the corresponding issues on level 2:
```php
<?php

namespace Tests;

use PHPUnit\Framework\TestCase;
use stdClass;

class ObjectTest extends TestCase
{
    /** @var stdClass */
    private $object;

    protected function setUp(): void
    {
        $this->object = new stdClass();
    }

    public function testObject(): void
    {
        self::assertIsNotNull($this->object);
    }
}
```
```
ERROR: PropertyNotSetInConstructor - tests/ObjectTest.php:8:7 - Property Doctrine\DBAL\Tests\ObjectTest::$backupStaticAttributes is not defined in constructor of Doctrine\DBAL\Tests\ObjectTest and in any private or final methods called in the constructor (see https://psalm.dev/074)
class ObjectTest extends TestCase

ERROR: PropertyNotSetInConstructor - tests/ObjectTest.php:8:7 - Property Doctrine\DBAL\Tests\ObjectTest::$runTestInSeparateProcess is not defined in constructor of Doctrine\DBAL\Tests\ObjectTest and in any private or final methods called in the constructor (see https://psalm.dev/074)
class ObjectTest extends TestCase