### PR TITLE
Use predefined PHP float epsilon

### DIFF
--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -35,11 +35,6 @@ use SebastianBergmann\Comparator\ComparisonFailure;
 final class IsIdentical extends Constraint
 {
     /**
-     * @var float
-     */
-    private const EPSILON = 0.0000000001;
-
-    /**
      * @var mixed
      */
     private $value;
@@ -67,7 +62,7 @@ final class IsIdentical extends Constraint
         if (is_float($this->value) && is_float($other) &&
             !is_infinite($this->value) && !is_infinite($other) &&
             !is_nan($this->value) && !is_nan($other)) {
-            $success = abs($this->value - $other) < self::EPSILON;
+            $success = abs($this->value - $other) < PHP_FLOAT_EPSILON;
         } else {
             $success = $this->value === $other;
         }


### PR DESCRIPTION
Instead of using an arbitrary epsilon, use the predefined PHP constant PHP_FLOAT_EPSILON, which is defined to be the smallest representable positive number "x", such that "x + 1.0 != 1.0".

See https://www.php.net/manual/en/reserved.constants.php#constant.php-float-epsilon for additional information.