### PR TITLE
fix: colors help

### DIFF
--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -88,7 +88,7 @@ final class Help
             ['arg'    => '--static-backup', 'desc' => 'Backup and restore static properties for each test'],
             ['spacer' => ''],
 
-            ['arg'    => '--colors <flag>', 'desc' => 'Use colors in output ("never", "auto" or "always")'],
+            ['arg'    => '--colors=<flag>', 'desc' => 'Use colors in output ("never", "auto" or "always")'],
             ['arg'    => '--columns <n>', 'desc' => 'Number of columns to use for progress output'],
             ['arg'    => '--columns max', 'desc' => 'Use maximum number of columns for progress output'],
             ['arg'    => '--stderr', 'desc' => 'Write to STDERR instead of STDOUT'],

--- a/tests/end-to-end/cli/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/cli/_files/output-cli-help-color.txt
@@ -74,7 +74,7 @@
   [32m--static-backup            [0m Backup and restore static properties for
                               each test
 
-  [32m--colors [36m<flag>[0m            [0m Use colors in output ("never", "auto" or
+  [32m--colors=[36m<flag>[0m            [0m Use colors in output ("never", "auto" or
                               "always")
   [32m--columns [36m<n>[0m              [0m Number of columns to use for progress
                               output

--- a/tests/end-to-end/cli/_files/output-cli-usage.txt
+++ b/tests/end-to-end/cli/_files/output-cli-usage.txt
@@ -57,7 +57,7 @@ Test Execution Options:
   --globals-backup            Backup and restore $GLOBALS for each test
   --static-backup             Backup and restore static properties for each test
 
-  --colors <flag>             Use colors in output ("never", "auto" or "always")
+  --colors=<flag>             Use colors in output ("never", "auto" or "always")
   --columns <n>               Number of columns to use for progress output
   --columns max               Use maximum number of columns for progress output
   --stderr                    Write to STDERR instead of STDOUT


### PR DESCRIPTION
colors help is wrong, it notice: no need equal sign, but actually need.

```shell
./vendor/bin/phpunit --help
PHPUnit 9.5.14 by Sebastian Bergmann and contributors.

  --coverage-php <file>       Export PHP_CodeCoverage object to file
  --coverage-text=<file>      Generate code coverage report in text format [default: standard output]

  --colors <flag>             Use colors in output ("never", "auto" or "always")
```

```shell
XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-text --colors never
```

> Cannot open file "never".


```shell
XDEBUG_MODE=coverage php vendor/bin/phpunit --coverage-text --colors=never
```

> OK (2 tests, 2 assertions)