### PR TITLE
Fix: Use `PHPUnit\TestFixture` as namespace for test fixtures

### DIFF
--- a/tests/end-to-end/cli/_files/MyCommand.php
+++ b/tests/end-to-end/cli/_files/MyCommand.php
@@ -7,6 +7,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+namespace PHPUnit\TestFixture;
+
 use PHPUnit\TextUI\Command;
 
 class MyCommand extends Command

--- a/tests/end-to-end/cli/mycommand.phpt
+++ b/tests/end-to-end/cli/mycommand.phpt
@@ -11,9 +11,9 @@ $_SERVER['argv'][] = \realpath(__DIR__ . '/../../_files/BankAccountTest.php');
 require_once __DIR__ . '/../../bootstrap.php';
 require_once __DIR__ . '/_files/MyCommand.php';
 
-MyCommand::main();
+PHPUnit\TestFixture\MyCommand::main();
 --EXPECTF--
-MyCommand::myHandler 123
+PHPUnit\TestFixture\MyCommand::myHandler 123
 PHPUnit %s #StandWithUkraine
 
 ...                                                                 3 / 3 (100%)


### PR DESCRIPTION
This pull request

- [x] uses `PHPUnit\TestFixture` as namespace for test fixtures

Spotted in #4921.