### PR TITLE
Skip tests/end-to-end/event/invalid-coverage-metadata.phpt without PCOV

### DIFF
--- a/tests/end-to-end/event/invalid-coverage-metadata.phpt
+++ b/tests/end-to-end/event/invalid-coverage-metadata.phpt
@@ -5,6 +5,9 @@ The right events are emitted in the right order for a test that has invalid code
 if (DIRECTORY_SEPARATOR === '\\') {
     print "skip: this test does not work on Windows / GitHub Actions\n";
 }
+if (!extension_loaded('pcov')) {
+    print "skip: this test requires pcov\n";
+}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);


### PR DESCRIPTION
Test suite is failing when the pcov extension is missing since a few days:

https://revive.beccati.com/bamboo/browse/PHP-PHPUN-2993

I suppose the failing test can be skipped in that case.