### PR TITLE
TestDox HTML report not displayed correctly when browser has custom colour settings

### DIFF
--- a/src/Util/TestDox/HtmlResultPrinter.php
+++ b/src/Util/TestDox/HtmlResultPrinter.php
@@ -31,6 +31,8 @@ final class HtmlResultPrinter extends ResultPrinter
                 font-variant-ligatures: common-ligatures;
                 font-kerning: normal;
                 margin-left: 2em;
+                background-color: #ffffff;
+                color: #000000;
             }
 
             body > ul > li {

--- a/tests/end-to-end/loggers/testdox-html.phpt
+++ b/tests/end-to-end/loggers/testdox-html.phpt
@@ -24,6 +24,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
                 font-variant-ligatures: common-ligatures;
                 font-kerning: normal;
                 margin-left: 2em;
+                background-color: #ffffff;
+                color: #000000;
             }
 
             body > ul > li {


### PR DESCRIPTION
Browsers support custom colour settings.
Some people might change default text and background colour.

The report defines custom colour for successful and failed tests.
It should therefore ensure that those colours work as expected.
Background colour and default text colour are set in addition.
This ensures an expected end result, no matter what colours might be set as defaults.