### PR TITLE
Assert file content equals expected string

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -625,6 +625,21 @@ abstract class Assert
     }
 
     /**
+     * Asserts that the contents of one file is equal to the string.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     */
+    public static function assertFileEqualsString(string $expectedString, string $actualFile, string $message = ''): void
+    {
+        static::assertFileExists($actualFile, $message);
+
+        $constraint = new IsEqual($expectedString);
+
+        static::assertThat(file_get_contents($actualFile), $constraint, $message);
+    }
+
+    /**
      * Asserts that the contents of a string is equal
      * to the contents of a file.
      *

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -615,6 +615,23 @@ if (!function_exists('PHPUnit\Framework\assertFileNotEqualsIgnoringCase')) {
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertFileEqualsString')) {
+    /**
+     * Asserts that the contents of one file is equal to the string.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertFileEqualsString
+     */
+    function assertFileEqualsString(string $expectedString, string $actualFile, string $message = ''): void
+    {
+        Assert::assertFileEqualsString(...func_get_args());
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertStringEqualsFile')) {
     /**
      * Asserts that the contents of a string is equal

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1075,6 +1075,21 @@ XML;
         );
     }
 
+    public function testAssertFileEqualsString(): void
+    {
+        $this->assertFileEqualsString(
+            file_get_contents(TEST_FILES_PATH . 'foo.xml'),
+            TEST_FILES_PATH . 'foo.xml'
+        );
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertFileEqualsString(
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
+            TEST_FILES_PATH . 'foo.xml'
+        );
+    }
+
     public function testAssertStringEqualsFile(): void
     {
         $this->assertStringEqualsFile(


### PR DESCRIPTION
I have a use case where I need to ensure that a file content is equal to an expected string. Since there is already a method for asserting the opposite case (string is equal to a file content), I just used the same code to create `assertFileEqualsString`.

@sebastianbergmann if you consider this assertion useful, I can work to get all of the following ones done:
- [x] `assertFileEqualsString`
- [ ] `assertFileNotEqualsString`
- [ ] `assertFileNotEqualsStringIgnoringCase`
- [ ] `assertFileNotEqualsStringCanonicalizing`