### PR TITLE
Fix: Do not declare test classes in global namespace

### DIFF
--- a/tests/unit/Framework/Constraint/LogicalXorTest.php
+++ b/tests/unit/Framework/Constraint/LogicalXorTest.php
@@ -7,12 +7,10 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-namespace Framework\Constraint;
+namespace PHPUnit\Framework\Constraint;
 
 use function array_fill;
 use function array_map;
-use PHPUnit\Framework\Constraint\Constraint;
-use PHPUnit\Framework\Constraint\LogicalXor;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
@@ -8,15 +8,17 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+namespace PHPUnit\Framework\MockObject;
+
+use ClassWithAllPossibleReturnTypes;
+use Foo;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
-use PHPUnit\Framework\MockObject\IncompatibleReturnValueException;
-use PHPUnit\Framework\MockObject\InvocationHandler;
-use PHPUnit\Framework\MockObject\Matcher;
 use PHPUnit\Framework\MockObject\Stub\ReturnSelf;
 use PHPUnit\Framework\MockObject\Stub\ReturnStub;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\ClassWithImplicitProtocol;
+use stdClass;
 
 /**
  * @covers \PHPUnit\Framework\MockObject\Builder\InvocationMocker

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -7,9 +7,26 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-use PHPUnit\Framework\MockObject\Generator;
-use PHPUnit\Framework\MockObject\MockObject;
+namespace PHPUnit\Framework\MockObject;
+
+use function class_exists;
+use function md5;
+use function method_exists;
+use function microtime;
+use AbstractMockTestClass;
+use AbstractTrait;
+use AnInterface;
+use AnInterfaceWithReturnType;
+use ClassWithVariadicArgumentMethod;
+use Countable;
+use Exception;
+use ExceptionWithThrowable;
+use FinalClass;
+use InterfaceWithSemiReservedMethodName;
 use PHPUnit\Framework\TestCase;
+use SingletonClass;
+use stdClass;
+use Throwable;
 
 /**
  * @covers \PHPUnit\Framework\MockObject\Generator
@@ -62,7 +79,7 @@ final class GeneratorTest extends TestCase
     {
         $this->expectException(\PHPUnit\Framework\MockObject\RuntimeException::class);
 
-        $this->assertFalse(\class_exists('Tux'));
+        $this->assertFalse(class_exists('Tux'));
 
         $this->generator->getMock('Tux', [], [], '', true, true, false, true, false, null, false);
     }
@@ -71,7 +88,7 @@ final class GeneratorTest extends TestCase
     {
         $this->expectException(\PHPUnit\Framework\MockObject\RuntimeException::class);
 
-        $this->assertFalse(\class_exists('Tux'));
+        $this->assertFalse(class_exists('Tux'));
 
         $this->generator->getMock(['Tux', false], [], [], '', true, true, false, true, false, null, false);
     }
@@ -87,7 +104,7 @@ final class GeneratorTest extends TestCase
     {
         $mock = $this->generator->getMock(stdClass::class, ['testFunction']);
 
-        $this->assertTrue(\method_exists($mock, 'testFunction'));
+        $this->assertTrue(method_exists($mock, 'testFunction'));
     }
 
     public function testGetMockGeneratorThrowsException(): void
@@ -102,7 +119,7 @@ final class GeneratorTest extends TestCase
     {
         $mock = $this->generator->getMock(InterfaceWithSemiReservedMethodName::class);
 
-        $this->assertTrue(\method_exists($mock, 'unset'));
+        $this->assertTrue(method_exists($mock, 'unset'));
         $this->assertInstanceOf(InterfaceWithSemiReservedMethodName::class, $mock);
     }
 
@@ -110,14 +127,14 @@ final class GeneratorTest extends TestCase
     {
         $mock = $this->generator->getMockForAbstractClass(Countable::class);
 
-        $this->assertTrue(\method_exists($mock, 'count'));
+        $this->assertTrue(method_exists($mock, 'count'));
     }
 
     public function testGetMockForAbstractClassStubbingAbstractClass(): void
     {
         $mock = $this->generator->getMockForAbstractClass(AbstractMockTestClass::class);
 
-        $this->assertTrue(\method_exists($mock, 'doSomething'));
+        $this->assertTrue(method_exists($mock, 'doSomething'));
     }
 
     public function testGetMockForAbstractClassWithNonExistentMethods(): void
@@ -132,8 +149,8 @@ final class GeneratorTest extends TestCase
             ['nonexistentMethod']
         );
 
-        $this->assertTrue(\method_exists($mock, 'nonexistentMethod'));
-        $this->assertTrue(\method_exists($mock, 'doSomething'));
+        $this->assertTrue(method_exists($mock, 'nonexistentMethod'));
+        $this->assertTrue(method_exists($mock, 'doSomething'));
     }
 
     public function testGetMockForAbstractClassShouldCreateStubsOnlyForAbstractMethodWhenNoMethodsWereInformed(): void
@@ -167,8 +184,8 @@ final class GeneratorTest extends TestCase
             ['nonexistentMethod']
         );
 
-        $this->assertTrue(\method_exists($mock, 'nonexistentMethod'));
-        $this->assertTrue(\method_exists($mock, 'doSomething'));
+        $this->assertTrue(method_exists($mock, 'nonexistentMethod'));
+        $this->assertTrue(method_exists($mock, 'doSomething'));
         $this->assertTrue($mock->mockableMethod());
         $this->assertTrue($mock->anotherMockableMethod());
     }
@@ -177,7 +194,7 @@ final class GeneratorTest extends TestCase
     {
         $mock = $this->generator->getMockForTrait(AbstractTrait::class);
 
-        $this->assertTrue(\method_exists($mock, 'doSomething'));
+        $this->assertTrue(method_exists($mock, 'doSomething'));
     }
 
     public function testGetMockForTraitWithNonExistantTrait(): void
@@ -226,7 +243,7 @@ final class GeneratorTest extends TestCase
 
     public function testCanConfigureMethodsForDoubleOfNonExistentClass(): void
     {
-        $className = 'X' . \md5(\microtime());
+        $className = 'X' . md5(microtime());
 
         $mock = $this->generator->getMock($className, ['someMethod']);
 
@@ -235,7 +252,7 @@ final class GeneratorTest extends TestCase
 
     public function testCanInvokeMethodsOfNonExistentClass(): void
     {
-        $className = 'X' . \md5(\microtime());
+        $className = 'X' . md5(microtime());
 
         $mock = $this->generator->getMock($className, ['someMethod']);
 

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -7,9 +7,12 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+namespace PHPUnit\Framework\MockObject;
+
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\InvalidParameterGroupException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * @small

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -7,7 +7,10 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-use PHPUnit\Framework\MockObject\MockBuilder;
+namespace PHPUnit\Framework\MockObject;
+
+use ACustomClassName;
+use Mockable;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -7,9 +7,32 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+namespace PHPUnit\Framework\MockObject;
+
+use function class_uses;
+use function func_get_args;
+use function get_class;
+use function get_parent_class;
+use AbstractMockTestClass;
+use AbstractTrait;
+use AnInterface;
+use ClassThatImplementsSerializable;
+use ClassWithAllPossibleReturnTypes;
+use ClassWithSelfTypeHint;
+use ClassWithStaticMethod;
+use ExampleTrait;
+use Exception;
+use InterfaceWithStaticMethod;
+use MethodCallback;
+use PartialMockTestClass;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionObject;
+use SomeClass;
+use stdClass;
+use StringableClass;
+use TraitWithConstructor;
+use Traversable;
 
 /**
  * @small
@@ -173,9 +196,9 @@ final class MockObjectTest extends TestCase
 
         $mock->expects($this->any())
              ->method('doSomething')
-             ->will($this->throwException(new \Exception));
+             ->will($this->throwException(new Exception));
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $mock->doSomething();
     }
@@ -187,9 +210,9 @@ final class MockObjectTest extends TestCase
 
         $mock->expects($this->any())
              ->method('doSomething')
-             ->willThrowException(new \Exception);
+             ->willThrowException(new Exception);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $mock->doSomething();
     }
@@ -369,7 +392,7 @@ final class MockObjectTest extends TestCase
         $mock2 = $this->getMockBuilder(AnInterface::class)
                      ->getMock();
 
-        $this->assertEquals(\get_class($mock1), \get_class($mock2));
+        $this->assertEquals(get_class($mock1), get_class($mock2));
     }
 
     public function testMockClassDifferentForPartialMocks(): void
@@ -393,14 +416,14 @@ final class MockObjectTest extends TestCase
                       ->setMethods(['doAnotherThing'])
                       ->getMock();
 
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock2));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock5));
-        $this->assertEquals(\get_class($mock2), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock5));
-        $this->assertEquals(\get_class($mock4), \get_class($mock5));
+        $this->assertNotEquals(get_class($mock1), get_class($mock2));
+        $this->assertNotEquals(get_class($mock1), get_class($mock3));
+        $this->assertNotEquals(get_class($mock1), get_class($mock4));
+        $this->assertNotEquals(get_class($mock1), get_class($mock5));
+        $this->assertEquals(get_class($mock2), get_class($mock3));
+        $this->assertNotEquals(get_class($mock2), get_class($mock4));
+        $this->assertNotEquals(get_class($mock2), get_class($mock5));
+        $this->assertEquals(get_class($mock4), get_class($mock5));
     }
 
     public function testMockClassStoreOverrulable(): void
@@ -424,15 +447,15 @@ final class MockObjectTest extends TestCase
                       ->setMockClassName('MyMockClassNameForPartialMockTestClass2')
                       ->getMock();
 
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock2));
-        $this->assertEquals(\get_class($mock1), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock5));
-        $this->assertNotEquals(\get_class($mock3), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock3), \get_class($mock5));
-        $this->assertNotEquals(\get_class($mock4), \get_class($mock5));
+        $this->assertNotEquals(get_class($mock1), get_class($mock2));
+        $this->assertEquals(get_class($mock1), get_class($mock3));
+        $this->assertNotEquals(get_class($mock1), get_class($mock4));
+        $this->assertNotEquals(get_class($mock2), get_class($mock3));
+        $this->assertNotEquals(get_class($mock2), get_class($mock4));
+        $this->assertNotEquals(get_class($mock2), get_class($mock5));
+        $this->assertNotEquals(get_class($mock3), get_class($mock4));
+        $this->assertNotEquals(get_class($mock3), get_class($mock5));
+        $this->assertNotEquals(get_class($mock4), get_class($mock5));
     }
 
     public function testGetMockWithFixedClassNameCanProduceTheSameMockTwice(): void
@@ -463,7 +486,7 @@ final class MockObjectTest extends TestCase
                       ->disableOriginalClone()
                       ->getMock();
 
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock2));
+        $this->assertNotEquals(get_class($mock1), get_class($mock2));
     }
 
     /**
@@ -500,8 +523,8 @@ final class MockObjectTest extends TestCase
         $mock->expects($this->never())
              ->method('doSomething');
 
-        $parent = \get_parent_class($mock);
-        $traits = \class_uses($parent, false);
+        $parent = get_parent_class($mock);
+        $traits = class_uses($parent, false);
 
         $this->assertContains(AbstractTrait::class, $traits);
     }
@@ -591,7 +614,7 @@ final class MockObjectTest extends TestCase
                  $this->returnCallback(
                      static function () use (&$actualArguments): void
                      {
-                         $actualArguments = \func_get_args();
+                         $actualArguments = func_get_args();
                      }
                  )
              );
@@ -620,7 +643,7 @@ final class MockObjectTest extends TestCase
                  $this->returnCallback(
                      static function () use (&$actualArguments): void
                      {
-                         $actualArguments = \func_get_args();
+                         $actualArguments = func_get_args();
                      }
                  )
              );
@@ -914,7 +937,7 @@ final class MockObjectTest extends TestCase
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            \get_class($mock)
+            get_class($mock)
         );
     }
 
@@ -927,7 +950,7 @@ final class MockObjectTest extends TestCase
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            \get_class($mock)
+            get_class($mock)
         );
     }
 
@@ -939,8 +962,8 @@ final class MockObjectTest extends TestCase
         $a = $this->getMockFromWsdl(TEST_FILES_PATH . 'GoogleSearch.wsdl');
         $b = $this->getMockFromWsdl(TEST_FILES_PATH . 'GoogleSearch.wsdl');
 
-        $this->assertStringStartsWith('Mock_GoogleSearch_', \get_class($a));
-        $this->assertEquals(\get_class($a), \get_class($b));
+        $this->assertStringStartsWith('Mock_GoogleSearch_', get_class($a));
+        $this->assertEquals(get_class($a), get_class($b));
     }
 
     /**
@@ -952,7 +975,7 @@ final class MockObjectTest extends TestCase
     {
         $mock = $this->getMockFromWsdl(TEST_FILES_PATH . 'Go ogle-Sea.rch.wsdl');
 
-        $this->assertStringStartsWith('Mock_GoogleSearch_', \get_class($mock));
+        $this->assertStringStartsWith('Mock_GoogleSearch_', get_class($mock));
     }
 
     /**
@@ -1001,7 +1024,7 @@ final class MockObjectTest extends TestCase
 
     public function testStringableClassDoesNotThrow(): void
     {
-        /** @var PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
+        /** @var \PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
         $mock = $this->getMockBuilder(StringableClass::class)->getMock();
 
         $this->assertIsString((string) $mock);
@@ -1009,7 +1032,7 @@ final class MockObjectTest extends TestCase
 
     public function testStringableClassCanBeMocked(): void
     {
-        /** @var PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
+        /** @var \PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
         $mock = $this->getMockBuilder(StringableClass::class)->getMock();
 
         $mock->method('__toString')->willReturn('foo');
@@ -1073,7 +1096,7 @@ final class MockObjectTest extends TestCase
 
     public function testDisableAutomaticReturnValueGenerationWithToString(): void
     {
-        /** @var PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
+        /** @var \PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
         $mock = $this->getMockBuilder(StringableClass::class)
             ->disableAutoReturnValueGeneration()
             ->getMock();

--- a/tests/unit/Framework/MockObject/ProxyObjectTest.php
+++ b/tests/unit/Framework/MockObject/ProxyObjectTest.php
@@ -7,8 +7,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-use PHPUnit\Framework\MockObject\MockObject;
+namespace PHPUnit\Framework\MockObject;
+
+use function assert;
 use PHPUnit\Framework\TestCase;
+use TestProxyFixture;
 
 /**
  * @small
@@ -22,8 +25,8 @@ final class ProxyObjectTest extends TestCase
         $proxy->expects($this->once())
               ->method('returnString');
 
-        \assert($proxy instanceof MockObject);
-        \assert($proxy instanceof TestProxyFixture);
+        assert($proxy instanceof MockObject);
+        assert($proxy instanceof TestProxyFixture);
 
         $this->assertSame('result', $proxy->returnString());
     }
@@ -35,8 +38,8 @@ final class ProxyObjectTest extends TestCase
         $proxy->expects($this->once())
               ->method('returnTypedString');
 
-        \assert($proxy instanceof MockObject);
-        \assert($proxy instanceof TestProxyFixture);
+        assert($proxy instanceof MockObject);
+        assert($proxy instanceof TestProxyFixture);
 
         $this->assertSame('result', $proxy->returnTypedString());
     }
@@ -48,8 +51,8 @@ final class ProxyObjectTest extends TestCase
         $proxy->expects($this->once())
               ->method('returnObject');
 
-        \assert($proxy instanceof MockObject);
-        \assert($proxy instanceof TestProxyFixture);
+        assert($proxy instanceof MockObject);
+        assert($proxy instanceof TestProxyFixture);
 
         $this->assertSame('bar', $proxy->returnObject()->foo);
     }
@@ -61,8 +64,8 @@ final class ProxyObjectTest extends TestCase
         $proxy->expects($this->once())
               ->method('returnTypedObject');
 
-        \assert($proxy instanceof MockObject);
-        \assert($proxy instanceof TestProxyFixture);
+        assert($proxy instanceof MockObject);
+        assert($proxy instanceof TestProxyFixture);
 
         $this->assertSame('bar', $proxy->returnTypedObject()->foo);
     }
@@ -74,8 +77,8 @@ final class ProxyObjectTest extends TestCase
         $proxy->expects($this->once())
               ->method('returnObjectOfFinalClass');
 
-        \assert($proxy instanceof MockObject);
-        \assert($proxy instanceof TestProxyFixture);
+        assert($proxy instanceof MockObject);
+        assert($proxy instanceof TestProxyFixture);
 
         $this->assertSame('value', $proxy->returnObjectOfFinalClass()->value());
     }
@@ -87,8 +90,8 @@ final class ProxyObjectTest extends TestCase
         $proxy->expects($this->once())
               ->method('returnTypedObjectOfFinalClass');
 
-        \assert($proxy instanceof MockObject);
-        \assert($proxy instanceof TestProxyFixture);
+        assert($proxy instanceof MockObject);
+        assert($proxy instanceof TestProxyFixture);
 
         $this->assertSame('value', $proxy->returnTypedObjectOfFinalClass()->value());
     }

--- a/tests/unit/Runner/NullTestResultCacheTest.php
+++ b/tests/unit/Runner/NullTestResultCacheTest.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+namespace PHPUnit\Runner;
+
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\BaseTestRunner;
-use PHPUnit\Runner\NullTestResultCache;
 
 /**
  * @group test-reorder


### PR DESCRIPTION
This pull request

- [x] stops declaring test classes in the global namespace

💁‍♂️ This is in preparation for moving test fixtures into the `PHPUnit\TestFixture` namespace.