### PR TITLE
Test classes loaded in data provider are not executed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "ext-xml": "*",
         "ext-xmlwriter": "*",
         "doctrine/instantiator": "^1.3.1",
+        "kubawerlos/class-finder": "dev-main",
         "myclabs/deep-copy": "^1.10.0",
         "phar-io/manifest": "^2.0.1",
         "phar-io/version": "^3.0.2",

--- a/tests/_files/discovering-classes/Testsuite1/FooTest.php
+++ b/tests/_files/discovering-classes/Testsuite1/FooTest.php
@@ -18,12 +18,13 @@ final class FooTest extends TestCase
      */
     public function testFoo($is): void
     {
-        $is = $is === is_subclass_of(\DiscoveringClasses\Testsuite2\BarTest::class, TestCase::class);
         $this->assertTrue($is);
     }
 
     public function dataProvider()
     {
-        return [[true]];
+        return [
+            [is_subclass_of(\DiscoveringClasses\Testsuite2\BarTest::class, TestCase::class)],
+        ];
     }
 }

--- a/tests/_files/discovering-classes/Testsuite1/FooTest.php
+++ b/tests/_files/discovering-classes/Testsuite1/FooTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace DiscoveringClasses\Testsuite1;
+
+use PHPUnit\Framework\TestCase;
+
+final class FooTest extends TestCase
+{
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testFoo($is): void
+    {
+        $is = $is === is_subclass_of(\DiscoveringClasses\Testsuite2\BarTest::class, TestCase::class);
+        $this->assertTrue($is);
+    }
+
+    public function dataProvider()
+    {
+        return [[true]];
+    }
+}

--- a/tests/_files/discovering-classes/Testsuite2/BarTest.php
+++ b/tests/_files/discovering-classes/Testsuite2/BarTest.php
@@ -16,5 +16,6 @@ final class BarTest extends TestCase
     public function testBar(): void
     {
         $this->assertTrue(true);
+        $this->assertTrue(true);
     }
 }

--- a/tests/_files/discovering-classes/Testsuite2/BarTest.php
+++ b/tests/_files/discovering-classes/Testsuite2/BarTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace DiscoveringClasses\Testsuite2;
+
+use PHPUnit\Framework\TestCase;
+
+final class BarTest extends TestCase
+{
+    public function testBar(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/_files/discovering-classes/Testsuite2/BazTest.php
+++ b/tests/_files/discovering-classes/Testsuite2/BazTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace DiscoveringClasses\Testsuite2;
+
+use PHPUnit\Framework\TestCase;
+
+final class BazTest extends TestCase
+{
+    public function testBaz(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/_files/discovering-classes/Testsuite2/BazTest.php
+++ b/tests/_files/discovering-classes/Testsuite2/BazTest.php
@@ -16,5 +16,8 @@ final class BazTest extends TestCase
     public function testBaz(): void
     {
         $this->assertTrue(true);
+        $this->assertTrue(true);
+        $this->assertTrue(true);
+        $this->assertTrue(true);
     }
 }

--- a/tests/_files/discovering-classes/autoload.php
+++ b/tests/_files/discovering-classes/autoload.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+\spl_autoload_register(
+    function ($class): void {
+        if (strpos($class, 'DiscoveringClasses\\') !== 0) {
+            return;
+        }
+
+        require_once __DIR__ . substr(str_replace('\\', DIRECTORY_SEPARATOR, $class), 18) . '.php';
+    }
+);

--- a/tests/_files/discovering-classes/config.xml
+++ b/tests/_files/discovering-classes/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="autoload.php">
+    <testsuites>
+        <testsuite name="Testsuite1">
+            <directory>Testsuite1</directory>
+        </testsuite>
+        <testsuite name="Testsuite2">
+            <directory>Testsuite2</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/discovering-classes.phpt
+++ b/tests/end-to-end/discovering-classes.phpt
@@ -14,4 +14,4 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Time: %s, Memory: %s
 
-OK (3 tests, 3 assertions)
+OK (3 tests, 7 assertions)

--- a/tests/end-to-end/discovering-classes.phpt
+++ b/tests/end-to-end/discovering-classes.phpt
@@ -1,0 +1,17 @@
+--TEST--
+phpunit --configuration ../../_files/discovering-classes/config.xml
+--FILE--
+<?php
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/discovering-classes/config.xml';
+
+require __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 3 assertions)


### PR DESCRIPTION
When there is test class loaded in data provider then tests from it are not executed.

- ✅ tests with classes loaded not in data provider: https://github.com/sebastianbergmann/phpunit/commit/71c04c4156559d41d5756e761fc55b8c39fcef03 (all check are passing except code coverage, which is really weird as the is no single line changed in `src` directory)
- ❎ when test is updated to load class `BarTest` in `FooTest` then tests from `BarTest` are not executed: https://github.com/sebastianbergmann/phpunit/pull/4639/commits/5c79e30ebcbd1c56ae8bdd01e7e44104470ded92

The idea for a fix would be to resign from using [get_declared_classes](https://www.php.net/manual/en/function.get-declared-classes.php) ~hack~ solution and discover the classes based on file content, something like in https://github.com/sebastianbergmann/phpunit/pull/4639/commits/38d421f9943e67004cf802c7a73130a98864f516 (obviously whithout using `dev-main` branch from a silly library.

@sebastianbergmann WDYT? Do you agree with replacing `get_declared_classes` with discovering the classes based on file content? If so, how would you like to have it? Somewhere in PHPUnit codebase (in `Util` package?) or as separate repository?