### PR TITLE
update meta to properly infer type of string parameters

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -3,43 +3,31 @@ namespace PHPSTORM_META {
 
     override(
         \PHPUnit\Framework\TestCase::createMock(0),
-        map([
-            '@&\PHPUnit\Framework\MockObject\MockObject',
-        ])
+        map(["" => "$0"])
     );
 
     override(
         \PHPUnit\Framework\TestCase::createStub(0),
-        map([
-            '@&\PHPUnit\Framework\MockObject\Stub',
-        ])
+        map(["" => "$0"])
     );
 
     override(
         \PHPUnit\Framework\TestCase::createConfiguredMock(0),
-        map([
-            '@&\PHPUnit\Framework\MockObject\MockObject',
-        ])
+        map(["" => "$0"])
     );
 
     override(
         \PHPUnit\Framework\TestCase::createPartialMock(0),
-        map([
-            '@&\PHPUnit\Framework\MockObject\MockObject',
-        ])
+        map(["" => "$0"])
     );
 
     override(
         \PHPUnit\Framework\TestCase::createTestProxy(0),
-        map([
-            '@&\PHPUnit\Framework\MockObject\MockObject',
-        ])
+        map(["" => "$0"])
     );
 
     override(
         \PHPUnit\Framework\TestCase::getMockForAbstractClass(0),
-        map([
-            '@&\PHPUnit\Framework\MockObject\MockObject',
-        ])
+        map(["" => "$0"])
     );
 }


### PR DESCRIPTION
After the fix of https://youtrack.jetbrains.com/issue/WI-60544 type() meta directive won't treat string literals contents as types anymore, prefered way is to use (map([""=>"$0"])). This PR updates meta file according to preferred way.