### PR TITLE
Fix GlobalState collection to ignore the Composer proxy

### DIFF
--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -67,7 +67,14 @@ final class GlobalState
             $prefix = 'phar://' . __PHPUNIT_PHAR__ . '/';
         }
 
-        for ($i = count($files) - 1; $i > 0; $i--) {
+        // Do not process bootstrap script
+        array_shift($files);
+        // If bootstrap script was a Composer bin proxy, skip the second entry as well
+        if (substr(strtr($files[0], '\\', '/'), -24) === '/phpunit/phpunit/phpunit') {
+            array_shift($files);
+        }
+
+        for ($i = count($files) - 1; $i >= 0; $i--) {
             $file = $files[$i];
 
             if (!empty($GLOBALS['__PHPUNIT_ISOLATION_BLACKLIST']) &&


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/10387

Composer 2.2 introduces some additional indirection for binaries to allow everyone to use custom PHP versions e.g. `php7.4 vendor/bin/phpunit` and ensure that `vendor/phpunit/phpunit/phpunit` is executed with php7.4 always (this previously worked only in cases/platforms where symlinks were supported).

Ideally this would be fixed in older PHPUnit versions too if possible.. The patch applies down to PHPUnit 4.x as far as I can tell.

I can workaround it to some extent in Composer using the global var `__PHPUNIT_ISOLATION_BLACKLIST` / `__PHPUNIT_ISOLATION_EXCLUDE_LIST` to mark the included (vendor/phpunit/phpunit/phpunit) file excluded but that is only going to fix it for PHPUnit 6+, and I am not sure how reliable that is going to be in the wild if third party code blindly overwrites the global instead of merging their values into it.