### PR TITLE
Update Ukraine word with the black foreground color

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -325,7 +325,7 @@ final class TestRunner extends BaseTestRunner
                 Version::id() .
                 ' ' .
                 Color::colorize('bg-blue,fg-white', '#StandWith') .
-                Color::colorize('bg-yellow', 'Ukraine') .
+                Color::colorize('bg-yellow,fg-black', 'Ukraine') .
                 "\n"
             );
         } else {

--- a/tests/end-to-end/cli/options-after-arguments.phpt
+++ b/tests/end-to-end/cli/options-after-arguments.phpt
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../../bootstrap.php';
 
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-PHPUnit %s [44;37m#StandWith[0m[43mUkraine[0m
+PHPUnit %s [44;37m#StandWith[0m[43;30mUkraine[0m
 
 ...                                                                 3 / 3 (100%)
 

--- a/tests/end-to-end/logging/_files/raw_output_ColorTest.txt
+++ b/tests/end-to-end/logging/_files/raw_output_ColorTest.txt
@@ -1,4 +1,4 @@
-PHPUnit %s [44;37m#StandWith[0m[43mUkraine[0m
+PHPUnit %s [44;37m#StandWith[0m[43;30mUkraine[0m
 
 Runtime:       %s
 

--- a/tests/end-to-end/logging/_files/raw_output_StatusTest.txt
+++ b/tests/end-to-end/logging/_files/raw_output_StatusTest.txt
@@ -1,4 +1,4 @@
-PHPUnit %s [44;37m#StandWith[0m[43mUkraine[0m
+PHPUnit %s [44;37m#StandWith[0m[43;30mUkraine[0m
 
 Runtime:       %s
 Configuration: %sconfiguration.basic.xml


### PR DESCRIPTION
Hi Sebastian :wave: Hi PHPUnit contributors:

**Summary**

The message `#StandWithUkraine` shows the Ukraine word with white text on a yellow background (when it uses a terminal with black background).

**Example of Current Behavior**

<img width="573" alt="Screen Shot 2022-07-13 at 21 02 42" src="https://user-images.githubusercontent.com/24535949/178857976-3f832c5b-ab4d-4106-b5b4-2769bc4df722.png">


**Example of Expected Behavior**

<img width="570" alt="Screen Shot 2022-07-13 at 21 03 46" src="https://user-images.githubusercontent.com/24535949/178857990-64adcab7-1f33-495b-b4d8-6640ef219757.png">


With these minor changes could use similar colors as Packagist/Composer.
