### PR TITLE
Restore support for PSR-0-style test-classes (main/10.x)

### DIFF
--- a/src/Runner/TestSuiteLoader.php
+++ b/src/Runner/TestSuiteLoader.php
@@ -81,6 +81,11 @@ final class TestSuiteLoader
 
                     break;
                 }
+                if (stripos(substr($loadedClass, $offset - 1), '_' . $suiteClassName) === 0) {
+                    $suiteClassName = $loadedClass;
+
+                    break;
+                }
             }
         }
 

--- a/src/Runner/TestSuiteLoader.php
+++ b/src/Runner/TestSuiteLoader.php
@@ -72,15 +72,17 @@ final class TestSuiteLoader
         }
 
         if (!class_exists($suiteClassName, false)) {
-            // this block will handle namespaced classes
+            // Perhaps this file defines a class inside a namespace? Let's check...
             $offset = 0 - strlen($suiteClassName);
 
             foreach (self::$loadedClasses as $loadedClass) {
+                // Detect modern namespace (eg './tests/Foo/Bar/WhizBangTest.php' <=> 'Foo\Bar\WhizBangTest')
                 if (stripos(substr($loadedClass, $offset - 1), '\\' . $suiteClassName) === 0) {
                     $suiteClassName = $loadedClass;
 
                     break;
                 }
+                // Detect old-school namespace (eg 'tests/Foo/Bar/WhizBangTest.php' <=> 'Foo_Bar_WhizBangTest'; #5020)
                 if (stripos(substr($loadedClass, $offset - 1), '_' . $suiteClassName) === 0) {
                     $suiteClassName = $loadedClass;
 

--- a/tests/end-to-end/regression/5020.phpt
+++ b/tests/end-to-end/regression/5020.phpt
@@ -1,0 +1,20 @@
+--TEST--
+GH-5020: Load PSR-0 tests
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/5020/Under/Score/Issue5020Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Application::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/5020/Under/Score/Issue5020Test.php
+++ b/tests/end-to-end/regression/5020/Under/Score/Issue5020Test.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class Under_Score_Issue5020Test extends PHPUnit\Framework\TestCase
+{
+    public function testTrue(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This is a forward-port of #5021 from `9.5` to `main`/`10.x`.