### PR TITLE
Fix access to optional array key when using `debug_backtrace()` function

### DIFF
--- a/src/Framework/Exception/InvalidArgumentException.php
+++ b/src/Framework/Exception/InvalidArgumentException.php
@@ -21,14 +21,18 @@ final class InvalidArgumentException extends Exception
 {
     public static function create(int $argument, string $type): self
     {
-        $stack = debug_backtrace();
+        $stack    = debug_backtrace();
+        $function = $stack[1]['function'];
+
+        if (isset($stack[1]['class'])) {
+            $function = sprintf('%s::%s', $stack[1]['class'], $stack[1]['function']);
+        }
 
         return new self(
             sprintf(
-                'Argument #%d of %s::%s() must be %s %s',
+                'Argument #%d of %s() must be %s %s',
                 $argument,
-                $stack[1]['class'],
-                $stack[1]['function'],
+                $function,
                 in_array(lcfirst($type)[0], ['a', 'e', 'i', 'o', 'u'], true) ? 'an' : 'a',
                 $type
             )

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -738,8 +738,8 @@ final class TestResult implements Countable
                 sprintf(
                     '%s in %s:%s',
                     $e->getMessage(),
-                    $frame['file'],
-                    $frame['line']
+                    $frame['file'] ?? $e->getFile(),
+                    $frame['line'] ?? $e->getLine()
                 )
             );
         } catch (Warning $e) {


### PR DESCRIPTION
The `class`, `file` and `line` array keys are optional for a stacktrace frame, so to silence PHPStan when the signature of the `debug_backtrace()` function will be narrowed down to an array shape with optional keys these little fixes are needed