### PR TITLE
GH Actions: set error reporting to E_ALL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
     env:
       PHP_EXTENSIONS: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
-      PHP_INI_VALUES: assert.exception=1, zend.assertions=1
+      PHP_INI_VALUES: assert.exception=1, zend.assertions=1, error_reporting=E_ALL, display_errors=On
 
     strategy:
       fail-fast: false
@@ -186,7 +186,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: pcov
           extensions: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
-          ini-values: assert.exception=1, zend.assertions=1
+          ini-values: assert.exception=1, zend.assertions=1, error_reporting=E_ALL, display_errors=On
 
       - name: Determine composer cache directory
         run: echo "COMPOSER_CACHE_DIR=$(./tools/composer config cache-dir)" >> $GITHUB_ENV
@@ -238,7 +238,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           coverage: pcov
           extensions: dom, json, libxml, mbstring, pdo_sqlite, soap, xml, xmlwriter
-          ini-values: assert.exception=1, zend.assertions=1
+          ini-values: assert.exception=1, zend.assertions=1, error_reporting=E_ALL, display_errors=On
 
       - name: Determine composer cache directory
         run: echo "COMPOSER_CACHE_DIR=$(tools/composer config cache-dir)" >> $GITHUB_ENV


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

Ref:
* https://github.com/shivammathur/setup-php/issues/469
* https://github.com/shivammathur/setup-php/issues/450