### PR TITLE
Allow including the PHPUnit phar from Composer bin proxies

### DIFF
--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -46,7 +46,8 @@ foreach (['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'] 
     die(1);
 }
 
-if (__FILE__ === realpath($_SERVER['SCRIPT_NAME'])) {
+// allowing execution if the file is executed directly or included by a Composer bin proxy (which sets the _composer_bin_dir global)
+if (__FILE__ === realpath($_SERVER['SCRIPT_NAME']) || isset($GLOBALS['_composer_bin_dir'])) {
     $execute = true;
 } else {
     $execute = false;
@@ -99,6 +100,12 @@ if ($execute) {
     unset($execute);
 
     PHPUnit\TextUI\Command::main();
+} else {
+    fwrite(
+        STDERR,
+        'PHPUnit X.Y.Z by Sebastian Bergmann and contributors.' . PHP_EOL .
+        'The PHPUnit PHAR cannot be included as a library.' . PHP_EOL .
+    );
 }
 
 __HALT_COMPILER();

--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -104,7 +104,7 @@ if ($execute) {
     fwrite(
         STDERR,
         'PHPUnit X.Y.Z by Sebastian Bergmann and contributors.' . PHP_EOL .
-        'The PHPUnit PHAR cannot be included as a library.' . PHP_EOL .
+        'The PHPUnit PHAR cannot be included as a library.' . PHP_EOL
     );
 }
 


### PR DESCRIPTION
I also added a hint in the output when execution is not allowed, because this was pretty confusing :)

Fixes https://github.com/composer/composer/issues/10471 where someone tried to package up the PHPUnit phar in a package and declares it as a Composer binary.