### PR TITLE
Fix for #4055: Added testAssertStringNotEqualsFileCanonicalizing

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1621,6 +1621,19 @@ XML;
         $this->assertStringNotMatchesFormatFile(TEST_FILES_PATH . 'expectedFileFormat.txt', "FOO\n");
     }
 
+    public function testAssertStringNotEqualsFileCanonicalizing(): void
+    {
+        $contents = file_get_contents(TEST_FILES_PATH . 'foo.xml');
+
+        $this->assertStringNotEqualsFileCanonicalizing(TEST_FILES_PATH . 'foo.xml', $contents . ' BAR');
+
+        $this->assertStringNotEqualsFileCanonicalizing(TEST_FILES_PATH . 'foo.xml', 'BAR');
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertStringNotEqualsFileCanonicalizing(TEST_FILES_PATH . 'foo.xml', $contents);
+    }
+
     public function testStringsCanBeComparedForEqualityIgnoringCase(): void
     {
         $this->assertEqualsIgnoringCase('a', 'A');


### PR DESCRIPTION
In AssertTest.php I have added a function that tests assertStringNotEqualsFileCanonicalizing() by comparing the contents of a test xml file with some test strings.