### PR TITLE
Do not pass null to ReflectionClass::getMethods()

### DIFF
--- a/src/Util/Reflection.php
+++ b/src/Util/Reflection.php
@@ -42,7 +42,11 @@ final class Reflection
     {
         $methods = [];
 
-        foreach ($class->getMethods($filter) as $method) {
+        // PHP <7.2.18 and <7.3.5 throw error when null is passed
+        // to ReflectionClass::getMethods() when strict_types is enabled.
+        $classMethods = $filter === null ? $class->getMethods() : $class->getMethods($filter);
+
+        foreach ($classMethods as $method) {
             if ($method->getDeclaringClass()->getName() === TestCase::class) {
                 continue;
             }


### PR DESCRIPTION
Fixes [#5016](https://github.com/sebastianbergmann/phpunit/issues/5016)

PHP <7.2.18 and PHP <7.3.5 throw error when null is passed to ReflectionClass::getMethods() when strict_types is enabled.