### PR TITLE
Fix: Unwrap data set name

### DIFF
--- a/src/Event/Value/Test/TestMethod.php
+++ b/src/Event/Value/Test/TestMethod.php
@@ -137,7 +137,7 @@ final class TestMethod extends Test
             return $this->methodName;
         }
 
-        $dataSetName = $this->testData->dataFromDataProvider();
+        $dataSetName = $this->testData->dataFromDataProvider()->dataSetName();
 
         if (is_int($dataSetName)) {
             $dataSetName = sprintf(

--- a/tests/unit/Event/Value/TestMethodTest.php
+++ b/tests/unit/Event/Value/TestMethodTest.php
@@ -9,9 +9,11 @@
  */
 namespace PHPUnit\Event\Code;
 
+use PHPUnit\Event\DataFromDataProvider;
 use PHPUnit\Event\TestDataCollection;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\MetadataCollection;
+use PHPUnit\Util\ExportedVariable;
 
 /**
  * @covers \PHPUnit\Event\Code\TestMethod
@@ -42,5 +44,79 @@ final class TestMethodTest extends TestCase
         $this->assertSame($line, $test->line());
         $this->assertSame($metadata, $test->metadata());
         $this->assertSame($testData, $test->testData());
+    }
+
+    public function testNameReturnsNameWhenTestDoesNotHaveDataFromDataProvider(): void
+    {
+        $test = new TestMethod(
+            'ExampleTest',
+            'testExample',
+            'ExampleTest.php',
+            1,
+            MetadataCollection::fromArray([]),
+            TestDataCollection::fromArray([])
+        );
+
+        $this->assertSame($test->methodName(), $test->name());
+    }
+
+    public function testNameReturnsNameWhenTestHasDataFromDataProviderAndDataSetNameIsInt(): void
+    {
+        $dataSetName = 9000;
+
+        $test = new TestMethod(
+            'ExampleTest',
+            'testExample',
+            'ExampleTest.php',
+            1,
+            MetadataCollection::fromArray([]),
+            TestDataCollection::fromArray([
+                DataFromDataProvider::from(
+                    $dataSetName,
+                    ExportedVariable::from(
+                        'foo',
+                        false
+                    )
+                ),
+            ])
+        );
+
+        $expected = sprintf(
+            '%s with data set #%d',
+            $test->methodName(),
+            $dataSetName
+        );
+
+        $this->assertSame($expected, $test->name());
+    }
+
+    public function testNameReturnsNameWhenTestHasDataFromDataProviderAndDataSetNameIsString(): void
+    {
+        $dataSetName = 'bar-9000';
+
+        $test = new TestMethod(
+            'ExampleTest',
+            'testExample',
+            'ExampleTest.php',
+            1,
+            MetadataCollection::fromArray([]),
+            TestDataCollection::fromArray([
+                DataFromDataProvider::from(
+                    $dataSetName,
+                    ExportedVariable::from(
+                        'foo',
+                        false
+                    )
+                ),
+            ])
+        );
+
+        $expected = sprintf(
+            '%s with data set "%s"',
+            $test->methodName(),
+            $dataSetName
+        );
+
+        $this->assertSame($expected, $test->name());
     }
 }


### PR DESCRIPTION
This pull request

- [x] asserts that the name of `TestMethod` is assembled as expected
- [x] unwraps the data set name before passing it to a condition and `sprintf()`