### PR TITLE
Iterable return types should return empty array by default

### DIFF
--- a/src/Framework/MockObject/Invocation.php
+++ b/src/Framework/MockObject/Invocation.php
@@ -152,7 +152,7 @@ final class Invocation implements SelfDescribing
             case 'generator':
             case 'iterable':
                 $generator = static function () {
-                    yield;
+                    yield from [];
                 };
 
                 return $generator();

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_generator_empty_by_default.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_generator_empty_by_default.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Iterable return types should return empty array by default
+--FILE--
+<?php declare(strict_types=1);
+interface Foo
+{
+    public function forTraversable(): traversable;
+    public function forGenerator(): Generator;
+    public function forIterable(): iterable;
+}
+
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+$generator = new \PHPUnit\Framework\MockObject\Generator;
+
+$mock = $generator->getMock('Foo');
+
+var_dump(iterator_to_array($mock->forTraversable()));
+var_dump(iterator_to_array($mock->forGenerator()));
+var_dump(iterator_to_array($mock->forIterable()));
+--EXPECTF--
+array(0) {
+}
+array(0) {
+}
+array(0) {
+}


### PR DESCRIPTION
Without this fix, mocked method with `traversable|Generator|iterable` return types return an array with one `null` element:

https://3v4l.org/mR8kdU

```console
1) ./tests/end-to-end/mock-objects/generator/return_type_declarations_generator_empty_by_default.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
-array(0) {
+array(1) {
+  [0]=>
+  NULL
 }
-array(0) {
+array(1) {
+  [0]=>
+  NULL
 }
-array(0) {
+array(1) {
+  [0]=>
+  NULL
 }
```