### PR TITLE
Allows running a single test by specifying line no

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -90,6 +90,7 @@ final class TestBuilder
         if (isset($data)) {
             $test = $this->buildDataProviderTestSuite(
                 $methodName,
+                $line,
                 $className,
                 $data,
                 $this->shouldTestMethodBeRunInSeparateProcess($className, $methodName),
@@ -118,7 +119,7 @@ final class TestBuilder
      * @psalm-param class-string $className
      * @psalm-param array{backupGlobals: ?bool, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?bool, backupStaticPropertiesExcludeList: array<string,list<string>>}
      */
-    private function buildDataProviderTestSuite(string $methodName, string $className, array|ErrorTestCase|IncompleteTestCase|SkippedTestCase $data, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, bool $runClassInSeparateProcess, array $backupSettings): DataProviderTestSuite
+    private function buildDataProviderTestSuite(string $methodName, int $line, string $className, array|ErrorTestCase|IncompleteTestCase|SkippedTestCase $data, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, bool $runClassInSeparateProcess, array $backupSettings): DataProviderTestSuite
     {
         $dataProviderTestSuite = new DataProviderTestSuite(
             $className . '::' . $methodName
@@ -132,7 +133,7 @@ final class TestBuilder
             $dataProviderTestSuite->addTest($data, $groups);
         } else {
             foreach ($data as $_dataName => $_data) {
-                $_test = new $className($methodName);
+                $_test = new $className($methodName, $line);
 
                 assert($_test instanceof TestCase);
 

--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -31,7 +31,7 @@ use Throwable;
  */
 final class TestBuilder
 {
-    public function build(ReflectionClass $theClass, string $methodName): Test
+    public function build(ReflectionClass $theClass, string $methodName, int $line): Test
     {
         $className = $theClass->getName();
 
@@ -98,7 +98,7 @@ final class TestBuilder
                 $this->backupSettings($className, $methodName)
             );
         } else {
-            $test = new $className($methodName);
+            $test = new $className($methodName, $line);
         }
 
         if ($test instanceof TestCase) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -161,6 +161,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
     private string $name;
 
+    private ?int $line;
+
     /**
      * @psalm-var list<string>
      */
@@ -335,9 +337,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function __construct(string $name)
+    public function __construct(string $name, ?int $line = null)
     {
         $this->setName($name);
+        $this->setLine($line);
 
         $this->status = TestStatus::unknown();
     }
@@ -1021,6 +1024,11 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         }
     }
 
+    public function setLine(?int $line): void
+    {
+        $this->line = $line;
+    }
+
     /**
      * @psalm-param list<ExecutionOrderDependency> $dependencies
      *
@@ -1354,6 +1362,11 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     public function wasPrepared(): bool
     {
         return $this->wasPrepared;
+    }
+
+    public function line(): int
+    {
+        return $this->line;
     }
 
     /**

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -722,7 +722,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     {
         $methodName = $method->getName();
 
-        $test = (new TestBuilder)->build($class, $methodName);
+        $test = (new TestBuilder)->build($class, $methodName, $method->getStartLine());
 
         if ($test instanceof TestCase || $test instanceof DataProviderTestSuite) {
             $test->setDependencies(

--- a/src/Runner/Filter/Factory.php
+++ b/src/Runner/Filter/Factory.php
@@ -46,6 +46,13 @@ final class Factory
         ];
     }
 
+    public function addLineFilter(int $line): void
+    {
+        $this->filters[] = [
+            new ReflectionClass(LineFilterIterator::class), $line,
+        ];
+    }
+
     public function factory(Iterator $iterator, TestSuite $suite): FilterIterator
     {
         foreach ($this->filters as $filter) {

--- a/src/Runner/Filter/LineFilterIterator.php
+++ b/src/Runner/Filter/LineFilterIterator.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\WarningTestCase;
 use PHPUnit\Util\RegularExpression;
 use RecursiveFilterIterator;
 use RecursiveIterator;
+use PHPUnit\Framework\DataProviderTestSuite;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -46,6 +47,14 @@ final class LineFilterIterator extends RecursiveFilterIterator
     {
         $test = $this->getInnerIterator()->current();
 
-        return $test instanceof TestCase && $this->line === $test->line();
+        if ($test instanceof TestSuite) {
+            return true;
+        }
+
+        if ($test instanceof TestCase) {
+            return $this->line === $test->line();
+        }
+
+        return false;
     }
 }

--- a/src/Runner/Filter/LineFilterIterator.php
+++ b/src/Runner/Filter/LineFilterIterator.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use function end;
+use function implode;
+use function preg_match;
+use function sprintf;
+use function str_replace;
+use Exception;
+use PHPUnit\Framework\ErrorTestCase;
+use PHPUnit\Framework\SelfDescribing;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\WarningTestCase;
+use PHPUnit\Util\RegularExpression;
+use RecursiveFilterIterator;
+use RecursiveIterator;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class LineFilterIterator extends RecursiveFilterIterator
+{
+    private int $line;
+
+    /**
+     * @throws Exception
+     */
+    public function __construct(RecursiveIterator $iterator, int $line)
+    {
+        parent::__construct($iterator);
+
+        $this->line = $line;
+    }
+
+    public function accept(): bool
+    {
+        $test = $this->getInnerIterator()->current();
+
+        return $test instanceof TestCase && $this->line === $test->line();
+    }
+}

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -218,9 +218,13 @@ final class Builder
         $plainTextTrace                    = null;
         $printerTeamCity                   = null;
         $printerTestDox                    = null;
+        $line                              = null;
 
         if (isset($options[1][0])) {
             $argument = $options[1][0];
+            if (false !== strpos($argument, ':')) {
+                [$argument, $line] = explode(':', $argument);
+            }
         }
 
         foreach ($options[0] as $option) {
@@ -830,7 +834,8 @@ final class Builder
             $coverageFilter,
             $plainTextTrace,
             $printerTeamCity,
-            $printerTestDox
+            $printerTestDox,
+            $line ? (int) $line : null
         );
     }
 }

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -191,7 +191,9 @@ final class Configuration
 
     private ?string $plainTextTrace;
 
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noOutput, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $plainTextTrace, ?bool $printerTeamCity, ?bool $printerTestDox)
+    private ?int $line;
+
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noOutput, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $plainTextTrace, ?bool $printerTeamCity, ?bool $printerTestDox, ?int $line)
     {
         $this->argument                          = $argument;
         $this->atLeastVersion                    = $atLeastVersion;
@@ -281,6 +283,7 @@ final class Configuration
         $this->plainTextTrace                    = $plainTextTrace;
         $this->teamCityPrinter                   = $printerTeamCity;
         $this->testdoxPrinter                    = $printerTestDox;
+        $this->line                              = $line;
     }
 
     /**
@@ -2038,5 +2041,19 @@ final class Configuration
         }
 
         return $this->plainTextTrace;
+    }
+
+    public function hasLine(): bool
+    {
+        return null !== $this->line;
+    }
+
+    public function line(): int
+    {
+        if (!$this->hasLine()) {
+            throw new Exception;
+        }
+
+        return $this->line;
     }
 }

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -189,7 +189,9 @@ final class Configuration
      */
     private array $warnings;
 
-    public function __construct(?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $tooFewColumnsRequested, bool $loadPharExtensions, ?string $pharExtensionDirectory, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $convertDeprecationsToExceptions, bool $convertErrorsToExceptions, bool $convertNoticesToExceptions, bool $convertWarningsToExceptions, bool $processIsolation, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $verbose, bool $reverseDefectList, bool $forceCoversAnnotation, bool $registerMockObjectsFromTestArgumentsRecursively, bool $noInteraction, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileText, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logfileTestdoxXml, ?string $plainTextTrace, bool $defaultOutput, bool $teamCityOutput, bool $testDoxOutput, int $repeat, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, array $testdoxGroups, array $testdoxExcludeGroups, ?string $includePath, int $randomOrderSeed, bool $includeUncoveredFiles, ?string $xmlValidationErrors, array $warnings)
+    private ?int $line;
+
+    public function __construct(?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $tooFewColumnsRequested, bool $loadPharExtensions, ?string $pharExtensionDirectory, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $convertDeprecationsToExceptions, bool $convertErrorsToExceptions, bool $convertNoticesToExceptions, bool $convertWarningsToExceptions, bool $processIsolation, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $verbose, bool $reverseDefectList, bool $forceCoversAnnotation, bool $registerMockObjectsFromTestArgumentsRecursively, bool $noInteraction, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileText, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logfileTestdoxXml, ?string $plainTextTrace, bool $defaultOutput, bool $teamCityOutput, bool $testDoxOutput, int $repeat, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, array $testdoxGroups, array $testdoxExcludeGroups, ?string $includePath, int $randomOrderSeed, bool $includeUncoveredFiles, ?string $xmlValidationErrors, array $warnings, ?int $line)
     {
         $this->configurationFile                               = $configurationFile;
         $this->bootstrap                                       = $bootstrap;
@@ -277,6 +279,7 @@ final class Configuration
         $this->includeUncoveredFiles                           = $includeUncoveredFiles;
         $this->xmlValidationErrors                             = $xmlValidationErrors;
         $this->warnings                                        = $warnings;
+        $this->line                                            = $line;
     }
 
     /**
@@ -1119,5 +1122,19 @@ final class Configuration
     public function warnings(): array
     {
         return $this->warnings;
+    }
+
+    public function hasLine(): bool
+    {
+        return null !== $this->line;
+    }
+
+    public function line(): int
+    {
+        if (!$this->hasLine()) {
+            throw new Exception;
+        }
+
+        return $this->line;
     }
 }

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -548,6 +548,11 @@ final class Merger
 
         $includeUncoveredFiles = $xmlConfiguration->codeCoverage()->includeUncoveredFiles();
 
+        $line = null;
+        if ($cliConfiguration->hasLine()) {
+            $line = $cliConfiguration->line();
+        }
+
         return new Configuration(
             $configurationFile,
             $bootstrap,
@@ -634,7 +639,8 @@ final class Merger
             $randomOrderSeed,
             $includeUncoveredFiles,
             $xmlValidationErrors,
-            $warnings
+            $warnings,
+            $line
         );
     }
 }

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -599,11 +599,18 @@ final class TestRunner
             !$this->configuration->hasGroups() &&
             !$this->configuration->hasExcludeGroups() &&
             !$this->configuration->hasTestsCovering() &&
-            !$this->configuration->hasTestsUsing()) {
+            !$this->configuration->hasTestsUsing() &&
+            !$this->configuration->hasLine()) {
             return;
         }
 
         $filterFactory = new Factory;
+
+        if ($this->configuration->hasLine()) {
+            $filterFactory->addLineFilter(
+                $this->configuration->line()
+            );
+        }
 
         if ($this->configuration->hasExcludeGroups()) {
             $filterFactory->addExcludeGroupFilter(

--- a/tests/end-to-end/filter-line-dataprovided.phpt
+++ b/tests/end-to-end/filter-line-dataprovided.phpt
@@ -1,0 +1,18 @@
+--TEST--
+phpunit ../../_files/DataProviderFilterTest.php:39
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/DataProviderFilterTest.php:39';
+
+require_once __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Application::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+....                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+OK (4 tests, 4 assertions)

--- a/tests/end-to-end/filter-line.phpt
+++ b/tests/end-to-end/filter-line.phpt
@@ -1,0 +1,18 @@
+--TEST--
+phpunit ../../_files/BankAccountTest.php:46
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/BankAccountTest.php:46';
+
+require_once __DIR__ . '/../bootstrap.php';
+PHPUnit\TextUI\Application::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/unit/Framework/TestBuilderTest.php
+++ b/tests/unit/Framework/TestBuilderTest.php
@@ -20,7 +20,7 @@ final class TestBuilderTest extends TestCase
 {
     public function testCreateWithEmptyData(): void
     {
-        $test = (new TestBuilder)->build(new ReflectionClass(EmptyDataProviderTest::class), 'testCase');
+        $test = (new TestBuilder)->build(new ReflectionClass(EmptyDataProviderTest::class), 'testCase', 24);
         $this->assertInstanceOf(DataProviderTestSuite::class, $test);
         /* @var DataProviderTestSuite $test */
         $this->assertInstanceOf(SkippedTestCase::class, $test->getGroupDetails()['default'][0]);
@@ -31,7 +31,7 @@ final class TestBuilderTest extends TestCase
      */
     public function testWithAnnotations(string $methodName): void
     {
-        $test = (new TestBuilder)->build(new ReflectionClass(TestWithAnnotations::class), $methodName);
+        $test = (new TestBuilder)->build(new ReflectionClass(TestWithAnnotations::class), $methodName, 0);
         $this->assertInstanceOf(TestWithAnnotations::class, $test);
     }
 
@@ -49,7 +49,7 @@ final class TestBuilderTest extends TestCase
      */
     public function testWithAnnotationsAndDataProvider(string $methodName): void
     {
-        $test = (new TestBuilder)->build(new ReflectionClass(TestWithAnnotations::class), $methodName);
+        $test = (new TestBuilder)->build(new ReflectionClass(TestWithAnnotations::class), $methodName, 0);
         $this->assertInstanceOf(DataProviderTestSuite::class, $test);
     }
 


### PR DESCRIPTION
## tl; dr;
This PR intends to introduce possiblity to run a single test through its line number : `phpunit test/Foo/BarTest.php:42`


---

Hello,

Being able to quickly run a single test is probably the feature I miss the most in phpunit.

Currently, I know of 2 ways to do it, either using `--filter <testName>` or `--groups`.

Unfortunately, I personnaly feel this is not easy, as it requires me to copy/paste values from my editor to the command line.

[PhpSpec has a neat option to execute a single test by specifying its line number.](https://github.com/phpspec/phpspec/blob/main/docs/cookbook/console.rst#run-command)

This PR ports this feature into PHPUnit (check the [filter-line.phpt](https://github.com/sebastianbergmann/phpunit/pull/4777/files#diff-cc8d1051a0dc9a2b4dab76c1340e31585b59fb3a3963ddbeca5b24b32c31e1f8) test case)*.

The testsuite is not passing yet, as I wanted to first gather feedbacks about such feature.

I haven't been able to find any related issue/PR, so feel free to add any if you know that one already exists!

*The port is actually not that identical. PhpSpec allows to specify any line between the first and end line of the test method. This port allows to only specify the first line.