### PR TITLE
Improve performance of TestCase::registerMockObjectsFromTestArguments() with large test arguments arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "sebastian/exporter": "^5.0",
         "sebastian/global-state": "^6.0",
         "sebastian/object-enumerator": "^5.0",
+        "sebastian/recursion-context": "^5.0",
         "sebastian/type": "^4.0",
         "sebastian/version": "^4.0"
     },

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -101,6 +101,7 @@ use SebastianBergmann\GlobalState\Restorer;
 use SebastianBergmann\GlobalState\Snapshot;
 use SebastianBergmann\Invoker\TimeoutException;
 use SebastianBergmann\ObjectEnumerator\Enumerator;
+use SebastianBergmann\RecursionContext\Context;
 use Throwable;
 
 /**
@@ -1713,7 +1714,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @throws \SebastianBergmann\ObjectEnumerator\InvalidArgumentException
      */
-    private function registerMockObjectsFromTestArguments(array $testArguments, array &$visited = []): void
+    private function registerMockObjectsFromTestArguments(array $testArguments, Context $context = new Context): void
     {
         if ($this->registerMockObjectsFromTestArgumentsRecursively) {
             foreach ((new Enumerator)->enumerate($testArguments) as $object) {
@@ -1727,12 +1728,12 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                     $testArgument = Cloner::clone($testArgument);
 
                     $this->registerMockObject($testArgument);
-                } elseif (is_array($testArgument) && !in_array($testArgument, $visited, true)) {
-                    $visited[] = $testArgument;
+                } elseif (is_array($testArgument) && !$context->contains($testArgument)) {
+                    $context->add($testArgument);
 
                     $this->registerMockObjectsFromTestArguments(
                         $testArgument,
-                        $visited
+                        $context
                     );
                 }
             }


### PR DESCRIPTION
`TestCase::registerMockObjectsFromTestArguments()` iterates recursively on arrays tests arguments (from data providers).

The "visited" strategy with `in_array` is super slow with large arrays.
I thought we could reuse the `Context` class from the `sebastian/recursion-context` package like we already do with the `Enumerator` class in the `if` block.
I'm not really sure if it makes sense and if we can use it though since I don't know much about internals :man_shrugging: 

I'm running a test with a data provider that provides one array argument of 50k items.
With the current strategy:
```
Time: 00:16.220, Memory: 76.02 MB
```

With the proposed change:
```
Time: 00:00.143, Memory: 76.02 MB
```

`sebastian/recursion-context` is already a transitive dependency through `sebastian/object-enumerator`.

If it looks good, should it be applied to lower branches?