### PR TITLE
Enhancement: Use `no_trailing_comma_in_singleline` instead of deprecated fixers

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -161,8 +161,7 @@ $config->setFinder($finder)
         'no_superfluous_phpdoc_tags' => [
             'allow_mixed' => true,
         ],
-        'no_trailing_comma_in_list_call' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,


### PR DESCRIPTION
This pull request

- [x] uses the `no_trailing_comma_in_singleline` instead of the deprecated `no_trailing_comma_in_list_call` and `no_trailing_comma_in_singleline_array` fixers

💁‍♂️ For reference, see

- https://github.com/FriendsOfPHP/PHP-CS-Fixer/compare/v3.10.0...v3.11.0
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.11.0/doc/rules/basic/no_trailing_comma_in_singleline.rst