### PR TITLE
Enhancement: Support string ending with empty suffix

### DIFF
--- a/src/Framework/Constraint/String/StringEndsWith.php
+++ b/src/Framework/Constraint/String/StringEndsWith.php
@@ -43,6 +43,10 @@ final class StringEndsWith extends Constraint
      */
     protected function matches($other): bool
     {
+        if ($this->suffix === '') {
+            return true;
+        }
+
         return substr($other, 0 - strlen($this->suffix)) === $this->suffix;
     }
 }

--- a/tests/unit/Framework/Constraint/StringEndsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringEndsWithTest.php
@@ -24,6 +24,13 @@ final class StringEndsWithTest extends ConstraintTestCase
         $this->assertTrue($constraint->evaluate('foosuffix', '', true));
     }
 
+    public function testConstraintStringEndsWithEmptyValueAndReturnResult(): void
+    {
+        $constraint = new StringEndsWith('');
+
+        $this->assertTrue($constraint->evaluate('foo', '', true));
+    }
+
     public function testConstraintStringEndsWithNotCorrectValueAndReturnResult(): void
     {
         $constraint = new StringEndsWith('suffix');


### PR DESCRIPTION
When asserting a suffix with an empty string it is failing when it should probably assume it does end wit the suffix
```php
assertStringEndsWith('', 'Some Text');
```
The way it is now, it throws an error:
```
Failed asserting that 'Some Text' ends with "".
```
I hope this contribution gets accepted. It would make some test configurations easier. Thanks.
If accepted, this commit should probably bubble up to the newer version.