### PR TITLE
(doc) TestCase::$backupStaticAttributes can be NULL.

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -137,7 +137,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     protected $backupStaticAttributesBlacklist = [];
 
     /**
-     * @var bool
+     * @var bool|null
      */
     protected $runTestInSeparateProcess;
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -127,7 +127,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     protected $backupGlobalsBlacklist = [];
 
     /**
-     * @var bool
+     * @var bool|null
      */
     protected $backupStaticAttributes;
 


### PR DESCRIPTION
I found this minor issue with psalm on a custom project that uses phpunit.

> psalm: PropertyNotSetInConstructor: Property Donquixote\QuickAttributes\Tests\ClassesTest::$backupStaticAttributes is not defined in constructor of Donquixote\QuickAttributes\Tests\ClassesTest or in any methods called in the constructor

Psalm is correct. Either the property type must allow null, or the property must be initialized in the constructor.
(or in a method that could be seen as equivalent to the constructor..)

I am branching this from 8.5 so that it can be merged both into 8.5 and 9.5.