### PR TITLE
Enable named data sets with the `#[TestWith*]` attributes

### DIFF
--- a/src/Framework/Attributes/TestWith.php
+++ b/src/Framework/Attributes/TestWith.php
@@ -20,14 +20,21 @@ use Attribute;
 final readonly class TestWith
 {
     private array $data;
+    private ?string $name;
 
-    public function __construct(array $data)
+    public function __construct(array $data, ?string $name = null)
     {
         $this->data = $data;
+        $this->name = $name;
     }
 
     public function data(): array
     {
         return $this->data;
+    }
+
+    public function name(): ?string
+    {
+        return $this->name;
     }
 }

--- a/src/Framework/Attributes/TestWithJson.php
+++ b/src/Framework/Attributes/TestWithJson.php
@@ -23,13 +23,15 @@ final readonly class TestWithJson
      * @psalm-var non-empty-string
      */
     private string $json;
+    private ?string $name;
 
     /**
      * @psalm-param non-empty-string $json
      */
-    public function __construct(string $json)
+    public function __construct(string $json, ?string $name = null)
     {
         $this->json = $json;
+        $this->name = $name;
     }
 
     /**
@@ -38,5 +40,10 @@ final readonly class TestWithJson
     public function json(): string
     {
         return $this->json;
+    }
+
+    public function name(): ?string
+    {
+        return $this->name;
     }
 }

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -201,7 +201,20 @@ final readonly class DataProvider
         foreach ($testWith as $_testWith) {
             assert($_testWith instanceof TestWith);
 
-            $result[] = $_testWith->data();
+            $key = $_testWith->name();
+
+            if (null === $key) {
+                $result[] = $_testWith->data();
+            } elseif (array_key_exists($key, $result)) {
+                throw new InvalidDataProviderException(
+                    sprintf(
+                        'The key "%s" has already been defined by a previous TestWith attribute',
+                        $key,
+                    ),
+                );
+            } else {
+                $result[$key] = $_testWith->data();
+            }
         }
 
         return $result;

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -404,9 +404,9 @@ abstract readonly class Metadata
         return new TestDox(self::METHOD_LEVEL, $text);
     }
 
-    public static function testWith(array $data): TestWith
+    public static function testWith(array $data, ?string $name = null): TestWith
     {
-        return new TestWith(self::METHOD_LEVEL, $data);
+        return new TestWith(self::METHOD_LEVEL, $data, $name);
     }
 
     /**

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -605,14 +605,17 @@ final readonly class AttributeParser implements Parser
                 case TestWith::class:
                     assert($attributeInstance instanceof TestWith);
 
-                    $result[] = Metadata::testWith($attributeInstance->data());
+                    $result[] = Metadata::testWith($attributeInstance->data(), $attributeInstance->name());
 
                     break;
 
                 case TestWithJson::class:
                     assert($attributeInstance instanceof TestWithJson);
 
-                    $result[] = Metadata::testWith(json_decode($attributeInstance->json(), true, 512, JSON_THROW_ON_ERROR));
+                    $result[] = Metadata::testWith(
+                        json_decode($attributeInstance->json(), true, 512, JSON_THROW_ON_ERROR),
+                        $attributeInstance->name(),
+                    );
 
                     break;
 

--- a/src/Metadata/TestWith.php
+++ b/src/Metadata/TestWith.php
@@ -17,15 +17,17 @@ namespace PHPUnit\Metadata;
 final readonly class TestWith extends Metadata
 {
     private array $data;
+    private ?string $name;
 
     /**
      * @psalm-param 0|1 $level
      */
-    protected function __construct(int $level, array $data)
+    protected function __construct(int $level, array $data, ?string $name = null)
     {
         parent::__construct($level);
 
         $this->data = $data;
+        $this->name = $name;
     }
 
     /**
@@ -39,5 +41,10 @@ final readonly class TestWith extends Metadata
     public function data(): array
     {
         return $this->data;
+    }
+
+    public function name(): ?string
+    {
+        return $this->name;
     }
 }

--- a/tests/_files/Metadata/Attribute/tests/TestWithTest.php
+++ b/tests/_files/Metadata/Attribute/tests/TestWithTest.php
@@ -21,8 +21,20 @@ final class TestWithTest extends TestCase
         $this->assertTrue(true);
     }
 
+    #[TestWith([1, 2, 3], 'Name1')]
+    public function testOneWithName(): void
+    {
+        $this->assertTrue(true);
+    }
+
     #[TestWithJson('[1, 2, 3]')]
     public function testTwo(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestWithJson('[1, 2, 3]', 'Name2')]
+    public function testTwoWithName(): void
     {
         $this->assertTrue(true);
     }

--- a/tests/_files/TestWithAttributeDataProviderTest.php
+++ b/tests/_files/TestWithAttributeDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+final class TestWithAttributeDataProviderTest extends TestCase
+{
+    #[TestWith(['a', 'b'], 'foo')]
+    #[TestWith(['c', 'd'], 'bar')]
+    #[TestWith(['e', 'f'])]
+    #[TestWith(['g', 'h'])]
+    public function testWithAttribute($one, $two): void
+    {
+    }
+
+    #[TestWith(['a', 'b'], 'foo')]
+    #[TestWith(['c', 'd'], 'foo')]
+    public function testWithDuplicateName($one, $two): void
+    {
+    }
+}

--- a/tests/end-to-end/event/testwith-attribute.phpt
+++ b/tests/end-to-end/event/testwith-attribute.phpt
@@ -21,25 +21,37 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (2 tests)
+Test Suite Loaded (4 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (2 tests)
-Test Suite Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest, 2 tests)
+Test Runner Execution Started (4 tests)
+Test Suite Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest, 4 tests)
 Test Suite Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOne, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOne#0)
 Test Prepared (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOne#0)
 Test Passed (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOne#0)
 Test Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOne#0)
 Test Suite Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOne, 1 test)
+Test Suite Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOneWithName, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOneWithName#Name1)
+Test Prepared (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOneWithName#Name1)
+Test Passed (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOneWithName#Name1)
+Test Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOneWithName#Name1)
+Test Suite Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testOneWithName, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwo, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwo#0)
 Test Prepared (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwo#0)
 Test Passed (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwo#0)
 Test Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwo#0)
 Test Suite Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwo, 1 test)
-Test Suite Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwoWithName, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwoWithName#Name2)
+Test Prepared (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwoWithName#Name2)
+Test Passed (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwoWithName#Name2)
+Test Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwoWithName#Name2)
+Test Suite Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest::testTwoWithName, 1 test)
+Test Suite Finished (PHPUnit\TestFixture\Metadata\Attribute\TestWithTest, 4 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Metadata/Api/DataProviderTest.php
+++ b/tests/unit/Metadata/Api/DataProviderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\InvalidDataProviderException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\DuplicateKeyDataProviderTest;
 use PHPUnit\TestFixture\MultipleDataProviderTest;
+use PHPUnit\TestFixture\TestWithAttributeDataProviderTest;
 use PHPUnit\TestFixture\VariousIterableDataProviderTest;
 
 #[CoversClass(DataProvider::class)]
@@ -161,5 +162,26 @@ final class DataProviderTest extends TestCase
 
         /* @noinspection UnusedFunctionResultInspection */
         (new DataProvider)->providedData(DuplicateKeyDataProviderTest::class, 'test');
+    }
+
+    public function testTestWithAttribute(): void
+    {
+        $dataSets = (new DataProvider)->providedData(TestWithAttributeDataProviderTest::class, 'testWithAttribute');
+
+        $this->assertSame([
+            'foo' => ['a', 'b'],
+            'bar' => ['c', 'd'],
+            0     => ['e', 'f'],
+            1     => ['g', 'h'],
+        ], $dataSets);
+    }
+
+    public function testTestWithAttributeWithDuplicateKey(): void
+    {
+        $this->expectException(InvalidDataProviderException::class);
+        $this->expectExceptionMessage('The key "foo" has already been defined by a previous TestWith attribute');
+
+        /* @noinspection UnusedFunctionResultInspection */
+        (new DataProvider)->providedData(TestWithAttributeDataProviderTest::class, 'testWithDuplicateName');
     }
 }

--- a/tests/unit/Metadata/Parser/AttributeParserTestCase.php
+++ b/tests/unit/Metadata/Parser/AttributeParserTestCase.php
@@ -863,6 +863,18 @@ abstract class AttributeParserTestCase extends TestCase
         $this->assertCount(1, $metadata);
         $this->assertTrue($metadata->asArray()[0]->isTestWith());
         $this->assertSame([1, 2, 3], $metadata->asArray()[0]->data());
+        $this->assertNull($metadata->asArray()[0]->name());
+    }
+
+    #[TestDox('Parses #[TestWith] attribute with name on method')]
+    public function test_parses_TestWith_attribute_with_name_on_method(): void
+    {
+        $metadata = $this->parser()->forMethod(TestWithTest::class, 'testOneWithName')->isTestWith();
+
+        $this->assertCount(1, $metadata);
+        $this->assertTrue($metadata->asArray()[0]->isTestWith());
+        $this->assertSame([1, 2, 3], $metadata->asArray()[0]->data());
+        $this->assertSame('Name1', $metadata->asArray()[0]->name());
     }
 
     #[TestDox('Parses #[TestWithJson] attribute on method')]
@@ -873,6 +885,18 @@ abstract class AttributeParserTestCase extends TestCase
         $this->assertCount(1, $metadata);
         $this->assertTrue($metadata->asArray()[0]->isTestWith());
         $this->assertSame([1, 2, 3], $metadata->asArray()[0]->data());
+        $this->assertNull($metadata->asArray()[0]->name());
+    }
+
+    #[TestDox('Parses #[TestWithJson] attribute with name on method')]
+    public function test_parses_TestWithJson_attribute_with_name_on_method(): void
+    {
+        $metadata = $this->parser()->forMethod(TestWithTest::class, 'testTwoWithName')->isTestWith();
+
+        $this->assertCount(1, $metadata);
+        $this->assertTrue($metadata->asArray()[0]->isTestWith());
+        $this->assertSame([1, 2, 3], $metadata->asArray()[0]->data());
+        $this->assertSame('Name2', $metadata->asArray()[0]->name());
     }
 
     #[TestDox('Parses #[Ticket] attribute on method')]


### PR DESCRIPTION
Adds an optional data set `name` argument to the `#[TestWith]` & `#[TestWithJson]` attributes:

```php
#[TestWith(['a', 'b'], 'Name1')]
#[TestWith(['c', 'd'], 'Name2')]
public function testFoo(string $one, string $two)
{}
```