### PR TITLE
Enhancement: Enable `get_class_to_class_keyword` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -91,6 +91,7 @@ $config->setFinder($finder)
         'function_declaration' => true,
         'function_to_constant' => true,
         'function_typehint_space' => true,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => [
             'import_classes' => true,
             'import_constants' => true,

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -11,7 +11,6 @@ namespace PHPUnit\Framework\MockObject;
 
 use function class_uses;
 use function func_get_args;
-use function get_class;
 use function get_parent_class;
 use Exception;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -370,7 +369,7 @@ final class MockObjectTest extends TestCase
         $mock2 = $this->getMockBuilder(AnInterface::class)
                      ->getMock();
 
-        $this->assertEquals(get_class($mock1), get_class($mock2));
+        $this->assertEquals($mock1::class, $mock2::class);
     }
 
     public function testMockClassDifferentForPartialMocks(): void
@@ -394,14 +393,14 @@ final class MockObjectTest extends TestCase
                       ->onlyMethods(['doAnotherThing'])
                       ->getMock();
 
-        $this->assertNotEquals(get_class($mock1), get_class($mock2));
-        $this->assertNotEquals(get_class($mock1), get_class($mock3));
-        $this->assertNotEquals(get_class($mock1), get_class($mock4));
-        $this->assertNotEquals(get_class($mock1), get_class($mock5));
-        $this->assertEquals(get_class($mock2), get_class($mock3));
-        $this->assertNotEquals(get_class($mock2), get_class($mock4));
-        $this->assertNotEquals(get_class($mock2), get_class($mock5));
-        $this->assertEquals(get_class($mock4), get_class($mock5));
+        $this->assertNotEquals($mock1::class, $mock2::class);
+        $this->assertNotEquals($mock1::class, $mock3::class);
+        $this->assertNotEquals($mock1::class, $mock4::class);
+        $this->assertNotEquals($mock1::class, $mock5::class);
+        $this->assertEquals($mock2::class, $mock3::class);
+        $this->assertNotEquals($mock2::class, $mock4::class);
+        $this->assertNotEquals($mock2::class, $mock5::class);
+        $this->assertEquals($mock4::class, $mock5::class);
     }
 
     public function testMockClassStoreOverrulable(): void
@@ -425,15 +424,15 @@ final class MockObjectTest extends TestCase
                       ->setMockClassName('MyMockClassNameForPartialMockTestClass2')
                       ->getMock();
 
-        $this->assertNotEquals(get_class($mock1), get_class($mock2));
-        $this->assertEquals(get_class($mock1), get_class($mock3));
-        $this->assertNotEquals(get_class($mock1), get_class($mock4));
-        $this->assertNotEquals(get_class($mock2), get_class($mock3));
-        $this->assertNotEquals(get_class($mock2), get_class($mock4));
-        $this->assertNotEquals(get_class($mock2), get_class($mock5));
-        $this->assertNotEquals(get_class($mock3), get_class($mock4));
-        $this->assertNotEquals(get_class($mock3), get_class($mock5));
-        $this->assertNotEquals(get_class($mock4), get_class($mock5));
+        $this->assertNotEquals($mock1::class, $mock2::class);
+        $this->assertEquals($mock1::class, $mock3::class);
+        $this->assertNotEquals($mock1::class, $mock4::class);
+        $this->assertNotEquals($mock2::class, $mock3::class);
+        $this->assertNotEquals($mock2::class, $mock4::class);
+        $this->assertNotEquals($mock2::class, $mock5::class);
+        $this->assertNotEquals($mock3::class, $mock4::class);
+        $this->assertNotEquals($mock3::class, $mock5::class);
+        $this->assertNotEquals($mock4::class, $mock5::class);
     }
 
     public function testGetMockWithFixedClassNameCanProduceTheSameMockTwice(): void
@@ -464,7 +463,7 @@ final class MockObjectTest extends TestCase
                       ->disableOriginalClone()
                       ->getMock();
 
-        $this->assertNotEquals(get_class($mock1), get_class($mock2));
+        $this->assertNotEquals($mock1::class, $mock2::class);
     }
 
     public function testGetMockForAbstractClass(): void
@@ -926,7 +925,7 @@ EOF
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            get_class($mock)
+            $mock::class
         );
     }
 
@@ -937,7 +936,7 @@ EOF
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            get_class($mock)
+            $mock::class
         );
     }
 
@@ -947,8 +946,8 @@ EOF
         $a = $this->getMockFromWsdl(TEST_FILES_PATH . 'GoogleSearch.wsdl');
         $b = $this->getMockFromWsdl(TEST_FILES_PATH . 'GoogleSearch.wsdl');
 
-        $this->assertStringStartsWith('Mock_GoogleSearch_', get_class($a));
-        $this->assertEquals(get_class($a), get_class($b));
+        $this->assertStringStartsWith('Mock_GoogleSearch_', $a::class);
+        $this->assertEquals($a::class, $b::class);
     }
 
     #[RequiresPhpExtension('soap')]
@@ -956,7 +955,7 @@ EOF
     {
         $mock = $this->getMockFromWsdl(TEST_FILES_PATH . 'Go ogle-Sea.rch.wsdl');
 
-        $this->assertStringStartsWith('Mock_GoogleSearch_', get_class($mock));
+        $this->assertStringStartsWith('Mock_GoogleSearch_', $mock::class);
     }
 
     public function testInterfaceWithStaticMethodCanBeStubbed(): void

--- a/tests/unit/Metadata/Facade/CodeCoverageFacadeTest.php
+++ b/tests/unit/Metadata/Facade/CodeCoverageFacadeTest.php
@@ -10,7 +10,6 @@
 namespace PHPUnit\Metadata;
 
 use function array_merge;
-use function get_class;
 use function range;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
@@ -210,7 +209,7 @@ final class CodeCoverageFacadeTest extends TestCase
     public function testCanSkipCoverage(string $testCase, bool $expectedCanSkip): void
     {
         $test             = new $testCase('testSomething');
-        $coverageRequired = (new CodeCoverage)->shouldCodeCoverageBeCollectedFor(get_class($test), $test->getName(false));
+        $coverageRequired = (new CodeCoverage)->shouldCodeCoverageBeCollectedFor($test::class, $test->getName(false));
         $canSkipCoverage  = !$coverageRequired;
 
         $this->assertEquals($expectedCanSkip, $canSkipCoverage);


### PR DESCRIPTION
This pull request

- [x] enables the `get_class_to_class_keyword` fixer
- [x] runs `tools/php-cs-fixer fix`

Follows #5003.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.8.0/doc/rules/language_construct/get_class_to_class_keyword.rst.