### PR TITLE
Make it easier to register multiple subscribers at once

### DIFF
--- a/src/Event/Facade.php
+++ b/src/Event/Facade.php
@@ -30,6 +30,17 @@ final class Facade
      * @throws EventFacadeIsSealedException
      * @throws UnknownSubscriberTypeException
      */
+    public static function registerSubscribers(Subscriber ...$subscribers): void
+    {
+        foreach ($subscribers as $subscriber) {
+            self::registerSubscriber($subscriber);
+        }
+    }
+
+    /**
+     * @throws EventFacadeIsSealedException
+     * @throws UnknownSubscriberTypeException
+     */
     public static function registerSubscriber(Subscriber $subscriber): void
     {
         if (self::$sealed) {

--- a/src/Logging/JUnit/JunitXmlLogger.php
+++ b/src/Logging/JUnit/JunitXmlLogger.php
@@ -293,17 +293,19 @@ final class JunitXmlLogger
      */
     private function registerSubscribers(bool $reportRiskyTests): void
     {
-        Facade::registerSubscriber(new TestSuiteStartedSubscriber($this));
-        Facade::registerSubscriber(new TestSuiteFinishedSubscriber($this));
-        Facade::registerSubscriber(new TestPreparedSubscriber($this));
-        Facade::registerSubscriber(new TestPrintedOutputSubscriber($this));
-        Facade::registerSubscriber(new TestFinishedSubscriber($this));
-        Facade::registerSubscriber(new TestPassedWithWarningSubscriber($this));
-        Facade::registerSubscriber(new TestErroredSubscriber($this));
-        Facade::registerSubscriber(new TestFailedSubscriber($this));
-        Facade::registerSubscriber(new TestAbortedSubscriber($this));
-        Facade::registerSubscriber(new TestSkippedSubscriber($this));
-        Facade::registerSubscriber(new AssertionMadeSubscriber($this));
+        Facade::registerSubscribers(
+            new TestSuiteStartedSubscriber($this),
+            new TestSuiteFinishedSubscriber($this),
+            new TestPreparedSubscriber($this),
+            new TestPrintedOutputSubscriber($this),
+            new TestFinishedSubscriber($this),
+            new TestPassedWithWarningSubscriber($this),
+            new TestErroredSubscriber($this),
+            new TestFailedSubscriber($this),
+            new TestAbortedSubscriber($this),
+            new TestSkippedSubscriber($this),
+            new AssertionMadeSubscriber($this)
+        );
 
         if ($reportRiskyTests) {
             Facade::registerSubscriber(new TestConsideredRiskySubscriber($this));

--- a/src/Runner/ResultCache/ResultCacheHandler.php
+++ b/src/Runner/ResultCache/ResultCacheHandler.php
@@ -142,15 +142,17 @@ final class ResultCacheHandler
      */
     private function registerSubscribers(): void
     {
-        Facade::registerSubscriber(new TestSuiteStartedSubscriber($this));
-        Facade::registerSubscriber(new TestSuiteFinishedSubscriber($this));
-        Facade::registerSubscriber(new TestPreparedSubscriber($this));
-        Facade::registerSubscriber(new TestAbortedSubscriber($this));
-        Facade::registerSubscriber(new TestConsideredRiskySubscriber($this));
-        Facade::registerSubscriber(new TestErroredSubscriber($this));
-        Facade::registerSubscriber(new TestFailedSubscriber($this));
-        Facade::registerSubscriber(new TestPassedWithWarningSubscriber($this));
-        Facade::registerSubscriber(new TestSkippedSubscriber($this));
-        Facade::registerSubscriber(new TestFinishedSubscriber($this));
+        Facade::registerSubscribers(
+            new TestSuiteStartedSubscriber($this),
+            new TestSuiteFinishedSubscriber($this),
+            new TestPreparedSubscriber($this),
+            new TestAbortedSubscriber($this),
+            new TestConsideredRiskySubscriber($this),
+            new TestErroredSubscriber($this),
+            new TestFailedSubscriber($this),
+            new TestPassedWithWarningSubscriber($this),
+            new TestSkippedSubscriber($this),
+            new TestFinishedSubscriber($this)
+        );
     }
 }


### PR DESCRIPTION
This change makes it much easier to register multiple subscribers with a single method call.