### PR TITLE
allow suite to have exclude in any order with directory and file

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -309,8 +309,10 @@
     </xs:complexType>
     <xs:complexType name="testSuiteType">
         <xs:sequence>
-            <xs:group ref="pathGroup"/>
-            <xs:element name="exclude" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="pathGroup"/>
+                <xs:element name="exclude" type="xs:string"/>
+            </xs:choice>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>


### PR DESCRIPTION
After upgrading from 6.5 to 7.5, few warning was visible for phpunit.xml schema validation each time phpunit was run.
```
  - Element 'directory': This element is not expected. Expected is ( exclude ).
```
and
```
  - Element 'file': This element is not expected. Expected is ( exclude ).
```


Having exclude tags interline with directory or file helps keeping things organized in a suite. Example:
```xml
<testsuite name="integration-without-db">
    <directory>test-integration/lib/Marketplace</directory>
    <exclude>test-integration/lib/Marketplace/WebService</exclude>

    <directory>test-integration/lib/Merchant</directory>
    
    <directory>test-integration/lib/MerchantToken</directory>
    <exclude>test-integration/lib/MerchantToken/MerchantTokenApiTest.php</exclude>

    <file>test-integration/lib/AdminIntegrationTest.php</file>
</testsuite>
```