### PR TITLE
Fix: Do not declare test classes in global namespace

### DIFF
--- a/tests/unit/Framework/ExecutionOrderDependencyTest.php
+++ b/tests/unit/Framework/ExecutionOrderDependencyTest.php
@@ -7,8 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-use PHPUnit\Framework\ExecutionOrderDependency;
-use PHPUnit\Framework\TestCase;
+namespace PHPUnit\Framework;
 
 /**
  * @covers \PHPUnit\Framework\ExecutionOrderDependency

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-use PHPUnit\Framework\MockObject\CannotUseAddMethodsException;
-use PHPUnit\Framework\MockObject\CannotUseOnlyMethodsException;
-use PHPUnit\Framework\MockObject\MockBuilder;
+namespace PHPUnit\Framework\MockObject;
+
+use ACustomClassName;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\Mockable;
 

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -7,10 +7,15 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+namespace PHPUnit\Framework\MockObject;
+
+use function class_uses;
+use function func_get_args;
+use function get_class;
+use function get_parent_class;
+use Exception;
+use Foo;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\ReturnValueNotConfiguredException;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\AbstractTrait;
 use PHPUnit\TestFixture\AnInterface;
@@ -31,6 +36,10 @@ use PHPUnit\TestFixture\SomeClass;
 use PHPUnit\TestFixture\StringableClass;
 use PHPUnit\TestFixture\TraitWithConstructor;
 use PHPUnit\TestFixture\TraversableMockTestInterface;
+use ReflectionObject;
+use RuntimeException;
+use stdClass;
+use Traversable;
 
 /**
  * @small
@@ -192,9 +201,9 @@ final class MockObjectTest extends TestCase
                      ->getMock();
 
         $mock->method('doSomething')
-             ->will($this->throwException(new \Exception));
+             ->will($this->throwException(new Exception));
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $mock->doSomething();
     }
@@ -205,9 +214,9 @@ final class MockObjectTest extends TestCase
                      ->getMock();
 
         $mock->method('doSomething')
-             ->willThrowException(new \Exception);
+             ->willThrowException(new Exception);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $mock->doSomething();
     }
@@ -377,7 +386,7 @@ final class MockObjectTest extends TestCase
         $mock2 = $this->getMockBuilder(AnInterface::class)
                      ->getMock();
 
-        $this->assertEquals(\get_class($mock1), \get_class($mock2));
+        $this->assertEquals(get_class($mock1), get_class($mock2));
     }
 
     public function testMockClassDifferentForPartialMocks(): void
@@ -401,14 +410,14 @@ final class MockObjectTest extends TestCase
                       ->onlyMethods(['doAnotherThing'])
                       ->getMock();
 
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock2));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock5));
-        $this->assertEquals(\get_class($mock2), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock5));
-        $this->assertEquals(\get_class($mock4), \get_class($mock5));
+        $this->assertNotEquals(get_class($mock1), get_class($mock2));
+        $this->assertNotEquals(get_class($mock1), get_class($mock3));
+        $this->assertNotEquals(get_class($mock1), get_class($mock4));
+        $this->assertNotEquals(get_class($mock1), get_class($mock5));
+        $this->assertEquals(get_class($mock2), get_class($mock3));
+        $this->assertNotEquals(get_class($mock2), get_class($mock4));
+        $this->assertNotEquals(get_class($mock2), get_class($mock5));
+        $this->assertEquals(get_class($mock4), get_class($mock5));
     }
 
     public function testMockClassStoreOverrulable(): void
@@ -432,15 +441,15 @@ final class MockObjectTest extends TestCase
                       ->setMockClassName('MyMockClassNameForPartialMockTestClass2')
                       ->getMock();
 
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock2));
-        $this->assertEquals(\get_class($mock1), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock3));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock2), \get_class($mock5));
-        $this->assertNotEquals(\get_class($mock3), \get_class($mock4));
-        $this->assertNotEquals(\get_class($mock3), \get_class($mock5));
-        $this->assertNotEquals(\get_class($mock4), \get_class($mock5));
+        $this->assertNotEquals(get_class($mock1), get_class($mock2));
+        $this->assertEquals(get_class($mock1), get_class($mock3));
+        $this->assertNotEquals(get_class($mock1), get_class($mock4));
+        $this->assertNotEquals(get_class($mock2), get_class($mock3));
+        $this->assertNotEquals(get_class($mock2), get_class($mock4));
+        $this->assertNotEquals(get_class($mock2), get_class($mock5));
+        $this->assertNotEquals(get_class($mock3), get_class($mock4));
+        $this->assertNotEquals(get_class($mock3), get_class($mock5));
+        $this->assertNotEquals(get_class($mock4), get_class($mock5));
     }
 
     public function testGetMockWithFixedClassNameCanProduceTheSameMockTwice(): void
@@ -471,7 +480,7 @@ final class MockObjectTest extends TestCase
                       ->disableOriginalClone()
                       ->getMock();
 
-        $this->assertNotEquals(\get_class($mock1), \get_class($mock2));
+        $this->assertNotEquals(get_class($mock1), get_class($mock2));
     }
 
     /**
@@ -508,8 +517,8 @@ final class MockObjectTest extends TestCase
         $mock->expects($this->never())
              ->method('doSomething');
 
-        $parent = \get_parent_class($mock);
-        $traits = \class_uses($parent, false);
+        $parent = get_parent_class($mock);
+        $traits = class_uses($parent, false);
 
         $this->assertContains(AbstractTrait::class, $traits);
     }
@@ -598,7 +607,7 @@ final class MockObjectTest extends TestCase
                  $this->returnCallback(
                      static function () use (&$actualArguments): void
                      {
-                         $actualArguments = \func_get_args();
+                         $actualArguments = func_get_args();
                      }
                  )
              );
@@ -626,7 +635,7 @@ final class MockObjectTest extends TestCase
                  $this->returnCallback(
                      static function () use (&$actualArguments): void
                      {
-                         $actualArguments = \func_get_args();
+                         $actualArguments = func_get_args();
                      }
                  )
              );
@@ -916,7 +925,7 @@ final class MockObjectTest extends TestCase
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            \get_class($mock)
+            get_class($mock)
         );
     }
 
@@ -929,7 +938,7 @@ final class MockObjectTest extends TestCase
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            \get_class($mock)
+            get_class($mock)
         );
     }
 
@@ -941,8 +950,8 @@ final class MockObjectTest extends TestCase
         $a = $this->getMockFromWsdl(TEST_FILES_PATH . 'GoogleSearch.wsdl');
         $b = $this->getMockFromWsdl(TEST_FILES_PATH . 'GoogleSearch.wsdl');
 
-        $this->assertStringStartsWith('Mock_GoogleSearch_', \get_class($a));
-        $this->assertEquals(\get_class($a), \get_class($b));
+        $this->assertStringStartsWith('Mock_GoogleSearch_', get_class($a));
+        $this->assertEquals(get_class($a), get_class($b));
     }
 
     /**
@@ -954,7 +963,7 @@ final class MockObjectTest extends TestCase
     {
         $mock = $this->getMockFromWsdl(TEST_FILES_PATH . 'Go ogle-Sea.rch.wsdl');
 
-        $this->assertStringStartsWith('Mock_GoogleSearch_', \get_class($mock));
+        $this->assertStringStartsWith('Mock_GoogleSearch_', get_class($mock));
     }
 
     /**
@@ -1073,7 +1082,7 @@ final class MockObjectTest extends TestCase
 
     public function testDisableAutomaticReturnValueGenerationWithToString(): void
     {
-        /** @var PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
+        /** @var \PHPUnit\Framework\MockObject\MockObject|StringableClass $mock */
         $mock = $this->getMockBuilder(StringableClass::class)
             ->disableAutoReturnValueGeneration()
             ->getMock();


### PR DESCRIPTION
This pull request

- [x] stops declaring test classes in the global namespace

Follows https://github.com/sebastianbergmann/phpunit/pull/4888#issuecomment-1046023847.