### PR TITLE
Fix memory leak in ExceptionWrapper

### DIFF
--- a/src/Framework/ExceptionWrapper.php
+++ b/src/Framework/ExceptionWrapper.php
@@ -9,11 +9,13 @@
  */
 namespace PHPUnit\Framework;
 
+use const PHP_VERSION_ID;
 use function array_keys;
 use function get_class;
 use function spl_object_hash;
 use PHPUnit\Util\Filter;
 use Throwable;
+use WeakReference;
 
 /**
  * Wraps Exceptions thrown by code under test.
@@ -37,6 +39,11 @@ final class ExceptionWrapper extends Exception
      * @var null|ExceptionWrapper
      */
     protected $previous;
+
+    /**
+     * @var null|WeakReference<Throwable>
+     */
+    private $originalException;
 
     public function __construct(Throwable $t)
     {
@@ -109,14 +116,23 @@ final class ExceptionWrapper extends Exception
      */
     private function originalException(Throwable $exceptionToStore = null): ?Throwable
     {
-        static $originalExceptions;
+        // drop once PHP 7.3 support is removed
+        if (PHP_VERSION_ID < 70400) {
+            static $originalExceptions;
 
-        $instanceId = spl_object_hash($this);
+            $instanceId = spl_object_hash($this);
 
-        if ($exceptionToStore) {
-            $originalExceptions[$instanceId] = $exceptionToStore;
+            if ($exceptionToStore) {
+                $originalExceptions[$instanceId] = $exceptionToStore;
+            }
+
+            return $originalExceptions[$instanceId] ?? null;
         }
 
-        return $originalExceptions[$instanceId] ?? null;
+        if ($exceptionToStore) {
+            $this->originalException = WeakReference::create($exceptionToStore);
+        }
+
+        return $this->originalException !== null ? $this->originalException->get() : null;
     }
 }


### PR DESCRIPTION
Currently `ExceptionWrapper` stores the original exception forever and prevents it to be GCed.

This is causing not only memory to grow/leak, but also if the original exception has a reference to an object, the object is not released as well. Such scenario is not uncommon, as exception stack trace/frame can contain object arguments.

In consequence when the unreleased object is a some limited resource like DB connection, with a lot of wrapped/unreleased exceptions, the resource can be exhausted by a few failing tests making the other tests fail because of them.

This fix maintains the shallow backtrace as WeakReference property is not expanded during backtrace dump.

No BC break introduced.