### PR TITLE
Declared two properties in TestCase as nullable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -116,20 +116,14 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      */
     protected $backupGlobalsExcludeList = [];
 
-    /**
-     * @var bool
-     */
-    protected $backupStaticAttributes;
+    protected ?bool $backupStaticAttributes;
 
     /**
      * @var array<string,array<int,string>>
      */
     protected $backupStaticAttributesExcludeList = [];
 
-    /**
-     * @var bool
-     */
-    protected $runTestInSeparateProcess;
+    protected ?bool $runTestInSeparateProcess;
 
     /**
      * @var bool


### PR DESCRIPTION
Currently the properties `TestCase::runTestInSeparateProcess` and `TestCase::backupStaticAttributes` are declared as non-nullable but are not being set in the constructor. This can cause psalm issues (see https://psalm.dev/074) in projects using phpunit:

```
ERROR: PropertyNotSetInConstructor - tests/unit/Foo/Bar/BazTest.php:19:13 - Property Foo\Bar\BazTest::$runTestInSeparateProcess is not defined in constructor of Foo\Bar\BazTest and in any methods called in the constructor (see https://psalm.dev/074)
final class BazTest extends TestCase
```
```
ERROR: PropertyNotSetInConstructor - tests/unit/Foo/Bar/BazTest.php:16:13 - Property Foo\Bar\BazTest::$backupStaticAttributes is not defined in constructor of Foo\Bar\BazTest and in any methods called in the constructor (see https://psalm.dev/074)
final class BazTest extends TestCase
```

This pull request solves this issue (for these two properties) by declaring these properties as nullable booleans.