### PR TITLE
Fix PHPUnit termination when data provider throws an Error

### DIFF
--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -126,13 +126,17 @@ final class DocBlock
     {
         $className = $class->getName();
 
+        $startLine = $class->getStartLine();
+        $endLine   = $class->getEndLine();
+        $fileName  = $class->getFileName();
+
         return new self(
             (string) $class->getDocComment(),
             false,
             self::extractAnnotationsFromReflector($class),
-            $class->getStartLine(),
-            $class->getEndLine(),
-            $class->getFileName(),
+            ($startLine === false ? 0 : $startLine),
+            ($endLine === false ? 0 : $endLine),
+            ($fileName === false ? '' : $fileName),
             $className,
             $className
         );


### PR DESCRIPTION
When a data provider triggers a PHP `Error` (for example, when accessing a uninitialized property), PHPUnit terminates with a cryptic error message:

> PHPUnit\Util\Annotation\DocBlock::__construct(): Argument #4 ($startLine) must be of type int, bool given, called in /(...)/vendor/phpunit/phpunit/src/Util/Annotation/DocBlock.php on line 129

This is because methods such as `ReflectionClass::getStartLine()` can return `false` when called on internal classes.

This PR fixes this issue.

_Note: please let me know if you prefer the explicit `=== false` syntax (the current PR), or just `?:`, which works the same for all cases but a file name that would contain just the string `'0'` (unlikely)._