### PR TITLE
Fixes phpunit/phpunit#5120

### DIFF
--- a/src/TextUI/Command/Commands/ListTestsAsTextCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsTextCommand.php
@@ -75,10 +75,6 @@ final class ListTestsAsTextCommand implements Command
             $buffer .= 'The --exclude-group and --list-tests options cannot be combined, --exclude-group is ignored' . PHP_EOL;
         }
 
-        if ($configuration->hasTestSuite()) {
-            $buffer .= 'The --testsuite and --list-tests options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
         if (!empty($buffer)) {
             $buffer .= PHP_EOL;
         }


### PR DESCRIPTION
Basically, these options do work together and are what I would consider a valid use case. List only the tests in a single test suite.

Note that if you don't accept this PR, there's a copy-paste error on line 79 - should say "--testsuite is ignored"