### PR TITLE
Add support for adding file attachments in junit report format

### DIFF
--- a/src/Framework/ReportAttachmentProviding.php
+++ b/src/Framework/ReportAttachmentProviding.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+interface ReportAttachmentProviding
+{
+    /**
+     * Provides paths to test report attachments.
+     *
+     * @return string[]
+     */
+    public function provideTestResultAttachmentPaths(): array;
+}

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -19,6 +19,7 @@ use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExceptionWrapper;
+use PHPUnit\Framework\ReportAttachmentProviding;
 use PHPUnit\Framework\SelfDescribing;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestFailure;
@@ -341,6 +342,12 @@ final class JUnit extends Printer implements TestListener
 
         if (method_exists($test, 'hasOutput') && method_exists($test, 'output')) {
             $testOutput = $test->hasOutput() ? $test->output() : '';
+        }
+
+        if ($test instanceof ReportAttachmentProviding) {
+            foreach ($test->provideTestResultAttachmentPaths() as $attachmentPath) {
+                $testOutput .= sprintf('[[ATTACHMENT|%s]]', $attachmentPath);
+            }
         }
 
         if (!empty($testOutput)) {

--- a/tests/end-to-end/loggers/_files/JunitAttachmentTest.php
+++ b/tests/end-to-end/loggers/_files/JunitAttachmentTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use PHPUnit\Framework\ReportAttachmentProviding;
+use PHPUnit\Framework\TestCase;
+
+class JunitAttachmentTest extends TestCase implements ReportAttachmentProviding
+{
+    private $attachments = [];
+
+    public function testOne(): void
+    {
+        $this->attachments = [
+            '/tmp/path/to/example.png',
+            '/tmp/there/can/be/more/than/one/attachment.txt',
+        ];
+
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        $this->attachments = [];
+
+        $this->assertTrue(true);
+    }
+
+    public function testWithOutput(): void
+    {
+        $this->attachments = [];
+
+        $this->assertTrue(true);
+
+        print 'test output';
+    }
+
+    public function testWithOutputAndAttachment(): void
+    {
+        $this->attachments = [
+            '/tmp/path/to/example.png',
+        ];
+
+        $this->assertTrue(true);
+
+        print 'test output';
+    }
+
+    public function testFailure(): void
+    {
+        $this->attachments = [
+            '/tmp/path/to/failure.png',
+        ];
+
+        $this->assertTrue(false);
+    }
+
+    public function provideTestResultAttachmentPaths(): array
+    {
+        return $this->attachments;
+    }
+}

--- a/tests/end-to-end/loggers/log-junit-attachment.phpt
+++ b/tests/end-to-end/loggers/log-junit-attachment.phpt
@@ -1,0 +1,51 @@
+--TEST--
+phpunit --log-junit php://stdout _files/StatusTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--log-junit';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] = \realpath(__DIR__ . '/_files/JunitAttachmentTest.php');
+
+require __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+...test output.test outputF                                                               5 / 5 (100%)<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="JunitAttachmentTest" file="%sJunitAttachmentTest.php" tests="5" assertions="5" errors="0" warnings="0" failures="1" skipped="0" time="%f">
+    <testcase name="testOne" class="JunitAttachmentTest" classname="JunitAttachmentTest" file="%sJunitAttachmentTest.php" line="%d" assertions="1" time="%f">
+      <system-out>[[ATTACHMENT|/tmp/path/to/example.png]][[ATTACHMENT|/tmp/there/can/be/more/than/one/attachment.txt]]</system-out>
+    </testcase>
+    <testcase name="testTwo" class="JunitAttachmentTest" classname="JunitAttachmentTest" file="%sJunitAttachmentTest.php" line="%d" assertions="1" time="%f"/>
+    <testcase name="testWithOutput" class="JunitAttachmentTest" classname="JunitAttachmentTest" file="%sJunitAttachmentTest.php" line="%d" assertions="1" time="%f">
+      <system-out>test output</system-out>
+    </testcase>
+    <testcase name="testWithOutputAndAttachment" class="JunitAttachmentTest" classname="JunitAttachmentTest" file="%sJunitAttachmentTest.php" line="%d" assertions="1" time="%f">
+      <system-out>test output[[ATTACHMENT|/tmp/path/to/example.png]]</system-out>
+    </testcase>
+    <testcase name="testFailure" class="JunitAttachmentTest" classname="JunitAttachmentTest" file="%sJunitAttachmentTest.php" line="%d" assertions="1" time="%f">
+      <failure type="PHPUnit\Framework\ExpectationFailedException">JunitAttachmentTest::testFailure
+Failed asserting that false is true.
+
+%sJunitAttachmentTest.php:60</failure>
+      <system-out>[[ATTACHMENT|/tmp/path/to/failure.png]]</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>
+
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) JunitAttachmentTest::testFailure
+Failed asserting that false is true.
+
+%sJunitAttachmentTest.php:60
+
+FAILURES!
+Tests: 5, Assertions: 5, Failures: 1.


### PR DESCRIPTION
Soon, gitlab will add ability to show images attached in junit report file on merge request/pipeline view:
- https://docs.gitlab.com/ee/ci/unit_test_reports.html#viewing-junit-screenshots-on-gitlab
- https://gitlab.com/gitlab-org/gitlab/-/merge_requests/26922

This was also possible in jenkins, with junit-attachments plugins and supported by some libraries like mocha:
- https://plugins.jenkins.io/junit-attachments/
- https://www.npmjs.com/package/mocha-junit-reporter#attachments
- https://kohsuke.org/2012/03/13/attaching-files-to-junit-tests/

The format is a bit weird, because it's simply supposed to be added to `system-out` element, example from gitlab:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="rspec" tests="1" skipped="0" failures="1" errors="0" time="0.017557" timestamp="2020-03-09T15:16:55-04:00" hostname="Maximes-MacBook-Pro.local">
  <properties>
    <property name="seed" value="9386"/>
  </properties>
  <testcase classname="spec.hello_world_spec" name="the home page return hello world" file="./spec/hello_world_spec.rb" time="0.016340">
    <failure message="" type="RuntimeError">Failure/Error: raise
RuntimeError:
./spec/hello_world_spec.rb:8:in `block (2 levels) in &lt;top (required)&gt;'</failure>
    <system-out>[[ATTACHMENT|tmp/capybara/screenshot_return-hello-world.html]]</system-out>
  </testcase>
</testsuite>
```

Example use-case for phpunit would be with library like `symfony/panther`: it already has option to make screenshots on failed assertions, but for now they are not linked in any way in the report: https://github.com/symfony/panther/pull/392

It is possible to achieve that simply by `echo`ing the attachment during the phpunit test, but I find this way flawed: it interferes with tests that have to check stdout and with `--disallow-test-output` option, it also pollutes job output in CI, and has to be done in the test itself or in `tearDown`.

I submit a proposition for basic interface that could be implemented by TestCases to attach files to junit report. For now it would only be used by junit format, since I'm not aware of other formats requiring such feature. 

I think it's simple enough, and doesn't introduce any BC, WDYT?