### PR TITLE
Enhancement: Configure `class_attributes_separation` fixer to use `only_if_meta` option for `property` element

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -73,7 +73,7 @@ $config->setFinder($finder)
             'elements' => [
                 'const' => 'one',
                 'method' => 'one',
-                'property' => 'one'
+                'property' => 'only_if_meta'
             ]
         ],
         'class_definition' => true,

--- a/src/Event/Dispatcher/DeferredDispatcher.php
+++ b/src/Event/Dispatcher/DeferredDispatcher.php
@@ -15,9 +15,7 @@ namespace PHPUnit\Event;
 final class DeferredDispatcher implements SubscribableDispatcher
 {
     private SubscribableDispatcher $dispatcher;
-
     private EventCollection $events;
-
     private bool $recording = true;
 
     public function __construct(SubscribableDispatcher $dispatcher)

--- a/src/Event/Emitter/DispatchingEmitter.php
+++ b/src/Event/Emitter/DispatchingEmitter.php
@@ -27,13 +27,9 @@ use SebastianBergmann\GlobalState\Snapshot;
 final class DispatchingEmitter implements Emitter
 {
     private Dispatcher $dispatcher;
-
     private Telemetry\System $system;
-
     private Telemetry\Snapshot $startSnapshot;
-
     private Telemetry\Snapshot $previousSnapshot;
-
     private bool $testExecutionStarted = false;
 
     public function __construct(Dispatcher $dispatcher, Telemetry\System $system)

--- a/src/Event/Events/EventCollectionIterator.php
+++ b/src/Event/Events/EventCollectionIterator.php
@@ -21,7 +21,6 @@ final class EventCollectionIterator implements Iterator
      * @psalm-var list<Event>
      */
     private array $events;
-
     private int $position = 0;
 
     public function __construct(EventCollection $events)

--- a/src/Event/Events/GlobalState/Captured.php
+++ b/src/Event/Events/GlobalState/Captured.php
@@ -19,7 +19,6 @@ use SebastianBergmann\GlobalState\Snapshot;
 final class Captured implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Snapshot $snapshot;
 
     public function __construct(Telemetry\Info $telemetryInfo, Snapshot $snapshot)

--- a/src/Event/Events/GlobalState/Modified.php
+++ b/src/Event/Events/GlobalState/Modified.php
@@ -21,11 +21,8 @@ use SebastianBergmann\GlobalState\Snapshot;
 final class Modified implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Snapshot $snapshotBefore;
-
     private Snapshot $snapshotAfter;
-
     private string $diff;
 
     public function __construct(Telemetry\Info $telemetryInfo, Snapshot $snapshotBefore, Snapshot $snapshotAfter, string $diff)

--- a/src/Event/Events/GlobalState/Restored.php
+++ b/src/Event/Events/GlobalState/Restored.php
@@ -19,7 +19,6 @@ use SebastianBergmann\GlobalState\Snapshot;
 final class Restored implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Snapshot $snapshot;
 
     public function __construct(Telemetry\Info $telemetryInfo, Snapshot $snapshot)

--- a/src/Event/Events/Test/Aborted.php
+++ b/src/Event/Events/Test/Aborted.php
@@ -22,9 +22,7 @@ use PHPUnit\Event\Telemetry;
 final class Aborted implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private Throwable $throwable;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, Throwable $throwable)

--- a/src/Event/Events/Test/AfterLastTestMethodCalled.php
+++ b/src/Event/Events/Test/AfterLastTestMethodCalled.php
@@ -25,7 +25,6 @@ final class AfterLastTestMethodCalled implements Event
      * @psalm-var class-string
      */
     private string $testClassName;
-
     private Code\ClassMethod $calledMethod;
 
     /**

--- a/src/Event/Events/Test/AfterTestMethodCalled.php
+++ b/src/Event/Events/Test/AfterTestMethodCalled.php
@@ -25,7 +25,6 @@ final class AfterTestMethodCalled implements Event
      * @psalm-var class-string
      */
     private string $testClassName;
-
     private Code\ClassMethod $calledMethod;
 
     /**

--- a/src/Event/Events/Test/AssertionMade.php
+++ b/src/Event/Events/Test/AssertionMade.php
@@ -20,13 +20,9 @@ use SebastianBergmann\Exporter\Exporter;
 final class AssertionMade implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private mixed $value;
-
     private Constraint\Constraint $constraint;
-
     private string $message;
-
     private bool $hasFailed;
 
     public function __construct(Telemetry\Info $telemetryInfo, mixed $value, Constraint\Constraint $constraint, string $message, bool $hasFailed)

--- a/src/Event/Events/Test/BeforeFirstTestMethodCalled.php
+++ b/src/Event/Events/Test/BeforeFirstTestMethodCalled.php
@@ -25,7 +25,6 @@ final class BeforeFirstTestMethodCalled implements Event
      * @psalm-var class-string
      */
     private string $testClassName;
-
     private Code\ClassMethod $calledMethod;
 
     /**

--- a/src/Event/Events/Test/BeforeTestMethodCalled.php
+++ b/src/Event/Events/Test/BeforeTestMethodCalled.php
@@ -25,7 +25,6 @@ final class BeforeTestMethodCalled implements Event
      * @psalm-var class-string
      */
     private string $testClassName;
-
     private Code\ClassMethod $calledMethod;
 
     /**

--- a/src/Event/Events/Test/ConsideredRisky.php
+++ b/src/Event/Events/Test/ConsideredRisky.php
@@ -22,9 +22,7 @@ use PHPUnit\Event\Telemetry;
 final class ConsideredRisky implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private Throwable $throwable;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, Throwable $throwable)

--- a/src/Event/Events/Test/DeprecatedFeatureUsed.php
+++ b/src/Event/Events/Test/DeprecatedFeatureUsed.php
@@ -20,13 +20,9 @@ use PHPUnit\Event\Telemetry;
 final class DeprecatedFeatureUsed implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Test $test;
-
     private string $message;
-
     private string $file;
-
     private int $line;
 
     public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message, string $file, int $line)

--- a/src/Event/Events/Test/DeprecatedPhpFeatureUsed.php
+++ b/src/Event/Events/Test/DeprecatedPhpFeatureUsed.php
@@ -20,13 +20,9 @@ use PHPUnit\Event\Telemetry;
 final class DeprecatedPhpFeatureUsed implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Test $test;
-
     private string $message;
-
     private string $file;
-
     private int $line;
 
     public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message, string $file, int $line)

--- a/src/Event/Events/Test/DeprecatedPhpunitFeatureUsed.php
+++ b/src/Event/Events/Test/DeprecatedPhpunitFeatureUsed.php
@@ -20,9 +20,7 @@ use PHPUnit\Event\Telemetry;
 final class DeprecatedPhpunitFeatureUsed implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Test $test;
-
     private string $message;
 
     public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message)

--- a/src/Event/Events/Test/Errored.php
+++ b/src/Event/Events/Test/Errored.php
@@ -22,9 +22,7 @@ use PHPUnit\Event\Telemetry;
 final class Errored implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private Throwable $throwable;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, Throwable $throwable)

--- a/src/Event/Events/Test/Failed.php
+++ b/src/Event/Events/Test/Failed.php
@@ -22,9 +22,7 @@ use PHPUnit\Event\Telemetry;
 final class Failed implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private Throwable $throwable;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, Throwable $throwable)

--- a/src/Event/Events/Test/Finished.php
+++ b/src/Event/Events/Test/Finished.php
@@ -20,9 +20,7 @@ use PHPUnit\Event\Telemetry;
 final class Finished implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private int $numberOfAssertionsPerformed;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, int $numberOfAssertionsPerformed)

--- a/src/Event/Events/Test/OutputPrinted.php
+++ b/src/Event/Events/Test/OutputPrinted.php
@@ -21,9 +21,7 @@ use PHPUnit\Event\Telemetry;
 final class OutputPrinted implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private string $output;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, string $output)

--- a/src/Event/Events/Test/Passed.php
+++ b/src/Event/Events/Test/Passed.php
@@ -20,7 +20,6 @@ use PHPUnit\Event\Telemetry;
 final class Passed implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test)

--- a/src/Event/Events/Test/PassedWithWarning.php
+++ b/src/Event/Events/Test/PassedWithWarning.php
@@ -22,9 +22,7 @@ use PHPUnit\Event\Telemetry;
 final class PassedWithWarning implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private Throwable $throwable;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, Throwable $throwable)

--- a/src/Event/Events/Test/PostConditionCalled.php
+++ b/src/Event/Events/Test/PostConditionCalled.php
@@ -25,7 +25,6 @@ final class PostConditionCalled implements Event
      * @psalm-var class-string
      */
     private string $testClassName;
-
     private Code\ClassMethod $calledMethod;
 
     /**

--- a/src/Event/Events/Test/PreConditionCalled.php
+++ b/src/Event/Events/Test/PreConditionCalled.php
@@ -25,7 +25,6 @@ final class PreConditionCalled implements Event
      * @psalm-var class-string
      */
     private string $testClassName;
-
     private Code\ClassMethod $calledMethod;
 
     /**

--- a/src/Event/Events/Test/Prepared.php
+++ b/src/Event/Events/Test/Prepared.php
@@ -20,7 +20,6 @@ use PHPUnit\Event\Telemetry;
 final class Prepared implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test)

--- a/src/Event/Events/Test/Skipped.php
+++ b/src/Event/Events/Test/Skipped.php
@@ -23,11 +23,8 @@ use PHPUnit\Event\Telemetry;
 final class Skipped implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Code\Test $test;
-
     private ?Throwable $throwable;
-
     private string $message;
 
     public function __construct(Telemetry\Info $telemetryInfo, Code\Test $test, ?Throwable $throwable, string $message)

--- a/src/Event/Events/TestDouble/MockObjectCreatedFromWsdl.php
+++ b/src/Event/Events/TestDouble/MockObjectCreatedFromWsdl.php
@@ -19,7 +19,6 @@ use PHPUnit\Event\Telemetry;
 final class MockObjectCreatedFromWsdl implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private string $wsdlFile;
 
     /**
@@ -36,9 +35,7 @@ final class MockObjectCreatedFromWsdl implements Event
      * @psalm-var list<string>
      */
     private array $methods;
-
     private bool $callOriginalConstructor;
-
     private array $options;
 
     /**

--- a/src/Event/Events/TestDouble/TestProxyCreated.php
+++ b/src/Event/Events/TestDouble/TestProxyCreated.php
@@ -24,7 +24,6 @@ final class TestProxyCreated implements Event
      * @psalm-var class-string
      */
     private string $className;
-
     private array $constructorArguments;
 
     /**

--- a/src/Event/Events/TestRunner/BootstrapFinished.php
+++ b/src/Event/Events/TestRunner/BootstrapFinished.php
@@ -19,7 +19,6 @@ use PHPUnit\Event\Telemetry;
 final class BootstrapFinished implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private string $filename;
 
     public function __construct(Telemetry\Info $telemetryInfo, string $filename)

--- a/src/Event/Events/TestRunner/Configured.php
+++ b/src/Event/Events/TestRunner/Configured.php
@@ -19,7 +19,6 @@ use PHPUnit\TextUI\Configuration\Configuration;
 final class Configured implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Configuration $configuration;
 
     public function __construct(Telemetry\Info $telemetryInfo, Configuration $configuration)

--- a/src/Event/Events/TestRunner/ExecutionStarted.php
+++ b/src/Event/Events/TestRunner/ExecutionStarted.php
@@ -20,7 +20,6 @@ use PHPUnit\Event\TestSuite\TestSuite;
 final class ExecutionStarted implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private TestSuite $testSuite;
 
     public function __construct(Telemetry\Info $telemetryInfo, TestSuite $testSuite)

--- a/src/Event/Events/TestRunner/ExtensionLoaded.php
+++ b/src/Event/Events/TestRunner/ExtensionLoaded.php
@@ -19,9 +19,7 @@ use PHPUnit\Event\Telemetry;
 final class ExtensionLoaded implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private string $name;
-
     private string $version;
 
     public function __construct(Telemetry\Info $telemetryInfo, string $name, string $version)

--- a/src/Event/Events/TestRunner/Started.php
+++ b/src/Event/Events/TestRunner/Started.php
@@ -20,7 +20,6 @@ use PHPUnit\Event\Telemetry;
 final class Started implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private Runtime $runtime;
 
     public function __construct(Telemetry\Info $telemetryInfo, Runtime $runtime)

--- a/src/Event/Events/TestSuite/Filtered.php
+++ b/src/Event/Events/TestSuite/Filtered.php
@@ -19,7 +19,6 @@ use PHPUnit\Event\Telemetry;
 final class Filtered implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private TestSuite $testSuite;
 
     public function __construct(Telemetry\Info $telemetryInfo, TestSuite $testSuite)

--- a/src/Event/Events/TestSuite/Finished.php
+++ b/src/Event/Events/TestSuite/Finished.php
@@ -19,9 +19,7 @@ use PHPUnit\Event\Telemetry;
 final class Finished implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private TestSuite $testSuite;
-
     private Result $result;
 
     public function __construct(Telemetry\Info $telemetryInfo, TestSuite $testSuite, Result $result)

--- a/src/Event/Events/TestSuite/Loaded.php
+++ b/src/Event/Events/TestSuite/Loaded.php
@@ -19,7 +19,6 @@ use PHPUnit\Event\Telemetry;
 final class Loaded implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private TestSuite $testSuite;
 
     public function __construct(Telemetry\Info $telemetryInfo, TestSuite $testSuite)

--- a/src/Event/Events/TestSuite/Sorted.php
+++ b/src/Event/Events/TestSuite/Sorted.php
@@ -18,11 +18,8 @@ use PHPUnit\Event\Telemetry;
 final class Sorted implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private int $executionOrder;
-
     private int $executionOrderDefects;
-
     private bool $resolveDependencies;
 
     public function __construct(Telemetry\Info $telemetryInfo, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies)

--- a/src/Event/Events/TestSuite/Started.php
+++ b/src/Event/Events/TestSuite/Started.php
@@ -19,7 +19,6 @@ use PHPUnit\Event\Telemetry;
 final class Started implements Event
 {
     private Telemetry\Info $telemetryInfo;
-
     private TestSuite $testSuite;
 
     public function __construct(Telemetry\Info $telemetryInfo, TestSuite $testSuite)

--- a/src/Event/Facade.php
+++ b/src/Event/Facade.php
@@ -16,15 +16,11 @@ use PHPUnit\Event\Telemetry\HRTime;
  */
 final class Facade
 {
-    private static ?TypeMap $typeMap = null;
-
-    private static ?Emitter $emitter = null;
-
-    private static ?Emitter $suspended = null;
-
+    private static ?TypeMap $typeMap                       = null;
+    private static ?Emitter $emitter                       = null;
+    private static ?Emitter $suspended                     = null;
     private static ?DeferredDispatcher $deferredDispatcher = null;
-
-    private static bool $sealed = false;
+    private static bool $sealed                            = false;
 
     /**
      * @throws EventFacadeIsSealedException

--- a/src/Event/Value/ClassMethod.php
+++ b/src/Event/Value/ClassMethod.php
@@ -19,7 +19,6 @@ final class ClassMethod
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Event/Value/Failure.php
+++ b/src/Event/Value/Failure.php
@@ -18,7 +18,6 @@ use Throwable;
 final class Failure
 {
     private string $testName;
-
     private Throwable $throwable;
 
     public function __construct(string $testName, Throwable $throwable)

--- a/src/Event/Value/Telemetry/Duration.php
+++ b/src/Event/Value/Telemetry/Duration.php
@@ -20,7 +20,6 @@ use InvalidArgumentException;
 final class Duration
 {
     private int $seconds;
-
     private int $nanoseconds;
 
     /**

--- a/src/Event/Value/Telemetry/HRTime.php
+++ b/src/Event/Value/Telemetry/HRTime.php
@@ -18,7 +18,6 @@ use PHPUnit\Event\InvalidArgumentException;
 final class HRTime
 {
     private int $seconds;
-
     private int $nanoseconds;
 
     /**

--- a/src/Event/Value/Telemetry/Info.php
+++ b/src/Event/Value/Telemetry/Info.php
@@ -16,13 +16,9 @@ namespace PHPUnit\Event\Telemetry;
 final class Info
 {
     private Snapshot $current;
-
     private Duration $durationSinceStart;
-
     private MemoryUsage $memorySinceStart;
-
     private Duration $durationSincePrevious;
-
     private MemoryUsage $memorySincePrevious;
 
     public function __construct(Snapshot $current, Duration $durationSinceStart, MemoryUsage $memorySinceStart, Duration $durationSincePrevious, MemoryUsage $memorySincePrevious)

--- a/src/Event/Value/Telemetry/Snapshot.php
+++ b/src/Event/Value/Telemetry/Snapshot.php
@@ -16,9 +16,7 @@ namespace PHPUnit\Event\Telemetry;
 final class Snapshot
 {
     private HRTime $time;
-
     private MemoryUsage $memoryUsage;
-
     private MemoryUsage $peakMemoryUsage;
 
     public function __construct(HRTime $time, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage)

--- a/src/Event/Value/Telemetry/System.php
+++ b/src/Event/Value/Telemetry/System.php
@@ -15,7 +15,6 @@ namespace PHPUnit\Event\Telemetry;
 final class System
 {
     private StopWatch $stopWatch;
-
     private MemoryMeter $memoryMeter;
 
     public function __construct(StopWatch $stopWatch, MemoryMeter $memoryMeter)

--- a/src/Event/Value/Test/TestCollectionIterator.php
+++ b/src/Event/Value/Test/TestCollectionIterator.php
@@ -21,7 +21,6 @@ final class TestCollectionIterator implements Iterator
      * @psalm-var list<Test>
      */
     private array $tests;
-
     private int $position = 0;
 
     public function __construct(TestCollection $tests)

--- a/src/Event/Value/Test/TestMethod.php
+++ b/src/Event/Value/Test/TestMethod.php
@@ -35,13 +35,9 @@ final class TestMethod extends Test
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
-
     private int $line;
-
     private MetadataCollection $metadata;
-
     private TestDataCollection $testData;
 
     public static function fromTestCase(TestCase $testCase): self

--- a/src/Event/Value/TestData/TestDataCollection.php
+++ b/src/Event/Value/TestData/TestDataCollection.php
@@ -21,7 +21,6 @@ final class TestDataCollection implements Countable, IteratorAggregate
      * @psalm-var list<TestData>
      */
     private array $data;
-
     private ?DataFromDataProvider $fromDataProvider = null;
 
     /**

--- a/src/Event/Value/TestData/TestDataCollectionIterator.php
+++ b/src/Event/Value/TestData/TestDataCollectionIterator.php
@@ -21,7 +21,6 @@ final class TestDataCollectionIterator implements Iterator
      * @psalm-var list<TestData>
      */
     private array $data;
-
     private int $position = 0;
 
     public function __construct(TestDataCollection $data)

--- a/src/Event/Value/TestSuite/FailureCollectionIterator.php
+++ b/src/Event/Value/TestSuite/FailureCollectionIterator.php
@@ -22,7 +22,6 @@ final class FailureCollectionIterator implements Iterator
      * @psalm-var list<Failure>
      */
     private array $failures;
-
     private int $position = 0;
 
     public function __construct(FailureCollection $failures)

--- a/src/Event/Value/TestSuite/Result.php
+++ b/src/Event/Value/TestSuite/Result.php
@@ -15,19 +15,12 @@ namespace PHPUnit\Event\TestSuite;
 final class Result
 {
     private int $count;
-
     private FailureCollection $errors;
-
     private FailureCollection $failures;
-
     private FailureCollection $notImplemented;
-
     private FailureCollection $risky;
-
     private FailureCollection $skipped;
-
     private FailureCollection $warnings;
-
     private array $passed;
 
     /**

--- a/src/Event/Value/TestSuite/TestSuite.php
+++ b/src/Event/Value/TestSuite/TestSuite.php
@@ -28,7 +28,6 @@ use ReflectionMethod;
 abstract class TestSuite
 {
     private string $name;
-
     private int $count;
 
     /**
@@ -45,9 +44,7 @@ abstract class TestSuite
      * @psalm-var list<ExecutionOrderDependency>
      */
     private array $requires;
-
     private string $sortId;
-
     private TestCollection $tests;
 
     /**

--- a/src/Event/Value/TestSuite/TestSuiteForTestClass.php
+++ b/src/Event/Value/TestSuite/TestSuiteForTestClass.php
@@ -20,9 +20,7 @@ final class TestSuiteForTestClass extends TestSuite
      * @psalm-var class-string
      */
     private string $className;
-
     private string $file;
-
     private int $line;
 
     /**

--- a/src/Event/Value/TestSuite/TestSuiteForTestMethodWithDataProvider.php
+++ b/src/Event/Value/TestSuite/TestSuiteForTestMethodWithDataProvider.php
@@ -20,11 +20,8 @@ final class TestSuiteForTestMethodWithDataProvider extends TestSuite
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
-
     private string $file;
-
     private int $line;
 
     /**

--- a/src/Event/Value/Throwable.php
+++ b/src/Event/Value/Throwable.php
@@ -24,13 +24,9 @@ final class Throwable
      * @psalm-var class-string
      */
     private string $className;
-
     private string $message;
-
     private string $description;
-
     private string $stackTrace;
-
     private ?Throwable $previous;
 
     public static function from(\Throwable $t): self

--- a/src/Framework/Attributes/DataProviderExternal.php
+++ b/src/Framework/Attributes/DataProviderExternal.php
@@ -21,7 +21,6 @@ final class DataProviderExternal
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Framework/Attributes/DependsExternal.php
+++ b/src/Framework/Attributes/DependsExternal.php
@@ -21,7 +21,6 @@ final class DependsExternal
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Framework/Attributes/DependsExternalUsingDeepClone.php
+++ b/src/Framework/Attributes/DependsExternalUsingDeepClone.php
@@ -21,7 +21,6 @@ final class DependsExternalUsingDeepClone
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Framework/Attributes/DependsExternalUsingShallowClone.php
+++ b/src/Framework/Attributes/DependsExternalUsingShallowClone.php
@@ -21,7 +21,6 @@ final class DependsExternalUsingShallowClone
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Framework/Attributes/ExcludeStaticPropertyFromBackup.php
+++ b/src/Framework/Attributes/ExcludeStaticPropertyFromBackup.php
@@ -21,7 +21,6 @@ final class ExcludeStaticPropertyFromBackup
      * @psalm-var class-string
      */
     private string $className;
-
     private string $propertyName;
 
     /**

--- a/src/Framework/Attributes/RequiresMethod.php
+++ b/src/Framework/Attributes/RequiresMethod.php
@@ -21,7 +21,6 @@ final class RequiresMethod
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Framework/Attributes/RequiresPhpExtension.php
+++ b/src/Framework/Attributes/RequiresPhpExtension.php
@@ -18,7 +18,6 @@ use Attribute;
 final class RequiresPhpExtension
 {
     private string $extension;
-
     private ?string $versionRequirement;
 
     public function __construct(string $extension, ?string $versionRequirement = null)

--- a/src/Framework/Attributes/RequiresSetting.php
+++ b/src/Framework/Attributes/RequiresSetting.php
@@ -18,7 +18,6 @@ use Attribute;
 final class RequiresSetting
 {
     private string $setting;
-
     private string $value;
 
     public function __construct(string $setting, string $value)

--- a/src/Framework/Constraint/Equality/IsEqual.php
+++ b/src/Framework/Constraint/Equality/IsEqual.php
@@ -23,11 +23,8 @@ use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 final class IsEqual extends Constraint
 {
     private mixed $value;
-
     private float $delta;
-
     private bool $canonicalize;
-
     private bool $ignoreCase;
 
     public function __construct(mixed $value, float $delta = 0.0, bool $canonicalize = false, bool $ignoreCase = false)

--- a/src/Framework/Constraint/Equality/IsEqualWithDelta.php
+++ b/src/Framework/Constraint/Equality/IsEqualWithDelta.php
@@ -21,7 +21,6 @@ use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 final class IsEqualWithDelta extends Constraint
 {
     private mixed $value;
-
     private float $delta;
 
     public function __construct(mixed $value, float $delta)

--- a/src/Framework/Constraint/Object/ObjectEquals.php
+++ b/src/Framework/Constraint/Object/ObjectEquals.php
@@ -25,7 +25,6 @@ use ReflectionObject;
 final class ObjectEquals extends Constraint
 {
     private object $expected;
-
     private string $method;
 
     public function __construct(object $object, string $method = 'equals')

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -22,9 +22,7 @@ use function strtr;
 final class StringContains extends Constraint
 {
     private string $string;
-
     private bool $ignoreCase;
-
     private bool $ignoreLineEndings;
 
     public function __construct(string $string, bool $ignoreCase = false, bool $ignoreLineEndings = false)

--- a/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
+++ b/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\ExpectationFailedException;
 final class TraversableContainsOnly extends Constraint
 {
     private Constraint $constraint;
-
     private string $type;
 
     /**

--- a/src/Framework/Constraint/Type/IsType.php
+++ b/src/Framework/Constraint/Type/IsType.php
@@ -114,7 +114,6 @@ final class IsType extends Constraint
         'callable'          => true,
         'iterable'          => true,
     ];
-
     private string $type;
 
     /**

--- a/src/Framework/DataProviderTestSuite.php
+++ b/src/Framework/DataProviderTestSuite.php
@@ -21,8 +21,7 @@ final class DataProviderTestSuite extends TestSuite
     /**
      * @psalm-var list<ExecutionOrderDependency>
      */
-    private array $dependencies = [];
-
+    private array $dependencies   = [];
     private ?array $providedTests = null;
 
     /**

--- a/src/Framework/ErrorTestCase.php
+++ b/src/Framework/ErrorTestCase.php
@@ -20,7 +20,6 @@ final class ErrorTestCase extends TestCase
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -31,7 +31,6 @@ final class ExceptionWrapper extends Exception
      * @psalm-var class-string
      */
     protected string $className;
-
     protected ?ExceptionWrapper $previous = null;
 
     public function __construct(Throwable $t)

--- a/src/Framework/ExecutionOrderDependency.php
+++ b/src/Framework/ExecutionOrderDependency.php
@@ -23,12 +23,9 @@ use PHPUnit\Metadata\DependsOnMethod;
  */
 final class ExecutionOrderDependency
 {
-    private string $className = '';
-
+    private string $className  = '';
     private string $methodName = '';
-
     private bool $shallowClone;
-
     private bool $deepClone;
 
     public static function invalid(): self

--- a/src/Framework/IncompleteTestCase.php
+++ b/src/Framework/IncompleteTestCase.php
@@ -18,9 +18,7 @@ final class IncompleteTestCase extends TestCase
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
-
     private string $message;
 
     /**

--- a/src/Framework/MockObject/Api/Api.php
+++ b/src/Framework/MockObject/Api/Api.php
@@ -21,11 +21,8 @@ trait Api
      * @psalm-var list<ConfigurableMethod>
      */
     private static array $__phpunit_configurableMethods;
-
     private object $__phpunit_originalObject;
-
-    private bool $__phpunit_returnValueGeneration = true;
-
+    private bool $__phpunit_returnValueGeneration          = true;
     private ?InvocationHandler $__phpunit_invocationMocker = null;
 
     /** @noinspection MagicMethodsValidityInspection */

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -44,7 +44,6 @@ use Throwable;
 final class InvocationMocker implements InvocationStubber, MethodNameMatch
 {
     private InvocationHandler $invocationHandler;
-
     private Matcher $matcher;
 
     /**

--- a/src/Framework/MockObject/ConfigurableMethod.php
+++ b/src/Framework/MockObject/ConfigurableMethod.php
@@ -17,7 +17,6 @@ use SebastianBergmann\Type\Type;
 final class ConfigurableMethod
 {
     private string $name;
-
     private Type $returnType;
 
     public function __construct(string $name, Type $returnType)

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -76,7 +76,6 @@ final class Generator
         '__clone'         => true,
         '__halt_compiler' => true,
     ];
-
     private static array $cache = [];
 
     /**

--- a/src/Framework/MockObject/Invocation.php
+++ b/src/Framework/MockObject/Invocation.php
@@ -33,17 +33,11 @@ use Throwable;
 final class Invocation implements SelfDescribing
 {
     private string $className;
-
     private string $methodName;
-
     private array $parameters;
-
     private string $returnType;
-
     private bool $isReturnTypeNullable = false;
-
     private bool $proxiedCall;
-
     private object $object;
 
     public function __construct(string $className, string $methodName, array $parameters, string $returnType, object $object, bool $cloneObjects = false, bool $proxiedCall = false)

--- a/src/Framework/MockObject/InvocationHandler.php
+++ b/src/Framework/MockObject/InvocationHandler.php
@@ -34,9 +34,7 @@ final class InvocationHandler
      * @psalm-var list<ConfigurableMethod>
      */
     private array $configurableMethods;
-
     private bool $returnValueGeneration;
-
     private ?ReturnValueNotConfiguredException $deferredError = null;
 
     /**

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -28,16 +28,11 @@ use PHPUnit\Framework\TestFailure;
 final class Matcher
 {
     private InvocationOrder $invocationRule;
-
-    private ?string $afterMatchBuilderId = null;
-
+    private ?string $afterMatchBuilderId     = null;
     private bool $afterMatchBuilderIsInvoked = false;
-
-    private ?MethodName $methodNameRule = null;
-
-    private ?ParametersRule $parametersRule = null;
-
-    private ?Stub $stub = null;
+    private ?MethodName $methodNameRule      = null;
+    private ?ParametersRule $parametersRule  = null;
+    private ?Stub $stub                      = null;
 
     public function __construct(InvocationOrder $rule)
     {

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -21,33 +21,19 @@ use ReflectionClass;
 final class MockBuilder
 {
     private TestCase $testCase;
-
     private string $type;
-
-    private ?array $methods = [];
-
-    private bool $emptyMethodsArray = false;
-
-    private string $mockClassName = '';
-
-    private array $constructorArgs = [];
-
-    private bool $originalConstructor = true;
-
-    private bool $originalClone = true;
-
-    private bool $autoload = true;
-
-    private bool $cloneArguments = false;
-
-    private bool $callOriginalMethods = false;
-
-    private ?object $proxyTarget = null;
-
+    private ?array $methods                = [];
+    private bool $emptyMethodsArray        = false;
+    private string $mockClassName          = '';
+    private array $constructorArgs         = [];
+    private bool $originalConstructor      = true;
+    private bool $originalClone            = true;
+    private bool $autoload                 = true;
+    private bool $cloneArguments           = false;
+    private bool $callOriginalMethods      = false;
+    private ?object $proxyTarget           = null;
     private bool $allowMockingUnknownTypes = true;
-
-    private bool $returnValueGeneration = true;
-
+    private bool $returnValueGeneration    = true;
     private Generator $generator;
 
     /**

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -32,27 +32,16 @@ use SebastianBergmann\Type\UnknownType;
 final class MockMethod
 {
     use TemplateLoader;
-
     private string $className;
-
     private string $methodName;
-
     private bool $cloneArguments;
-
     private string $modifier;
-
     private string $argumentsForDeclaration;
-
     private string $argumentsForCall;
-
     private Type $returnType;
-
     private string $reference;
-
     private bool $callOriginalMethod;
-
     private bool $static;
-
     private ?string $deprecation;
 
     /**

--- a/src/Framework/MockObject/Rule/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Rule/ConsecutiveParameters.php
@@ -25,8 +25,7 @@ use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
 final class ConsecutiveParameters implements ParametersRule
 {
     private array $parameterGroups = [];
-
-    private array $invocations = [];
+    private array $invocations     = [];
 
     /**
      * @throws \PHPUnit\Framework\Exception

--- a/src/Framework/MockObject/Rule/Parameters.php
+++ b/src/Framework/MockObject/Rule/Parameters.php
@@ -26,10 +26,8 @@ final class Parameters implements ParametersRule
     /**
      * @psalm-var list<Constraint>
      */
-    private array $parameters = [];
-
+    private array $parameters           = [];
     private ?BaseInvocation $invocation = null;
-
     private null|bool|ExpectationFailedException $parameterVerificationResult;
 
     /**

--- a/src/Framework/MockObject/Stub/ConsecutiveCalls.php
+++ b/src/Framework/MockObject/Stub/ConsecutiveCalls.php
@@ -20,7 +20,6 @@ use SebastianBergmann\Exporter\Exporter;
 final class ConsecutiveCalls implements Stub
 {
     private array $stack;
-
     private mixed $value;
 
     public function __construct(array $stack)

--- a/src/Framework/SkippedTestCase.php
+++ b/src/Framework/SkippedTestCase.php
@@ -18,9 +18,7 @@ final class SkippedTestCase extends TestCase
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
-
     private string $message;
 
     /**

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -111,50 +111,35 @@ use Throwable;
 abstract class TestCase extends Assert implements Reorderable, SelfDescribing, Test
 {
     private const LOCALE_CATEGORIES = [LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME];
-
-    private ?bool $backupGlobals = null;
+    private ?bool $backupGlobals    = null;
 
     /**
      * @psalm-var list<string>
      */
     private array $backupGlobalsExcludeList = [];
-
-    private ?bool $backupStaticProperties = null;
+    private ?bool $backupStaticProperties   = null;
 
     /**
      * @psalm-var array<string,list<class-string>>
      */
     private array $backupStaticPropertiesExcludeList = [];
-
     private ?bool $beStrictAboutChangesToGlobalState = false;
-
-    private ?Snapshot $snapshot = null;
-
-    private ?bool $runClassInSeparateProcess = null;
-
-    private ?bool $runTestInSeparateProcess = null;
-
-    private bool $preserveGlobalState = false;
-
-    private bool $inIsolation = false;
-
-    private ?string $expectedException = null;
-
-    private ?string $expectedExceptionMessage = null;
-
-    private ?string $expectedExceptionMessageRegExp = null;
-
-    private null|int|string $expectedExceptionCode = null;
+    private ?Snapshot $snapshot                      = null;
+    private ?bool $runClassInSeparateProcess         = null;
+    private ?bool $runTestInSeparateProcess          = null;
+    private bool $preserveGlobalState                = false;
+    private bool $inIsolation                        = false;
+    private ?string $expectedException               = null;
+    private ?string $expectedExceptionMessage        = null;
+    private ?string $expectedExceptionMessageRegExp  = null;
+    private null|int|string $expectedExceptionCode   = null;
 
     /**
      * @psalm-var list<ExecutionOrderDependency>
      */
     private array $providedTests = [];
-
-    private array $data = [];
-
+    private array $data          = [];
     private int|string $dataName = '';
-
     private string $name;
 
     /**
@@ -165,17 +150,14 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @psalm-var list<ExecutionOrderDependency>
      */
-    private array $dependencies = [];
-
+    private array $dependencies    = [];
     private array $dependencyInput = [];
 
     /**
      * @psalm-var array<string,string>
      */
-    private array $iniSettings = [];
-
-    private array $locale = [];
-
+    private array $iniSettings                  = [];
+    private array $locale                       = [];
     private ?MockGenerator $mockObjectGenerator = null;
 
     /**
@@ -186,45 +168,31 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @psalm-var list<class-string>
      */
-    private array $doubledTypes = [];
-
+    private array $doubledTypes                                   = [];
     private bool $registerMockObjectsFromTestArgumentsRecursively = false;
-
-    private ?TestResult $result = null;
-
+    private ?TestResult $result                                   = null;
     private TestStatus $status;
-
     private int $numberOfAssertionsPerformed = 0;
-
-    private mixed $testResult = null;
-
-    private string $output = '';
-
-    private ?string $outputExpectedRegex = null;
-
-    private ?string $outputExpectedString = null;
-
-    private bool $outputBufferingActive = false;
-
+    private mixed $testResult                = null;
+    private string $output                   = '';
+    private ?string $outputExpectedRegex     = null;
+    private ?string $outputExpectedString    = null;
+    private bool $outputBufferingActive      = false;
     private int $outputBufferingLevel;
-
     private bool $outputRetrievedForAssertion = false;
 
     /**
      * @psalm-var list<string>
      */
-    private array $warnings = [];
-
+    private array $warnings                = [];
     private bool $doesNotPerformAssertions = false;
 
     /**
      * @psalm-var list<Comparator>
      */
-    private array $customComparators = [];
-
+    private array $customComparators                         = [];
     private ?Event\Code\TestMethod $testValueObjectForEvents = null;
-
-    private bool $wasPrepared = false;
+    private bool $wasPrepared                                = false;
 
     /**
      * Returns a matcher that matches when the method is executed

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -20,9 +20,7 @@ use Throwable;
 final class TestFailure
 {
     private ?Test $failedTest = null;
-
     private Throwable $thrownException;
-
     private string $testName;
 
     /**

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -31,8 +31,7 @@ final class TestResult implements Countable
     /**
      * @psalm-var list<string>
      */
-    private array $passedTestClasses = [];
-
+    private array $passedTestClasses     = [];
     private bool $currentTestSuiteFailed = false;
 
     /**
@@ -68,54 +67,30 @@ final class TestResult implements Countable
     /**
      * @psalm-var list<TestListener>
      */
-    private array $listeners = [];
-
-    private int $runTests = 0;
-
-    private float $time = 0;
-
-    private bool $convertDeprecationsToExceptions = false;
-
-    private bool $convertErrorsToExceptions = true;
-
-    private bool $convertNoticesToExceptions = true;
-
-    private bool $convertWarningsToExceptions = true;
-
-    private bool $stop = false;
-
-    private bool $stopOnError = false;
-
-    private bool $stopOnFailure = false;
-
-    private bool $stopOnWarning = false;
-
-    private bool $beStrictAboutTestsThatDoNotTestAnything = true;
-
-    private bool $beStrictAboutOutputDuringTests = false;
-
-    private bool $enforceTimeLimit = false;
-
-    private bool $requireCoverageMetadata = false;
-
-    private int $timeoutForSmallTests = 1;
-
-    private int $timeoutForMediumTests = 10;
-
-    private int $timeoutForLargeTests = 60;
-
-    private bool $stopOnRisky = false;
-
-    private bool $stopOnIncomplete = false;
-
-    private bool $stopOnSkipped = false;
-
-    private bool $lastTestFailed = false;
-
-    private int $defaultTimeLimit = 0;
-
-    private bool $stopOnDefect = false;
-
+    private array $listeners                                      = [];
+    private int $runTests                                         = 0;
+    private float $time                                           = 0;
+    private bool $convertDeprecationsToExceptions                 = false;
+    private bool $convertErrorsToExceptions                       = true;
+    private bool $convertNoticesToExceptions                      = true;
+    private bool $convertWarningsToExceptions                     = true;
+    private bool $stop                                            = false;
+    private bool $stopOnError                                     = false;
+    private bool $stopOnFailure                                   = false;
+    private bool $stopOnWarning                                   = false;
+    private bool $beStrictAboutTestsThatDoNotTestAnything         = true;
+    private bool $beStrictAboutOutputDuringTests                  = false;
+    private bool $enforceTimeLimit                                = false;
+    private bool $requireCoverageMetadata                         = false;
+    private int $timeoutForSmallTests                             = 1;
+    private int $timeoutForMediumTests                            = 10;
+    private int $timeoutForLargeTests                             = 60;
+    private bool $stopOnRisky                                     = false;
+    private bool $stopOnIncomplete                                = false;
+    private bool $stopOnSkipped                                   = false;
+    private bool $lastTestFailed                                  = false;
+    private int $defaultTimeLimit                                 = 0;
+    private bool $stopOnDefect                                    = false;
     private bool $registerMockObjectsFromTestArgumentsRecursively = false;
 
     /**

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -53,8 +53,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     /**
      * Enable or disable the backup and restoration of static attributes.
      */
-    protected ?bool $backupStaticProperties = null;
-
+    protected ?bool $backupStaticProperties  = null;
     protected bool $runTestInSeparateProcess = false;
 
     /**
@@ -72,20 +71,16 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     /**
      * The number of tests in the test suite.
      */
-    protected int $numTests = -1;
-
+    protected int $numTests         = -1;
     protected ?array $requiredTests = null;
 
     /**
      * @psalm-var list<Test>
      */
-    private array $tests = [];
-
-    private ?array $providedTests = null;
-
+    private array $tests                             = [];
+    private ?array $providedTests                    = null;
     private ?bool $beStrictAboutChangesToGlobalState = null;
-
-    private ?Factory $iteratorFilter = null;
+    private ?Factory $iteratorFilter                 = null;
 
     /**
      * @psalm-var array<int,string>

--- a/src/Framework/WarningTestCase.php
+++ b/src/Framework/WarningTestCase.php
@@ -18,9 +18,7 @@ final class WarningTestCase extends TestCase
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
-
     private string $message;
 
     /**

--- a/src/Logging/JUnit/JunitXmlLogger.php
+++ b/src/Logging/JUnit/JunitXmlLogger.php
@@ -44,7 +44,6 @@ use SebastianBergmann\Exporter\Exporter;
 final class JunitXmlLogger
 {
     private DOMDocument $document;
-
     private DOMElement $root;
 
     /**
@@ -85,17 +84,12 @@ final class JunitXmlLogger
     /**
      * @psalm-var array<int,int>
      */
-    private array $testSuiteTimes = [0];
-
-    private int $testSuiteLevel = 0;
-
+    private array $testSuiteTimes        = [0];
+    private int $testSuiteLevel          = 0;
     private ?DOMElement $currentTestCase = null;
-
-    private int $numberOfAssertions = 0;
-
-    private ?HRTime $time = null;
-
-    private ?string $output = null;
+    private int $numberOfAssertions      = 0;
+    private ?HRTime $time                = null;
+    private ?string $output              = null;
 
     /**
      * @throws EventFacadeIsSealedException

--- a/src/Logging/TeamCity/TeamCityLogger.php
+++ b/src/Logging/TeamCity/TeamCityLogger.php
@@ -45,9 +45,7 @@ use PHPUnit\Util\Printer;
 final class TeamCityLogger extends Printer
 {
     private bool $isSummaryTestCountPrinted = false;
-
-    private ?HRTime $time = null;
-
+    private ?HRTime $time                   = null;
     private ?int $flowId;
 
     /**

--- a/src/Logging/TestDox/CliTestDoxPrinter.php
+++ b/src/Logging/TestDox/CliTestDoxPrinter.php
@@ -113,7 +113,6 @@ class CliTestDoxPrinter extends TestDoxPrinter
      * @psalm-var list<int>
      */
     private array $nonSuccessfulTestResults = [];
-
     private Timer $timer;
 
     /**

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -57,7 +57,6 @@ final class NamePrettifier
      * @psalm-var list<string>
      */
     private array $strings = [];
-
     private bool $useColor;
 
     public function __construct(bool $useColor = false)

--- a/src/Logging/TestDox/ResultPrinter.php
+++ b/src/Logging/TestDox/ResultPrinter.php
@@ -32,28 +32,17 @@ abstract class ResultPrinter extends Printer implements ResultPrinterInterface
     /**
      * @psalm-var class-string
      */
-    protected ?string $testClass = null;
-
-    protected ?TestStatus $testStatus = null;
-
-    protected array $tests = [];
-
-    protected int $warned = 0;
-
-    protected int $failed = 0;
-
-    protected int $risky = 0;
-
-    protected int $skipped = 0;
-
-    protected int $incomplete = 0;
-
-    protected ?string $currentTestClassPrettified = null;
-
+    protected ?string $testClass                   = null;
+    protected ?TestStatus $testStatus              = null;
+    protected array $tests                         = [];
+    protected int $warned                          = 0;
+    protected int $failed                          = 0;
+    protected int $risky                           = 0;
+    protected int $skipped                         = 0;
+    protected int $incomplete                      = 0;
+    protected ?string $currentTestClassPrettified  = null;
     protected ?string $currentTestMethodPrettified = null;
-
     private array $groups;
-
     private array $excludeGroups;
 
     /**

--- a/src/Logging/TestDox/TestDoxPrinter.php
+++ b/src/Logging/TestDox/TestDoxPrinter.php
@@ -55,8 +55,7 @@ abstract class TestDoxPrinter extends DefaultResultPrinter
      * @psalm-var array<string, int> Lookup table for testname to testResults[index]
      */
     protected array $testNameResultIndex = [];
-
-    protected bool $enableOutputBuffer = false;
+    protected bool $enableOutputBuffer   = false;
 
     /**
      * @psalm-var array<string>
@@ -66,8 +65,7 @@ abstract class TestDoxPrinter extends DefaultResultPrinter
     /**
      * @psalm-var 0|positive-int
      */
-    protected int $spinState = 0;
-
+    protected int $spinState     = 0;
     protected bool $showProgress = true;
 
     /**

--- a/src/Logging/TestDox/XmlResultPrinter.php
+++ b/src/Logging/TestDox/XmlResultPrinter.php
@@ -41,11 +41,8 @@ use Throwable;
 final class XmlResultPrinter extends Printer implements TestListener
 {
     private DOMDocument $document;
-
     private DOMElement $root;
-
     private NamePrettifier $prettifier;
-
     private ?Throwable $exception = null;
 
     /**

--- a/src/Metadata/DataProvider.php
+++ b/src/Metadata/DataProvider.php
@@ -19,7 +19,6 @@ final class DataProvider extends Metadata
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Metadata/DependsOnClass.php
+++ b/src/Metadata/DependsOnClass.php
@@ -19,9 +19,7 @@ final class DependsOnClass extends Metadata
      * @psalm-var class-string
      */
     private string $className;
-
     private bool $deepClone;
-
     private bool $shallowClone;
 
     /**

--- a/src/Metadata/DependsOnMethod.php
+++ b/src/Metadata/DependsOnMethod.php
@@ -19,11 +19,8 @@ final class DependsOnMethod extends Metadata
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
-
     private bool $deepClone;
-
     private bool $shallowClone;
 
     /**

--- a/src/Metadata/ExcludeStaticPropertyFromBackup.php
+++ b/src/Metadata/ExcludeStaticPropertyFromBackup.php
@@ -19,7 +19,6 @@ final class ExcludeStaticPropertyFromBackup extends Metadata
      * @psalm-var class-string
      */
     private string $className;
-
     private string $propertyName;
 
     /**

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -20,7 +20,6 @@ abstract class Metadata
     private const CLASS_LEVEL = 0;
 
     private const METHOD_LEVEL = 1;
-
     private int $level;
 
     public static function after(): After

--- a/src/Metadata/MetadataCollectionIterator.php
+++ b/src/Metadata/MetadataCollectionIterator.php
@@ -21,7 +21,6 @@ final class MetadataCollectionIterator implements Iterator
      * @psalm-var list<Metadata>
      */
     private array $metadata;
-
     private int $position = 0;
 
     public function __construct(MetadataCollection $metadata)

--- a/src/Metadata/Parser/Annotation/DocBlock.php
+++ b/src/Metadata/Parser/Annotation/DocBlock.php
@@ -44,7 +44,6 @@ final class DocBlock
     private const REGEX_REQUIRES_SETTING = '/@requires\s+(?P<name>setting)\s+(?P<setting>([^ ]+?))\s*(?P<value>[\w\.-]+[\w\.]?)?[ \t]*\r?$/m';
 
     private const REGEX_REQUIRES = '/@requires\s+(?P<name>function|extension)\s+(?P<value>([^\s<>=!]+))\s*(?P<operator>[<>=!]{0,2})\s*(?P<version>[\d\.-]+[\d\.]?)?[ \t]*\r?$/m';
-
     private string $docComment;
 
     /**
@@ -63,9 +62,7 @@ final class DocBlock
      * >)
      */
     private ?array $parsedRequirements = null;
-
     private int $startLine;
-
     private string $fileName;
 
     public static function ofClass(ReflectionClass $class): self

--- a/src/Metadata/Parser/CachingParser.php
+++ b/src/Metadata/Parser/CachingParser.php
@@ -17,11 +17,8 @@ use PHPUnit\Metadata\MetadataCollection;
 final class CachingParser implements Parser
 {
     private Parser $reader;
-
-    private array $classCache = [];
-
-    private array $methodCache = [];
-
+    private array $classCache          = [];
+    private array $methodCache         = [];
     private array $classAndMethodCache = [];
 
     public function __construct(Parser $reader)

--- a/src/Metadata/Parser/ParserChain.php
+++ b/src/Metadata/Parser/ParserChain.php
@@ -17,7 +17,6 @@ use PHPUnit\Metadata\MetadataCollection;
 final class ParserChain implements Parser
 {
     private Parser $attributeReader;
-
     private Parser $annotationReader;
 
     public function __construct(Parser $attributeReader, Parser $annotationReader)

--- a/src/Metadata/RequiresMethod.php
+++ b/src/Metadata/RequiresMethod.php
@@ -19,7 +19,6 @@ final class RequiresMethod extends Metadata
      * @psalm-var class-string
      */
     private string $className;
-
     private string $methodName;
 
     /**

--- a/src/Metadata/RequiresPhpExtension.php
+++ b/src/Metadata/RequiresPhpExtension.php
@@ -18,7 +18,6 @@ use PHPUnit\Metadata\Version\Requirement;
 final class RequiresPhpExtension extends Metadata
 {
     private string $extension;
-
     private ?Requirement $versionRequirement;
 
     protected function __construct(int $level, string $extension, ?Requirement $versionRequirement)

--- a/src/Metadata/RequiresSetting.php
+++ b/src/Metadata/RequiresSetting.php
@@ -16,7 +16,6 @@ namespace PHPUnit\Metadata;
 final class RequiresSetting extends Metadata
 {
     private string $setting;
-
     private string $value;
 
     protected function __construct(int $level, string $setting, string $value)

--- a/src/Metadata/Version/ComparisonRequirement.php
+++ b/src/Metadata/Version/ComparisonRequirement.php
@@ -20,7 +20,6 @@ use PHPUnit\Util\VersionComparisonOperator;
 final class ComparisonRequirement extends Requirement
 {
     private string $version;
-
     private VersionComparisonOperator $operator;
 
     public function __construct(string $version, VersionComparisonOperator $operator)

--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -20,10 +20,8 @@ use SebastianBergmann\CodeCoverage\Filter;
 final class CodeCoverage
 {
     private static ?\SebastianBergmann\CodeCoverage\CodeCoverage $instance = null;
-
-    private static ?Driver $driver = null;
-
-    private static bool $collecting = false;
+    private static ?Driver $driver                                         = null;
+    private static bool $collecting                                        = false;
 
     /**
      * @throws Exception

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -31,9 +31,7 @@ use RecursiveIterator;
 final class NameFilterIterator extends RecursiveFilterIterator
 {
     private ?string $filter = null;
-
     private ?int $filterMin = null;
-
     private ?int $filterMax = null;
 
     /**

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -67,9 +67,7 @@ use Throwable;
 final class PhptTestCase implements Reorderable, SelfDescribing, Test
 {
     private string $filename;
-
     private AbstractPhpProcess $phpUtil;
-
     private string $output = '';
 
     /**

--- a/src/Runner/PlainTextTracer.php
+++ b/src/Runner/PlainTextTracer.php
@@ -25,7 +25,6 @@ use PHPUnit\Event\Tracer\Tracer;
 final class PlainTextTracer implements Tracer
 {
     private string $path;
-
     private bool $includeTelemetryInfo;
 
     public function __construct(string $path, bool $includeTelemetryInfo)

--- a/src/Runner/ResultCache/DefaultResultCache.php
+++ b/src/Runner/ResultCache/DefaultResultCache.php
@@ -35,7 +35,6 @@ final class DefaultResultCache implements ResultCache
      * @var string
      */
     private const DEFAULT_RESULT_CACHE_FILENAME = '.phpunit.result.cache';
-
     private string $cacheFilename;
 
     /**

--- a/src/Runner/ResultCache/ResultCacheHandler.php
+++ b/src/Runner/ResultCache/ResultCacheHandler.php
@@ -32,9 +32,7 @@ use PHPUnit\Framework\TestStatus\TestStatus;
 final class ResultCacheHandler
 {
     private ResultCache $cache;
-
-    private ?HRTime $time = null;
-
+    private ?HRTime $time  = null;
     private int $testSuite = 0;
 
     /**

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -85,7 +85,6 @@ final class TestSuiteSorter
      * @psalm-var array<string, int> Associative array of (string => DEFECT_SORT_WEIGHT) elements
      */
     private array $defectSortOrder = [];
-
     private ResultCache $cache;
 
     /**

--- a/src/Runner/Version.php
+++ b/src/Runner/Version.php
@@ -22,8 +22,7 @@ use SebastianBergmann\Version as VersionId;
 final class Version
 {
     private static string $pharVersion = '';
-
-    private static string $version = '';
+    private static string $version     = '';
 
     /**
      * Returns the current version of PHPUnit.

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -65,10 +65,8 @@ final class Application
     /**
      * @psalm-var array<string,mixed>
      */
-    private array $longOptions = [];
-
-    private bool $versionStringPrinted = false;
-
+    private array $longOptions                  = [];
+    private bool $versionStringPrinted          = false;
     private ?XmlConfiguration $xmlConfiguration = null;
 
     /**

--- a/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
@@ -23,7 +23,6 @@ use XMLWriter;
 final class ListTestsAsXmlCommand implements Command
 {
     private string $filename;
-
     private TestSuite $suite;
 
     public function __construct(string $filename, TestSuite $suite)

--- a/src/TextUI/Command/Result.php
+++ b/src/TextUI/Command/Result.php
@@ -17,7 +17,6 @@ namespace PHPUnit\TextUI\Command;
 final class Result
 {
     private string $output;
-
     private bool $success;
 
     public static function from(string $output = '', bool $success = true): self

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -16,179 +16,92 @@ namespace PHPUnit\TextUI\CliArguments;
 final class Configuration
 {
     private ?string $argument;
-
     private ?string $atLeastVersion;
-
     private ?bool $backupGlobals;
-
     private ?bool $backupStaticProperties;
-
     private ?bool $beStrictAboutChangesToGlobalState;
-
     private ?string $bootstrap;
-
     private ?string $cacheDirectory;
-
     private ?bool $cacheResult;
-
     private ?string $cacheResultFile;
-
     private ?bool $checkVersion;
-
     private ?string $colors;
-
     private null|int|string $columns;
-
     private ?string $configuration;
-
     private ?array $coverageFilter;
-
     private ?string $coverageClover;
-
     private ?string $coverageCobertura;
-
     private ?string $coverageCrap4J;
-
     private ?string $coverageHtml;
-
     private ?string $coveragePhp;
-
     private ?string $coverageText;
-
     private ?bool $coverageTextShowUncoveredFiles;
-
     private ?bool $coverageTextShowOnlySummary;
-
     private ?string $coverageXml;
-
     private ?bool $pathCoverage;
-
     private ?string $coverageCacheDirectory;
-
     private ?bool $warmCoverageCache;
-
     private ?int $defaultTimeLimit;
-
     private ?bool $disableCodeCoverageIgnore;
-
     private ?bool $disallowTestOutput;
-
     private ?bool $enforceTimeLimit;
-
     private ?array $excludeGroups;
-
     private ?int $executionOrder;
-
     private ?int $executionOrderDefects;
-
     private ?bool $failOnEmptyTestSuite;
-
     private ?bool $failOnIncomplete;
-
     private ?bool $failOnRisky;
-
     private ?bool $failOnSkipped;
-
     private ?bool $failOnWarning;
-
     private ?string $filter;
-
     private ?bool $generateConfiguration;
-
     private ?bool $migrateConfiguration;
-
     private ?array $groups;
-
     private ?array $testsCovering;
-
     private ?array $testsUsing;
-
     private ?bool $help;
-
     private ?string $includePath;
-
     private ?array $iniSettings;
-
     private ?string $junitLogfile;
-
     private ?bool $listGroups;
-
     private ?bool $listSuites;
-
     private ?bool $listTests;
-
     private ?string $listTestsXml;
-
     private ?bool $noCoverage;
-
     private ?bool $noExtensions;
-
     private ?bool $noInteraction;
-
     private ?bool $noOutput;
-
     private ?bool $noLogging;
-
     private ?bool $processIsolation;
-
     private ?int $randomOrderSeed;
-
     private ?int $repeat;
-
     private ?bool $reportUselessTests;
-
     private ?bool $resolveDependencies;
-
     private ?bool $reverseList;
-
     private ?bool $stderr;
-
     private ?bool $strictCoverage;
-
     private ?bool $stopOnDefect;
-
     private ?bool $stopOnError;
-
     private ?bool $stopOnFailure;
-
     private ?bool $stopOnIncomplete;
-
     private ?bool $stopOnRisky;
-
     private ?bool $stopOnSkipped;
-
     private ?bool $stopOnWarning;
-
     private ?string $teamcityLogfile;
-
     private ?bool $teamCityPrinter;
-
     private ?array $testdoxExcludeGroups;
-
     private ?array $testdoxGroups;
-
     private ?string $testdoxHtmlFile;
-
     private ?string $testdoxTextFile;
-
     private ?string $testdoxXmlFile;
-
     private ?bool $testdoxPrinter;
-
     private ?array $testSuffixes;
-
     private ?string $testSuite;
-
     private ?string $excludeTestSuite = null;
-
     private ?string $unrecognizedOrderBy;
-
     private ?bool $useDefaultConfiguration;
-
     private ?bool $verbose;
-
     private ?bool $version;
-
     private ?string $plainTextTrace;
 
     public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, ?bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configuration, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, ?bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, ?bool $generateConfiguration, ?bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?bool $listGroups, ?bool $listSuites, ?bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noInteraction, ?bool $noOutput, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?int $repeat, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?array $testdoxExcludeGroups, ?array $testdoxGroups, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?string $testdoxXmlFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, ?string $unrecognizedOrderBy, ?bool $useDefaultConfiguration, ?bool $verbose, ?bool $version, ?array $coverageFilter, ?string $plainTextTrace, ?bool $printerTeamCity, ?bool $printerTestDox)

--- a/src/TextUI/Configuration/CodeCoverageFilterRegistry.php
+++ b/src/TextUI/Configuration/CodeCoverageFilterRegistry.php
@@ -23,8 +23,7 @@ use SebastianBergmann\CodeCoverage\Filter;
  */
 final class CodeCoverageFilterRegistry
 {
-    private static ?Filter $filter = null;
-
+    private static ?Filter $filter  = null;
     private static bool $configured = false;
 
     public static function get(): Filter

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -21,175 +21,90 @@ final class Configuration
     public const COLOR_ALWAYS = 'always';
 
     public const COLOR_DEFAULT = self::COLOR_NEVER;
-
     private ?string $configurationFile;
-
     private ?string $bootstrap;
-
     private bool $cacheResult;
-
     private ?string $cacheDirectory;
-
     private ?string $coverageCacheDirectory;
-
     private bool $pathCoverage;
-
     private ?string $coverageClover;
-
     private ?string $coverageCobertura;
-
     private ?string $coverageCrap4j;
-
     private int $coverageCrap4jThreshold;
-
     private ?string $coverageHtml;
-
     private int $coverageHtmlLowUpperBound;
-
     private int $coverageHtmlHighLowerBound;
-
     private ?string $coveragePhp;
-
     private ?string $coverageText;
-
     private bool $coverageTextShowUncoveredFiles;
-
     private bool $coverageTextShowOnlySummary;
-
     private ?string $coverageXml;
-
     private string $testResultCacheFile;
-
     private bool $ignoreDeprecatedCodeUnitsFromCodeCoverage;
-
     private bool $disableCodeCoverageIgnore;
-
     private bool $failOnEmptyTestSuite;
-
     private bool $failOnIncomplete;
-
     private bool $failOnRisky;
-
     private bool $failOnSkipped;
-
     private bool $failOnWarning;
-
     private bool $outputToStandardErrorStream;
-
     private int|string $columns;
-
     private bool $tooFewColumnsRequested;
-
     private bool $loadPharExtensions;
-
     private ?string $pharExtensionDirectory;
-
     private bool $backupGlobals;
-
     private bool $backupStaticProperties;
-
     private bool $beStrictAboutChangesToGlobalState;
-
     private bool $colors;
-
     private bool $convertDeprecationsToExceptions;
-
     private bool $convertErrorsToExceptions;
-
     private bool $convertNoticesToExceptions;
-
     private bool $convertWarningsToExceptions;
-
     private bool $processIsolation;
-
     private bool $stopOnDefect;
-
     private bool $stopOnError;
-
     private bool $stopOnFailure;
-
     private bool $stopOnWarning;
-
     private bool $stopOnIncomplete;
-
     private bool $stopOnRisky;
-
     private bool $stopOnSkipped;
-
     private bool $enforceTimeLimit;
-
     private int $defaultTimeLimit;
-
     private int $timeoutForSmallTests;
-
     private int $timeoutForMediumTests;
-
     private int $timeoutForLargeTests;
-
     private bool $reportUselessTests;
-
     private bool $strictCoverage;
-
     private bool $disallowTestOutput;
-
     private bool $verbose;
-
     private bool $reverseDefectList;
-
     private bool $requireCoverageMetadata;
-
     private bool $registerMockObjectsFromTestArgumentsRecursively;
-
     private bool $noInteraction;
-
     private int $executionOrder;
-
     private int $executionOrderDefects;
-
     private bool $resolveDependencies;
-
     private ?string $logfileText;
-
     private ?string $logfileTeamcity;
-
     private ?string $logfileJunit;
-
     private ?string $logfileTestdoxHtml;
-
     private ?string $logfileTestdoxText;
-
     private ?string $logfileTestdoxXml;
-
     private ?string $plainTextTrace;
-
     private ?array $testsCovering;
-
     private ?array $testsUsing;
-
     private bool $defaultOutput;
-
     private bool $teamCityOutput;
-
     private bool $testDoxOutput;
-
     private int $repeat;
-
     private ?string $filter;
-
     private ?array $groups;
-
     private ?array $excludeGroups;
-
     private array $testdoxGroups;
-
     private array $testdoxExcludeGroups;
-
     private ?string $includePath;
-
     private int $randomOrderSeed;
-
     private ?string $xmlValidationErrors;
-
     private bool $includeUncoveredFiles;
 
     /**

--- a/src/TextUI/Configuration/Xml/CodeCoverage/CodeCoverage.php
+++ b/src/TextUI/Configuration/Xml/CodeCoverage/CodeCoverage.php
@@ -29,35 +29,20 @@ use PHPUnit\TextUI\XmlConfiguration\FileCollection;
 final class CodeCoverage
 {
     private ?Directory $cacheDirectory;
-
     private DirectoryCollection $directories;
-
     private FileCollection $files;
-
     private DirectoryCollection $excludeDirectories;
-
     private FileCollection $excludeFiles;
-
     private bool $pathCoverage;
-
     private bool $includeUncoveredFiles;
-
     private bool $ignoreDeprecatedCodeUnits;
-
     private bool $disableCodeCoverageIgnore;
-
     private ?Clover $clover;
-
     private ?Cobertura $cobertura;
-
     private ?Crap4j $crap4j;
-
     private ?Html $html;
-
     private ?Php $php;
-
     private ?Text $text;
-
     private ?Xml $xml;
 
     public function __construct(?Directory $cacheDirectory, DirectoryCollection $directories, FileCollection $files, DirectoryCollection $excludeDirectories, FileCollection $excludeFiles, bool $pathCoverage, bool $includeUncoveredFiles, bool $ignoreDeprecatedCodeUnits, bool $disableCodeCoverageIgnore, ?Clover $clover, ?Cobertura $cobertura, ?Crap4j $crap4j, ?Html $html, ?Php $php, ?Text $text, ?Xml $xml)

--- a/src/TextUI/Configuration/Xml/CodeCoverage/Filter/Directory.php
+++ b/src/TextUI/Configuration/Xml/CodeCoverage/Filter/Directory.php
@@ -16,11 +16,8 @@ namespace PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Filter;
 final class Directory
 {
     private string $path;
-
     private string $prefix;
-
     private string $suffix;
-
     private string $group;
 
     public function __construct(string $path, string $prefix, string $suffix, string $group)

--- a/src/TextUI/Configuration/Xml/CodeCoverage/Filter/DirectoryCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/CodeCoverage/Filter/DirectoryCollectionIterator.php
@@ -23,7 +23,6 @@ final class DirectoryCollectionIterator implements Countable, Iterator
      * @psalm-var list<Directory>
      */
     private array $directories;
-
     private ?int $position = null;
 
     public function __construct(DirectoryCollection $directories)

--- a/src/TextUI/Configuration/Xml/CodeCoverage/Report/Crap4j.php
+++ b/src/TextUI/Configuration/Xml/CodeCoverage/Report/Crap4j.php
@@ -18,7 +18,6 @@ use PHPUnit\TextUI\XmlConfiguration\File;
 final class Crap4j
 {
     private File $target;
-
     private int $threshold;
 
     public function __construct(File $target, int $threshold)

--- a/src/TextUI/Configuration/Xml/CodeCoverage/Report/Html.php
+++ b/src/TextUI/Configuration/Xml/CodeCoverage/Report/Html.php
@@ -18,9 +18,7 @@ use PHPUnit\TextUI\XmlConfiguration\Directory;
 final class Html
 {
     private Directory $target;
-
     private int $lowUpperBound;
-
     private int $highLowerBound;
 
     public function __construct(Directory $target, int $lowUpperBound, int $highLowerBound)

--- a/src/TextUI/Configuration/Xml/CodeCoverage/Report/Text.php
+++ b/src/TextUI/Configuration/Xml/CodeCoverage/Report/Text.php
@@ -18,9 +18,7 @@ use PHPUnit\TextUI\XmlConfiguration\File;
 final class Text
 {
     private File $target;
-
     private bool $showUncoveredFiles;
-
     private bool $showOnlySummary;
 
     public function __construct(File $target, bool $showUncoveredFiles, bool $showOnlySummary)

--- a/src/TextUI/Configuration/Xml/Configuration.php
+++ b/src/TextUI/Configuration/Xml/Configuration.php
@@ -19,19 +19,12 @@ use PHPUnit\TextUI\XmlConfiguration\Logging\Logging;
 abstract class Configuration
 {
     private ExtensionCollection $extensions;
-
     private CodeCoverage $codeCoverage;
-
     private Groups $groups;
-
     private Groups $testdoxGroups;
-
     private Logging $logging;
-
     private Php $php;
-
     private PHPUnit $phpunit;
-
     private TestSuiteCollection $testSuite;
 
     public function __construct(ExtensionCollection $extensions, CodeCoverage $codeCoverage, Groups $groups, Groups $testdoxGroups, Logging $logging, Php $php, PHPUnit $phpunit, TestSuiteCollection $testSuite)

--- a/src/TextUI/Configuration/Xml/Filesystem/DirectoryCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/Filesystem/DirectoryCollectionIterator.php
@@ -23,7 +23,6 @@ final class DirectoryCollectionIterator implements Countable, Iterator
      * @psalm-var list<Directory>
      */
     private array $directories;
-
     private ?int $position = null;
 
     public function __construct(DirectoryCollection $directories)

--- a/src/TextUI/Configuration/Xml/Filesystem/FileCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/Filesystem/FileCollectionIterator.php
@@ -23,7 +23,6 @@ final class FileCollectionIterator implements Countable, Iterator
      * @psalm-var list<File>
      */
     private array $files;
-
     private ?int $position = null;
 
     public function __construct(FileCollection $files)

--- a/src/TextUI/Configuration/Xml/Group/GroupCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/Group/GroupCollectionIterator.php
@@ -23,7 +23,6 @@ final class GroupCollectionIterator implements Countable, Iterator
      * @psalm-var list<Group>
      */
     private array $groups;
-
     private ?int $position = null;
 
     public function __construct(GroupCollection $groups)

--- a/src/TextUI/Configuration/Xml/Group/Groups.php
+++ b/src/TextUI/Configuration/Xml/Group/Groups.php
@@ -16,7 +16,6 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class Groups
 {
     private GroupCollection $include;
-
     private GroupCollection $exclude;
 
     public function __construct(GroupCollection $include, GroupCollection $exclude)

--- a/src/TextUI/Configuration/Xml/LoadedFromFileConfiguration.php
+++ b/src/TextUI/Configuration/Xml/LoadedFromFileConfiguration.php
@@ -20,7 +20,6 @@ use PHPUnit\Util\Xml\ValidationResult;
 final class LoadedFromFileConfiguration extends Configuration
 {
     private string $filename;
-
     private ValidationResult $validationResult;
 
     public function __construct(string $filename, ValidationResult $validationResult, ExtensionCollection $extensions, CodeCoverage $codeCoverage, Groups $groups, Groups $testdoxGroups, Logging $logging, Php $php, PHPUnit $phpunit, TestSuiteCollection $testSuite)

--- a/src/TextUI/Configuration/Xml/Logging/Logging.php
+++ b/src/TextUI/Configuration/Xml/Logging/Logging.php
@@ -21,15 +21,10 @@ use PHPUnit\TextUI\XmlConfiguration\Logging\TestDox\Xml as TestDoxXml;
 final class Logging
 {
     private ?Junit $junit;
-
     private ?Text $text;
-
     private ?TeamCity $teamCity;
-
     private ?TestDoxHtml $testDoxHtml;
-
     private ?TestDoxText $testDoxText;
-
     private ?TestDoxXml $testDoxXml;
 
     public function __construct(?Junit $junit, ?Text $text, ?TeamCity $teamCity, ?TestDoxHtml $testDoxHtml, ?TestDoxText $testDoxText, ?TestDoxXml $testDoxXml)

--- a/src/TextUI/Configuration/Xml/PHP/Constant.php
+++ b/src/TextUI/Configuration/Xml/PHP/Constant.php
@@ -16,7 +16,6 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class Constant
 {
     private string $name;
-
     private mixed $value;
 
     public function __construct(string $name, mixed $value)

--- a/src/TextUI/Configuration/Xml/PHP/ConstantCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/PHP/ConstantCollectionIterator.php
@@ -23,7 +23,6 @@ final class ConstantCollectionIterator implements Countable, Iterator
      * @psalm-var list<Constant>
      */
     private array $constants;
-
     private ?int $position = null;
 
     public function __construct(ConstantCollection $constants)

--- a/src/TextUI/Configuration/Xml/PHP/IniSetting.php
+++ b/src/TextUI/Configuration/Xml/PHP/IniSetting.php
@@ -16,7 +16,6 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class IniSetting
 {
     private string $name;
-
     private string $value;
 
     public function __construct(string $name, string $value)

--- a/src/TextUI/Configuration/Xml/PHP/IniSettingCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/PHP/IniSettingCollectionIterator.php
@@ -23,7 +23,6 @@ final class IniSettingCollectionIterator implements Countable, Iterator
      * @psalm-var list<IniSetting>
      */
     private array $iniSettings;
-
     private ?int $position = null;
 
     public function __construct(IniSettingCollection $iniSettings)

--- a/src/TextUI/Configuration/Xml/PHP/Php.php
+++ b/src/TextUI/Configuration/Xml/PHP/Php.php
@@ -16,25 +16,15 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class Php
 {
     private DirectoryCollection $includePaths;
-
     private IniSettingCollection $iniSettings;
-
     private ConstantCollection $constants;
-
     private VariableCollection $globalVariables;
-
     private VariableCollection $envVariables;
-
     private VariableCollection $postVariables;
-
     private VariableCollection $getVariables;
-
     private VariableCollection $cookieVariables;
-
     private VariableCollection $serverVariables;
-
     private VariableCollection $filesVariables;
-
     private VariableCollection $requestVariables;
 
     public function __construct(DirectoryCollection $includePaths, IniSettingCollection $iniSettings, ConstantCollection $constants, VariableCollection $globalVariables, VariableCollection $envVariables, VariableCollection $postVariables, VariableCollection $getVariables, VariableCollection $cookieVariables, VariableCollection $serverVariables, VariableCollection $filesVariables, VariableCollection $requestVariables)

--- a/src/TextUI/Configuration/Xml/PHP/Variable.php
+++ b/src/TextUI/Configuration/Xml/PHP/Variable.php
@@ -16,9 +16,7 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class Variable
 {
     private string $name;
-
     private mixed $value;
-
     private bool $force;
 
     public function __construct(string $name, $value, bool $force)

--- a/src/TextUI/Configuration/Xml/PHP/VariableCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/PHP/VariableCollectionIterator.php
@@ -23,7 +23,6 @@ final class VariableCollectionIterator implements Countable, Iterator
      * @psalm-var list<Variable>
      */
     private array $variables;
-
     private ?int $position = null;
 
     public function __construct(VariableCollection $variables)

--- a/src/TextUI/Configuration/Xml/PHPUnit/Extension.php
+++ b/src/TextUI/Configuration/Xml/PHPUnit/Extension.php
@@ -19,9 +19,7 @@ final class Extension
      * @psalm-var class-string
      */
     private string $className;
-
     private string $sourceFile;
-
     private array $arguments;
 
     /**

--- a/src/TextUI/Configuration/Xml/PHPUnit/ExtensionCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/PHPUnit/ExtensionCollectionIterator.php
@@ -23,7 +23,6 @@ final class ExtensionCollectionIterator implements Countable, Iterator
      * @psalm-var list<Extension>
      */
     private array $extensions;
-
     private ?int $position = null;
 
     public function __construct(ExtensionCollection $extensions)

--- a/src/TextUI/Configuration/Xml/PHPUnit/PHPUnit.php
+++ b/src/TextUI/Configuration/Xml/PHPUnit/PHPUnit.php
@@ -16,95 +16,50 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class PHPUnit
 {
     private ?string $cacheDirectory;
-
     private bool $cacheResult;
-
     private ?string $cacheResultFile;
-
     private int|string $columns;
-
     private string $colors;
-
     private bool $stderr;
-
     private bool $noInteraction;
-
     private bool $verbose;
-
     private bool $reverseDefectList;
-
     private bool $convertDeprecationsToExceptions;
-
     private bool $convertErrorsToExceptions;
-
     private bool $convertNoticesToExceptions;
-
     private bool $convertWarningsToExceptions;
-
     private bool $requireCoverageMetadata;
-
     private ?string $bootstrap;
-
     private bool $processIsolation;
-
     private bool $failOnEmptyTestSuite;
-
     private bool $failOnIncomplete;
-
     private bool $failOnRisky;
-
     private bool $failOnSkipped;
-
     private bool $failOnWarning;
-
     private bool $stopOnDefect;
-
     private bool $stopOnError;
-
     private bool $stopOnFailure;
-
     private bool $stopOnWarning;
-
     private bool $stopOnIncomplete;
-
     private bool $stopOnRisky;
-
     private bool $stopOnSkipped;
-
     private ?string $extensionsDirectory;
-
     private bool $beStrictAboutChangesToGlobalState;
-
     private bool $beStrictAboutOutputDuringTests;
-
     private bool $beStrictAboutTestsThatDoNotTestAnything;
-
     private bool $beStrictAboutCoverageMetadata;
-
     private bool $enforceTimeLimit;
-
     private int $defaultTimeLimit;
-
     private int $timeoutForSmallTests;
-
     private int $timeoutForMediumTests;
-
     private int $timeoutForLargeTests;
-
     private ?string $defaultTestSuite;
-
     private int $executionOrder;
-
     private bool $resolveDependencies;
-
     private bool $defectsFirst;
-
     private bool $backupGlobals;
-
     private bool $backupStaticProperties;
-
     private bool $registerMockObjectsFromTestArgumentsRecursively;
-
     private bool $testdoxPrinter;
 
     public function __construct(?string $cacheDirectory, bool $cacheResult, ?string $cacheResultFile, int|string $columns, string $colors, bool $stderr, bool $noInteraction, bool $verbose, bool $reverseDefectList, bool $convertDeprecationsToExceptions, bool $convertErrorsToExceptions, bool $convertNoticesToExceptions, bool $convertWarningsToExceptions, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $registerMockObjectsFromTestArgumentsRecursively, bool $testdoxPrinter)

--- a/src/TextUI/Configuration/Xml/TestSuite/TestDirectory.php
+++ b/src/TextUI/Configuration/Xml/TestSuite/TestDirectory.php
@@ -18,13 +18,9 @@ use PHPUnit\Util\VersionComparisonOperator;
 final class TestDirectory
 {
     private string $path;
-
     private string $prefix;
-
     private string $suffix;
-
     private string $phpVersion;
-
     private VersionComparisonOperator $phpVersionOperator;
 
     public function __construct(string $path, string $prefix, string $suffix, string $phpVersion, VersionComparisonOperator $phpVersionOperator)

--- a/src/TextUI/Configuration/Xml/TestSuite/TestDirectoryCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/TestSuite/TestDirectoryCollectionIterator.php
@@ -23,7 +23,6 @@ final class TestDirectoryCollectionIterator implements Countable, Iterator
      * @psalm-var list<TestDirectory>
      */
     private array $directories;
-
     private ?int $position = null;
 
     public function __construct(TestDirectoryCollection $directories)

--- a/src/TextUI/Configuration/Xml/TestSuite/TestFile.php
+++ b/src/TextUI/Configuration/Xml/TestSuite/TestFile.php
@@ -18,9 +18,7 @@ use PHPUnit\Util\VersionComparisonOperator;
 final class TestFile
 {
     private string $path;
-
     private string $phpVersion;
-
     private VersionComparisonOperator $phpVersionOperator;
 
     public function __construct(string $path, string $phpVersion, VersionComparisonOperator $phpVersionOperator)

--- a/src/TextUI/Configuration/Xml/TestSuite/TestFileCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/TestSuite/TestFileCollectionIterator.php
@@ -23,7 +23,6 @@ final class TestFileCollectionIterator implements Countable, Iterator
      * @psalm-var list<TestFile>
      */
     private array $files;
-
     private ?int $position = null;
 
     public function __construct(TestFileCollection $files)

--- a/src/TextUI/Configuration/Xml/TestSuite/TestSuite.php
+++ b/src/TextUI/Configuration/Xml/TestSuite/TestSuite.php
@@ -16,11 +16,8 @@ namespace PHPUnit\TextUI\XmlConfiguration;
 final class TestSuite
 {
     private string $name;
-
     private TestDirectoryCollection $directories;
-
     private TestFileCollection $files;
-
     private FileCollection $exclude;
 
     public function __construct(string $name, TestDirectoryCollection $directories, TestFileCollection $files, FileCollection $exclude)

--- a/src/TextUI/Configuration/Xml/TestSuite/TestSuiteCollectionIterator.php
+++ b/src/TextUI/Configuration/Xml/TestSuite/TestSuiteCollectionIterator.php
@@ -23,7 +23,6 @@ final class TestSuiteCollectionIterator implements Countable, Iterator
      * @psalm-var list<TestSuite>
      */
     private array $testSuites;
-
     private ?int $position = null;
 
     public function __construct(TestSuiteCollection $testSuites)

--- a/src/TextUI/DefaultResultPrinter.php
+++ b/src/TextUI/DefaultResultPrinter.php
@@ -47,30 +47,18 @@ use Throwable;
  */
 class DefaultResultPrinter extends Printer implements ResultPrinter
 {
-    protected int $column = 0;
-
-    protected ?int $maxColumn = null;
-
+    protected int $column          = 0;
+    protected ?int $maxColumn      = null;
     protected bool $lastTestFailed = false;
-
-    protected int $numAssertions = 0;
-
-    protected int $numTests = -1;
-
-    protected int $numTestsRun = 0;
-
-    protected ?int $numTestsWidth = null;
-
-    protected bool $colors = false;
-
-    protected bool $verbose = false;
-
+    protected int $numAssertions   = 0;
+    protected int $numTests        = -1;
+    protected int $numTestsRun     = 0;
+    protected ?int $numTestsWidth  = null;
+    protected bool $colors         = false;
+    protected bool $verbose        = false;
     private int $numberOfColumns;
-
     private bool $reverse;
-
     private bool $defectListPrinted = false;
-
     private Timer $timer;
 
     /**

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -141,11 +141,8 @@ final class Help
         ],
 
     ];
-
     private int $lengthOfLongestOptionName = 0;
-
     private int $columnsAvailableForDescription;
-
     private ?bool $hasColor;
 
     public function __construct(?int $width = null, ?bool $withColor = null)

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -65,12 +65,9 @@ use SebastianBergmann\Timer\Timer;
 final class TestRunner
 {
     private Configuration $configuration;
-
     private ?ResultPrinter $printer = null;
-
-    private bool $messagePrinted = false;
-
-    private ?Timer $timer = null;
+    private bool $messagePrinted    = false;
+    private ?Timer $timer           = null;
 
     public function __construct()
     {

--- a/src/Util/Error/Handler.php
+++ b/src/Util/Error/Handler.php
@@ -30,13 +30,9 @@ use PHPUnit\Util\Exception;
 final class Handler
 {
     private bool $convertDeprecationsToExceptions;
-
     private bool $convertErrorsToExceptions;
-
     private bool $convertNoticesToExceptions;
-
     private bool $convertWarningsToExceptions;
-
     private bool $registered = false;
 
     public static function invokeIgnoringWarnings(callable $callable): mixed

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -44,18 +44,14 @@ use SebastianBergmann\Environment\Runtime;
 abstract class AbstractPhpProcess
 {
     protected Runtime $runtime;
-
     protected bool $stderrRedirection = false;
-
-    protected string $stdin = '';
-
-    protected string $arguments = '';
+    protected string $stdin           = '';
+    protected string $arguments       = '';
 
     /**
      * @psalm-var array<string, string>
      */
-    protected array $env = [];
-
+    protected array $env   = [];
     protected int $timeout = 0;
 
     public static function factory(): self

--- a/src/Util/Printer.php
+++ b/src/Util/Printer.php
@@ -32,9 +32,7 @@ class Printer
      * @psalm-var closed-resource|resource
      */
     private $stream;
-
     private bool $isPhpStream;
-
     private bool $isOpen;
 
     /**

--- a/src/Util/Variable/ExportedVariable.php
+++ b/src/Util/Variable/ExportedVariable.php
@@ -15,7 +15,6 @@ namespace PHPUnit\Util;
 final class ExportedVariable
 {
     private string $export;
-
     private bool $warningWasTriggered;
 
     public static function from(?string $export, bool $warningWasTriggered): self

--- a/tests/_files/Author.php
+++ b/tests/_files/Author.php
@@ -13,7 +13,6 @@ class Author
 {
     // the order of properties is important for testing the cycle!
     public $books = [];
-
     private $name = '';
 
     public function __construct($name)

--- a/tests/_files/BeforeAndAfterTest.php
+++ b/tests/_files/BeforeAndAfterTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 class BeforeAndAfterTest extends TestCase
 {
     public static $beforeWasRun;
-
     public static $afterWasRun;
 
     public static function resetProperties(): void

--- a/tests/_files/BeforeClassAndAfterClassTest.php
+++ b/tests/_files/BeforeClassAndAfterClassTest.php
@@ -14,8 +14,7 @@ use PHPUnit\Framework\TestCase;
 class BeforeClassAndAfterClassTest extends TestCase
 {
     public static $beforeClassWasRun = 0;
-
-    public static $afterClassWasRun = 0;
+    public static $afterClassWasRun  = 0;
 
     public static function resetProperties(): void
     {

--- a/tests/_files/BeforeClassWithOnlyDataProviderTest.php
+++ b/tests/_files/BeforeClassWithOnlyDataProviderTest.php
@@ -12,7 +12,6 @@ namespace PHPUnit\TestFixture;
 class BeforeClassWithOnlyDataProviderTest extends \PHPUnit\Framework\TestCase
 {
     public static $setUpBeforeClassWasCalled;
-
     public static $beforeClassWasCalled;
 
     public static function resetProperties(): void

--- a/tests/_files/ClassWithNonPublicAttributes.php
+++ b/tests/_files/ClassWithNonPublicAttributes.php
@@ -11,25 +11,15 @@ namespace PHPUnit\TestFixture;
 
 class ClassWithNonPublicAttributes extends ParentClassWithProtectedAttributes
 {
-    public static $publicStaticAttribute = 'foo';
-
+    public static $publicStaticAttribute       = 'foo';
     protected static $protectedStaticAttribute = 'bar';
-
-    protected static $privateStaticAttribute = 'baz';
-
-    public $publicAttribute = 'foo';
-
-    public $foo = 1;
-
-    public $bar = 2;
-
-    public $publicArray = ['foo'];
-
-    protected $protectedAttribute = 'bar';
-
-    protected $privateAttribute = 'baz';
-
-    protected $protectedArray = ['bar'];
-
-    protected $privateArray = ['baz'];
+    protected static $privateStaticAttribute   = 'baz';
+    public $publicAttribute                    = 'foo';
+    public $foo                                = 1;
+    public $bar                                = 2;
+    public $publicArray                        = ['foo'];
+    protected $protectedAttribute              = 'bar';
+    protected $privateAttribute                = 'baz';
+    protected $protectedArray                  = ['bar'];
+    protected $privateArray                    = ['baz'];
 }

--- a/tests/_files/ExceptionInAssertPostConditionsTest.php
+++ b/tests/_files/ExceptionInAssertPostConditionsTest.php
@@ -14,15 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionInAssertPostConditionsTest extends TestCase
 {
-    public $setUp = false;
-
-    public $assertPreConditions = false;
-
+    public $setUp                = false;
+    public $assertPreConditions  = false;
     public $assertPostConditions = false;
-
-    public $tearDown = false;
-
-    public $testSomething = false;
+    public $tearDown             = false;
+    public $testSomething        = false;
 
     protected function setUp(): void
     {

--- a/tests/_files/ExceptionInAssertPreConditionsTest.php
+++ b/tests/_files/ExceptionInAssertPreConditionsTest.php
@@ -14,15 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionInAssertPreConditionsTest extends TestCase
 {
-    public $setUp = false;
-
-    public $assertPreConditions = false;
-
+    public $setUp                = false;
+    public $assertPreConditions  = false;
     public $assertPostConditions = false;
-
-    public $tearDown = false;
-
-    public $testSomething = false;
+    public $tearDown             = false;
+    public $testSomething        = false;
 
     protected function setUp(): void
     {

--- a/tests/_files/ExceptionInSetUpTest.php
+++ b/tests/_files/ExceptionInSetUpTest.php
@@ -14,15 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionInSetUpTest extends TestCase
 {
-    public $setUp = false;
-
-    public $assertPreConditions = false;
-
+    public $setUp                = false;
+    public $assertPreConditions  = false;
     public $assertPostConditions = false;
-
-    public $tearDown = false;
-
-    public $testSomething = false;
+    public $tearDown             = false;
+    public $testSomething        = false;
 
     protected function setUp(): void
     {

--- a/tests/_files/ExceptionInTearDownTest.php
+++ b/tests/_files/ExceptionInTearDownTest.php
@@ -14,15 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionInTearDownTest extends TestCase
 {
-    public $setUp = false;
-
-    public $assertPreConditions = false;
-
+    public $setUp                = false;
+    public $assertPreConditions  = false;
     public $assertPostConditions = false;
-
-    public $tearDown = false;
-
-    public $testSomething = false;
+    public $tearDown             = false;
+    public $testSomething        = false;
 
     protected function setUp(): void
     {

--- a/tests/_files/ExceptionInTest.php
+++ b/tests/_files/ExceptionInTest.php
@@ -14,15 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 class ExceptionInTest extends TestCase
 {
-    public $setUp = false;
-
-    public $assertPreConditions = false;
-
+    public $setUp                = false;
+    public $assertPreConditions  = false;
     public $assertPostConditions = false;
-
-    public $tearDown = false;
-
-    public $testSomething = false;
+    public $tearDown             = false;
+    public $testSomething        = false;
 
     protected function setUp(): void
     {

--- a/tests/_files/Mockable.php
+++ b/tests/_files/Mockable.php
@@ -12,7 +12,6 @@ namespace PHPUnit\TestFixture;
 class Mockable
 {
     public $constructorArgs;
-
     public $cloned;
 
     public function __construct($arg1 = null, $arg2 = null)

--- a/tests/_files/ParentClassWithPrivateAttributes.php
+++ b/tests/_files/ParentClassWithPrivateAttributes.php
@@ -12,6 +12,5 @@ namespace PHPUnit\TestFixture;
 class ParentClassWithPrivateAttributes
 {
     private static $privateStaticParentAttribute = 'foo';
-
-    private $privateParentAttribute = 'bar';
+    private $privateParentAttribute              = 'bar';
 }

--- a/tests/_files/ParentClassWithProtectedAttributes.php
+++ b/tests/_files/ParentClassWithProtectedAttributes.php
@@ -12,6 +12,5 @@ namespace PHPUnit\TestFixture;
 class ParentClassWithProtectedAttributes extends ParentClassWithPrivateAttributes
 {
     protected static $protectedStaticParentAttribute = 'foo';
-
-    protected $protectedParentAttribute = 'bar';
+    protected $protectedParentAttribute              = 'bar';
 }

--- a/tests/_files/PreConditionAndPostConditionTest.php
+++ b/tests/_files/PreConditionAndPostConditionTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 final class PreConditionAndPostConditionTest extends TestCase
 {
     public static $preConditionWasVerified;
-
     public static $postConditionWasVerified;
 
     public static function resetProperties(): void

--- a/tests/_files/SampleClass.php
+++ b/tests/_files/SampleClass.php
@@ -12,9 +12,7 @@ namespace PHPUnit\TestFixture;
 class SampleClass
 {
     public $a;
-
     public $b;
-
     public $c;
 
     public function __construct($a, $b, $c)

--- a/tests/_files/TestIterator.php
+++ b/tests/_files/TestIterator.php
@@ -16,7 +16,6 @@ use ReturnTypeWillChange;
 class TestIterator implements Iterator
 {
     protected $array;
-
     protected $position = 0;
 
     public function __construct($array = [])

--- a/tests/end-to-end/regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
+++ b/tests/end-to-end/regression/GitHub/2724/SeparateClassRunMethodInNewProcessTest.php
@@ -17,10 +17,8 @@ class SeparateClassRunMethodInNewProcessTest extends PHPUnit\Framework\TestCase
     public const INITIAL_MASTER_PID = 0;
 
     public const INITIAL_PID1 = 1;
-
-    public static $masterPid = self::INITIAL_MASTER_PID;
-
-    public static $pid1 = self::INITIAL_PID1;
+    public static $masterPid  = self::INITIAL_MASTER_PID;
+    public static $pid1       = self::INITIAL_PID1;
 
     public static function setUpBeforeClass(): void
     {

--- a/tests/unit/Event/Value/Telemetry/SystemTest.php
+++ b/tests/unit/Event/Value/Telemetry/SystemTest.php
@@ -42,7 +42,6 @@ final class SystemTest extends TestCase
         $memoryMeter = new class($memoryUsage, $peakMemoryUsage) implements MemoryMeter
         {
             private MemoryUsage $memoryUsage;
-
             private MemoryUsage $peakMemoryUsage;
 
             public function __construct(MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage)

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -33,11 +33,8 @@ EXPECT test
 --EXPECT--
 Hello PHPUnit!
 EOF;
-
     private string $filename;
-
     private ?PhptTestCase $testCase;
-
     private AbstractPhpProcess|MockObject|null $phpProcess;
 
     protected function setUp(): void

--- a/tests/unit/Util/TestDox/CliTestDoxPrinterTest.php
+++ b/tests/unit/Util/TestDox/CliTestDoxPrinterTest.php
@@ -22,7 +22,6 @@ use PHPUnit\TestFixture\TestableCliTestDoxPrinter;
 final class CliTestDoxPrinterTest extends TestCase
 {
     private ?TestableCliTestDoxPrinter $printer;
-
     private ?TestableCliTestDoxPrinter $verbosePrinter;
 
     protected function setUp(): void


### PR DESCRIPTION
This pull request

- [x] configures the `class_attributes_separation` fixer to use the `only_if_meta` option for the `property` element
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/class_notation/class_attributes_separation.rst. 