### PR TITLE
Adds Assert::assertThrows() for easier exception checking

### DIFF
--- a/ChangeLog-10.0.md
+++ b/ChangeLog-10.0.md
@@ -28,6 +28,7 @@ All notable changes of the PHPUnit 10.0 release series are documented in this fi
 * `--display-errors` option and `displayDetailsOnTestsThatTriggerErrors` XML configuration attribute to control whether details on tests that trigger `E_ERROR` or `E_USER_ERROR` should be displayed
 * `--display-notices` option and `displayDetailsOnTestsThatTriggerNotices` XML configuration attribute to control whether details on tests that trigger `E_STRING`, `E_NOTICE`, or `E_USER_NOTICE` should be displayed
 * `--display-warnings` option and `displayDetailsOnTestsThatTriggerWarnings` XML configuration attribute to control whether details on tests that trigger `E_WARNING` or `E_USER_WARNING` should be displayed
+* `Assert::assertThrows()`
 
 ### Changed
 

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\Count;
 use PHPUnit\Framework\Constraint\DirectoryExists;
+use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
 use PHPUnit\Framework\Constraint\FileExists;
 use PHPUnit\Framework\Constraint\GreaterThan;
 use PHPUnit\Framework\Constraint\IsAnything;
@@ -1915,6 +1916,23 @@ abstract class Assert
 
         static::assertThat($expectedJson, new LogicalNot($constraintActual), $message);
         static::assertThat($actualJson, new LogicalNot($constraintExpected), $message);
+    }
+
+    /**
+     * Asserts that $code() throws an exception of the class $expectedException.
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertThrows(string $expectedException, callable $code, string $message = ''): void
+    {
+        $thrownException = null;
+        try {
+            $code();
+        } catch (\Throwable $e) {
+            $thrownException = $e;
+        }
+
+        static::assertThat($thrownException, new ExceptionConstraint($expectedException), $message);
     }
 
     /**

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -2191,6 +2191,20 @@ if (!function_exists('PHPUnit\Framework\assertJsonFileNotEqualsJsonFile')) {
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertThrows')) {
+    /**
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertThrows
+     */
+    function assertThrows(string $expectedException, callable $code, string $message = ''): void
+    {
+        Assert::assertThrows($expectedException, $code, $message);
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\logicalAnd')) {
     /**
      * @throws Exception

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -39,6 +39,7 @@ use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\TestFixture\Author;
 use PHPUnit\TestFixture\Book;
 use PHPUnit\TestFixture\ClassWithToString;
+use PHPUnit\TestFixture\DummyException;
 use PHPUnit\TestFixture\ObjectEquals\ValueObject;
 use PHPUnit\TestFixture\SampleArrayAccess;
 use PHPUnit\TestFixture\SampleClass;
@@ -2031,6 +2032,23 @@ XML;
         }
 
         $this->fail();
+    }
+
+    public function testAssertThrowsSucceeds(): void
+    {
+        $this->assertThrows(DummyException::class, fn () => throw new DummyException());
+    }
+
+    public function testAssertThrowsFailsIfNotExceptionThrown(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->assertThrows(DummyException::class, fn () => null);
+    }
+
+    public function testAssertThrowsFailsIfExceptionOfUnexpectedTypeThrown(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->assertThrows(DummyException::class, fn () => throw new Exception());
     }
 
     protected static function sameValues(): array


### PR DESCRIPTION
This pull request adds `Assert::assertThrows()` which reuses `Exception` constraint in a way different from `TestCase::expectException()`.

Usage of `Assert::assertThrows()` enables us to validate postconditions after the exception in a strain forward way:

```php
public function testExample(): void
{
    $component = new MyComponent();

    $this->assertThrows(MyException::class, fn () => $component->send('hello'));

    // and here we can write more assertions to validate postconditions..
}
```

instead of:

```php
public function testExample(): void
{
    $component = new MyComponent();

    try {
        $component->send('hello');
        $this->fail('Exception should be thrown.');
    } catch (MyException) {}
    
    // other assertions to validate postconditions..
}
```