### PR TITLE
Fix: Remove unnecessary `require_once`

### DIFF
--- a/tests/end-to-end/regression/GitHub/74/Issue74Test.php
+++ b/tests/end-to-end/regression/GitHub/74/Issue74Test.php
@@ -13,8 +13,6 @@ class Issue74Test extends TestCase
 {
     public function testCreateAndThrowNewExceptionInProcessIsolation(): void
     {
-        require_once __DIR__ . '/NewException.php';
-
         throw new NewException('Testing GH-74');
     }
 }

--- a/tests/end-to-end/regression/Trac/783/ChildSuite.php
+++ b/tests/end-to-end/regression/Trac/783/ChildSuite.php
@@ -9,10 +9,6 @@
  */
 use PHPUnit\Framework\TestSuite;
 
-require_once 'OneTest.php';
-
-require_once 'TwoTest.php';
-
 class ChildSuite
 {
     public static function suite()

--- a/tests/end-to-end/regression/Trac/783/ParentSuite.php
+++ b/tests/end-to-end/regression/Trac/783/ParentSuite.php
@@ -9,8 +9,6 @@
  */
 use PHPUnit\Framework\TestSuite;
 
-require_once 'ChildSuite.php';
-
 class ParentSuite
 {
     public static function suite()


### PR DESCRIPTION
This pull request

- [x] removes unnecessary `require_once` statements

Spotted in #4919.

💁‍♂️ Not sure why they are there, tests pass when they are not.