### PR TITLE
refine PHPDoc in TestDoxPrinter

### DIFF
--- a/src/Logging/TestDox/TestDoxPrinter.php
+++ b/src/Logging/TestDox/TestDoxPrinter.php
@@ -63,6 +63,9 @@ abstract class TestDoxPrinter extends DefaultResultPrinter
      */
     protected array $originalExecutionOrder = [];
 
+    /**
+     * @psalm-var 0|positive-int
+     */
     protected int $spinState = 0;
 
     protected bool $showProgress = true;


### PR DESCRIPTION
This PR is adding some phpdoc to a specific property involved in a modulo operation here:
https://github.com/sebastianbergmann/phpunit/blob/60826632c99448293e94ae6c615a3939524ec119/src/Logging/TestDox/CliTestDoxPrinter.php#L324

With the incoming Integer Range feature in Psalm (https://github.com/vimeo/psalm/pull/6241) this is detected as a potential issue because if the property can be a negative int, then it means there could be an out of bounds array access. With this PR, Psalm won't break the build later.