### PR TITLE
Fixed missing the assert diff message of phpt in a teamcity output

### DIFF
--- a/src/Framework/Exception/ComparisonFailureContains.php
+++ b/src/Framework/Exception/ComparisonFailureContains.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * The exception, which implement this interface contains a
+ * SebastianBergmann\Comparator\ComparisonFailure which is used to
+ * generate diff output of the failed expectations.
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+interface ComparisonFailureContains
+{
+    public function getComparisonFailure(): ?ComparisonFailure;
+}

--- a/src/Framework/Exception/ExpectationFailedException.php
+++ b/src/Framework/Exception/ExpectationFailedException.php
@@ -21,7 +21,7 @@ use SebastianBergmann\Comparator\ComparisonFailure;
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class ExpectationFailedException extends AssertionFailedError
+final class ExpectationFailedException extends AssertionFailedError implements ComparisonFailureContains
 {
     /**
      * @var ComparisonFailure

--- a/src/Framework/Exception/PHPTAssertionFailedError.php
+++ b/src/Framework/Exception/PHPTAssertionFailedError.php
@@ -9,24 +9,26 @@
  */
 namespace PHPUnit\Framework;
 
+use SebastianBergmann\Comparator\ComparisonFailure;
+
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class PHPTAssertionFailedError extends SyntheticError
+final class PHPTAssertionFailedError extends SyntheticError implements ComparisonFailureContains
 {
     /**
-     * @var string
+     * @var ComparisonFailure|null
      */
-    private $diff;
+    private $comparisonFailure;
 
-    public function __construct(string $message, int $code, string $file, int $line, array $trace, string $diff)
+    public function __construct(string $message, int $code, string $file, int $line, array $trace, ?ComparisonFailure $comparisonFailure)
     {
         parent::__construct($message, $code, $file, $line, $trace);
-        $this->diff = $diff;
+        $this->comparisonFailure = $comparisonFailure;
     }
 
-    public function getDiff(): string
+    public function getComparisonFailure(): ?ComparisonFailure
     {
-        return $this->diff;
+        return $this->comparisonFailure;
     }
 }

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -43,12 +43,8 @@ final class TestFailure
         if ($e instanceof SelfDescribing) {
             $buffer = $e->toString();
 
-            if ($e instanceof ExpectationFailedException && $e->getComparisonFailure()) {
+            if ($e instanceof ComparisonFailureContains && $e->getComparisonFailure()) {
                 $buffer .= $e->getComparisonFailure()->getDiff();
-            }
-
-            if ($e instanceof PHPTAssertionFailedError) {
-                $buffer .= $e->getDiff();
             }
 
             if (!empty($buffer)) {

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -223,7 +223,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                     $trace[0]['file'],
                     $trace[0]['line'],
                     $trace,
-                    $comparisonFailure ? $diff : ''
+                    $comparisonFailure
                 );
             }
 

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -23,8 +23,8 @@ use function round;
 use function str_replace;
 use function stripos;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ComparisonFailureContains;
 use PHPUnit\Framework\ExceptionWrapper;
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestFailure;
@@ -101,7 +101,7 @@ final class TeamCity extends DefaultResultPrinter
             'duration' => self::toMilliseconds($time),
         ];
 
-        if ($e instanceof ExpectationFailedException) {
+        if ($e instanceof ComparisonFailureContains) {
             $comparisonFailure = $e->getComparisonFailure();
 
             if ($comparisonFailure instanceof ComparisonFailure) {

--- a/tests/end-to-end/loggers/log-teamcity-failed-phpt-expect.phpt
+++ b/tests/end-to-end/loggers/log-teamcity-failed-phpt-expect.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit --teamcity  ../../fail/fail-expect.phpt
+--DESCRIPTION--
+Check that teamcity logger correctly print fails with Actual\Expected attributes
+on phpt tests with `--EXPECT--` section
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--teamcity';
+$_SERVER['argv'][] = \realpath(__DIR__ . '/../../fail/fail-expect.phpt');
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+##teamcity[testCount count='1' flowId='%d']
+
+##teamcity[testStarted name='%s' flowId='%d']
+
+##teamcity[testFailed name='%sfail%efail-expect.phpt' message='Failed asserting that two strings are equal.' details='%s' duration='%s' type='comparisonFailure' actual='|'Foo\n|nMultiline diff\n|nBuzz|'' expected='|'Foo\n|nMultiline\n|nBuzz|'' flowId='%s']
+
+##teamcity[testFinished name='%s' duration='%d' flowId='%d']
+
+
+Time: %s, Memory: %s
+
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/end-to-end/loggers/log-teamcity-failed-phpt-expectf.phpt
+++ b/tests/end-to-end/loggers/log-teamcity-failed-phpt-expectf.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit --teamcity  ../../fail/fail-expectf.phpt
+--DESCRIPTION--
+Check that teamcity logger correctly print fails with Actual\Expected attributes
+on phpt tests with `--EXPECTF--` section
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--teamcity';
+$_SERVER['argv'][] = \realpath(__DIR__ . '/../../fail/fail-expectf.phpt');
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+##teamcity[testCount count='1' flowId='%d']
+
+##teamcity[testStarted name='%s' flowId='%d']
+
+##teamcity[testFailed name='%sfail%efail-expectf.phpt' message='Failed asserting that string matches format description.' details='%s' duration='%s' type='comparisonFailure' actual='Foo|nMultiline diff|nBuzz' expected='Foo|nMultiline|nBuzz' flowId='%s']
+
+##teamcity[testFinished name='%s' duration='%d' flowId='%d']
+
+
+Time: %s, Memory: %s
+
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/tests/fail/fail-expect.phpt
+++ b/tests/fail/fail-expect.phpt
@@ -1,5 +1,10 @@
 --TEST--
 // This test intentionally fails and it is checked by Travis.
 --FILE--
---EXPECTF--
-unexpected
+Foo
+Multiline diff
+Buzz
+--EXPECT--
+Foo
+Multiline
+Buzz

--- a/tests/fail/fail-expectf.phpt
+++ b/tests/fail/fail-expectf.phpt
@@ -1,0 +1,10 @@
+--TEST--
+// This test intentionally fails and it is checked by Travis.
+--FILE--
+Foo
+Multiline diff
+Buzz
+--EXPECTF--
+%s
+Multiline
+%s

--- a/tests/unit/Framework/Constraint/StringMatchesFormatDescriptionTest.php
+++ b/tests/unit/Framework/Constraint/StringMatchesFormatDescriptionTest.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use const DIRECTORY_SEPARATOR;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestFailure;
 
 /**
  * @small
@@ -276,7 +277,7 @@ Failed asserting that string matches format description.
  *
 
 EOD;
-            $this->assertEquals($expected, $e->getMessage());
+            $this->assertEquals($expected, TestFailure::exceptionToString($e));
         }
     }
 }


### PR DESCRIPTION
Hi! 

1. I've added missed diff output in case of failure phpt test in `--teamcity` configuration, 
when phpt scenario contains `--EXPECT--` section.
2. I've put the diff output in case of failure phpt test with section `--EXPECTF--` into the same style as `--EXPECT--`.


## Background

PHPUnit 9.5, **failed** test scenarious in `*.phpt` files, output in `--teamcity` 
Note:  `--teamcity` output is also used by PHPStorm, so all screenshot examples are taken from it.

![image](https://user-images.githubusercontent.com/2703238/143475340-1cb41229-458f-415f-8212-c306b1648243.png)

As you can see:
1.  `--EXPECT--` and `--EXPECTF--` output is different. 
2. `<Click to see difference>` tool is absent


## First attempt

In the first attempt  https://github.com/sebastianbergmann/phpunit/commit/1086fedd4ea3df6ba6320a7d93cd33afecff4b2b I connected missed `--EXPECT--` diff to the message, in the same style, as it had been done for `--EXPECTF--` 

Pros: 
- That were small code changes 

Cons: 
- Diff was printed as plained text, i.e. the tool `<Click to see difference>` still hadn't work

### First attempt result, the `<Click to see difference>` was absent:
![image](https://user-images.githubusercontent.com/2703238/143478111-3747e162-65f4-463e-9c37-5e2d1dc33cb1.png)


## Second attempt (current version)

I  founded, that  PHPStorm can work with diff in prettier way (you can see how common `PHPUnit\Framework\TestCase` works on top of screenshots), and I started to investigate. 
I've discovered the following: 
* `PHPTAssertionFailedError` is not consistent with `ExpectationFailedException`, which works perfect in `PHPUnit\Framework\TestCase` test cases. 
* `PHPTAssertionFailedError` displayed information in message for `--EXPECTF--`, because of  https://github.com/sebastianbergmann/phpunit/pull/3659 
* Difference in `--EXPECT--` and `--EXPECTF--` exists because  phpunit uses different  constraints: `StringMatchesFormatDescription`  and `IsEqual`. The first one used it's own `attach diff in message` implementation. 

So, I fixed all of them together, because they are coupled. What has been done:
1. Now `StringMatchesFormatDescription` works with expected diff as other classes: manipulates with `ComparisonFailure` object. I used the same idea of implementation as in `JsonMatches` constraint. 
2. Interface `ComparisonFailureContains` has been created, to have possibility to accept `ComparisonFailure` object from both classes: `PHPTAssertionFailedError` and `ExpectationFailedException`
3. Added two end-to-end logger tests  for both `--EXPECT--` and `--EXPECTF--` cases. 

### In comparison with First attempt fix: 
Pros: 
- both phpt scenarios `--EXPECT--` and `--EXPECTF--` have `<Click to see difference>`
- framework class `src/Framework/TestFailure.php`  became  independed from `PHPTAssertionFailedError` 
- `StringMatchesFormatDescription` works with `ComparisonFailure`  as all others.
 
Cons: 
- More changes

## Second attempt result:
![image](https://user-images.githubusercontent.com/2703238/143480312-88493498-2095-4594-94f1-77e60a45f3e4.png)




### Questions to maintainers: 
* Please, let me know which solution is okay for PHPUnit, the First or the Second.
* Please, let me know whether I should do additional patches? And for which branches? This is 9.5 branch. Are patches in 8.5 enough? Or master also is required? Sorry, it is my very first PR in this repo, so I can't figure out whether this pr is a bugfix or a  new feature

Thanks! 