### PR TITLE
Enhancement: Enable `no_unneeded_import_alias` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -168,6 +168,7 @@ $config->setFinder($finder)
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_unneeded_import_alias` fixer

❗ This fixer has effects in current `main`.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.11.0/doc/rules/import/no_unneeded_import_alias.rst.