### PR TITLE
Better "crash" output

### DIFF
--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -112,7 +112,16 @@ final class Application
         } catch (Throwable $t) {
             $returnCode = self::EXCEPTION_EXIT;
 
-            print $t->getMessage() . PHP_EOL;
+            printf(
+                '%s in %s:%d' . PHP_EOL,
+                $t->getMessage(),
+                $t->getFile(),
+                $t->getLine()
+            );
+
+            if (Registry::get()->debug()) {
+                print PHP_EOL . $t->getTraceAsString() . PHP_EOL;
+            }
         }
 
         Event\Facade::emitter()->testRunnerFinished();


### PR DESCRIPTION
This change updates the crash output from just showing the error message to also containing file and line info. Additionally, when `--debug` is given, the back trace is also shown.

@sebastianbergmann: Not sure if calling `Registry::get()` is the best way to determine whether debug is enabled or not.