### PR TITLE
Collect coverage when no assertion is expected

### DIFF
--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -782,6 +782,7 @@ final class TestResult implements Countable
         }
 
         if ($this->beStrictAboutTestsThatDoNotTestAnything &&
+            !$test->doesNotPerformAssertions() &&
             $test->getNumAssertions() == 0) {
             $risky = true;
         }


### PR DESCRIPTION
fixes https://github.com/sebastianbergmann/php-code-coverage/issues/921#issuecomment-1177377309

when no assertion is expected - test is annotated with `@doesNotPerformAssertions` (or with php attribute) - coverage must be collected

the added condition matches the condition used a few lines below for reporting a risky test

🎉 UPDATE: It was actually fixed a yer later: https://github.com/sebastianbergmann/phpunit/commit/b771002b7b1022610272f7789f9b0603948573f7 and https://github.com/sebastianbergmann/phpunit/commit/262b0dc2bbee91a5d4a66dbb80dc4fa34dfe8a96 backported, thank you!