### PR TITLE
Assert::assertThrows()

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1916,6 +1916,23 @@ abstract class Assert
         static::assertThat($expectedJson, new LogicalNot($constraintActual), $message);
         static::assertThat($actualJson, new LogicalNot($constraintExpected), $message);
     }
+    
+    /**
+     * @param \Closure(): void $function
+     */
+    public static function assertThrows(\Closure $function): \Throwable
+    {
+        $e = null;
+        try {
+            $function();
+        } catch (\Throwable $e) {
+            // Handled bellow
+        }
+
+        self::assertNotNull($e);
+
+        return $e;
+    }
 
     /**
      * @throws Exception


### PR DESCRIPTION
Just an idea for alternative exceptions checking. I am using this pattern often for checked exceptions with extra methods which cannot be tested with `expectException*` methods.

Let me know if you like the idea and if I should finish the PR.

```php
final class Test extends \PHPUnit\Framework\TestCase
{
	public function test(): void
	{
		$e = self::assertThrows(fn () => throw new \Exception());
		self::assertInstanceOf(\Exception::class, $e);
		self::assertSame('', $e->getMessage());
	}
}
```