### PR TITLE
Use spl_object_id instead of spl_object_hash where possible.

### DIFF
--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -10,7 +10,7 @@
 namespace PHPUnit\Framework;
 
 use function array_keys;
-use function spl_object_hash;
+use function spl_object_id;
 use PHPUnit\Util\Filter;
 use Throwable;
 
@@ -109,7 +109,7 @@ final class ExceptionWrapper extends Exception
     {
         static $originalExceptions;
 
-        $instanceId = spl_object_hash($this);
+        $instanceId = spl_object_id($this);
 
         if ($exceptionToStore) {
             $originalExceptions[$instanceId] = $exceptionToStore;

--- a/src/Runner/Filter/ExcludeGroupFilterIterator.php
+++ b/src/Runner/Filter/ExcludeGroupFilterIterator.php
@@ -16,8 +16,8 @@ use function in_array;
  */
 final class ExcludeGroupFilterIterator extends GroupFilterIterator
 {
-    protected function doAccept(string $hash): bool
+    protected function doAccept(int $id): bool
     {
-        return !in_array($hash, $this->groupTests, true);
+        return !in_array($id, $this->groupTests, true);
     }
 }

--- a/src/Runner/Filter/GroupFilterIterator.php
+++ b/src/Runner/Filter/GroupFilterIterator.php
@@ -10,9 +10,9 @@
 namespace PHPUnit\Runner\Filter;
 
 use function array_map;
-use function array_merge;
+use function array_push;
 use function in_array;
-use function spl_object_hash;
+use function spl_object_id;
 use PHPUnit\Framework\TestSuite;
 use RecursiveFilterIterator;
 use RecursiveIterator;
@@ -23,7 +23,7 @@ use RecursiveIterator;
 abstract class GroupFilterIterator extends RecursiveFilterIterator
 {
     /**
-     * @psalm-var list<string>
+     * @psalm-var list<int>
      */
     protected array $groupTests = [];
 
@@ -34,11 +34,11 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
         foreach ($suite->getGroupDetails() as $group => $tests) {
             if (in_array((string) $group, $groups, true)) {
                 $testHashes = array_map(
-                    'spl_object_hash',
+                    'spl_object_id',
                     $tests
                 );
 
-                $this->groupTests = array_merge($this->groupTests, $testHashes);
+                array_push($this->groupTests, ...$testHashes);
             }
         }
     }
@@ -51,8 +51,8 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
             return true;
         }
 
-        return $this->doAccept(spl_object_hash($test));
+        return $this->doAccept(spl_object_id($test));
     }
 
-    abstract protected function doAccept(string $hash): bool;
+    abstract protected function doAccept(int $id): bool;
 }

--- a/src/Runner/Filter/IncludeGroupFilterIterator.php
+++ b/src/Runner/Filter/IncludeGroupFilterIterator.php
@@ -16,8 +16,8 @@ use function in_array;
  */
 final class IncludeGroupFilterIterator extends GroupFilterIterator
 {
-    protected function doAccept(string $hash): bool
+    protected function doAccept(int $id): bool
     {
-        return in_array($hash, $this->groupTests, true);
+        return in_array($id, $this->groupTests, true);
     }
 }


### PR DESCRIPTION
spl_object_id was added in php 7.2.
array_push allows calling with only one parameter since php 7.3.
Modify array in place rather than copying all values to new arrays
repeatedly.

Integers are slightly faster to compare than strings and use less
memory.

This in particular isn't performance sensitive, but update this as an
example for future additions or code based on it.