### PR TITLE
build the exclude list only once for each suite

### DIFF
--- a/src/TextUI/TestSuiteMapper.php
+++ b/src/TextUI/TestSuiteMapper.php
@@ -45,15 +45,15 @@ final class TestSuiteMapper
                 $testSuite      = new TestSuiteObject($testSuiteConfiguration->name());
                 $testSuiteEmpty = true;
 
+                $exclude = [];
+
+                foreach ($testSuiteConfiguration->exclude()->asArray() as $file) {
+                    $exclude[] = $file->path();
+                }
+
                 foreach ($testSuiteConfiguration->directories() as $directory) {
                     if (!version_compare(PHP_VERSION, $directory->phpVersion(), $directory->phpVersionOperator()->asString())) {
                         continue;
-                    }
-
-                    $exclude = [];
-
-                    foreach ($testSuiteConfiguration->exclude()->asArray() as $file) {
-                        $exclude[] = $file->path();
                     }
 
                     $files = (new Facade)->getFilesAsArray(


### PR DESCRIPTION
Optimize building of the exclude list, a commit that was initially in https://github.com/sebastianbergmann/phpunit/pull/4958
but as that targeted 8.5 branch can only be done separately for 9.5 branch.