### PR TITLE
Fix: Allow bootstrapping extension without parameters

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -61,7 +61,7 @@
     </xs:complexType>
     <xs:complexType name="bootstrapType">
         <xs:sequence>
-            <xs:element name="parameter" type="parameterType" maxOccurs="unbounded"/>
+            <xs:element name="parameter" type="parameterType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="class" type="xs:string" use="required"/>
     </xs:complexType>


### PR DESCRIPTION
This pull request

- [x] adjusts `phpunit.xsd` to allow bootstrapping an extension without parameters

💁‍♂️ Attempting to register an extension without defining a parameter works, but emits a warning as the XML validation fails.

```xml
<phpunit
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
>
    <extensions>
        <bootstrap class="Localheinz\Example\ExampleExtension" />
    </extensions>

    <testsuites>
        <testsuite name="unit">
            <directory>test/Unit/</directory>
        </testsuite>
    </testsuites>
</phpunit>
```

```
vendor/bin/phpunit --configuration=phpunit.xml
PHPUnit 10.0-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.10
Configuration: phpunit.xml
Random Seed:   1666541097

.....                                                                                                                                                                                                                                                                                                             5 / 5 (100%)

Time: 00:01.703, Memory: 8.00 MB

There was 1 PHPUnit warning:

1) Test results may not be as expected because the XML configuration file did not pass validation:

  Line 14:
  - Element 'bootstrap': Missing child element(s). Expected is ( parameter ).


WARNINGS!
Tests: 5, Assertions: 5, Warnings: 1.
```