### PR TITLE
Enhancement: Configure braces fixer to position opening braces for anonymous constructs on next line

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -63,7 +63,9 @@ $config->setFinder($finder)
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'position_after_anonymous_constructs' => 'next',
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -693,7 +693,7 @@
   </file>
   <file src="src/Framework/MockObject/Invocation.php">
     <MissingClosureReturnType occurrences="1">
-      <code>static function () {</code>
+      <code>static function ()</code>
     </MissingClosureReturnType>
   </file>
   <file src="src/Framework/MockObject/InvocationHandler.php">

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -217,7 +217,8 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         }
 
         $configurableMethodNames = array_map(
-            static function (ConfigurableMethod $configurable) {
+            static function (ConfigurableMethod $configurable)
+            {
                 return strtolower($configurable->getName());
             },
             $this->configurableMethods

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -114,7 +114,8 @@ final class Generator
         if (is_array($type)) {
             $type = array_unique(
                 array_map(
-                    static function ($type) {
+                    static function ($type)
+                    {
                         if ($type === 'Traversable' ||
                             $type === '\\Traversable' ||
                             $type === '\\Iterator') {

--- a/src/Framework/MockObject/Invocation.php
+++ b/src/Framework/MockObject/Invocation.php
@@ -145,13 +145,15 @@ final class Invocation implements SelfDescribing
 
             case 'callable':
             case 'closure':
-                return static function (): void {
+                return static function (): void
+                {
                 };
 
             case 'traversable':
             case 'generator':
             case 'iterable':
-                $generator = static function () {
+                $generator = static function ()
+                {
                     yield from [];
                 };
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1708,7 +1708,8 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
 
             $mockedMethodsThatDontExist = array_filter(
                 $methods,
-                static function (string $method) use ($reflection) {
+                static function (string $method) use ($reflection)
+                {
                     return !$reflection->hasMethod($method);
                 }
             );

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -246,7 +246,8 @@ final class TestSuiteSorter
     {
         return array_reduce(
             $suite->tests(),
-            static function ($carry, $test) {
+            static function ($carry, $test)
+            {
                 return $carry && ($test instanceof TestCase || $test instanceof DataProviderTestSuite);
             },
             true
@@ -272,7 +273,8 @@ final class TestSuiteSorter
             /**
              * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
              */
-            function ($left, $right) {
+            function ($left, $right)
+            {
                 return $this->cmpDefectPriorityAndTime($left, $right);
             }
         );
@@ -287,7 +289,8 @@ final class TestSuiteSorter
             /**
              * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
              */
-            function ($left, $right) {
+            function ($left, $right)
+            {
                 return $this->cmpDuration($left, $right);
             }
         );
@@ -302,7 +305,8 @@ final class TestSuiteSorter
             /**
              * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
              */
-            function ($left, $right) {
+            function ($left, $right)
+            {
                 return $this->cmpSize($left, $right);
             }
         );
@@ -386,7 +390,8 @@ final class TestSuiteSorter
                 /**
                  * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
                  */
-                static function ($test) {
+                static function ($test)
+                {
                     return self::getTestSorterUID($test);
                 },
                 $tests
@@ -417,7 +422,8 @@ final class TestSuiteSorter
         }
 
         $names = array_map(
-            static function ($name) use ($testClass) {
+            static function ($name) use ($testClass)
+            {
                 return strpos($name, '::') === false ? $testClass . '::' . $name : $name;
             },
             $test->getDependencies()

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -234,7 +234,8 @@ final class Help
                     $arg = Color::colorize('fg-green', str_pad($option['arg'], $this->maxArgLength));
                     $arg = preg_replace_callback(
                         '/(<[^>]+>)/',
-                        static function ($matches) {
+                        static function ($matches)
+                        {
                             return Color::colorize('fg-cyan', $matches[0]);
                         },
                         $arg

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -604,7 +604,8 @@ final class DocBlock
             $annotations = array_merge(
                 $annotations,
                 ...array_map(
-                    static function (ReflectionClass $trait): array {
+                    static function (ReflectionClass $trait): array
+                    {
                         return self::parseDocBlock((string) $trait->getDocComment());
                     },
                     array_values($reflector->getTraits())

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -116,7 +116,8 @@ final class Color
             $last        = count($path) - 1;
             $path[$last] = preg_replace_callback(
                 '/([\-_\.]+|phpt$)/',
-                static function ($matches) {
+                static function ($matches)
+                {
                     return self::dim($matches[0]);
                 },
                 $path[$last]
@@ -139,7 +140,8 @@ final class Color
     {
         $replaceMap = $visualizeEOL ? self::WHITESPACE_EOL_MAP : self::WHITESPACE_MAP;
 
-        return preg_replace_callback('/\s+/', static function ($matches) use ($replaceMap) {
+        return preg_replace_callback('/\s+/', static function ($matches) use ($replaceMap)
+        {
             return self::dim(strtr($matches[0], $replaceMap));
         }, $buffer);
     }

--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -57,7 +57,8 @@ final class ErrorHandler
     public static function invokeIgnoringWarnings(callable $callable)
     {
         set_error_handler(
-            static function ($errorNumber, $errorString) {
+            static function ($errorNumber, $errorString)
+            {
                 if ($errorNumber === E_WARNING) {
                     return;
                 }

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -275,7 +275,8 @@ abstract class AbstractPhpProcess
                 /**
                  * @throws ErrorException
                  */
-                static function ($errno, $errstr, $errfile, $errline): void {
+                static function ($errno, $errstr, $errfile, $errline): void
+                {
                     throw new ErrorException($errstr, $errno, $errno, $errfile, $errline);
                 }
             );

--- a/src/Util/RegularExpression.php
+++ b/src/Util/RegularExpression.php
@@ -22,7 +22,8 @@ final class RegularExpression
     public static function safeMatch(string $pattern, string $subject)
     {
         return ErrorHandler::invokeIgnoringWarnings(
-            static function () use ($pattern, $subject) {
+            static function () use ($pattern, $subject)
+            {
                 return preg_match($pattern, $subject);
             }
         );

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -286,7 +286,8 @@ class CliTestDoxPrinter extends TestDoxPrinter
 
         if ($this->colors) {
             $color  = self::STATUS_STYLES[$result['status']]['color'] ?? '';
-            $prefix = array_map(static function ($p) use ($color) {
+            $prefix = array_map(static function ($p) use ($color)
+            {
                 return Color::colorize($color, $p);
             }, self::PREFIX_DECORATED);
         }

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -143,7 +143,8 @@ final class NamePrettifier
         $annotations                = $test->getAnnotations();
         $annotationWithPlaceholders = false;
 
-        $callback = static function (string $variable): string {
+        $callback = static function (string $variable): string
+        {
             return sprintf('/%s(?=\b)/', preg_quote($variable, '/'));
         };
 
@@ -314,7 +315,8 @@ final class NamePrettifier
         }
 
         if ($this->useColor) {
-            $providedData = array_map(static function ($value) {
+            $providedData = array_map(static function ($value)
+            {
                 return Color::colorize('fg-cyan', Color::visualizeWhitespace((string) $value, true));
             }, $providedData);
         }

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -374,7 +374,8 @@ class TestDoxPrinter extends ResultPrinter
         return implode(
             PHP_EOL,
             array_map(
-                static function (string $text) use ($prefix) {
+                static function (string $text) use ($prefix)
+                {
                     return '   ' . $prefix . ($text ? ' ' . $text : '');
                 },
                 preg_split('/\r\n|\r|\n/', $message)

--- a/src/Util/TestDox/XmlResultPrinter.php
+++ b/src/Util/TestDox/XmlResultPrinter.php
@@ -158,7 +158,8 @@ final class XmlResultPrinter extends Printer implements TestListener
 
         $groups = array_filter(
             $test->getGroups(),
-            static function ($group) {
+            static function ($group)
+            {
                 return !($group === 'small' || $group === 'medium' || $group === 'large');
             }
         );

--- a/src/Util/XdebugFilterScriptGenerator.php
+++ b/src/Util/XdebugFilterScriptGenerator.php
@@ -27,7 +27,8 @@ final class XdebugFilterScriptGenerator
         $items = $this->getWhitelistItems($filterData);
 
         $files = array_map(
-            static function ($item) {
+            static function ($item)
+            {
                 return sprintf(
                     "        '%s'",
                     $item

--- a/tests/unit/Framework/Assert/FunctionsTest.php
+++ b/tests/unit/Framework/Assert/FunctionsTest.php
@@ -54,7 +54,8 @@ final class FunctionsTest extends TestCase
 
         return array_reduce(
             $matches[1],
-            static function (array $functionNames, string $functionName) {
+            static function (array $functionNames, string $functionName)
+            {
                 $functionNames[$functionName] = [$functionName];
 
                 return $functionNames;

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1368,7 +1368,8 @@ XML;
     {
         $this->assertThat(
             null,
-            $this->callback(static function ($other) {
+            $this->callback(static function ($other)
+            {
                 return true;
             })
         );
@@ -2041,7 +2042,8 @@ XML;
 
     public function testCallableTypeCanBeAsserted(): void
     {
-        $this->assertIsCallable(static function (): void {
+        $this->assertIsCallable(static function (): void
+        {
         });
 
         try {
@@ -2188,7 +2190,8 @@ XML;
         $this->assertIsNotCallable(null);
 
         try {
-            $this->assertIsNotCallable(static function (): void {
+            $this->assertIsNotCallable(static function (): void
+            {
             });
         } catch (AssertionFailedError $e) {
             return;

--- a/tests/unit/Framework/Constraint/CallbackTest.php
+++ b/tests/unit/Framework/Constraint/CallbackTest.php
@@ -28,11 +28,13 @@ final class CallbackTest extends ConstraintTestCase
 
     public function testConstraintCallback(): void
     {
-        $closureReflect = static function ($parameter) {
+        $closureReflect = static function ($parameter)
+        {
             return $parameter;
         };
 
-        $closureWithoutParameter = static function () {
+        $closureWithoutParameter = static function ()
+        {
             return true;
         };
 
@@ -56,7 +58,8 @@ final class CallbackTest extends ConstraintTestCase
 
     public function testConstraintCallbackFailure(): void
     {
-        $constraint = new Callback(static function () {
+        $constraint = new Callback(static function ()
+        {
             return false;
         });
 

--- a/tests/unit/Framework/Constraint/LogicalAndTest.php
+++ b/tests/unit/Framework/Constraint/LogicalAndTest.php
@@ -55,7 +55,8 @@ final class LogicalAndTest extends ConstraintTestCase
             8,
         ];
 
-        $constraints = array_map(static function (int $count) {
+        $constraints = array_map(static function (int $count)
+        {
             return CountConstraint::fromCount($count);
         }, $counts);
 
@@ -76,7 +77,8 @@ final class LogicalAndTest extends ConstraintTestCase
             'is rich in unsaturated fats',
         ];
 
-        $constraints = array_map(static function (string $name) {
+        $constraints = array_map(static function (string $name)
+        {
             return NamedConstraint::fromName($name);
         }, $names);
 
@@ -240,7 +242,8 @@ EOF;
     {
         return implode(
             ' and ',
-            array_map(static function (Constraint $constraint) {
+            array_map(static function (Constraint $constraint)
+            {
                 return $constraint->toString();
             }, $constraints)
         );

--- a/tests/unit/Framework/Constraint/LogicalOrTest.php
+++ b/tests/unit/Framework/Constraint/LogicalOrTest.php
@@ -47,7 +47,8 @@ final class LogicalOrTest extends ConstraintTestCase
             8,
         ];
 
-        $constraints = array_map(static function (int $count) {
+        $constraints = array_map(static function (int $count)
+        {
             return CountConstraint::fromCount($count);
         }, $counts);
 
@@ -68,7 +69,8 @@ final class LogicalOrTest extends ConstraintTestCase
             'is rich in unsaturated fats',
         ];
 
-        $constraints = array_map(static function (string $name) {
+        $constraints = array_map(static function (string $name)
+        {
             return NamedConstraint::fromName($name);
         }, $names);
 
@@ -234,7 +236,8 @@ EOF;
     {
         return implode(
             ' or ',
-            array_map(static function (Constraint $constraint) {
+            array_map(static function (Constraint $constraint)
+            {
                 return $constraint->toString();
             }, $constraints)
         );

--- a/tests/unit/Framework/Constraint/LogicalXorTest.php
+++ b/tests/unit/Framework/Constraint/LogicalXorTest.php
@@ -25,7 +25,8 @@ final class LogicalXorTest extends TestCase
         $other = 'Foo';
         $count = 5;
 
-        $constraints = array_map(function () use ($other) {
+        $constraints = array_map(function () use ($other)
+        {
             static $count = 0;
 
             $constraint = $this->getMockBuilder(Constraint::class)->getMock();

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -589,7 +589,8 @@ final class MockObjectTest extends TestCase
              ->method('doSomethingElse')
              ->will(
                  $this->returnCallback(
-                     static function () use (&$actualArguments): void {
+                     static function () use (&$actualArguments): void
+                     {
                          $actualArguments = \func_get_args();
                      }
                  )
@@ -617,7 +618,8 @@ final class MockObjectTest extends TestCase
              ->method('doSomethingElse')
              ->will(
                  $this->returnCallback(
-                     static function () use (&$actualArguments): void {
+                     static function () use (&$actualArguments): void
+                     {
                          $actualArguments = \func_get_args();
                      }
                  )
@@ -846,7 +848,8 @@ final class MockObjectTest extends TestCase
         $foo->expects($this->any())
             ->method('bar')
             ->will($this->returnCallback(
-                static function (&$a, &$b, $c): void {
+                static function (&$a, &$b, $c): void
+                {
                     $b = 1;
                 }
             ));
@@ -1030,7 +1033,8 @@ final class MockObjectTest extends TestCase
         $callCount             = 0;
 
         $mock->expects($this->exactly($expectedNumberOfCalls))->method('bar')
-            ->with($this->callback(static function ($argument) use (&$callCount) {
+            ->with($this->callback(static function ($argument) use (&$callCount)
+            {
                 return $argument === 'call_' . $callCount++;
             }));
 

--- a/tests/unit/Util/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Util/TestDox/NamePrettifierTest.php
@@ -65,7 +65,8 @@ final class NamePrettifierTest extends TestCase
 
     public function testPhpDoxIgnoreDataKeys(): void
     {
-        $test = new class extends TestCase {
+        $test = new class extends TestCase
+        {
             public function __construct()
             {
                 parent::__construct('testAddition', [
@@ -94,7 +95,8 @@ final class NamePrettifierTest extends TestCase
 
     public function testPhpDoxUsesDefaultValue(): void
     {
-        $test = new class extends TestCase {
+        $test = new class extends TestCase
+        {
             public function __construct()
             {
                 parent::__construct('testAddition', []);
@@ -119,7 +121,8 @@ final class NamePrettifierTest extends TestCase
 
     public function testPhpDoxArgumentExporting(): void
     {
-        $test = new class extends TestCase {
+        $test = new class extends TestCase
+        {
             public function __construct()
             {
                 parent::__construct('testExport', [
@@ -152,7 +155,8 @@ final class NamePrettifierTest extends TestCase
 
     public function testPhpDoxReplacesLongerVariablesFirst(): void
     {
-        $test = new class extends TestCase {
+        $test = new class extends TestCase
+        {
             public function __construct()
             {
                 parent::__construct('testFoo', []);


### PR DESCRIPTION
This pull request

* [x] configures the `braces` fixer to position opening braces for anonymous constructs on next line
* [x] runs `./tools/php-cs-fixer fix`
* [x] regenerates the baseline for `psalm`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.2/doc/rules/basic/braces.rst.
