### PR TITLE
Issue #4051: Added test for assertFileNotEqualsCanonicalizing

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -712,6 +712,29 @@ XML;
         $this->assertFileIsWritable(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
     }
 
+    public function testAssertFileNotEqualsCanonicalizing(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        try {
+            $this->assertFileNotEqualsCanonicalizing(__FILE__, __DIR__ . DIRECTORY_SEPARATOR . 'NotExisting');
+        } catch (AssertionFailedError $e) {
+        }
+
+        $this->expectException(AssertionFailedError::class);
+
+        try {
+            $this->assertFileNotEqualsCanonicalizing(__DIR__ . DIRECTORY_SEPARATOR . 'NotExisting', __FILE__);
+        } catch (AssertionFailedError $e) {
+        }
+
+        $this->assertFileNotEqualsCanonicalizing(TEST_FILES_PATH . 'foo.xml', TEST_FILES_PATH . 'bar.xml');
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertFileNotEqualsCanonicalizing(__FILE__, __FILE__);
+    }
+
     public function testAssertFinite(): void
     {
         $this->assertFinite(1);


### PR DESCRIPTION
Linked to issue: #4051 

I first test if the method checks the existence of both the expected and actual files. I then test if the method correctly asserts that the files have different contents.