### PR TITLE
Enable xdebug manually

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "sebastian/code-unit": "^1.0.6",
         "sebastian/comparator": "^4.0.8",
         "sebastian/diff": "^4.0.3",
-        "sebastian/environment": "^5.1.3",
+        "sebastian/environment": "^5.1.4",
         "sebastian/exporter": "^4.0.5",
         "sebastian/global-state": "^5.0.1",
         "sebastian/object-enumerator": "^4.0.3",

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -209,6 +209,10 @@ abstract class AbstractPhpProcess
                     array_keys(ini_get_all('xdebug'))
                 )
             );
+
+            if (!$this->runtime->isXdebugLoadedByDefault()) {
+                $settings[] = 'zend_extension=' . (getenv('TODO_USE_PHPUNIT_SETTINGS') ?: 'php_xdebug');
+            }
         }
 
         $command .= $this->settingsToParameters($settings);


### PR DESCRIPTION
>For XDebug, this is a bit different, as there is no "enable" option (may have to be enabled using -d zend_extension=xdebug, but this can be another issue because of extension load order).

_Originally posted by @remicollet in https://github.com/sebastianbergmann/phpunit/issues/3506#issuecomment-459941554_
            

It is very typical for developers to run PHP without xdebug and only enable it when necessary through `-d zend_extension=xdebug`.
PhpStorm, for example follows this approach once properly configured: running tests does not enable xdebug. Debugging or covering tests enables xdebug.

This however does not work for process-isolated-tests (`@runTestsInSeparateProcess`): even though settings are [now copied to the child process](https://github.com/sebastianbergmann/phpunit/issues/3506), xdebug will not be enabled. This is understandable since it's not trivial to find if xdebug is enabled by default (and I was also not able to find the location of the library programmatically, so PR comment below).

The objective of this PR is to do exactly that. 🙏 

----

@sebastianbergmann as soon as it's decided where to go, I can also open PRs for other versions.

