### PR TITLE
Test associative arrays comparison with canonicalization

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -1507,6 +1507,13 @@ XML;
         $this->assertNotEqualsCanonicalizing([3, 2, 1], [2, 3, 4]);
     }
 
+    public function testAssociativeArraysCanBeComparedForEqualityWithCanonicalization(): void
+    {
+        $this->assertEqualsCanonicalizing(['a' => 2, 'b' => 3], ['b' => 3, 'a' => 2]);
+
+        $this->assertNotEqualsCanonicalizing(['aa' => 2, 'b' => 3], ['a' => 2, 'b' => 3]);
+    }
+
     public function testArrayTypeCanBeAsserted(): void
     {
         $this->assertIsArray([]);


### PR DESCRIPTION
One of these assertions will likely fail, resulting in a bug report.