### PR TITLE
Compare PHP versions by string first

### DIFF
--- a/src/TextUI/TestSuiteMapper.php
+++ b/src/TextUI/TestSuiteMapper.php
@@ -51,7 +51,7 @@ final class TestSuiteMapper
                 $testSuiteEmpty = true;
 
                 foreach ($testSuiteConfiguration->directories() as $directory) {
-                    if (!version_compare(PHP_VERSION, $directory->phpVersion(), $directory->phpVersionOperator()->asString())) {
+                    if ($directory->phpVersion() !== PHP_VERSION && !version_compare(PHP_VERSION, $directory->phpVersion(), $directory->phpVersionOperator()->asString())) {
                         continue;
                     }
 
@@ -82,7 +82,7 @@ final class TestSuiteMapper
                         throw new TestFileNotFoundException($file->path());
                     }
 
-                    if (!version_compare(PHP_VERSION, $file->phpVersion(), $file->phpVersionOperator()->asString())) {
+                    if ($file->phpVersion() !== PHP_VERSION && !version_compare(PHP_VERSION, $file->phpVersion(), $file->phpVersionOperator()->asString())) {
                         continue;
                     }
 


### PR DESCRIPTION
Issue:
 - MacOS has a weird PHP version by default (`7.3.24-(to be removed in future macOS)`)
 - For some reason, checking this version against itself with `>=` is `false` (https://3v4l.org/EVYsT)
 - This allows PHPUnit to run (it passes against the 7.3 check) but fails against the directory check, which results in `No tests executed!`
 - See for a more extensive read: https://bbqsoftwares.com/blog/phpunit-big-sur by @lcharette

Proposed fixes:
 - Normalize PHP version instead of PHP_VERSION constants
 - Use internal version_compare method to normalize results
 - Check if strings are equal and skip version checks in that case (this PR)