### PR TITLE
Restore support for PSR-0-style test-classes (#5020)

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -473,7 +473,8 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                         $this->addTest($method->invoke(null, $className));
                     }
                 } elseif ($class->implementsInterface(Test::class)) {
-                    $expectedClassName = $shortName;
+                    $isPsr0            = (!$class->inNamespace()) && (strpos($class->getName(), '_') !== false);
+                    $expectedClassName = $isPsr0 ? $className : $shortName;
 
                     if (($pos = strpos($expectedClassName, '.')) !== false) {
                         $expectedClassName = substr(

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -473,6 +473,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                         $this->addTest($method->invoke(null, $className));
                     }
                 } elseif ($class->implementsInterface(Test::class)) {
+                    // Do we have modern namespacing ('Foo\Bar\WhizBangTest') or old-school namespacing ('Foo_Bar_WhizBangTest')?
                     $isPsr0            = (!$class->inNamespace()) && (strpos($class->getName(), '_') !== false);
                     $expectedClassName = $isPsr0 ? $className : $shortName;
 

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -61,6 +61,12 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
 
                     break;
                 }
+
+                if (stripos(substr($loadedClass, $offset - 1), '_' . $suiteClassName) === 0) {
+                    $suiteClassName = $loadedClass;
+
+                    break;
+                }
             }
         }
 

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -52,16 +52,18 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
         }
 
         if (!class_exists($suiteClassName, false)) {
-            // this block will handle namespaced classes
+            // Perhaps this file defines a class inside a namespace? Let's check...
             $offset = 0 - strlen($suiteClassName);
 
             foreach ($loadedClasses as $loadedClass) {
+                // Detect modern namespace (eg './tests/Foo/Bar/WhizBangTest.php' <=> 'Foo\Bar\WhizBangTest')
                 if (stripos(substr($loadedClass, $offset - 1), '\\' . $suiteClassName) === 0) {
                     $suiteClassName = $loadedClass;
 
                     break;
                 }
 
+                // Detect old-school namespace (eg 'tests/Foo/Bar/WhizBangTest.php' <=> 'Foo_Bar_WhizBangTest'; #5020)
                 if (stripos(substr($loadedClass, $offset - 1), '_' . $suiteClassName) === 0) {
                     $suiteClassName = $loadedClass;
 

--- a/tests/end-to-end/regression/5020.phpt
+++ b/tests/end-to-end/regression/5020.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GH-5020: Load PSR-0 tests
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/5020/Under/Score/Issue5020Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s #StandWithUkraine
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/5020/Under/Score/Issue5020Test.php
+++ b/tests/end-to-end/regression/5020/Under/Score/Issue5020Test.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Under_Score_Issue5020Test extends PHPUnit\Framework\TestCase
+{
+    public function testTrue(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
As per #5020, this PR fixes loading of test-classes which have underscore-based namespacing (e.g. loading `CRM_Utils_StringTest` in file `tests/phpunit/CRM/Utils/StringTest.php` from example repo https://github.com/totten/phpunit-underscore-namespace). The PR also adds an end-to-end regression test.

Note: The patch for `main` is very slightly different (and slightly shorter). I've only opened the PR for 9.x (since that's the older version with the bug), but you can see `main` patches at https://github.com/totten/phpunit/commits/main-psr0