### PR TITLE
Fix: Continue on error when running tests on PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         run: bash ./build/scripts/sanity-check
 
       - name: Run tests with phpunit
+        continue-on-error: ${{ matrix.php-version }} == '8.1'
         run: php ./phpunit
 
   code-coverage:


### PR DESCRIPTION
This pull requests

* [x] continues on error when running tests on PHP 8.1

💁‍♂️ For reference, see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error.