### PR TITLE
Implement support for namespaced mock class names

### DIFF
--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -702,9 +702,9 @@ final class Generator
         }
 
         if (!$isClass && !$isInterface) {
-            $prologue = sprintf(
-                "namespace %s {\n\nclass %s\n{\n}\n\n}\n\n",
-                $_mockClassName['namespaceName'],
+            $prologue .= sprintf(
+                "namespace %s{\n\nclass %s\n{\n}\n\n}\n\n",
+                $_mockClassName['namespaceName'] ? $_mockClassName['namespaceName'] . ' ' : '',
                 $_mockClassName['originalClassName']
             );
 
@@ -781,12 +781,6 @@ final class Generator
                 );
             }
 
-            if (class_exists($_mockClassName['fullClassName'], $callAutoload)) {
-                $isClass = true;
-            } elseif (interface_exists($_mockClassName['fullClassName'], $callAutoload)) {
-                $isInterface = true;
-            }
-
             // @see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/103
             if ($isInterface && $class->implementsInterface(Traversable::class) &&
                 !$class->implementsInterface(Iterator::class) &&
@@ -830,7 +824,7 @@ final class Generator
         );
 
         $mockClassNamespace = $_mockClassNameDestructured['namespaceName'];
-        $prologue .= 'namespace ' . $mockClassNamespace . ' {' . PHP_EOL . PHP_EOL;
+        $prologue .= 'namespace ' . ($mockClassNamespace ? $mockClassNamespace . ' ' : '') . '{' . PHP_EOL . PHP_EOL;
         $epilogue .= PHP_EOL . PHP_EOL . '}';
 
         if ($mockClassNamespace) {
@@ -993,11 +987,14 @@ final class Generator
             if (!in_array($mockClassName['originalClassName'], $additionalInterfaces, true)) {
                 $buffer .= ', ';
 
+                $nextInterface = '';
+
                 if (!empty($mockClassName['namespaceName'])) {
-                    $buffer .= $mockClassName['namespaceName'] . '\\';
+                    $nextInterface .= $mockClassName['namespaceName'] . '\\';
                 }
 
-                $buffer .= $mockClassName['originalClassName'];
+                $nextInterface .= $mockClassName['originalClassName'];
+                $buffer .= $this->toFQCN($nextInterface);
             }
         } else {
             $extendedClassName = sprintf(

--- a/tests/end-to-end/mock-objects/generator/232.phpt
+++ b/tests/end-to-end/mock-objects/generator/232.phpt
@@ -54,7 +54,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -81,4 +83,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/3154_namespaced_constant_resolving.phpt
+++ b/tests/end-to-end/mock-objects/generator/3154_namespaced_constant_resolving.phpt
@@ -39,7 +39,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class Issue3154Mock extends Is\Namespaced\Issue3154 implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class Issue3154Mock extends \Is\Namespaced\Issue3154 implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -66,4 +68,6 @@ class Issue3154Mock extends Is\Namespaced\Issue3154 implements PHPUnit\Framework
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/3967-php80.phpt
+++ b/tests/end-to-end/mock-objects/generator/3967-php80.phpt
@@ -32,7 +32,9 @@ print $mock->getClassCode();
 --EXPECT--
 declare(strict_types=1);
 
-class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockBaz extends \Exception implements \Baz, \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -58,4 +60,6 @@ class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\Moc
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/3967.phpt
+++ b/tests/end-to-end/mock-objects/generator/3967.phpt
@@ -32,7 +32,9 @@ print $mock->getClassCode();
 --EXPECT--
 declare(strict_types=1);
 
-class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockBaz extends Exception implements \Baz, \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -59,4 +61,6 @@ class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\Moc
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/397.phpt
+++ b/tests/end-to-end/mock-objects/generator/397.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockC extends C implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockC extends \C implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockC extends C implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/4139.phpt
+++ b/tests/end-to-end/mock-objects/generator/4139.phpt
@@ -16,7 +16,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class %s implements PHPUnit\Framework\MockObject\MockObject, InterfaceWithConstructor
+namespace {
+
+class %s implements \PHPUnit\Framework\MockObject\MockObject, \InterfaceWithConstructor
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -43,4 +45,6 @@ class %s implements PHPUnit\Framework\MockObject\MockObject, InterfaceWithConstr
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/abstract_class.phpt
+++ b/tests/end-to-end/mock-objects/generator/abstract_class.phpt
@@ -29,7 +29,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -100,4 +102,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class.phpt
+++ b/tests/end-to-end/mock-objects/generator/class.phpt
@@ -29,7 +29,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -78,4 +80,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_call_parent_clone.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_call_parent_clone.phpt
@@ -24,9 +24,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\UnmockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_call_parent_constructor.phpt
@@ -24,9 +24,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_dont_call_parent_clone.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_dont_call_parent_clone.phpt
@@ -24,9 +24,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_dont_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_dont_call_parent_constructor.phpt
@@ -24,9 +24,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_implementing_interface_call_parent_constructor.phpt
@@ -29,9 +29,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_implementing_interface_dont_call_parent_constructor.phpt
@@ -29,9 +29,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_nonexistent_method.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_nonexistent_method.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_partial.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_partial.phpt
@@ -29,7 +29,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -56,4 +58,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_with_deprecated_method.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_deprecated_method.phpt
@@ -29,7 +29,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \ClassWithDeprecatedMethod implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -58,4 +60,6 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_with_final_method.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_final_method.phpt
@@ -25,9 +25,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends ClassWithFinalMethod implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \ClassWithFinalMethod implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_with_method_named_method.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_named_method.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
@@ -51,4 +53,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_with_method_with_nullable_typehinted_variadic_arguments.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_with_nullable_typehinted_variadic_arguments.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends ClassWithMethodWithNullableTypehintedVariadicArguments implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \ClassWithMethodWithNullableTypehintedVariadicArguments implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends ClassWithMethodWithNullableTypehintedVariadicArguments imp
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_with_method_with_typehinted_variadic_arguments.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_with_typehinted_variadic_arguments.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends ClassWithMethodWithTypehintedVariadicArguments implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \ClassWithMethodWithTypehintedVariadicArguments implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends ClassWithMethodWithTypehintedVariadicArguments implements 
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/class_with_method_with_variadic_arguments.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_with_variadic_arguments.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \ClassWithMethodWithVariadicArguments implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit\Fr
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/constant_as_parameter_default_value.phpt
+++ b/tests/end-to-end/mock-objects/generator/constant_as_parameter_default_value.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/interface.phpt
+++ b/tests/end-to-end/mock-objects/generator/interface.phpt
@@ -23,7 +23,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -50,4 +52,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/intersection_type_parameter.phpt
+++ b/tests/end-to-end/mock-objects/generator/intersection_type_parameter.phpt
@@ -38,7 +38,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -65,4 +67,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/intersection_type_return.phpt
+++ b/tests/end-to-end/mock-objects/generator/intersection_type_return.phpt
@@ -38,7 +38,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -65,4 +67,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/invocation_object_clone_object.phpt
+++ b/tests/end-to-end/mock-objects/generator/invocation_object_clone_object.phpt
@@ -30,7 +30,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -79,4 +81,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/mock_with_namespace.phpt
+++ b/tests/end-to-end/mock-objects/generator/mock_with_namespace.phpt
@@ -1,34 +1,30 @@
---TEST--
-\PHPUnit\Framework\MockObject\Generator::generate('NonExistentClass', [], 'MockFoo', true, true)
 --FILE--
 <?php declare(strict_types=1);
+namespace Bar\Test {
+    class Bar {
+        public function something(Bar $bar) {}
+    }
+}
+
+namespace {
 require_once __DIR__ . '/../../../bootstrap.php';
 
 $generator = new \PHPUnit\Framework\MockObject\Generator;
 
 $mock = $generator->generate(
-    'NonExistentClass',
-    [],
-    'MockFoo',
-    true,
-    true
+    Bar::class,
+    null,
+    'Some\\Mock\\Class',
 );
 
 print $mock->getClassCode();
---EXPECTF--
+}
+--EXPECT--
 declare(strict_types=1);
 
-namespace {
+namespace Some\Mock {
 
-class NonExistentClass
-{
-}
-
-}
-
-namespace {
-
-class MockFoo extends \NonExistentClass implements \PHPUnit\Framework\MockObject\MockObject
+class Class extends \Bar implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;

--- a/tests/end-to-end/mock-objects/generator/namespaced_class.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class.phpt
@@ -31,7 +31,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -80,4 +82,6 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_call_parent_clone.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_call_parent_clone.phpt
@@ -26,9 +26,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\UnmockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_call_parent_constructor.phpt
@@ -26,9 +26,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_dont_call_parent_clone.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_dont_call_parent_clone.phpt
@@ -26,9 +26,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_dont_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_dont_call_parent_constructor.phpt
@@ -26,9 +26,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_implementing_interface_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_implementing_interface_call_parent_constructor.phpt
@@ -31,9 +31,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_implementing_interface_dont_call_parent_constructor.phpt
@@ -31,9 +31,13 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
     use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_partial.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_partial.phpt
@@ -31,7 +31,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -58,4 +60,6 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/namespaced_interface.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_interface.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, NS\Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \NS\Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, NS\Foo
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/nonexistent_class_with_namespace.phpt
+++ b/tests/end-to-end/mock-objects/generator/nonexistent_class_with_namespace.phpt
@@ -28,7 +28,7 @@ class Foo
 
 namespace {
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;

--- a/tests/end-to-end/mock-objects/generator/nonexistent_class_with_namespace_starting_with_separator.phpt
+++ b/tests/end-to-end/mock-objects/generator/nonexistent_class_with_namespace_starting_with_separator.phpt
@@ -28,7 +28,7 @@ class Foo
 
 namespace {
 
-class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
+class MockFoo extends \NS\Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;

--- a/tests/end-to-end/mock-objects/generator/nullable_types.phpt
+++ b/tests/end-to-end/mock-objects/generator/nullable_types.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/nullable_union_type_parameter.phpt
+++ b/tests/end-to-end/mock-objects/generator/nullable_union_type_parameter.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/nullable_union_type_return.phpt
+++ b/tests/end-to-end/mock-objects/generator/nullable_union_type_return.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/proxy.phpt
+++ b/tests/end-to-end/mock-objects/generator/proxy.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class ProxyFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -74,4 +76,6 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return call_user_func_array(array($this->__phpunit_originalObject, "baz"), $__phpunit_arguments);
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_closure.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_closure.phpt
@@ -23,7 +23,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -50,4 +52,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_final.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_final.phpt
@@ -30,7 +30,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -57,4 +59,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_generator.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_generator.phpt
@@ -23,7 +23,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -50,4 +52,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_never.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_never.phpt
@@ -28,7 +28,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -53,4 +55,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
             )
         );
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_nullable.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_nullable.phpt
@@ -23,7 +23,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -50,4 +52,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_object_method.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_object_method.phpt
@@ -26,7 +26,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -53,4 +55,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_parent.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_parent.phpt
@@ -30,7 +30,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockBar extends \Bar implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -57,4 +59,6 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_self.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_self.phpt
@@ -23,7 +23,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -50,4 +52,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_static.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_static.phpt
@@ -33,7 +33,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockClassWithStaticReturnTypes extends \ClassWithStaticReturnTypes implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -104,4 +106,6 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_static_method.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_static_method.phpt
@@ -26,7 +26,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -36,4 +38,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
     {
         throw new \PHPUnit\Framework\MockObject\BadMethodCallException('Static method "bar" cannot be invoked on mock object');
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_void.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_void.phpt
@@ -23,7 +23,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
+namespace {
+
+class MockFoo implements \PHPUnit\Framework\MockObject\MockObject, \Foo
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -48,4 +50,6 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
             )
         );
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/scalar_type_declarations.phpt
+++ b/tests/end-to-end/mock-objects/generator/scalar_type_declarations.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/union_type_parameter.phpt
+++ b/tests/end-to-end/mock-objects/generator/union_type_parameter.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/end-to-end/mock-objects/generator/union_type_return.phpt
+++ b/tests/end-to-end/mock-objects/generator/union_type_return.phpt
@@ -25,7 +25,9 @@ print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
-class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
+namespace {
+
+class MockFoo extends \Foo implements \PHPUnit\Framework\MockObject\MockObject
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
@@ -52,4 +54,6 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
         return $__phpunit_result;
     }
+}
+
 }

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -13,6 +13,7 @@ use function class_exists;
 use function md5;
 use function method_exists;
 use function microtime;
+use ArrayObject;
 use Countable;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -335,5 +336,27 @@ final class GeneratorTest extends TestCase
 
         $this->assertTrue($stub->doSomething());
         $this->assertFalse($stub->doSomethingElse());
+    }
+
+    public function testGetMockSupportsNamespacedMockClassname(): void
+    {
+        $namespacedClassname = 'Some\\Test\\Class_' . random_int(10000, 100000);
+
+        $mock = $this->generator->getMock(ArrayObject::class, [], [], $namespacedClassname);
+
+        $this->assertTrue(class_exists($namespacedClassname));
+        $this->assertEquals($namespacedClassname, get_class($mock));
+    }
+
+    public function testGetMockSupportsNamespacedMockClassnameWhenMockedTypeDoesNotExist(): void
+    {
+        $namespacedClassname = 'Some\\Test\\Class_' . random_int(10000, 100000);
+        $type                = 'Some\\Test\\OtherClass_' . random_int(10000, 100000);
+
+        $mock = $this->generator->getMock($type, [], [], $namespacedClassname);
+
+        $this->assertTrue(class_exists($namespacedClassname));
+        $this->assertTrue(class_exists($type));
+        $this->assertEquals($namespacedClassname, get_class($mock));
     }
 }


### PR DESCRIPTION
The current mock class generation routines do not support using mock class names with namespaces, i.e. `\Some\Test\Class`. This PR supplies such support.