### PR TITLE
[10] Remove unnecessary ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require": {
         "php": ">=8.1",
         "ext-dom": "*",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-xml": "*",


### PR DESCRIPTION
The minimum PHP version for PHPUnit 10 was [recently bumped to `8.1`](https://github.com/sebastianbergmann/phpunit/commit/95b61586c5d9b90bcaa516ddca0af00efc408940#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34)  and as of PHP `8.0.0`, the [JSON extension is a core PHP extension](https://www.php.net/manual/en/json.installation.php). Therefore, it should be safe to drop the `ext-json` requirement from `composer.json`.