### PR TITLE
Allow `doctrine/instantiator` 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-mbstring": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
-        "doctrine/instantiator": "^1.3.1",
+        "doctrine/instantiator": "^1.3.1 || ^2",
         "myclabs/deep-copy": "^1.10.1",
         "phar-io/manifest": "^2.0.3",
         "phar-io/version": "^3.0.2",


### PR DESCRIPTION
Hello. I hope you've had a wonderful Christmas.

The Doctrine project has given the old Instantiator a PHP 8.1 update with added native types and release it as version 2.0.

This PR enables projects that run their test suites with PHPUnit to install version 2 of the `doctrine/instantiator` package. Although PHPUnit's PHAR cannot be built with Instantiator 2 (because PHP 8.1 is required), allowing v2 here would avoid dependency conflicts downstream.

Since PHPUnit shares this dependency with Doctrine ORM for the ORM's own test suite.