### PR TITLE
Fix: Reference `main` instead of `master`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/IMPROVEMENT.md
+++ b/.github/PULL_REQUEST_TEMPLATE/IMPROVEMENT.md
@@ -5,5 +5,5 @@ labels: type/enhancement
 ---
 
 <!--
-- Please target the master branch of PHPUnit.
+- Please target the main branch of PHPUnit.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE/NEW_FEATURE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/NEW_FEATURE.md
@@ -5,5 +5,5 @@ labels: type/enhancement
 ---
 
 <!--
-- Please target the master branch of PHPUnit.
+- Please target the main branch of PHPUnit.
 -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PHPUnit is a programmer-oriented testing framework for PHP. It is an instance of
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/phpunit/phpunit.svg?style=flat-square)](https://packagist.org/packages/phpunit/phpunit)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg?style=flat-square)](https://php.net/)
-[![CI Status](https://github.com/sebastianbergmann/phpunit/workflows/CI/badge.svg?branch=master&event=push)](https://phpunit.de/build-status.html)
+[![CI Status](https://github.com/sebastianbergmann/phpunit/workflows/CI/badge.svg?branch=main&event=push)](https://phpunit.de/build-status.html)
 [![Type Coverage](https://shepherd.dev/github/sebastianbergmann/phpunit/coverage.svg)](https://shepherd.dev/github/sebastianbergmann/phpunit)
 
 ## Installation
@@ -23,7 +23,7 @@ Alternatively, you may use [Composer](https://getcomposer.org/) to download and 
 
 ## Contribute
 
-Please refer to [CONTRIBUTING.md](https://github.com/sebastianbergmann/phpunit/blob/master/.github/CONTRIBUTING.md) for information on how to contribute to PHPUnit and its related projects.
+Please refer to [CONTRIBUTING.md](https://github.com/sebastianbergmann/phpunit/blob/main/.github/CONTRIBUTING.md) for information on how to contribute to PHPUnit and its related projects.
 
 ## List of Contributors
 


### PR DESCRIPTION
This pull request

- [x] references `main` instead of `master` in pull request templates