### PR TITLE
Implement --no-output

### DIFF
--- a/src/Logging/VoidLogger.php
+++ b/src/Logging/VoidLogger.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\TextUI\ResultPrinter;
+use Throwable;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class VoidLogger implements ResultPrinter
+{
+    public function addError(Test $test, Throwable $t, float $time): void
+    {
+    }
+
+    public function addWarning(Test $test, Warning $e, float $time): void
+    {
+    }
+
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
+    {
+    }
+
+    public function addIncompleteTest(Test $test, Throwable $t, float $time): void
+    {
+    }
+
+    public function addRiskyTest(Test $test, Throwable $t, float $time): void
+    {
+    }
+
+    public function addSkippedTest(Test $test, Throwable $t, float $time): void
+    {
+    }
+
+    public function startTestSuite(TestSuite $suite): void
+    {
+    }
+
+    public function endTestSuite(TestSuite $suite): void
+    {
+    }
+
+    public function startTest(Test $test): void
+    {
+    }
+
+    public function endTest(Test $test, float $time): void
+    {
+    }
+
+    public function printResult(TestResult $result): void
+    {
+    }
+
+    public function write(string $buffer): void
+    {
+    }
+}

--- a/src/TextUI/CliArguments/Builder.php
+++ b/src/TextUI/CliArguments/Builder.php
@@ -75,6 +75,7 @@ final class Builder
         'no-logging',
         'no-interaction',
         'no-extensions',
+        'no-output',
         'order-by=',
         'process-isolation',
         'repeat=',
@@ -191,6 +192,7 @@ final class Builder
         $noCoverage                        = null;
         $noExtensions                      = null;
         $noInteraction                     = null;
+        $noOutput                          = null;
         $noLogging                         = null;
         $processIsolation                  = null;
         $randomOrderSeed                   = null;
@@ -640,6 +642,11 @@ final class Builder
 
                     break;
 
+                case '--no-output':
+                    $noOutput = true;
+
+                    break;
+
                 case '--globals-backup':
                     $backupGlobals = true;
 
@@ -826,6 +833,7 @@ final class Builder
             $noCoverage,
             $noExtensions,
             $noInteraction,
+            $noOutput,
             $noLogging,
             $processIsolation,
             $randomOrderSeed,

--- a/src/TextUI/CliArguments/Configuration.php
+++ b/src/TextUI/CliArguments/Configuration.php
@@ -131,6 +131,8 @@ final class Configuration
 
     private ?bool $noInteraction;
 
+    private ?bool $noOutput;
+
     private ?bool $noLogging;
 
     private ?bool $processIsolation;
@@ -195,7 +197,7 @@ final class Configuration
 
     private ?string $plainTextTrace;
 
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $plainTextTrace, ?bool $printerTeamCity, ?bool $printerTestDox)
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?bool $debug, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?array $extensions, ?array $unavailableExtensions, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noOutput, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $plainTextTrace, ?bool $printerTeamCity, ?bool $printerTestDox)
     {
         $this->argument                          = $argument;
         $this->atLeastVersion                    = $atLeastVersion;
@@ -255,6 +257,7 @@ final class Configuration
         $this->noCoverage                        = $noCoverage;
         $this->noExtensions                      = $noExtensions;
         $this->noInteraction                     = $noInteraction;
+        $this->noOutput                          = $noOutput;
         $this->noLogging                         = $noLogging;
         $this->processIsolation                  = $processIsolation;
         $this->randomOrderSeed                   = $randomOrderSeed;
@@ -1273,6 +1276,23 @@ final class Configuration
         }
 
         return $this->noInteraction;
+    }
+
+    public function hasNoOutput(): bool
+    {
+        return $this->noOutput !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function noOutput(): bool
+    {
+        if ($this->noOutput === null) {
+            throw new Exception;
+        }
+
+        return $this->noOutput;
     }
 
     public function hasNoLogging(): bool

--- a/src/TextUI/CliArguments/Mapper.php
+++ b/src/TextUI/CliArguments/Mapper.php
@@ -287,6 +287,10 @@ final class Mapper
             $result['noCoverage'] = $arguments->noCoverage();
         }
 
+        if ($arguments->hasNoOutput()) {
+            $result['noOutput'] = $arguments->noOutput();
+        }
+
         if ($arguments->hasNoLogging()) {
             $result['noLogging'] = $arguments->noLogging();
         }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -38,6 +38,7 @@ use PHPUnit\Logging\TestDox\CliTestDoxPrinter;
 use PHPUnit\Logging\TestDox\HtmlResultPrinter;
 use PHPUnit\Logging\TestDox\TextResultPrinter;
 use PHPUnit\Logging\TestDox\XmlResultPrinter;
+use PHPUnit\Logging\VoidLogger;
 use PHPUnit\Runner\AfterLastTestHook;
 use PHPUnit\Runner\BeforeFirstTestHook;
 use PHPUnit\Runner\CodeCoverage;
@@ -267,6 +268,8 @@ final class TestRunner
             $printerClassName = TeamCityLogger::class;
         } elseif (isset($arguments['testdoxPrinter']) && $arguments['testdoxPrinter'] === true) {
             $printerClassName = CliTestDoxPrinter::class;
+        } elseif (isset($arguments['noOutput']) && $arguments['noOutput'] === true) {
+            $printerClassName = VoidLogger::class;
         }
 
         $this->printer = $this->createPrinter($printerClassName, $arguments);

--- a/tests/end-to-end/loggers/no-output.phpt
+++ b/tests/end-to-end/loggers/no-output.phpt
@@ -1,0 +1,17 @@
+--TEST--
+phpunit --teamcity ../../_files/BankAccountTest.php
+--FILE--
+<?php declare(strict_types=1);
+
+print 'placeholder' . PHP_EOL;
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = \realpath(__DIR__ . '/../../_files/BankAccountTest.php');
+
+require __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+placeholder


### PR DESCRIPTION
Hi, https://github.com/sebastianbergmann/phpunit/commit/916cfb94382fcb3cd2ef43713a036af2d950ca29 removed the possibility to have a custom printer, which is fine.

But in [ParaTest](https://github.com/paratestphp/paratest) we need to have no output from PHPUnit process to be able to gather erroneous outputs sent to `STDOUT` and also be able to have a clear overview of the eventual exception thrown in case it happens.

Only `--no-output` has been implemented here: no `phpunit.xml` entry added, on purpose, as I see no point for disabled the output by default by configuration.