### PR TITLE
Fix: Regenerate baseline for `vimeo/psalm`

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -339,6 +339,17 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) var_export($parameter-&gt;getDefaultValue(), true)</code>
     </RedundantCastGivenDocblockType>
+    <RedundantCondition occurrences="1">
+      <code>$type instanceof ReflectionIntersectionType</code>
+    </RedundantCondition>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$type instanceof ReflectionIntersectionType</code>
+    </TypeDoesNotContainType>
+    <UndefinedClass occurrences="3">
+      <code>ReflectionIntersectionType</code>
+      <code>ReflectionIntersectionType</code>
+      <code>ReflectionIntersectionType</code>
+    </UndefinedClass>
   </file>
   <file src="src/Framework/MockObject/Rule/Parameters.php">
     <PropertyNotSetInConstructor occurrences="1">


### PR DESCRIPTION
This pull request

- [x] regenerates the baseline for `vimeo/psalm`

Slightly related to #4903, where the static code analysis fails.