### PR TITLE
update deprecation information

### DIFF
--- a/src/Framework/TestListener.php
+++ b/src/Framework/TestListener.php
@@ -12,49 +12,37 @@ namespace PHPUnit\Framework;
 use Throwable;
 
 /**
- * @deprecated Use the `TestHook` interfaces instead
+ * Note: The TestListener will be replaced in phpunit 10 with a new test system. See https://github.com/sebastianbergmann/phpunit/issues/4676
  */
 interface TestListener
 {
     /**
      * An error occurred.
-     *
-     * @deprecated Use `AfterTestErrorHook::executeAfterTestError` instead
      */
     public function addError(Test $test, Throwable $t, float $time): void;
 
     /**
      * A warning occurred.
-     *
-     * @deprecated Use `AfterTestWarningHook::executeAfterTestWarning` instead
      */
     public function addWarning(Test $test, Warning $e, float $time): void;
 
     /**
      * A failure occurred.
-     *
-     * @deprecated Use `AfterTestFailureHook::executeAfterTestFailure` instead
      */
     public function addFailure(Test $test, AssertionFailedError $e, float $time): void;
 
     /**
      * Incomplete test.
-     *
-     * @deprecated Use `AfterIncompleteTestHook::executeAfterIncompleteTest` instead
      */
     public function addIncompleteTest(Test $test, Throwable $t, float $time): void;
 
     /**
      * Risky test.
-     *
-     * @deprecated Use `AfterRiskyTestHook::executeAfterRiskyTest` instead
      */
     public function addRiskyTest(Test $test, Throwable $t, float $time): void;
 
     /**
      * Skipped test.
-     *
-     * @deprecated Use `AfterSkippedTestHook::executeAfterSkippedTest` instead
      */
     public function addSkippedTest(Test $test, Throwable $t, float $time): void;
 
@@ -70,15 +58,11 @@ interface TestListener
 
     /**
      * A test started.
-     *
-     * @deprecated Use `BeforeTestHook::executeBeforeTest` instead
      */
     public function startTest(Test $test): void;
 
     /**
      * A test ended.
-     *
-     * @deprecated Use `AfterTestHook::executeAfterTest` instead
      */
     public function endTest(Test $test, float $time): void;
 }


### PR DESCRIPTION
Following the discussion in #3390

Imho there is no use in having `@deprecated` annotation if the new system is not available, as people can not avoid using this interface. And to my understanding, for version 8 and 9, implementing this interface is the way to go.