### PR TITLE
Final public method for abstract class

### DIFF
--- a/src/Event/Value/Test/Test.php
+++ b/src/Event/Value/Test/Test.php
@@ -22,7 +22,7 @@ abstract class Test
         $this->file = $file;
     }
 
-    public function file(): string
+    final public function file(): string
     {
         return $this->file;
     }
@@ -30,7 +30,7 @@ abstract class Test
     /**
      * @psalm-assert-if-true TestMethod $this
      */
-    public function isTestMethod(): bool
+    final public function isTestMethod(): bool
     {
         return false;
     }
@@ -38,7 +38,7 @@ abstract class Test
     /**
      * @psalm-assert-if-true Phpt $this
      */
-    public function isPhpt(): bool
+    final public function isPhpt(): bool
     {
         return false;
     }

--- a/src/Event/Value/TestData/TestData.php
+++ b/src/Event/Value/TestData/TestData.php
@@ -24,7 +24,7 @@ abstract class TestData
         $this->data = $data;
     }
 
-    public function data(): ExportedVariable
+    final public function data(): ExportedVariable
     {
         return $this->data;
     }
@@ -32,7 +32,7 @@ abstract class TestData
     /**
      * @psalm-assert-if-true DataFromDataProvider $this
      */
-    public function isFromDataProvider(): bool
+    final public function isFromDataProvider(): bool
     {
         return false;
     }
@@ -40,7 +40,7 @@ abstract class TestData
     /**
      * @psalm-assert-if-true DataFromTestDependency $this
      */
-    public function isFromTestDependency(): bool
+    final public function isFromTestDependency(): bool
     {
         return false;
     }

--- a/src/Event/Value/TestSuite/TestSuite.php
+++ b/src/Event/Value/TestSuite/TestSuite.php
@@ -47,7 +47,7 @@ abstract class TestSuite
     private string $sortId;
     private TestCollection $tests;
 
-    public static function fromTestSuite(FrameworkTestSuite $testSuite): self
+    final public static function fromTestSuite(FrameworkTestSuite $testSuite): self
     {
         $groups = [];
 
@@ -147,12 +147,12 @@ abstract class TestSuite
         $this->tests    = $tests;
     }
 
-    public function name(): string
+    final public function name(): string
     {
         return $this->name;
     }
 
-    public function count(): int
+    final public function count(): int
     {
         return $this->count;
     }
@@ -160,7 +160,7 @@ abstract class TestSuite
     /**
      * @psalm-return array<string, list<class-string>>
      */
-    public function groups(): array
+    final public function groups(): array
     {
         return $this->groups;
     }
@@ -168,7 +168,7 @@ abstract class TestSuite
     /**
      * @psalm-return list<ExecutionOrderDependency>
      */
-    public function provides(): array
+    final public function provides(): array
     {
         return $this->provides;
     }
@@ -176,17 +176,17 @@ abstract class TestSuite
     /**
      * @psalm-return list<ExecutionOrderDependency>
      */
-    public function requires(): array
+    final public function requires(): array
     {
         return $this->requires;
     }
 
-    public function sortId(): string
+    final public function sortId(): string
     {
         return $this->sortId;
     }
 
-    public function tests(): TestCollection
+    final public function tests(): TestCollection
     {
         return $this->tests;
     }
@@ -194,7 +194,7 @@ abstract class TestSuite
     /**
      * @psalm-assert-if-true TestSuiteWithName $this
      */
-    public function isWithName(): bool
+    final public function isWithName(): bool
     {
         return false;
     }
@@ -202,7 +202,7 @@ abstract class TestSuite
     /**
      * @psalm-assert-if-true TestSuiteForTestClass $this
      */
-    public function isForTestClass(): bool
+    final public function isForTestClass(): bool
     {
         return false;
     }
@@ -210,7 +210,7 @@ abstract class TestSuite
     /**
      * @psalm-assert-if-true TestSuiteForTestMethodWithDataProvider $this
      */
-    public function isForTestMethodWithDataProvider(): bool
+    final public function isForTestMethodWithDataProvider(): bool
     {
         return false;
     }

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -35,7 +35,7 @@ abstract class Constraint implements Countable, SelfDescribing
      *
      * @throws ExpectationFailedException
      */
-    public function evaluate(mixed $other, string $description = '', bool $returnResult = false): ?bool
+    final public function evaluate(mixed $other, string $description = '', bool $returnResult = false): ?bool
     {
         $success = false;
 
@@ -57,7 +57,7 @@ abstract class Constraint implements Countable, SelfDescribing
     /**
      * Counts the number of constraint elements.
      */
-    public function count(): int
+    final public function count(): int
     {
         return 1;
     }

--- a/src/Framework/Constraint/Operator/BinaryOperator.php
+++ b/src/Framework/Constraint/Operator/BinaryOperator.php
@@ -43,7 +43,7 @@ abstract class BinaryOperator extends Operator
     /**
      * Returns a string representation of the constraint.
      */
-    public function toString(): string
+    final public function toString(): string
     {
         $reduced = $this->reduce();
 
@@ -65,7 +65,7 @@ abstract class BinaryOperator extends Operator
     /**
      * Counts the number of constraint elements.
      */
-    public function count(): int
+    final public function count(): int
     {
         $count = 0;
 

--- a/src/Framework/Constraint/Operator/UnaryOperator.php
+++ b/src/Framework/Constraint/Operator/UnaryOperator.php
@@ -26,7 +26,7 @@ abstract class UnaryOperator extends Operator
     /**
      * Returns the number of operands (constraints).
      */
-    public function arity(): int
+    final public function arity(): int
     {
         return 1;
     }
@@ -34,7 +34,7 @@ abstract class UnaryOperator extends Operator
     /**
      * Returns a string representation of the constraint.
      */
-    public function toString(): string
+    final public function toString(): string
     {
         $reduced = $this->reduce();
 
@@ -60,7 +60,7 @@ abstract class UnaryOperator extends Operator
     /**
      * Counts the number of constraint elements.
      */
-    public function count(): int
+    final public function count(): int
     {
         return count($this->constraint);
     }

--- a/src/Framework/Constraint/Traversable/TraversableContains.php
+++ b/src/Framework/Constraint/Traversable/TraversableContains.php
@@ -27,7 +27,7 @@ abstract class TraversableContains extends Constraint
     /**
      * Returns a string representation of the constraint.
      */
-    public function toString(): string
+    final public function toString(): string
     {
         return 'contains ' . $this->exporter()->export($this->value);
     }

--- a/src/Framework/MockObject/Rule/InvocationOrder.php
+++ b/src/Framework/MockObject/Rule/InvocationOrder.php
@@ -24,12 +24,12 @@ abstract class InvocationOrder implements SelfDescribing, Verifiable
      */
     private array $invocations = [];
 
-    public function getInvocationCount(): int
+    final public function getInvocationCount(): int
     {
         return count($this->invocations);
     }
 
-    public function hasBeenInvoked(): bool
+    final public function hasBeenInvoked(): bool
     {
         return count($this->invocations) > 0;
     }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -313,14 +313,14 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * This method is called before the first test of this test class is run.
      */
-    public static function setUpBeforeClass(): void
+    final public static function setUpBeforeClass(): void
     {
     }
 
     /**
      * This method is called after the last test of this test class is run.
      */
-    public static function tearDownAfterClass(): void
+    final public static function tearDownAfterClass(): void
     {
     }
 
@@ -361,7 +361,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      *
      * @throws Exception
      */
-    public function toString(): string
+    final public function toString(): string
     {
         $buffer = sprintf(
             '%s::%s',

--- a/src/Framework/TestSize/Known.php
+++ b/src/Framework/TestSize/Known.php
@@ -18,7 +18,7 @@ abstract class Known extends TestSize
     /**
      * @psalm-assert-if-true Known $this
      */
-    public function isKnown(): bool
+    final public function isKnown(): bool
     {
         return true;
     }

--- a/src/Framework/TestSize/TestSize.php
+++ b/src/Framework/TestSize/TestSize.php
@@ -15,22 +15,22 @@ namespace PHPUnit\Framework\TestSize;
  */
 abstract class TestSize
 {
-    public static function unknown(): self
+    final public static function unknown(): self
     {
         return new Unknown;
     }
 
-    public static function small(): self
+    final public static function small(): self
     {
         return new Small;
     }
 
-    public static function medium(): self
+    final public static function medium(): self
     {
         return new Medium;
     }
 
-    public static function large(): self
+    final public static function large(): self
     {
         return new Large;
     }
@@ -38,7 +38,7 @@ abstract class TestSize
     /**
      * @psalm-assert-if-true Known $this
      */
-    public function isKnown(): bool
+    final public function isKnown(): bool
     {
         return false;
     }
@@ -46,7 +46,7 @@ abstract class TestSize
     /**
      * @psalm-assert-if-true Unknown $this
      */
-    public function isUnknown(): bool
+    final public function isUnknown(): bool
     {
         return false;
     }
@@ -54,7 +54,7 @@ abstract class TestSize
     /**
      * @psalm-assert-if-true Small $this
      */
-    public function isSmall(): bool
+    final public function isSmall(): bool
     {
         return false;
     }
@@ -62,7 +62,7 @@ abstract class TestSize
     /**
      * @psalm-assert-if-true Medium $this
      */
-    public function isMedium(): bool
+    final public function isMedium(): bool
     {
         return false;
     }
@@ -70,7 +70,7 @@ abstract class TestSize
     /**
      * @psalm-assert-if-true Large $this
      */
-    public function isLarge(): bool
+    final public function isLarge(): bool
     {
         return false;
     }

--- a/src/Framework/TestStatus/Known.php
+++ b/src/Framework/TestStatus/Known.php
@@ -18,7 +18,7 @@ abstract class Known extends TestStatus
     /**
      * @psalm-assert-if-true Known $this
      */
-    public function isKnown(): bool
+    final public function isKnown(): bool
     {
         return true;
     }

--- a/src/Framework/TestStatus/TestStatus.php
+++ b/src/Framework/TestStatus/TestStatus.php
@@ -17,7 +17,7 @@ abstract class TestStatus
 {
     private string $message;
 
-    public static function from(int $status): self
+    final public static function from(int $status): self
     {
         return match ($status) {
             0       => self::success(),
@@ -33,52 +33,52 @@ abstract class TestStatus
         };
     }
 
-    public static function unknown(): self
+    final public static function unknown(): self
     {
         return new Unknown;
     }
 
-    public static function success(): self
+    final public static function success(): self
     {
         return new Success;
     }
 
-    public static function skipped(string $message = ''): self
+    final public static function skipped(string $message = ''): self
     {
         return new Skipped($message);
     }
 
-    public static function incomplete(string $message = ''): self
+    final public static function incomplete(string $message = ''): self
     {
         return new Incomplete($message);
     }
 
-    public static function notice(string $message = ''): self
+    final public static function notice(string $message = ''): self
     {
         return new Notice($message);
     }
 
-    public static function deprecation(string $message = ''): self
+    final public static function deprecation(string $message = ''): self
     {
         return new Deprecation($message);
     }
 
-    public static function failure(string $message = ''): self
+    final public static function failure(string $message = ''): self
     {
         return new Failure($message);
     }
 
-    public static function error(string $message = ''): self
+    final public static function error(string $message = ''): self
     {
         return new Error($message);
     }
 
-    public static function warning(string $message = ''): self
+    final public static function warning(string $message = ''): self
     {
         return new Warning($message);
     }
 
-    public static function risky(string $message = ''): self
+    final public static function risky(string $message = ''): self
     {
         return new Risky($message);
     }
@@ -91,7 +91,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Known $this
      */
-    public function isKnown(): bool
+    final public function isKnown(): bool
     {
         return false;
     }
@@ -99,7 +99,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Unknown $this
      */
-    public function isUnknown(): bool
+    final public function isUnknown(): bool
     {
         return false;
     }
@@ -107,7 +107,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Success $this
      */
-    public function isSuccess(): bool
+    final public function isSuccess(): bool
     {
         return false;
     }
@@ -115,7 +115,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Skipped $this
      */
-    public function isSkipped(): bool
+    final public function isSkipped(): bool
     {
         return false;
     }
@@ -123,7 +123,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Incomplete $this
      */
-    public function isIncomplete(): bool
+    final public function isIncomplete(): bool
     {
         return false;
     }
@@ -131,7 +131,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Notice $this
      */
-    public function isNotice(): bool
+    final public function isNotice(): bool
     {
         return false;
     }
@@ -139,7 +139,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Deprecation $this
      */
-    public function isDeprecation(): bool
+    final public function isDeprecation(): bool
     {
         return false;
     }
@@ -147,7 +147,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Failure $this
      */
-    public function isFailure(): bool
+    final public function isFailure(): bool
     {
         return false;
     }
@@ -155,7 +155,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Error $this
      */
-    public function isError(): bool
+    final public function isError(): bool
     {
         return false;
     }
@@ -163,7 +163,7 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Warning $this
      */
-    public function isWarning(): bool
+    final public function isWarning(): bool
     {
         return false;
     }
@@ -171,17 +171,17 @@ abstract class TestStatus
     /**
      * @psalm-assert-if-true Risky $this
      */
-    public function isRisky(): bool
+    final public function isRisky(): bool
     {
         return false;
     }
 
-    public function message(): string
+    final public function message(): string
     {
         return $this->message;
     }
 
-    public function isMoreImportantThan(self $other): bool
+    final public function isMoreImportantThan(self $other): bool
     {
         return $this->asInt() > $other->asInt();
     }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -22,52 +22,52 @@ abstract class Metadata
     private const METHOD_LEVEL = 1;
     private int $level;
 
-    public static function after(): After
+    final public static function after(): After
     {
         return new After(self::METHOD_LEVEL);
     }
 
-    public static function afterClass(): AfterClass
+    final public static function afterClass(): AfterClass
     {
         return new AfterClass(self::METHOD_LEVEL);
     }
 
-    public static function backupGlobalsOnClass(?bool $enabled): BackupGlobals
+    final public static function backupGlobalsOnClass(?bool $enabled): BackupGlobals
     {
         return new BackupGlobals(self::CLASS_LEVEL, $enabled);
     }
 
-    public static function backupGlobalsOnMethod(?bool $enabled): BackupGlobals
+    final public static function backupGlobalsOnMethod(?bool $enabled): BackupGlobals
     {
         return new BackupGlobals(self::METHOD_LEVEL, $enabled);
     }
 
-    public static function backupStaticPropertiesOnClass(?bool $enabled): BackupStaticProperties
+    final public static function backupStaticPropertiesOnClass(?bool $enabled): BackupStaticProperties
     {
         return new BackupStaticProperties(self::CLASS_LEVEL, $enabled);
     }
 
-    public static function backupStaticPropertiesOnMethod(?bool $enabled): BackupStaticProperties
+    final public static function backupStaticPropertiesOnMethod(?bool $enabled): BackupStaticProperties
     {
         return new BackupStaticProperties(self::METHOD_LEVEL, $enabled);
     }
 
-    public static function before(): Before
+    final public static function before(): Before
     {
         return new Before(self::METHOD_LEVEL);
     }
 
-    public static function beforeClass(): BeforeClass
+    final public static function beforeClass(): BeforeClass
     {
         return new BeforeClass(self::METHOD_LEVEL);
     }
 
-    public static function codeCoverageIgnoreOnClass(): CodeCoverageIgnore
+    final public static function codeCoverageIgnoreOnClass(): CodeCoverageIgnore
     {
         return new CodeCoverageIgnore(self::CLASS_LEVEL);
     }
 
-    public static function codeCoverageIgnoreOnMethod(): CodeCoverageIgnore
+    final public static function codeCoverageIgnoreOnMethod(): CodeCoverageIgnore
     {
         return new CodeCoverageIgnore(self::METHOD_LEVEL);
     }
@@ -75,22 +75,22 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function coversClass(string $className): CoversClass
+    final public static function coversClass(string $className): CoversClass
     {
         return new CoversClass(self::CLASS_LEVEL, $className);
     }
 
-    public static function coversFunction(string $functionName): CoversFunction
+    final public static function coversFunction(string $functionName): CoversFunction
     {
         return new CoversFunction(self::CLASS_LEVEL, $functionName);
     }
 
-    public static function coversOnClass(string $target): Covers
+    final public static function coversOnClass(string $target): Covers
     {
         return new Covers(self::CLASS_LEVEL, $target);
     }
 
-    public static function coversOnMethod(string $target): Covers
+    final public static function coversOnMethod(string $target): Covers
     {
         return new Covers(self::METHOD_LEVEL, $target);
     }
@@ -98,17 +98,17 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function coversDefaultClass(string $className): CoversDefaultClass
+    final public static function coversDefaultClass(string $className): CoversDefaultClass
     {
         return new CoversDefaultClass(self::CLASS_LEVEL, $className);
     }
 
-    public static function coversNothingOnClass(): CoversNothing
+    final public static function coversNothingOnClass(): CoversNothing
     {
         return new CoversNothing(self::CLASS_LEVEL);
     }
 
-    public static function coversNothingOnMethod(): CoversNothing
+    final public static function coversNothingOnMethod(): CoversNothing
     {
         return new CoversNothing(self::METHOD_LEVEL);
     }
@@ -116,37 +116,37 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function dataProvider(string $className, string $methodName): DataProvider
+    final public static function dataProvider(string $className, string $methodName): DataProvider
     {
         return new DataProvider(self::METHOD_LEVEL, $className, $methodName);
     }
 
-    public static function dependsOnClass(string $className, bool $deepClone, bool $shallowClone): DependsOnClass
+    final public static function dependsOnClass(string $className, bool $deepClone, bool $shallowClone): DependsOnClass
     {
         return new DependsOnClass(self::METHOD_LEVEL, $className, $deepClone, $shallowClone);
     }
 
-    public static function dependsOnMethod(string $className, string $methodName, bool $deepClone, bool $shallowClone): DependsOnMethod
+    final public static function dependsOnMethod(string $className, string $methodName, bool $deepClone, bool $shallowClone): DependsOnMethod
     {
         return new DependsOnMethod(self::METHOD_LEVEL, $className, $methodName, $deepClone, $shallowClone);
     }
 
-    public static function doesNotPerformAssertionsOnClass(): DoesNotPerformAssertions
+    final public static function doesNotPerformAssertionsOnClass(): DoesNotPerformAssertions
     {
         return new DoesNotPerformAssertions(self::CLASS_LEVEL);
     }
 
-    public static function doesNotPerformAssertionsOnMethod(): DoesNotPerformAssertions
+    final public static function doesNotPerformAssertionsOnMethod(): DoesNotPerformAssertions
     {
         return new DoesNotPerformAssertions(self::METHOD_LEVEL);
     }
 
-    public static function excludeGlobalVariableFromBackupOnClass(string $globalVariableName): ExcludeGlobalVariableFromBackup
+    final public static function excludeGlobalVariableFromBackupOnClass(string $globalVariableName): ExcludeGlobalVariableFromBackup
     {
         return new ExcludeGlobalVariableFromBackup(self::CLASS_LEVEL, $globalVariableName);
     }
 
-    public static function excludeGlobalVariableFromBackupOnMethod(string $globalVariableName): ExcludeGlobalVariableFromBackup
+    final public static function excludeGlobalVariableFromBackupOnMethod(string $globalVariableName): ExcludeGlobalVariableFromBackup
     {
         return new ExcludeGlobalVariableFromBackup(self::METHOD_LEVEL, $globalVariableName);
     }
@@ -154,7 +154,7 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function excludeStaticPropertyFromBackupOnClass(string $className, string $propertyName): ExcludeStaticPropertyFromBackup
+    final public static function excludeStaticPropertyFromBackupOnClass(string $className, string $propertyName): ExcludeStaticPropertyFromBackup
     {
         return new ExcludeStaticPropertyFromBackup(self::CLASS_LEVEL, $className, $propertyName);
     }
@@ -162,47 +162,47 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function excludeStaticPropertyFromBackupOnMethod(string $className, string $propertyName): ExcludeStaticPropertyFromBackup
+    final public static function excludeStaticPropertyFromBackupOnMethod(string $className, string $propertyName): ExcludeStaticPropertyFromBackup
     {
         return new ExcludeStaticPropertyFromBackup(self::METHOD_LEVEL, $className, $propertyName);
     }
 
-    public static function groupOnClass(string $groupName): Group
+    final public static function groupOnClass(string $groupName): Group
     {
         return new Group(self::CLASS_LEVEL, $groupName);
     }
 
-    public static function groupOnMethod(string $groupName): Group
+    final public static function groupOnMethod(string $groupName): Group
     {
         return new Group(self::METHOD_LEVEL, $groupName);
     }
 
-    public static function postCondition(): PostCondition
+    final public static function postCondition(): PostCondition
     {
         return new PostCondition(self::METHOD_LEVEL);
     }
 
-    public static function preCondition(): PreCondition
+    final public static function preCondition(): PreCondition
     {
         return new PreCondition(self::METHOD_LEVEL);
     }
 
-    public static function preserveGlobalStateOnClass(?bool $enabled): PreserveGlobalState
+    final public static function preserveGlobalStateOnClass(?bool $enabled): PreserveGlobalState
     {
         return new PreserveGlobalState(self::CLASS_LEVEL, $enabled);
     }
 
-    public static function preserveGlobalStateOnMethod(?bool $enabled): PreserveGlobalState
+    final public static function preserveGlobalStateOnMethod(?bool $enabled): PreserveGlobalState
     {
         return new PreserveGlobalState(self::METHOD_LEVEL, $enabled);
     }
 
-    public static function requiresFunctionOnClass(string $functionName): RequiresFunction
+    final public static function requiresFunctionOnClass(string $functionName): RequiresFunction
     {
         return new RequiresFunction(self::CLASS_LEVEL, $functionName);
     }
 
-    public static function requiresFunctionOnMethod(string $functionName): RequiresFunction
+    final public static function requiresFunctionOnMethod(string $functionName): RequiresFunction
     {
         return new RequiresFunction(self::METHOD_LEVEL, $functionName);
     }
@@ -210,7 +210,7 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function requiresMethodOnClass(string $className, string $methodName): RequiresMethod
+    final public static function requiresMethodOnClass(string $className, string $methodName): RequiresMethod
     {
         return new RequiresMethod(self::CLASS_LEVEL, $className, $methodName);
     }
@@ -218,102 +218,102 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function requiresMethodOnMethod(string $className, string $methodName): RequiresMethod
+    final public static function requiresMethodOnMethod(string $className, string $methodName): RequiresMethod
     {
         return new RequiresMethod(self::METHOD_LEVEL, $className, $methodName);
     }
 
-    public static function requiresOperatingSystemOnClass(string $operatingSystem): RequiresOperatingSystem
+    final public static function requiresOperatingSystemOnClass(string $operatingSystem): RequiresOperatingSystem
     {
         return new RequiresOperatingSystem(self::CLASS_LEVEL, $operatingSystem);
     }
 
-    public static function requiresOperatingSystemOnMethod(string $operatingSystem): RequiresOperatingSystem
+    final public static function requiresOperatingSystemOnMethod(string $operatingSystem): RequiresOperatingSystem
     {
         return new RequiresOperatingSystem(self::METHOD_LEVEL, $operatingSystem);
     }
 
-    public static function requiresOperatingSystemFamilyOnClass(string $operatingSystemFamily): RequiresOperatingSystemFamily
+    final public static function requiresOperatingSystemFamilyOnClass(string $operatingSystemFamily): RequiresOperatingSystemFamily
     {
         return new RequiresOperatingSystemFamily(self::CLASS_LEVEL, $operatingSystemFamily);
     }
 
-    public static function requiresOperatingSystemFamilyOnMethod(string $operatingSystemFamily): RequiresOperatingSystemFamily
+    final public static function requiresOperatingSystemFamilyOnMethod(string $operatingSystemFamily): RequiresOperatingSystemFamily
     {
         return new RequiresOperatingSystemFamily(self::METHOD_LEVEL, $operatingSystemFamily);
     }
 
-    public static function requiresPhpOnClass(Requirement $versionRequirement): RequiresPhp
+    final public static function requiresPhpOnClass(Requirement $versionRequirement): RequiresPhp
     {
         return new RequiresPhp(self::CLASS_LEVEL, $versionRequirement);
     }
 
-    public static function requiresPhpOnMethod(Requirement $versionRequirement): RequiresPhp
+    final public static function requiresPhpOnMethod(Requirement $versionRequirement): RequiresPhp
     {
         return new RequiresPhp(self::METHOD_LEVEL, $versionRequirement);
     }
 
-    public static function requiresPhpExtensionOnClass(string $extension, ?Requirement $versionRequirement): RequiresPhpExtension
+    final public static function requiresPhpExtensionOnClass(string $extension, ?Requirement $versionRequirement): RequiresPhpExtension
     {
         return new RequiresPhpExtension(self::CLASS_LEVEL, $extension, $versionRequirement);
     }
 
-    public static function requiresPhpExtensionOnMethod(string $extension, ?Requirement $versionRequirement): RequiresPhpExtension
+    final public static function requiresPhpExtensionOnMethod(string $extension, ?Requirement $versionRequirement): RequiresPhpExtension
     {
         return new RequiresPhpExtension(self::METHOD_LEVEL, $extension, $versionRequirement);
     }
 
-    public static function requiresPhpunitOnClass(Requirement $versionRequirement): RequiresPhpunit
+    final public static function requiresPhpunitOnClass(Requirement $versionRequirement): RequiresPhpunit
     {
         return new RequiresPhpunit(self::CLASS_LEVEL, $versionRequirement);
     }
 
-    public static function requiresPhpunitOnMethod(Requirement $versionRequirement): RequiresPhpunit
+    final public static function requiresPhpunitOnMethod(Requirement $versionRequirement): RequiresPhpunit
     {
         return new RequiresPhpunit(self::METHOD_LEVEL, $versionRequirement);
     }
 
-    public static function requiresSettingOnClass(string $setting, string $value): RequiresSetting
+    final public static function requiresSettingOnClass(string $setting, string $value): RequiresSetting
     {
         return new RequiresSetting(self::CLASS_LEVEL, $setting, $value);
     }
 
-    public static function requiresSettingOnMethod(string $setting, string $value): RequiresSetting
+    final public static function requiresSettingOnMethod(string $setting, string $value): RequiresSetting
     {
         return new RequiresSetting(self::METHOD_LEVEL, $setting, $value);
     }
 
-    public static function runClassInSeparateProcess(): RunClassInSeparateProcess
+    final public static function runClassInSeparateProcess(): RunClassInSeparateProcess
     {
         return new RunClassInSeparateProcess(self::CLASS_LEVEL);
     }
 
-    public static function runTestsInSeparateProcesses(): RunTestsInSeparateProcesses
+    final public static function runTestsInSeparateProcesses(): RunTestsInSeparateProcesses
     {
         return new RunTestsInSeparateProcesses(self::CLASS_LEVEL);
     }
 
-    public static function runInSeparateProcess(): RunInSeparateProcess
+    final public static function runInSeparateProcess(): RunInSeparateProcess
     {
         return new RunInSeparateProcess(self::METHOD_LEVEL);
     }
 
-    public static function test(): Test
+    final public static function test(): Test
     {
         return new Test(self::METHOD_LEVEL);
     }
 
-    public static function testDoxOnClass(string $text): TestDox
+    final public static function testDoxOnClass(string $text): TestDox
     {
         return new TestDox(self::CLASS_LEVEL, $text);
     }
 
-    public static function testDoxOnMethod(string $text): TestDox
+    final public static function testDoxOnMethod(string $text): TestDox
     {
         return new TestDox(self::METHOD_LEVEL, $text);
     }
 
-    public static function testWith(array $data): TestWith
+    final public static function testWith(array $data): TestWith
     {
         return new TestWith(self::METHOD_LEVEL, $data);
     }
@@ -321,22 +321,22 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function usesClass(string $className): UsesClass
+    final public static function usesClass(string $className): UsesClass
     {
         return new UsesClass(self::CLASS_LEVEL, $className);
     }
 
-    public static function usesFunction(string $functionName): UsesFunction
+    final public static function usesFunction(string $functionName): UsesFunction
     {
         return new UsesFunction(self::CLASS_LEVEL, $functionName);
     }
 
-    public static function usesOnClass(string $target): Uses
+    final public static function usesOnClass(string $target): Uses
     {
         return new Uses(self::CLASS_LEVEL, $target);
     }
 
-    public static function usesOnMethod(string $target): Uses
+    final public static function usesOnMethod(string $target): Uses
     {
         return new Uses(self::METHOD_LEVEL, $target);
     }
@@ -344,7 +344,7 @@ abstract class Metadata
     /**
      * @psalm-param class-string $className
      */
-    public static function usesDefaultClass(string $className): UsesDefaultClass
+    final public static function usesDefaultClass(string $className): UsesDefaultClass
     {
         return new UsesDefaultClass(self::CLASS_LEVEL, $className);
     }
@@ -354,12 +354,12 @@ abstract class Metadata
         $this->level = $level;
     }
 
-    public function isClassLevel(): bool
+    final public function isClassLevel(): bool
     {
         return $this->level === self::CLASS_LEVEL;
     }
 
-    public function isMethodLevel(): bool
+    final public function isMethodLevel(): bool
     {
         return $this->level === self::METHOD_LEVEL;
     }
@@ -367,7 +367,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true After $this
      */
-    public function isAfter(): bool
+    final public function isAfter(): bool
     {
         return false;
     }
@@ -375,7 +375,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true AfterClass $this
      */
-    public function isAfterClass(): bool
+    final public function isAfterClass(): bool
     {
         return false;
     }
@@ -383,7 +383,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true BackupGlobals $this
      */
-    public function isBackupGlobals(): bool
+    final public function isBackupGlobals(): bool
     {
         return false;
     }
@@ -391,7 +391,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true BackupStaticProperties $this
      */
-    public function isBackupStaticProperties(): bool
+    final public function isBackupStaticProperties(): bool
     {
         return false;
     }
@@ -399,7 +399,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true BeforeClass $this
      */
-    public function isBeforeClass(): bool
+    final public function isBeforeClass(): bool
     {
         return false;
     }
@@ -407,7 +407,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true Before $this
      */
-    public function isBefore(): bool
+    final public function isBefore(): bool
     {
         return false;
     }
@@ -415,7 +415,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true CodeCoverageIgnore $this
      */
-    public function isCodeCoverageIgnore(): bool
+    final public function isCodeCoverageIgnore(): bool
     {
         return false;
     }
@@ -423,7 +423,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true Covers $this
      */
-    public function isCovers(): bool
+    final public function isCovers(): bool
     {
         return false;
     }
@@ -431,7 +431,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true CoversClass $this
      */
-    public function isCoversClass(): bool
+    final public function isCoversClass(): bool
     {
         return false;
     }
@@ -439,7 +439,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true CoversDefaultClass $this
      */
-    public function isCoversDefaultClass(): bool
+    final public function isCoversDefaultClass(): bool
     {
         return false;
     }
@@ -447,7 +447,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true CoversFunction $this
      */
-    public function isCoversFunction(): bool
+    final public function isCoversFunction(): bool
     {
         return false;
     }
@@ -455,7 +455,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true CoversNothing $this
      */
-    public function isCoversNothing(): bool
+    final public function isCoversNothing(): bool
     {
         return false;
     }
@@ -463,7 +463,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true DataProvider $this
      */
-    public function isDataProvider(): bool
+    final public function isDataProvider(): bool
     {
         return false;
     }
@@ -471,7 +471,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true DependsOnClass $this
      */
-    public function isDependsOnClass(): bool
+    final public function isDependsOnClass(): bool
     {
         return false;
     }
@@ -479,7 +479,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true DependsOnMethod $this
      */
-    public function isDependsOnMethod(): bool
+    final public function isDependsOnMethod(): bool
     {
         return false;
     }
@@ -487,17 +487,17 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true DoesNotPerformAssertions $this
      */
-    public function isDoesNotPerformAssertions(): bool
+    final public function isDoesNotPerformAssertions(): bool
     {
         return false;
     }
 
-    public function isExcludeGlobalVariableFromBackup(): bool
+    final public function isExcludeGlobalVariableFromBackup(): bool
     {
         return false;
     }
 
-    public function isExcludeStaticPropertyFromBackup(): bool
+    final public function isExcludeStaticPropertyFromBackup(): bool
     {
         return false;
     }
@@ -505,7 +505,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true Group $this
      */
-    public function isGroup(): bool
+    final public function isGroup(): bool
     {
         return false;
     }
@@ -513,7 +513,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RunClassInSeparateProcess $this
      */
-    public function isRunClassInSeparateProcess(): bool
+    final public function isRunClassInSeparateProcess(): bool
     {
         return false;
     }
@@ -521,7 +521,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RunInSeparateProcess $this
      */
-    public function isRunInSeparateProcess(): bool
+    final public function isRunInSeparateProcess(): bool
     {
         return false;
     }
@@ -529,7 +529,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RunTestsInSeparateProcesses $this
      */
-    public function isRunTestsInSeparateProcesses(): bool
+    final public function isRunTestsInSeparateProcesses(): bool
     {
         return false;
     }
@@ -537,7 +537,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true Test $this
      */
-    public function isTest(): bool
+    final public function isTest(): bool
     {
         return false;
     }
@@ -545,7 +545,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true PreCondition $this
      */
-    public function isPreCondition(): bool
+    final public function isPreCondition(): bool
     {
         return false;
     }
@@ -553,7 +553,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true PostCondition $this
      */
-    public function isPostCondition(): bool
+    final public function isPostCondition(): bool
     {
         return false;
     }
@@ -561,7 +561,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true PreserveGlobalState $this
      */
-    public function isPreserveGlobalState(): bool
+    final public function isPreserveGlobalState(): bool
     {
         return false;
     }
@@ -569,7 +569,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresMethod $this
      */
-    public function isRequiresMethod(): bool
+    final public function isRequiresMethod(): bool
     {
         return false;
     }
@@ -577,7 +577,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresFunction $this
      */
-    public function isRequiresFunction(): bool
+    final public function isRequiresFunction(): bool
     {
         return false;
     }
@@ -585,7 +585,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresOperatingSystem $this
      */
-    public function isRequiresOperatingSystem(): bool
+    final public function isRequiresOperatingSystem(): bool
     {
         return false;
     }
@@ -593,7 +593,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresOperatingSystemFamily $this
      */
-    public function isRequiresOperatingSystemFamily(): bool
+    final public function isRequiresOperatingSystemFamily(): bool
     {
         return false;
     }
@@ -601,7 +601,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresPhp $this
      */
-    public function isRequiresPhp(): bool
+    final public function isRequiresPhp(): bool
     {
         return false;
     }
@@ -609,7 +609,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresPhpExtension $this
      */
-    public function isRequiresPhpExtension(): bool
+    final public function isRequiresPhpExtension(): bool
     {
         return false;
     }
@@ -617,7 +617,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresPhpunit $this
      */
-    public function isRequiresPhpunit(): bool
+    final public function isRequiresPhpunit(): bool
     {
         return false;
     }
@@ -625,7 +625,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true RequiresSetting $this
      */
-    public function isRequiresSetting(): bool
+    final public function isRequiresSetting(): bool
     {
         return false;
     }
@@ -633,7 +633,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true TestDox $this
      */
-    public function isTestDox(): bool
+    final public function isTestDox(): bool
     {
         return false;
     }
@@ -641,7 +641,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true TestWith $this
      */
-    public function isTestWith(): bool
+    final public function isTestWith(): bool
     {
         return false;
     }
@@ -649,7 +649,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true Uses $this
      */
-    public function isUses(): bool
+    final public function isUses(): bool
     {
         return false;
     }
@@ -657,7 +657,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true UsesClass $this
      */
-    public function isUsesClass(): bool
+    final public function isUsesClass(): bool
     {
         return false;
     }
@@ -665,7 +665,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true UsesDefaultClass $this
      */
-    public function isUsesDefaultClass(): bool
+    final public function isUsesDefaultClass(): bool
     {
         return false;
     }
@@ -673,7 +673,7 @@ abstract class Metadata
     /**
      * @psalm-assert-if-true UsesFunction $this
      */
-    public function isUsesFunction(): bool
+    final public function isUsesFunction(): bool
     {
         return false;
     }

--- a/src/Metadata/Version/Requirement.php
+++ b/src/Metadata/Version/Requirement.php
@@ -27,7 +27,7 @@ abstract class Requirement
     /**
      * @throws InvalidVersionRequirementException
      */
-    public static function from(string $versionRequirement): self
+    final public static function from(string $versionRequirement): self
     {
         try {
             return new ConstraintRequirement(

--- a/src/Runner/Filter/GroupFilterIterator.php
+++ b/src/Runner/Filter/GroupFilterIterator.php
@@ -43,7 +43,7 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
         }
     }
 
-    public function accept(): bool
+    final public function accept(): bool
     {
         $test = $this->getInnerIterator()->current();
 

--- a/src/TextUI/Configuration/Xml/Configuration.php
+++ b/src/TextUI/Configuration/Xml/Configuration.php
@@ -39,42 +39,42 @@ abstract class Configuration
         $this->testSuite     = $testSuite;
     }
 
-    public function extensions(): ExtensionCollection
+    final public function extensions(): ExtensionCollection
     {
         return $this->extensions;
     }
 
-    public function codeCoverage(): CodeCoverage
+    final public function codeCoverage(): CodeCoverage
     {
         return $this->codeCoverage;
     }
 
-    public function groups(): Groups
+    final public function groups(): Groups
     {
         return $this->groups;
     }
 
-    public function testdoxGroups(): Groups
+    final public function testdoxGroups(): Groups
     {
         return $this->testdoxGroups;
     }
 
-    public function logging(): Logging
+    final public function logging(): Logging
     {
         return $this->logging;
     }
 
-    public function php(): Php
+    final public function php(): Php
     {
         return $this->php;
     }
 
-    public function phpunit(): PHPUnit
+    final public function phpunit(): PHPUnit
     {
         return $this->phpunit;
     }
 
-    public function testSuite(): TestSuiteCollection
+    final public function testSuite(): TestSuiteCollection
     {
         return $this->testSuite;
     }
@@ -82,7 +82,7 @@ abstract class Configuration
     /**
      * @psalm-assert-if-true DefaultConfiguration $this
      */
-    public function isDefault(): bool
+    final public function isDefault(): bool
     {
         return false;
     }
@@ -90,7 +90,7 @@ abstract class Configuration
     /**
      * @psalm-assert-if-true LoadedFromFileConfiguration $this
      */
-    public function wasLoadedFromFile(): bool
+    final public function wasLoadedFromFile(): bool
     {
         return false;
     }

--- a/src/TextUI/Configuration/Xml/Migration/Migrations/LogToReportMigration.php
+++ b/src/TextUI/Configuration/Xml/Migration/Migrations/LogToReportMigration.php
@@ -22,7 +22,7 @@ abstract class LogToReportMigration implements Migration
     /**
      * @throws MigrationException
      */
-    public function migrate(DOMDocument $document): void
+    final public function migrate(DOMDocument $document): void
     {
         $coverage = $document->getElementsByTagName('coverage')->item(0);
 

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -56,7 +56,7 @@ abstract class AbstractPhpProcess
     protected array $env   = [];
     protected int $timeout = 0;
 
-    public static function factory(): self
+    final public static function factory(): self
     {
         if (DIRECTORY_SEPARATOR === '\\') {
             return new WindowsPhpProcess;
@@ -75,7 +75,7 @@ abstract class AbstractPhpProcess
      *
      * Then $stderrRedirection is TRUE, STDERR is redirected to STDOUT.
      */
-    public function setUseStderrRedirection(bool $stderrRedirection): void
+    final public function setUseStderrRedirection(bool $stderrRedirection): void
     {
         $this->stderrRedirection = $stderrRedirection;
     }
@@ -83,7 +83,7 @@ abstract class AbstractPhpProcess
     /**
      * Returns TRUE if uses STDERR redirection or FALSE if not.
      */
-    public function useStderrRedirection(): bool
+    final public function useStderrRedirection(): bool
     {
         return $this->stderrRedirection;
     }
@@ -91,7 +91,7 @@ abstract class AbstractPhpProcess
     /**
      * Sets the input string to be sent via STDIN.
      */
-    public function setStdin(string $stdin): void
+    final public function setStdin(string $stdin): void
     {
         $this->stdin = $stdin;
     }
@@ -99,7 +99,7 @@ abstract class AbstractPhpProcess
     /**
      * Returns the input string to be sent via STDIN.
      */
-    public function getStdin(): string
+    final public function getStdin(): string
     {
         return $this->stdin;
     }
@@ -107,7 +107,7 @@ abstract class AbstractPhpProcess
     /**
      * Sets the string of arguments to pass to the php job.
      */
-    public function setArgs(string $arguments): void
+    final public function setArgs(string $arguments): void
     {
         $this->arguments = $arguments;
     }
@@ -115,7 +115,7 @@ abstract class AbstractPhpProcess
     /**
      * Returns the string of arguments to pass to the php job.
      */
-    public function getArgs(): string
+    final public function getArgs(): string
     {
         return $this->arguments;
     }
@@ -125,7 +125,7 @@ abstract class AbstractPhpProcess
      *
      * @psalm-param array<string, string> $env
      */
-    public function setEnv(array $env): void
+    final public function setEnv(array $env): void
     {
         $this->env = $env;
     }
@@ -133,7 +133,7 @@ abstract class AbstractPhpProcess
     /**
      * Returns the array of environment variables to start the child process with.
      */
-    public function getEnv(): array
+    final public function getEnv(): array
     {
         return $this->env;
     }
@@ -141,7 +141,7 @@ abstract class AbstractPhpProcess
     /**
      * Sets the amount of seconds to wait before timing out.
      */
-    public function setTimeout(int $timeout): void
+    final public function setTimeout(int $timeout): void
     {
         $this->timeout = $timeout;
     }
@@ -149,7 +149,7 @@ abstract class AbstractPhpProcess
     /**
      * Returns the amount of seconds to wait before timing out.
      */
-    public function getTimeout(): int
+    final public function getTimeout(): int
     {
         return $this->timeout;
     }
@@ -157,7 +157,7 @@ abstract class AbstractPhpProcess
     /**
      * Runs a single test in a separate PHP process.
      */
-    public function runTestJob(string $job, Test $test, TestResult $result): void
+    final public function runTestJob(string $job, Test $test, TestResult $result): void
     {
         $result->startTest($test);
 
@@ -174,7 +174,7 @@ abstract class AbstractPhpProcess
     /**
      * Returns the command based into the configurations.
      */
-    public function getCommand(array $settings, string $file = null): string
+    final public function getCommand(array $settings, string $file = null): string
     {
         $command = $this->runtime->getBinary();
 

--- a/src/Util/Xml/SchemaDetectionResult.php
+++ b/src/Util/Xml/SchemaDetectionResult.php
@@ -16,7 +16,7 @@ namespace PHPUnit\Util\Xml;
  */
 abstract class SchemaDetectionResult
 {
-    public function detected(): bool
+    final public function detected(): bool
     {
         return false;
     }
@@ -24,7 +24,7 @@ abstract class SchemaDetectionResult
     /**
      * @throws Exception
      */
-    public function version(): string
+    final public function version(): string
     {
         throw new Exception('No supported schema was detected');
     }


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.