### PR TITLE
Regular callable call

### DIFF
--- a/src/Framework/MockObject/Stub/ReturnCallback.php
+++ b/src/Framework/MockObject/Stub/ReturnCallback.php
@@ -32,7 +32,7 @@ final class ReturnCallback implements Stub
 
     public function invoke(Invocation $invocation): mixed
     {
-        return call_user_func_array($this->callback, $invocation->getParameters());
+        return ($this->callback)(...$invocation->getParameters());
     }
 
     public function toString(): string


### PR DESCRIPTION
Callables must be called without using call_user_func* when possible.