### PR TITLE
Loader: more precise return type

### DIFF
--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -65,7 +65,7 @@ final class Loader
     /**
      * @throws Exception
      */
-    public function load(string $filename): Configuration
+    public function load(string $filename): LoadedFromFileConfiguration
     {
         try {
             $document = (new XmlLoader)->loadFile($filename, false, true, true);


### PR DESCRIPTION
Due to the purpose of `Loader` class, where it belongs to and how its contract are presented (no interface, final class), I guess we can safely be more precise over its return type