### PR TITLE
Add warning to MockBuilder::setMethods() about deprecated method

### DIFF
--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -208,6 +208,8 @@ final class MockBuilder
      */
     public function setMethods(?array $methods = null): self
     {
+        $this->createWarning('setMethods() and setMethodsExcept() methods are deprecated and will be removed in PHPUnit 10. Refactor your code to use addMethods() and onlyMethods() instead.');
+
         if ($methods === null) {
             $this->methods = $methods;
         } else {
@@ -512,5 +514,25 @@ final class MockBuilder
         $this->returnValueGeneration = false;
 
         return $this;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private function createWarning(string $warning): void
+    {
+        foreach (debug_backtrace() as $step) {
+            if (!isset($step['object']) || !$step['object'] instanceof TestCase) {
+                continue;
+            }
+
+            if ($step['function'] === 'createPartialMock') {
+                return;
+            }
+
+            $step['object']->addWarning($warning);
+
+            return;
+        }
     }
 }

--- a/tests/_files/TestWithDifferentStatuses.php
+++ b/tests/_files/TestWithDifferentStatuses.php
@@ -60,4 +60,16 @@ final class TestWithDifferentStatuses extends TestCase
 
         $this->assertNull($mock->mockableMethod());
     }
+
+    public function testWithSetMethodsWarning(): void
+    {
+        $mockBuilder = $this->getMockBuilder(Mockable::class);
+        $mockBuilder->setMethods(['mockableMethod', 'anotherMockableMethod']);
+    }
+
+    public function testWithSetMethodsExceptWarning(): void
+    {
+        $mockBuilder = $this->getMockBuilder(Mockable::class);
+        $mockBuilder->setMethodsExcept(['mockableMethod', 'anotherMockableMethod']);
+    }
 }

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -44,15 +44,6 @@ final class MockBuilderTest extends TestCase
         $this->assertTrue($mock->anotherMockableMethod());
     }
 
-    public function testSetMethodsAllowsNonExistentMethodNames(): void
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethodWithCrazyName'])
-                     ->getMock();
-
-        $this->assertNull($mock->mockableMethodWithCrazyName());
-    }
-
     public function testOnlyMethodsWithNonExistentMethodNames(): void
     {
         $this->expectException(CannotUseOnlyMethodsException::class);
@@ -137,58 +128,6 @@ final class MockBuilderTest extends TestCase
 
         $this->assertNull($mock->mockableMethodWithFakeMethod());
         $this->assertNull($mock->mockableMethod());
-    }
-
-    public function testAbleToUseSetMethodsAfterOnlyMethods(): void
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-                     ->onlyMethods(['mockableMethod'])
-                     ->setMethods(['mockableMethodWithCrazyName'])
-                     ->getMock();
-
-        $this->assertNull($mock->mockableMethodWithCrazyName());
-    }
-
-    public function testAbleToUseSetMethodsAfterAddMethods(): void
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-                     ->addMethods(['notAMethod'])
-                     ->setMethods(['mockableMethodWithCrazyName'])
-                     ->getMock();
-
-        $this->assertNull($mock->mockableMethodWithCrazyName());
-    }
-
-    public function testAbleToUseAddMethodsAfterSetMethods(): void
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethod'])
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->getMock();
-
-        $this->assertNull($mock->mockableMethod());
-        $this->assertNull($mock->mockableMethodWithFakeMethod());
-    }
-
-    public function testAbleToUseOnlyMethodsAfterSetMethods(): void
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethodWithFakeMethod'])
-                     ->onlyMethods(['mockableMethod'])
-                     ->getMock();
-
-        $this->assertNull($mock->mockableMethod());
-        $this->assertNull($mock->mockableMethodWithFakeMethod());
-    }
-
-    public function testAbleToUseAddMethodsAfterSetMethodsWithNull(): void
-    {
-        $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods()
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->getMock();
-
-        $this->assertNull($mock->mockableMethodWithFakeMethod());
     }
 
     public function testByDefaultDoesNotPassArgumentsToTheConstructor(): void

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -1317,6 +1317,26 @@ class TestCaseTest extends TestCase
         $this->assertCount(1, $result);
     }
 
+    public function testMockBuilderSetMethodsWarning(): void
+    {
+        $test = new TestWithDifferentStatuses('testWithSetMethodsWarning');
+
+        $test->run();
+
+        $this->assertSame(BaseTestRunner::STATUS_WARNING, $test->getStatus());
+        $this->assertFalse($test->hasFailed());
+    }
+
+    public function testMockBuilderSetMethodsExceptWarning(): void
+    {
+        $test = new TestWithDifferentStatuses('testWithSetMethodsExceptWarning');
+
+        $test->run();
+
+        $this->assertSame(BaseTestRunner::STATUS_WARNING, $test->getStatus());
+        $this->assertFalse($test->hasFailed());
+    }
+
     /**
      * @return array<string, array>
      */


### PR DESCRIPTION
It's my very first PR to the PHPUnit project, so any suggestions are welcomed.

These changes are referring to the #4775 issue. Until now, there is no warning about the deprecated `setMethods()` method.

Problem I had was that `TestCase::createPartialMock()` still using `MockBuilder::setMethods()` and I'm not sure if it's possible to refactor code to use `onlyMethods()` & `addMethods()` instead. I decided to exclude warning for this specific use case.