### PR TITLE
#4591 do not treat warnings as error in teamcity

### DIFF
--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -9,19 +9,6 @@
  */
 namespace PHPUnit\Util\Log;
 
-use function class_exists;
-use function count;
-use function explode;
-use function get_class;
-use function getmypid;
-use function ini_get;
-use function is_bool;
-use function is_scalar;
-use function method_exists;
-use function print_r;
-use function round;
-use function str_replace;
-use function stripos;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -38,6 +25,19 @@ use ReflectionClass;
 use ReflectionException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use Throwable;
+use function class_exists;
+use function count;
+use function explode;
+use function get_class;
+use function getmypid;
+use function ini_get;
+use function is_bool;
+use function is_scalar;
+use function method_exists;
+use function print_r;
+use function round;
+use function str_replace;
+use function stripos;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -80,7 +80,7 @@ final class TeamCity extends DefaultResultPrinter
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {
-        $this->write(self::getMessage($e).PHP_EOL);
+        $this->write(self::getMessage($e) . PHP_EOL);
     }
 
     /**

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -80,15 +80,7 @@ final class TeamCity extends DefaultResultPrinter
      */
     public function addWarning(Test $test, Warning $e, float $time): void
     {
-        $this->printEvent(
-            'testFailed',
-            [
-                'name'     => $test->getName(),
-                'message'  => self::getMessage($e),
-                'details'  => self::getDetails($e),
-                'duration' => self::toMilliseconds($time),
-            ]
-        );
+        $this->write(self::getMessage($e).PHP_EOL);
     }
 
     /**

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -9,6 +9,19 @@
  */
 namespace PHPUnit\Util\Log;
 
+use function class_exists;
+use function count;
+use function explode;
+use function get_class;
+use function getmypid;
+use function ini_get;
+use function is_bool;
+use function is_scalar;
+use function method_exists;
+use function print_r;
+use function round;
+use function str_replace;
+use function stripos;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExceptionWrapper;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -25,19 +38,6 @@ use ReflectionClass;
 use ReflectionException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use Throwable;
-use function class_exists;
-use function count;
-use function explode;
-use function get_class;
-use function getmypid;
-use function ini_get;
-use function is_bool;
-use function is_scalar;
-use function method_exists;
-use function print_r;
-use function round;
-use function str_replace;
-use function stripos;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit


### PR DESCRIPTION
As suggested by Jetbrains in https://youtrack.jetbrains.com/issue/WI-57958 , just write warnings to stdout in the teamcity logger. This fixes #4591.
Should I create a PR for 8.5.x, as it may be worth having it there also?