### PR TITLE
Get class to class keyword

### DIFF
--- a/src/Event/Value/TestSuite/TestSuite.php
+++ b/src/Event/Value/TestSuite/TestSuite.php
@@ -57,7 +57,7 @@ abstract class TestSuite
             }
 
             foreach ($tests as $test) {
-                $groups[$groupName][] = get_class($test);
+                $groups[$groupName][] = $test::class;
             }
         }
 


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.