### PR TITLE
Fix #4641: Added assertions assertStringEqualIgnoringLineEndings and assertStringContainsStringIgnoringLineEndings

### DIFF
--- a/ChangeLog-10.0.md
+++ b/ChangeLog-10.0.md
@@ -1,4 +1,5 @@
 # Changes in PHPUnit 10.0
+# Changes in PHPUnit 10.0
 
 All notable changes of the PHPUnit 10.0 release series are documented in this file using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
@@ -8,6 +9,7 @@ All notable changes of the PHPUnit 10.0 release series are documented in this fi
 
 * [#4502](https://github.com/sebastianbergmann/phpunit/issues/4502): Support PHP 8 attributes for adding metadata to test classes and test methods as well as tested code units
 * [#4650](https://github.com/sebastianbergmann/phpunit/issues/4650): Support dist file name `phpunit.dist.xml`
+* [#4641](https://github.com/sebastianbergmann/phpunit/issues/4641): Asertions `PHPUnit\Framework\assertStringEqualIgnoringLineEndings` and `PHPUnit\Framework\assertStringContainsStringIgnoringLineEndings`
 * `@excludeGlobalVariableFromBackup variable` annotation for excluding a global variable from the backup/restore of global and super-global variables
 * `#[ExcludeGlobalVariableFromBackup('variable')]` attribute for excluding a global variable from the backup/restore of global and super-global variables
 * `@excludeStaticPropertyFromBackup className propertyName` annotation for excluding a static property from the backup/restore of static properties in user-defined classes

--- a/ChangeLog-10.0.md
+++ b/ChangeLog-10.0.md
@@ -1,5 +1,4 @@
 # Changes in PHPUnit 10.0
-# Changes in PHPUnit 10.0
 
 All notable changes of the PHPUnit 10.0 release series are documented in this file using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1732,6 +1732,32 @@ abstract class Assert
     }
 
     /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     */
+    public static function assertStringContainsStringIgnoringLineEndings(string $needle, string $haystack, string $message = ''): void
+    {
+        $needle = self::normalizeLineEndings($needle);
+        $haystack = self::normalizeLineEndings($haystack);
+
+        static::assertThat($haystack, new StringContains($needle, false), $message);
+    }
+
+    /**
+     * Asserts that two strings equality ignoring line endings.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     */
+    public static function assertStringEqualIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
+    {
+        $expected = self::normalizeLineEndings($expected);
+        $actual = self::normalizeLineEndings($actual);
+
+        static::assertThat($actual, new IsEqual($expected), $message);
+    }
+
+    /**
      * Asserts that a string matches a given format string.
      *
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
@@ -2501,5 +2527,13 @@ abstract class Assert
     private static function isValidClassAttributeName(string $attributeName): bool
     {
         return (bool) preg_match('/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $attributeName);
+    }
+
+    private static function normalizeLineEndings(string $value): string
+    {
+        return strtr($value, [
+            "\r\n" => "\n",
+            "\r" => "\n",
+        ]);
     }
 }

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1896,6 +1896,34 @@ if (!function_exists('PHPUnit\Framework\assertNotSameSize')) {
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertStringContainsStringIgnoringLineEndings')) {
+    /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     *
+     * @see Assert::assertStringContainsStringIgnoringLineEndings
+     */
+    function assertStringContainsStringIgnoringLineEndings(string $needle, string $haystack, string $message = ''): void
+    {
+        Assert::assertStringContainsStringIgnoringLineEndings(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertStringContainsStringIgnoringLineEndings')) {
+    /**
+     * Asserts that two strings equality ignoring line endings.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     *
+     * @see Assert::assertStringEqualIgnoringLineEndings
+     */
+    function assertStringEqualIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
+    {
+        Assert::assertStringEqualIgnoringLineEndings(...func_get_args());
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertStringMatchesFormat')) {
     /**
      * Asserts that a string matches a given format string.

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1173,6 +1173,69 @@ XML;
         $this->assertStringEndsNotWith('suffix', 'foosuffix');
     }
 
+    public function dataAssertStringContainsStringIgnoringLineEndings(): array
+    {
+        return [
+            ["b\nc", "b\r\nc"],
+            ["b\nc", "a\r\nb\r\nc\r\nd"],
+        ];
+    }
+
+    /**
+     * @dataProvider dataAssertStringContainsStringIgnoringLineEndings
+     */
+    public function testAssertStringContainsStringIgnoringLineEndings(string $needle, string $haystack): void
+    {
+        $this->assertStringContainsStringIgnoringLineEndings($needle, $haystack);
+    }
+
+    public function testNotAssertStringContainsStringIgnoringLineEndings(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->assertStringContainsStringIgnoringLineEndings("b\nc", "\r\nc\r\n");
+    }
+
+    public function dataAssertStringEqualIgnoringLineEndings(): array
+    {
+        return [
+            'lf-crlf' => ["a\nb", "a\r\nb"],
+            'cr-crlf' => ["a\rb", "a\r\nb"],
+            'crlf-crlf' => ["a\r\nb", "a\r\nb"],
+            'lf-cr' => ["a\nb", "a\rb"],
+            'cr-cr' => ["a\rb", "a\rb"],
+            'crlf-cr' => ["a\r\nb", "a\rb"],
+            'lf-lf' => ["a\nb", "a\nb"],
+            'cr-lf' => ["a\rb", "a\nb"],
+            'crlf-lf' => ["a\r\nb", "a\nb"],
+        ];
+    }
+
+    /**
+     * @dataProvider dataAssertStringEqualIgnoringLineEndings
+     */
+    public function testAssertStringEqualIgnoringLineEndings(string $expected, string $actual): void
+    {
+        $this->assertStringEqualIgnoringLineEndings($expected, $actual);
+    }
+
+    public function dataNotAssertStringEqualIgnoringLineEndings(): array
+    {
+        return [
+            ["a\nb", 'ab'],
+            ["a\rb", 'ab'],
+            ["a\r\nb", 'ab'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataNotAssertStringEqualIgnoringLineEndings
+     */
+    public function testNotAssertStringEqualIgnoringLineEndings(string $expected, string $actual): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->assertStringEqualIgnoringLineEndings($expected, $actual);
+    }
+
     public function testAssertStringMatchesFormat(): void
     {
         $this->assertStringMatchesFormat('*%s*', '***');


### PR DESCRIPTION
Fix #4641

Added assertions `PHPUnit\Framework\assertStringEqualIgnoringLineEndings` and `PHPUnit\Framework\assertStringContainsStringIgnoringLineEndings`.