### PR TITLE
Add stack trace to bootstrap error message

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -567,10 +567,12 @@ class Command
 
             $this->exitWithErrorMessage(
                 sprintf(
-                    'Error in bootstrap script: %s:%s%s',
+                    'Error in bootstrap script: %s:%s%s%s%s',
                     get_class($t),
                     PHP_EOL,
-                    $t->getMessage()
+                    $t->getMessage(),
+                    PHP_EOL,
+                    $t->getTraceAsString()
                 )
             );
         }

--- a/tests/end-to-end/regression/GitHub/4620.phpt
+++ b/tests/end-to-end/regression/GitHub/4620.phpt
@@ -1,5 +1,5 @@
 --TEST--
-https://github.com/sebastianbergmann/phpunit/issues/4620
+GH-4620 GH-4877
 --FILE--
 <?php declare(strict_types=1);
 
@@ -17,3 +17,4 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Error in bootstrap script: PHPUnit\TestFixture\MyException:
 Big boom. Big bada boom.
+%a


### PR DESCRIPTION
Addendum to #4620
Closes #4877 

- Add stack trace to bootstrap error message

Sample output:

```
PHPUnit 10.0-ga5ad02566 by Sebastian Bergmann and contributors.
 
Error in bootstrap script: PHPUnit\TestFixture\MyException:
Big boom. Big bada boom.
#0 /Users/shane/phpunit/src/TextUI/Application.php(415): include_once()
#1 /Users/shane/phpunit/src/TextUI/Application.php(238): PHPUnit\TextUI\Application-handleBootstrap('/Users/shane/ph...')
#2 /Users/shane/phpunit/src/TextUI/Application.php(95): PHPUnit\TextUI\Application->handleArguments(Array)
#3 /Users/shane/phpunit/src/TextUI/Application.php(78): PHPUnit\TextUI\Application->run(Array, true)
#4 Standard input code(11): PHPUnit\TextUI\Application::main()
#5 {main}
```

I edited the regression test for #4620 to expect output including a variable number of newlines as would be expected for a stack trace output -- please let me know if any changes are needed!