### PR TITLE
Added deafult value for TestCase::runTestInSeparateProcess

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -129,7 +129,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @var bool
      */
-    protected $runTestInSeparateProcess;
+    protected $runTestInSeparateProcess = false;
 
     /**
      * @var bool


### PR DESCRIPTION
Currently there is no default value for the non-nullable boolean member property `TestCase::runTestInSeparateProcess` and it is also not set in the constructor. 
This can cause psalm issues (see https://psalm.dev/074) in projects using phpunit:

```
ERROR: PropertyNotSetInConstructor - tests/unit/Foo/Bar/BazTest.php:12:34 - Property Foo\Bar\BazTest::$runTestInSeparateProcess is not defined in constructor of Foo\Bar\BazTest and in any methods called in the constructor (see https://psalm.dev/074)
final class BazTest extends TestCase
```

To solve this, I have added a default value (false) to that property.

(If it is important, I'm using `Psalm 4.5.2@15a9eece1305fd26eb1336a78e5a2ee7a4b36214` / `PHPUnit 9.5.2`, but this issue is probably mostly version-independent)