### PR TITLE
Handle invalid PHP version strings

### DIFF
--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-if (substr(PHP_VERSION, 0 - strlen('-(to be removed in future macOS)')) === '-(to be removed in future macOS)') {
+if (!version_compare(PHP_VERSION, PHP_VERSION, "=")) {
     fwrite(
         STDERR,
         sprintf(

--- a/phpunit
+++ b/phpunit
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-if (substr(PHP_VERSION, 0 - strlen('-(to be removed in future macOS)')) === '-(to be removed in future macOS)') {
+if (!version_compare(PHP_VERSION, PHP_VERSION, "=")) {
     fwrite(
         STDERR,
         sprintf(


### PR DESCRIPTION
A better workaround for https://github.com/sebastianbergmann/phpunit/commit/2b0a4bb65811306a09d62d4c406b9d060baa8480. This way, PHPUnit will error for _any_ invalid PHP version strings (like "PHP 7.4.1-(custom)"), not just the one macOS currently has.