### PR TITLE
Fix: Use class keyword

### DIFF
--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -214,20 +214,20 @@ final class AssertTest extends TestCase
 
     public function testAssertArrayContainsOnlyStdClass(): void
     {
-        $this->assertContainsOnly('StdClass', [new stdClass]);
+        $this->assertContainsOnly(stdClass::class, [new stdClass]);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertContainsOnly('StdClass', ['StdClass']);
+        $this->assertContainsOnly(stdClass::class, [stdClass::class]);
     }
 
     public function testAssertArrayNotContainsOnlyStdClass(): void
     {
-        $this->assertNotContainsOnly('StdClass', ['StdClass']);
+        $this->assertNotContainsOnly(stdClass::class, [stdClass::class]);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertNotContainsOnly('StdClass', [new stdClass]);
+        $this->assertNotContainsOnly(stdClass::class, [new stdClass]);
     }
 
     public function equalProvider(): array
@@ -930,7 +930,7 @@ XML;
 
     public function testAssertThatIsInstanceOf(): void
     {
-        $this->assertThat(new stdClass, $this->isInstanceOf('StdClass'));
+        $this->assertThat(new stdClass, $this->isInstanceOf(stdClass::class));
     }
 
     public function testAssertThatIsType(): void
@@ -1412,7 +1412,7 @@ XML;
     {
         $this->expectException(Exception::class);
 
-        $this->assertInstanceOf('ClassThatDoesNotExist', new stdClass);
+        $this->assertInstanceOf(ClassThatDoesNotExist::class, new stdClass);
     }
 
     public function testAssertInstanceOf(): void
@@ -1428,7 +1428,7 @@ XML;
     {
         $this->expectException(Exception::class);
 
-        $this->assertNotInstanceOf('ClassThatDoesNotExist', new stdClass);
+        $this->assertNotInstanceOf(ClassThatDoesNotExist::class, new stdClass);
     }
 
     public function testAssertNotInstanceOf(): void

--- a/tests/unit/Framework/Constraint/ClassHasAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ClassHasAttributeTest.php
@@ -33,11 +33,14 @@ final class ClassHasAttributeTest extends ConstraintTestCase
             $constraint->evaluate(stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
-Failed asserting that class "stdClass" has attribute "privateAttribute".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that class "%s" has attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -57,12 +60,15 @@ EOF
             $constraint->evaluate(stdClass::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that class "stdClass" has attribute "privateAttribute".
+Failed asserting that class "%s" has attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 

--- a/tests/unit/Framework/Constraint/ClassHasStaticAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ClassHasStaticAttributeTest.php
@@ -31,11 +31,14 @@ final class ClassHasStaticAttributeTest extends ConstraintTestCase
             $constraint->evaluate(stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
-Failed asserting that class "stdClass" has static attribute "privateStaticAttribute".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that class "%s" has static attribute "privateStaticAttribute".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -53,12 +56,15 @@ EOF
             $constraint->evaluate(stdClass::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that class "stdClass" has static attribute "foo".
+Failed asserting that class "%s" has static attribute "foo".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 

--- a/tests/unit/Framework/Constraint/IsIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/IsIdenticalTest.php
@@ -26,7 +26,13 @@ final class IsIdenticalTest extends ConstraintTestCase
 
         $this->assertFalse($constraint->evaluate($b, '', true));
         $this->assertTrue($constraint->evaluate($a, '', true));
-        $this->assertEquals('is identical to an object of class "stdClass"', $constraint->toString());
+        $this->assertEquals(
+            sprintf(
+                'is identical to an object of class "%s"',
+                stdClass::class
+            ),
+            $constraint->toString()
+        );
         $this->assertCount(1, $constraint);
 
         try {

--- a/tests/unit/Framework/Constraint/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/IsInstanceOfTest.php
@@ -30,14 +30,18 @@ final class IsInstanceOfTest extends ConstraintTestCase
         $constraint = new IsInstanceOf(stdClass::class);
 
         try {
-            $constraint->evaluate('stdClass');
+            $constraint->evaluate(stdClass::class);
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                <<<'EOT'
-Failed asserting that 'stdClass' is an instance of class "stdClass".
+                sprintf(
+                    <<<'EOT'
+Failed asserting that '%s' is an instance of class "%s".
 
 EOT
-                ,
+                    ,
+                    stdClass::class,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
         }
@@ -50,7 +54,10 @@ EOT
         $constraint = new IsInstanceOf(NotExistingClass::class);
 
         $this->assertSame(
-            'is instance of class "PHPUnit\Framework\Constraint\NotExistingClass"',
+            sprintf(
+                'is instance of class "%s"',
+                NotExistingClass::class
+            ),
             $constraint->toString()
         );
     }

--- a/tests/unit/Framework/Constraint/IsTypeTest.php
+++ b/tests/unit/Framework/Constraint/IsTypeTest.php
@@ -36,11 +36,14 @@ final class IsTypeTest extends ConstraintTestCase
             $constraint->evaluate(new stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertStringMatchesFormat(
-                <<<'EOF'
-Failed asserting that stdClass Object #%d () is of type "string".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that %s Object #%%d () is of type "string".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 $this->trimnl(TestFailure::exceptionToString($e))
             );
 
@@ -58,12 +61,15 @@ EOF
             $constraint->evaluate(new stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertStringMatchesFormat(
-                <<<'EOF'
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that stdClass Object #%d () is of type "string".
+Failed asserting that %s Object #%%d () is of type "string".
 
 EOF
                 ,
+                    stdClass::class
+                ),
                 $this->trimnl(TestFailure::exceptionToString($e))
             );
 

--- a/tests/unit/Framework/Constraint/ObjectHasAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ObjectHasAttributeTest.php
@@ -31,11 +31,14 @@ final class ObjectHasAttributeTest extends ConstraintTestCase
             $constraint->evaluate(new stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
-Failed asserting that object of class "stdClass" has attribute "privateAttribute".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that object of class "%s" has attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -53,12 +56,15 @@ EOF
             $constraint->evaluate(new stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that object of class "stdClass" has attribute "privateAttribute".
+Failed asserting that object of class "%s" has attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 

--- a/tests/unit/Framework/ConstraintTest.php
+++ b/tests/unit/Framework/ConstraintTest.php
@@ -418,7 +418,13 @@ EOF
 
         $this->assertTrue($constraint->evaluate($b, '', true));
         $this->assertFalse($constraint->evaluate($a, '', true));
-        $this->assertEquals('is not identical to an object of class "stdClass"', $constraint->toString());
+        $this->assertEquals(
+            sprintf(
+                'is not identical to an object of class "%s"',
+                stdClass::class
+            ),
+            $constraint->toString()
+        );
         $this->assertCount(1, $constraint);
 
         try {
@@ -497,23 +503,39 @@ EOF
 
         $this->assertFalse($constraint->evaluate(new stdClass, '', true));
         $this->assertTrue($constraint->evaluate(new \Exception, '', true));
-        $this->assertEquals('is instance of class "Exception"', $constraint->toString());
+        $this->assertEquals(
+            sprintf(
+                'is instance of class "%s"',
+                \Exception::class
+            ),
+            $constraint->toString()
+        );
         $this->assertCount(1, $constraint);
 
         $interfaceConstraint = Assert::isInstanceOf(Countable::class);
         $this->assertFalse($interfaceConstraint->evaluate(new stdClass, '', true));
         $this->assertTrue($interfaceConstraint->evaluate(new ArrayObject, '', true));
-        $this->assertEquals('is instance of interface "Countable"', $interfaceConstraint->toString());
+        $this->assertEquals(
+            sprintf(
+                'is instance of interface "%s"',
+                Countable::class
+            ),
+            $interfaceConstraint->toString()
+        );
 
         try {
             $constraint->evaluate(new stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
-Failed asserting that stdClass Object () is an instance of class "Exception".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that %s Object () is an instance of class "%s".
 
 EOF
-                ,
+                    ,
+                    stdClass::class,
+                    \Exception::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -531,12 +553,16 @@ EOF
             $constraint->evaluate(new stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that stdClass Object () is an instance of class "Exception".
+Failed asserting that %s Object () is an instance of class "%s".
 
 EOF
-                ,
+                    ,
+                    stdClass::class,
+                    \Exception::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -554,18 +580,28 @@ EOF
 
         $this->assertFalse($constraint->evaluate(new stdClass, '', true));
         $this->assertTrue($constraint->evaluate(new Exception, '', true));
-        $this->assertEquals('is not instance of class "stdClass"', $constraint->toString());
+        $this->assertEquals(
+            sprintf(
+                'is not instance of class "%s"',
+                stdClass::class
+            ),
+            $constraint->toString()
+        );
         $this->assertCount(1, $constraint);
 
         try {
             $constraint->evaluate(new stdClass);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
-Failed asserting that stdClass Object () is not an instance of class "stdClass".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that %s Object () is not an instance of class "%s".
 
 EOF
-                ,
+                    ,
+                    stdClass::class,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -585,12 +621,16 @@ EOF
             $constraint->evaluate(new stdClass, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<'EOF'
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that stdClass Object () is not an instance of class "stdClass".
+Failed asserting that %s Object () is not an instance of class "%s".
 
 EOF
-                ,
+                    ,
+                    stdClass::class,
+                    stdClass::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -881,11 +921,14 @@ EOF
             $constraint->evaluate(ClassWithNonPublicAttributes::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
-Failed asserting that class "PHPUnit\TestFixture\ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that class "%s" does not have attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    ClassWithNonPublicAttributes::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -905,12 +948,15 @@ EOF
             $constraint->evaluate(ClassWithNonPublicAttributes::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that class "PHPUnit\TestFixture\ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
+Failed asserting that class "%s" does not have attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    ClassWithNonPublicAttributes::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -935,11 +981,14 @@ EOF
             $constraint->evaluate(ClassWithNonPublicAttributes::class);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
-Failed asserting that class "PHPUnit\TestFixture\ClassWithNonPublicAttributes" does not have static attribute "privateStaticAttribute".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that class "%s" does not have static attribute "privateStaticAttribute".
 
 EOF
-                ,
+                    ,
+                    ClassWithNonPublicAttributes::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -959,12 +1008,15 @@ EOF
             $constraint->evaluate(ClassWithNonPublicAttributes::class, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that class "PHPUnit\TestFixture\ClassWithNonPublicAttributes" does not have static attribute "privateStaticAttribute".
+Failed asserting that class "%s" does not have static attribute "privateStaticAttribute".
 
 EOF
-                ,
+                    ,
+                    ClassWithNonPublicAttributes::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -989,11 +1041,14 @@ EOF
             $constraint->evaluate(new ClassWithNonPublicAttributes);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
-Failed asserting that object of class "PHPUnit\TestFixture\ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
+                sprintf(
+                    <<<'EOF'
+Failed asserting that object of class "%s" does not have attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    ClassWithNonPublicAttributes::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -1013,12 +1068,15 @@ EOF
             $constraint->evaluate(new ClassWithNonPublicAttributes, 'custom message');
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
+                sprintf(
+                    <<<'EOF'
 custom message
-Failed asserting that object of class "PHPUnit\TestFixture\ClassWithNonPublicAttributes" does not have attribute "privateAttribute".
+Failed asserting that object of class "%s" does not have attribute "privateAttribute".
 
 EOF
-                ,
+                    ,
+                    ClassWithNonPublicAttributes::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 
@@ -1382,12 +1440,15 @@ EOF
             $constraint->evaluate($exception);
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
-                <<<EOF
-Failed asserting that exception of type "PHPUnit\TestFixture\DummyException" matches expected exception "FoobarException". Message was: "Test" at
+                sprintf(
+                    <<<EOF
+Failed asserting that exception of type "%s" matches expected exception "FoobarException". Message was: "Test" at
 {$stackTrace}.
 
 EOF
-                ,
+                    ,
+                    DummyException::class
+                ),
                 TestFailure::exceptionToString($e)
             );
 

--- a/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
@@ -126,7 +126,10 @@ final class InvocationMockerTest extends TestCase
         $invocationMocker = $mock->method('methodWithClassReturnTypeDeclaration');
 
         $this->expectException(IncompatibleReturnValueException::class);
-        $this->expectExceptionMessage('Method methodWithClassReturnTypeDeclaration may not return value of type Foo, its declared return type is "stdClass"');
+        $this->expectExceptionMessage(sprintf(
+            'Method methodWithClassReturnTypeDeclaration may not return value of type Foo, its declared return type is "%s"',
+            stdClass::class
+        ));
         $invocationMocker->willReturn(new Foo);
     }
 

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Framework\MockObject;
 
+use ACustomClassname;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\Mockable;
@@ -44,7 +45,10 @@ final class MockBuilderTest extends TestCase
     public function testOnlyMethodsWithNonExistentMethodNames(): void
     {
         $this->expectException(CannotUseOnlyMethodsException::class);
-        $this->expectExceptionMessage('Trying to configure method "mockableMethodWithCrazyName" with onlyMethods(), but it does not exist in class "PHPUnit\TestFixture\Mockable". Use addMethods() for methods that do not exist in the class');
+        $this->expectExceptionMessage(sprintf(
+            'Trying to configure method "mockableMethodWithCrazyName" with onlyMethods(), but it does not exist in class "%s". Use addMethods() for methods that do not exist in the class',
+            Mockable::class
+        ));
 
         $this->getMockBuilder(Mockable::class)
              ->onlyMethods(['mockableMethodWithCrazyName'])
@@ -73,7 +77,10 @@ final class MockBuilderTest extends TestCase
     public function testAddMethodsWithExistentMethodNames(): void
     {
         $this->expectException(CannotUseAddMethodsException::class);
-        $this->expectExceptionMessage('Trying to configure method "mockableMethod" with addMethods(), but it exists in class "PHPUnit\TestFixture\Mockable". Use onlyMethods() for methods that exist in the class');
+        $this->expectExceptionMessage(sprintf(
+            'Trying to configure method "mockableMethod" with addMethods(), but it exists in class "%s". Use onlyMethods() for methods that exist in the class',
+            Mockable::class
+        ));
 
         $this->getMockBuilder(Mockable::class)
              ->addMethods(['mockableMethod'])
@@ -131,7 +138,7 @@ final class MockBuilderTest extends TestCase
     public function testMockClassNameCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMockClassName('ACustomClassName')
+                     ->setMockClassName(ACustomClassName::class)
                      ->getMock();
 
         $this->assertInstanceOf('ACustomClassName', $mock);

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -33,6 +33,7 @@ use PHPUnit\TestFixture\MockObject\ClassWithStaticMethod;
 use PHPUnit\TestFixture\MockObject\ClassWithStaticReturnTypes;
 use PHPUnit\TestFixture\MockObject\ClassWithUnionReturnTypes;
 use PHPUnit\TestFixture\MockObject\ExampleTrait;
+use PHPUnit\TestFixture\MockObject\FunctionCallbackWrapper;
 use PHPUnit\TestFixture\MockObject\InterfaceWithMethodReturningIntersection;
 use PHPUnit\TestFixture\MockObject\InterfaceWithMethodReturningIntersectionWithClass;
 use PHPUnit\TestFixture\MockObject\InterfaceWithMethodsThatDeclareBooleanReturnTypes;
@@ -297,7 +298,10 @@ final class MockObjectTest extends TestCase
 
         $mock->expects($this->once())
              ->method('doSomething')
-             ->willReturnCallback('PHPUnit\TestFixture\MockObject\FunctionCallbackWrapper::functionCallback');
+             ->will($this->returnCallback(sprintf(
+                 '%s::functionCallback',
+                 FunctionCallbackWrapper::class
+             )));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
 
@@ -307,7 +311,10 @@ final class MockObjectTest extends TestCase
 
         $mock->expects($this->once())
              ->method('doSomething')
-             ->willReturnCallback('PHPUnit\TestFixture\MockObject\FunctionCallbackWrapper::functionCallback');
+             ->willReturnCallback(sprintf(
+                 '%s::functionCallback',
+                 FunctionCallbackWrapper::class
+             ));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
     }
@@ -698,9 +705,15 @@ final class MockObjectTest extends TestCase
             $mock->right(['second']);
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s)\n" .
-                'Parameter 0 for invocation PHPUnit\TestFixture\SomeClass::right(Array (...)) does not match expected value.' . "\n" .
-                'Failed asserting that two arrays are equal.',
+                sprintf(
+                    <<<'EOF'
+Expectation failed for method name is "right" when invoked 1 time(s)
+Parameter 0 for invocation %s::right(Array (...)) does not match expected value.
+Failed asserting that two arrays are equal.
+EOF
+                    ,
+                    SomeClass::class
+                ),
                 $e->getMessage()
             );
         }
@@ -712,17 +725,24 @@ final class MockObjectTest extends TestCase
 //            $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s).\n" .
-                'Parameter 0 for invocation PHPUnit\TestFixture\SomeClass::right(Array (...)) does not match expected value.' . "\n" .
-                'Failed asserting that two arrays are equal.' . "\n" .
-                '--- Expected' . "\n" .
-                '+++ Actual' . "\n" .
-                '@@ @@' . "\n" .
-                ' Array (' . "\n" .
-                '-    0 => \'first\'' . "\n" .
-                '-    1 => \'second\'' . "\n" .
-                '+    0 => \'second\'' . "\n" .
-                ' )' . "\n",
+                sprintf(
+                    <<<'EOF'
+Expectation failed for method name is "right" when invoked 1 time(s).
+Parameter 0 for invocation %s::right(Array (...)) does not match expected value.
+Failed asserting that two arrays are equal.
+--- Expected
++++ Actual
+@@ @@
+ Array (
+-    0 => 'first'
+-    1 => 'second'
++    0 => 'second'
+ )
+
+EOF
+                    ,
+                    SomeClass::class
+                ),
                 $e->getMessage()
             );
         }
@@ -745,7 +765,10 @@ final class MockObjectTest extends TestCase
             $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                'PHPUnit\TestFixture\SomeClass::right() was not expected to be called.',
+                sprintf(
+                    '%s::right() was not expected to be called.',
+                    SomeClass::class
+                ),
                 $e->getMessage()
             );
         }
@@ -768,7 +791,10 @@ final class MockObjectTest extends TestCase
             $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                'PHPUnit\TestFixture\SomeClass::right() was not expected to be called.',
+                sprintf(
+                    '%s::right() was not expected to be called.',
+                    SomeClass::class
+                ),
                 $e->getMessage()
             );
         }
@@ -791,9 +817,15 @@ final class MockObjectTest extends TestCase
             $this->fail('Expected exception');
         } catch (ExpectationFailedException $e) {
             $this->assertSame(
-                "Expectation failed for method name is \"right\" when invoked 1 time(s)\n" .
-                'Parameter count for invocation PHPUnit\TestFixture\SomeClass::right() is too low.' . "\n" .
-                'To allow 0 or more parameters with any value, omit ->with() or use ->withAnyParameters() instead.',
+                sprintf(
+                    <<<'EOF'
+Expectation failed for method name is "right" when invoked 1 time(s)
+Parameter count for invocation %s::right() is too low.
+To allow 0 or more parameters with any value, omit ->with() or use ->withAnyParameters() instead.
+EOF
+                    ,
+                    SomeClass::class
+                ),
                 $e->getMessage()
             );
         }
@@ -987,7 +1019,6 @@ final class MockObjectTest extends TestCase
     {
         return [
             Traversable::class                  => [Traversable::class],
-            '\Traversable'                      => [Traversable::class],
             TraversableMockTestInterface::class => [TraversableMockTestInterface::class],
         ];
     }
@@ -1030,7 +1061,10 @@ final class MockObjectTest extends TestCase
                      ->getMock();
 
         $this->expectException(ReturnValueNotConfiguredException::class);
-        $this->expectExceptionMessage('Return value inference disabled and no expectation set up for PHPUnit\TestFixture\SomeClass::doSomethingElse()');
+        $this->expectExceptionMessage(sprintf(
+            'Return value inference disabled and no expectation set up for %s::doSomethingElse()',
+            SomeClass::class
+        ));
 
         $mock->doSomethingElse(1);
     }
@@ -1049,7 +1083,10 @@ final class MockObjectTest extends TestCase
             $this->fail('Exception expected');
         } catch (RuntimeException $e) {
             $this->assertSame(
-                'Return value inference disabled and no expectation set up for PHPUnit\TestFixture\MockObject\StringableClass::__toString()',
+                sprintf(
+                    'Return value inference disabled and no expectation set up for %s::__toString()',
+                    StringableClass::class
+                ),
                 $e->getMessage()
             );
         }

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -94,7 +94,10 @@ class TestCaseTest extends TestCase
     public function testCaseToString(): void
     {
         $this->assertEquals(
-            'PHPUnit\Framework\TestCaseTest::testCaseToString',
+            sprintf(
+                '%s::testCaseToString',
+                self::class
+            ),
             $this->toString()
         );
     }

--- a/tests/unit/Framework/TestSuiteTest.php
+++ b/tests/unit/Framework/TestSuiteTest.php
@@ -55,7 +55,7 @@ final class TestSuiteTest extends TestCase
 
     public function testSuiteNameCanBeSameAsExistingNonTestClassName(): void
     {
-        $suite = new TestSuite('stdClass');
+        $suite = new TestSuite(stdClass::class);
         $suite->addTestSuite(OneTestCase::class);
 
         Facade::suspend();

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -587,7 +587,13 @@ final class TestSuiteSorterTest extends TestCase
         $sorter->reorderTestsInSuite($suite, TestSuiteSorter::ORDER_DEFAULT, false, TestSuiteSorter::ORDER_DEFAULT);
 
         $this->assertSame(EmptyTestCaseTest::class, $suite->tests()[0]->getName());
-        $this->assertSame('No tests found in class "PHPUnit\TestFixture\EmptyTestCaseTest".', $suite->tests()[0]->tests()[0]->getMessage());
+        $this->assertSame(
+            sprintf(
+                'No tests found in class "%s".',
+                EmptyTestCaseTest::class
+            ),
+            $suite->tests()[0]->tests()[0]->getMessage()
+        );
     }
 
     public function suiteSorterOptionPermutationsProvider(): array

--- a/tests/unit/Util/XmlTest.php
+++ b/tests/unit/Util/XmlTest.php
@@ -41,8 +41,10 @@ final class XmlTest extends TestCase
         $this->assertNull(
             $e,
             sprintf(
-                '\PHPUnit\Util\Xml::prepareString("\x%02x") should not crash DomDocument',
-                ord($char)
+                '%s::prepareString("\x%02x") should not crash %s',
+                Xml::class,
+                ord($char),
+                DOMDocument::class
             )
         );
     }


### PR DESCRIPTION
This pull request

- [x] makes use of the class keyword where possible

Somewhat related to #4907.
Follows https://github.com/sebastianbergmann/phpunit/pull/4916#issuecomment-1061512453.