### PR TITLE
Fix: Remove unnecessary `require_once`

### DIFF
--- a/tests/end-to-end/cli/mycommand.phpt
+++ b/tests/end-to-end/cli/mycommand.phpt
@@ -9,7 +9,6 @@ $_SERVER['argv'][] = '--my-other-option';
 $_SERVER['argv'][] = \realpath(__DIR__ . '/../../_files/BankAccountTest.php');
 
 require_once __DIR__ . '/../../bootstrap.php';
-require_once __DIR__ . '/_files/MyCommand.php';
 
 MyCommand::main();
 --EXPECTF--

--- a/tests/end-to-end/regression/GitHub/4232/Issue4232Test.php
+++ b/tests/end-to-end/regression/GitHub/4232/Issue4232Test.php
@@ -9,8 +9,6 @@
  */
 namespace Foo\Bar;
 
-require_once __DIR__ . '/ParentIssue4232Test.php';
-
 final class Issue4232Test extends ParentIssue4232Test
 {
     public function testOne(): void

--- a/tests/end-to-end/regression/GitHub/74/Issue74Test.php
+++ b/tests/end-to-end/regression/GitHub/74/Issue74Test.php
@@ -13,8 +13,6 @@ class Issue74Test extends TestCase
 {
     public function testCreateAndThrowNewExceptionInProcessIsolation(): void
     {
-        require_once __DIR__ . '/NewException.php';
-
         throw new NewException('Testing GH-74');
     }
 }

--- a/tests/end-to-end/regression/Trac/783/ChildSuite.php
+++ b/tests/end-to-end/regression/Trac/783/ChildSuite.php
@@ -9,10 +9,6 @@
  */
 use PHPUnit\Framework\TestSuite;
 
-require_once 'OneTest.php';
-
-require_once 'TwoTest.php';
-
 class ChildSuite
 {
     public static function suite()

--- a/tests/end-to-end/regression/Trac/783/ParentSuite.php
+++ b/tests/end-to-end/regression/Trac/783/ParentSuite.php
@@ -9,8 +9,6 @@
  */
 use PHPUnit\Framework\TestSuite;
 
-require_once 'ChildSuite.php';
-
 class ParentSuite
 {
     public static function suite()


### PR DESCRIPTION
This pull request

- [x] removes unnecessary `require_once` statements

Follows https://github.com/sebastianbergmann/phpunit/pull/4920#issuecomment-1062587292.