### PR TITLE
Make PHARs created during build available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,3 +256,10 @@ jobs:
 
       - name: Run PHAR-specific tests with scoped PHAR
         run: ./build/artifacts/phpunit-snapshot.phar --configuration tests/phar/phpunit.xml
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.php-version == 7.4 }}
+        with:
+          name: phpunit-snapshot-phar
+          path: ./build/artifacts/phpunit-snapshot.phar
+          retention-days: 7


### PR DESCRIPTION
I wanted to try and test something with the latest `dev-9.5` version (against PHP 8.1) and realized I would have to build the phar myself.

To make it easier for people to test proposed changes or test the latest dev version of PHPUnit with a phar, I'd like to propose to automatically make the phar(s) generated during the CI builds available as artifacts.

Each phar test build will generate a zip file for each uploaded file - in this case for PHPUnit 8, that would be 8 different zips containing phars.
The zips can be downloaded from the Actions Summary page after each CI run.

The default retention period for build artifacts is 90 days, but as this repo is under active development, I'd like to suggest limiting this to 14 days to conserve resources.

Also see: https://github.com/actions/upload-artifact

Note: while I didn't want to go outside the scope of this PR, I do wonder why the phar is being build on each PHP version.
I imagine building the phar once (against the lowest supported PHP version ?) and then using that phar for all the test runs against the various supported PHP versions would make the script more efficient as well as reflect the reality more closely as the Phar which is released is not differentiated for each PHP version either.

I'd happily adjust this PR to make that change (and reduce the artifact uploads to two phars - scoped and unscoped) if so desired.