### PR TITLE
PHP error instead of PHPUnit error when trying to create test double for read-only class

### DIFF
--- a/src/Framework/MockObject/Exception/ClassIsReadonlyException.php
+++ b/src/Framework/MockObject/Exception/ClassIsReadonlyException.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use function sprintf;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ClassIsReadonlyException extends \PHPUnit\Framework\Exception implements Exception
+{
+    public function __construct(string $className)
+    {
+        parent::__construct(
+            sprintf(
+                'Class "%s" is declared "readonly" and cannot be doubled',
+                $className
+            )
+        );
+    }
+}

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -81,6 +81,7 @@ final class Generator
      * @throws ClassAlreadyExistsException
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
+     * @throws ClassIsReadonlyException
      * @throws DuplicateMethodException
      * @throws InvalidMethodNameException
      * @throws OriginalConstructorInvocationRequiredException
@@ -202,6 +203,7 @@ final class Generator
      * @throws ClassAlreadyExistsException
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
+     * @throws ClassIsReadonlyException
      * @throws DuplicateMethodException
      * @throws InvalidArgumentException
      * @throws InvalidMethodNameException
@@ -264,6 +266,7 @@ final class Generator
      * @throws ClassAlreadyExistsException
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
+     * @throws ClassIsReadonlyException
      * @throws DuplicateMethodException
      * @throws InvalidArgumentException
      * @throws InvalidMethodNameException
@@ -347,6 +350,7 @@ final class Generator
     /**
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
+     * @throws ClassIsReadonlyException
      * @throws ReflectionException
      * @throws RuntimeException
      */
@@ -625,6 +629,7 @@ final class Generator
     /**
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
+     * @throws ClassIsReadonlyException
      * @throws ReflectionException
      * @throws RuntimeException
      */
@@ -682,6 +687,10 @@ final class Generator
 
             if ($class->isFinal()) {
                 throw new ClassIsFinalException($_mockClassName['fullClassName']);
+            }
+
+            if (method_exists($class, 'isReadOnly') && $class->isReadOnly()) {
+                throw new ClassIsReadonlyException($_mockClassName['fullClassName']);
             }
 
             // @see https://github.com/sebastianbergmann/phpunit/issues/2995

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -53,6 +53,7 @@ final class MockBuilder
      * @throws ClassAlreadyExistsException
      * @throws ClassIsEnumerationException
      * @throws ClassIsFinalException
+     * @throws ClassIsReadonlyException
      * @throws DuplicateMethodException
      * @throws InvalidMethodNameException
      * @throws OriginalConstructorInvocationRequiredException

--- a/tests/_files/mock-object/ReadonlyClass.php
+++ b/tests/_files/mock-object/ReadonlyClass.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\MockObject;
+
+readonly class ReadonlyClass
+{
+    public function __construct(private mixed $value)
+    {
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -32,6 +32,7 @@ use PHPUnit\TestFixture\MockObject\AnInterfaceWithReturnType;
 use PHPUnit\TestFixture\MockObject\AnotherInterface;
 use PHPUnit\TestFixture\MockObject\ClassWithVariadicArgumentMethod;
 use PHPUnit\TestFixture\MockObject\FinalClass;
+use PHPUnit\TestFixture\MockObject\ReadonlyClass;
 use PHPUnit\TestFixture\MockObject\InterfaceWithSemiReservedMethodName;
 use PHPUnit\TestFixture\SingletonClass;
 use RuntimeException;
@@ -322,6 +323,14 @@ final class GeneratorTest extends TestCase
 
         /* @noinspection ClassMockingCorrectnessInspection */
         $this->createMock(FinalClass::class);
+    }
+
+    public function testCannotMockReadonlyClass(): void
+    {
+        $this->expectException(ClassIsReadonlyException::class);
+
+        /* @noinspection ClassMockingCorrectnessInspection */
+        $this->createMock(ReadonlyClass::class);
     }
 
     public function testCanDoubleIntersectionOfMultipleInterfaces(): void


### PR DESCRIPTION
Hi!

According to new changes delivered in PHP 8.2, we cannot mock `readonly` classes like `final` or `enum` by extending them.

See reference: https://github.com/php/php-src/blob/7850c103894c50c4af4c2632c5ab60480a0fbdd3/Zend/tests/readonly_classes/readonly_class_inheritance_error1.phpt

Or shall we to add `readonly` keyword into generated mocked class to skip Runtime exception from PHP like: https://github.com/php/php-src/blob/7850c103894c50c4af4c2632c5ab60480a0fbdd3/Zend/tests/readonly_classes/readonly_class_inheritance_success.phpt