### PR TITLE
Protect result cache against old data format

### DIFF
--- a/src/Runner/DefaultTestResultCache.php
+++ b/src/Runner/DefaultTestResultCache.php
@@ -168,6 +168,11 @@ final class DefaultTestResultCache implements Serializable, TestResultCache
         }
     }
 
+    /**
+     * @psalm-suppress RedundantConditionGivenDocblockType
+     *
+     * PHPUnit before version 10 used a different cache file format without TestStatus
+     */
     public function copyStateToCache(self $targetCache): void
     {
         foreach ($this->defects as $name => $state) {

--- a/src/Runner/DefaultTestResultCache.php
+++ b/src/Runner/DefaultTestResultCache.php
@@ -10,7 +10,6 @@
 namespace PHPUnit\Runner;
 
 use const DIRECTORY_SEPARATOR;
-use function assert;
 use function defined;
 use function dirname;
 use function file_get_contents;
@@ -209,18 +208,17 @@ final class DefaultTestResultCache implements Serializable, TestResultCache
 
         if (isset($data['times'])) {
             foreach ($data['times'] as $testName => $testTime) {
-                assert(is_string($testName));
-                assert(is_float($testTime));
-                $this->times[$testName] = $testTime;
+                if (is_string($testName) && is_float($testTime)) {
+                    $this->times[$testName] = $testTime;
+                }
             }
         }
 
         if (isset($data['defects'])) {
             foreach ($data['defects'] as $testName => $testStatus) {
-                assert(is_string($testName));
-                assert($testStatus instanceof TestStatus);
-
-                $this->defects[$testName] = $testStatus;
+                if (is_string($testName) && $testStatus instanceof TestStatus) {
+                    $this->defects[$testName] = $testStatus;
+                }
             }
         }
     }

--- a/src/Runner/DefaultTestResultCache.php
+++ b/src/Runner/DefaultTestResultCache.php
@@ -171,7 +171,9 @@ final class DefaultTestResultCache implements Serializable, TestResultCache
     public function copyStateToCache(self $targetCache): void
     {
         foreach ($this->defects as $name => $state) {
-            $targetCache->setStatus($name, $state);
+            if ($state instanceof TestStatus) {
+                $targetCache->setStatus($name, $state);
+            }
         }
 
         foreach ($this->times as $name => $time) {

--- a/tests/unit/Runner/DefaultTestResultCacheTest.php
+++ b/tests/unit/Runner/DefaultTestResultCacheTest.php
@@ -10,6 +10,8 @@
 namespace PHPUnit\Runner;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestStatus\TestStatus;
+use ReflectionClass;
 
 /**
  * @covers \PHPUnit\Runner\DefaultTestResultCache
@@ -30,5 +32,27 @@ final class DefaultTestResultCacheTest extends TestCase
     public function testGetTimeForNonExistentTestNameReturnsFloatZero(): void
     {
         $this->assertSame(0.0, $this->subject->time('doesNotExist'));
+    }
+
+    public function testOldResultCacheFormatDoesNotTriggerError(): void
+    {
+        // PHPUnit before version 10 used integer constants instead of TestStatus.
+        // Note: this is a quick and cheap test for this uncommon edge case, without having
+        // to set up a full end-to-end test with an old cache file
+        $cache          = new DefaultTestResultCache;
+        $reflectedCache = new ReflectionClass($cache);
+        $defects        = $reflectedCache->getProperty('defects');
+        $defects->setAccessible(true);
+        $defects->setValue($cache, [
+            'testOne' => TestStatus::skipped(),
+            'testTwo' => 1,
+        ]);
+
+        $targetCache = new DefaultTestResultCache;
+        $cache->copyStateToCache($targetCache);
+
+        // Validate expected behaviour: the test with old success value is silently ignored
+        $this->assertEquals(TestStatus::skipped(), $targetCache->status('testOne'));
+        $this->assertEquals(TestStatus::unknown(), $targetCache->status('testTwo'));
     }
 }

--- a/tests/unit/Runner/DefaultTestResultCacheTest.php
+++ b/tests/unit/Runner/DefaultTestResultCacheTest.php
@@ -19,14 +19,11 @@ use ReflectionClass;
  */
 final class DefaultTestResultCacheTest extends TestCase
 {
-    /**
-     * @var DefaultTestResultCache
-     */
-    private $subject;
+    private DefaultTestResultCache $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new DefaultTestResultCache();
+        $this->subject = new DefaultTestResultCache;
     }
 
     public function testGetTimeForNonExistentTestNameReturnsFloatZero(): void


### PR DESCRIPTION
Fixes #4580 by ignoring legacy cache data on first load. As PHPUnit moves towards using value objects instead of magic constants the internals need some adjustments.