### PR TITLE
[8.5] Add force attribute to env tag Xsd schema

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -212,8 +212,15 @@
                 <xs:element name="ini" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="const" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="var" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="env" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="env" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:complexContent>
+                            <xs:extension base="namedValueType">
+                                <xs:attribute name="force" type="xs:boolean" default="false" />
+                            </xs:extension>
+                        </xs:complexContent>
+                    </xs:complexType>
+                </xs:element>                <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="get" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="cookie" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="server" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -220,7 +220,8 @@
                             </xs:extension>
                         </xs:complexContent>
                     </xs:complexType>
-                </xs:element>                <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:element>
+                <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="get" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="cookie" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="server" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>


### PR DESCRIPTION
From issue https://github.com/sebastianbergmann/phpunit/issues/2353 it is possible to set force boolean attribute to env tag like

 <env name="APP_ENV" value="test" force="true" />
The PR adds the hint to Xsd schema to fix XML validator error (PHPStorm IDE for example)