### PR TITLE
Enable proxying to methods with static return type

### DIFF
--- a/src/Framework/MockObject/Generator/proxied_method_static.tpl
+++ b/src/Framework/MockObject/Generator/proxied_method_static.tpl
@@ -1,0 +1,23 @@
+
+    {modifier} function {reference}{method_name}({arguments_decl}){return_declaration}
+    {
+        $__phpunit_arguments = [{arguments_call}];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > {arguments_count}) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = {arguments_count}; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $this->__phpunit_getInvocationHandler()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation(
+                '{class_name}', '{method_name}', $__phpunit_arguments, '{return_type}', $this, {clone_arguments}, true
+            )
+        );
+
+        call_user_func_array(array($this->__phpunit_originalObject, "{method_name}"), $__phpunit_arguments);
+        return $this;
+    }

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Framework\MockObject;
 use const DIRECTORY_SEPARATOR;
 use function explode;
 use function implode;
+use function in_array;
 use function is_object;
 use function is_string;
 use function preg_match;

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -193,6 +193,8 @@ final class MockMethod
                 '%s_method_never_or_void.tpl',
                 $this->callOriginalMethod ? 'proxied' : 'mocked'
             );
+        } elseif ($this->callOriginalMethod === true && $this->returnType->isStatic()) {
+            $templateFile = 'proxied_method_static.tpl';
         } else {
             $templateFile = sprintf(
                 '%s_method.tpl',

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -193,7 +193,8 @@ final class MockMethod
                 '%s_method_never_or_void.tpl',
                 $this->callOriginalMethod ? 'proxied' : 'mocked'
             );
-        } elseif ($this->callOriginalMethod === true && $this->returnType->isStatic()) {
+        } elseif ($this->callOriginalMethod === true &&
+            in_array('static', explode('|', $this->returnType->name()), true)) {
             $templateFile = 'proxied_method_static.tpl';
         } else {
             $templateFile = sprintf(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_static_proxy.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_static_proxy.phpt
@@ -1,5 +1,10 @@
 --TEST--
 \PHPUnit\Framework\MockObject\Generator::generate('Foo', [], 'MockFoo', true, true, true, true)
+--SKIPIF--
+<?php declare(strict_types=1);
+if (PHP_MAJOR_VERSION < 8) {
+    print 'skip: PHP 8 is required.';
+}
 --FILE--
 <?php declare(strict_types=1);
 class ClassWithStaticReturnTypes
@@ -31,7 +36,7 @@ $mock = $generator->generate(
     true
 );
 
-print $mock->classCode();
+print $mock->getClassCode();
 --EXPECTF--
 declare(strict_types=1);
 
@@ -39,7 +44,7 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
 {
     use \PHPUnit\Framework\MockObject\Api;
     use \PHPUnit\Framework\MockObject\Method;
-    use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+    use \PHPUnit\Framework\MockObject\MockedCloneMethodWithVoidReturnType;
 
     public function returnsStatic(): static
     {

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_static_proxy.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_static_proxy.phpt
@@ -1,0 +1,112 @@
+--TEST--
+\PHPUnit\Framework\MockObject\Generator::generate('Foo', [], 'MockFoo', true, true, true, true)
+--FILE--
+<?php declare(strict_types=1);
+class ClassWithStaticReturnTypes
+{
+    public function returnsStatic(): static
+    {
+    }
+
+    public function returnsStaticOrNull(): ?static
+    {
+    }
+
+    public function returnsUnionWithStatic(): static|\stdClass
+    {
+    }
+}
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+$generator = new \PHPUnit\Framework\MockObject\Generator;
+
+$mock = $generator->generate(
+    'ClassWithStaticReturnTypes',
+    [],
+    'MockClassWithStaticReturnTypes',
+    true,
+    true,
+    true,
+    true
+);
+
+print $mock->classCode();
+--EXPECTF--
+declare(strict_types=1);
+
+class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implements PHPUnit\Framework\MockObject\MockObject
+{
+    use \PHPUnit\Framework\MockObject\Api;
+    use \PHPUnit\Framework\MockObject\Method;
+    use \PHPUnit\Framework\MockObject\MockedCloneMethod;
+
+    public function returnsStatic(): static
+    {
+        $__phpunit_arguments = [];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > 0) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = 0; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $this->__phpunit_getInvocationHandler()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation(
+                'ClassWithStaticReturnTypes', 'returnsStatic', $__phpunit_arguments, 'static', $this, true, true
+            )
+        );
+
+        call_user_func_array(array($this->__phpunit_originalObject, "returnsStatic"), $__phpunit_arguments);
+        return $this;
+    }
+
+    public function returnsStaticOrNull(): ?static
+    {
+        $__phpunit_arguments = [];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > 0) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = 0; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $this->__phpunit_getInvocationHandler()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation(
+                'ClassWithStaticReturnTypes', 'returnsStaticOrNull', $__phpunit_arguments, '?static', $this, true, true
+            )
+        );
+
+        call_user_func_array(array($this->__phpunit_originalObject, "returnsStaticOrNull"), $__phpunit_arguments);
+        return $this;
+    }
+
+    public function returnsUnionWithStatic(): static|stdClass
+    {
+        $__phpunit_arguments = [];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > 0) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = 0; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $this->__phpunit_getInvocationHandler()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation(
+                'ClassWithStaticReturnTypes', 'returnsUnionWithStatic', $__phpunit_arguments, 'static|stdClass', $this, true, true
+            )
+        );
+
+        call_user_func_array(array($this->__phpunit_originalObject, "returnsUnionWithStatic"), $__phpunit_arguments);
+        return $this;
+    }
+}

--- a/tests/end-to-end/mock-objects/mock-method/return_type_static_proxy.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_type_static_proxy.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Mock static method when proxying is enabled
+--SKIPIF--
+<?php declare(strict_types=1);
+if (PHP_MAJOR_VERSION < 8) {
+    print 'skip: PHP 8 is required.';
+}
 --FILE--
 <?php declare(strict_types=1);
 class Foo

--- a/tests/end-to-end/mock-objects/mock-method/return_type_static_proxy.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_type_static_proxy.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Mock static method when proxying is enabled
+--FILE--
+<?php declare(strict_types=1);
+class Foo
+{
+    public function bar(): static{}
+}
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+$class = new ReflectionClass('Foo');
+$mockMethod = \PHPUnit\Framework\MockObject\MockMethod::fromReflection(
+    $class->getMethod('bar'),
+    true,
+    false
+);
+
+$code = $mockMethod->generateCode();
+
+print $code;
+--EXPECTF--
+
+public function bar(): static
+    {
+        $__phpunit_arguments = [];
+        $__phpunit_count     = func_num_args();
+
+        if ($__phpunit_count > 0) {
+            $__phpunit_arguments_tmp = func_get_args();
+
+            for ($__phpunit_i = 0; $__phpunit_i < $__phpunit_count; $__phpunit_i++) {
+                $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
+            }
+        }
+
+        $this->__phpunit_getInvocationHandler()->invoke(
+            new \PHPUnit\Framework\MockObject\Invocation(
+                'Foo', 'bar', $__phpunit_arguments, 'static', $this, false, true
+            )
+        );
+
+        call_user_func_array(array($this->__phpunit_originalObject, "bar"), $__phpunit_arguments);
+        return $this;
+    }


### PR DESCRIPTION
### Problem
Using method `createTestProxy` or creating a mock by using `enableProxyingToOriginalMethods` on mock builder leads to following issues when a method uses `static` in its return type - consider following:

```php
# MyClass
public function method(): static
{
    ...
    return $this;
}
```
and the following code to create the proxy class in test
```php
$class = $this->createTestProxy(MyClass::class);
$class->method();
```
which will result in something like
> TypeError: Mock_MyClass_26f4ca80::method(): Return value must be of type Mock_MyClass_26f4ca80, Vendor\MyClass returned

### Solution
Inside of [MockMethod](src/Framework/MockObject/MockMethod.php) class we check if original methods should be called and the return type contains `static` type. If that's true we use another template to render. The template always calls the original method as before but instead always returns the test proxy mock object.

This will fix the issue for all methods that are returning `static` but may break existing test expectations which are using `static` in a union return type due to the fact that the return value is no longer the return value of the real object but the test proxy itself.