### PR TITLE
XSD Schema Location: add local reference to ease autocompletion and validation

### DIFF
--- a/src/TextUI/XmlConfiguration/Generator.php
+++ b/src/TextUI/XmlConfiguration/Generator.php
@@ -22,7 +22,7 @@ final class Generator
     private const TEMPLATE = <<<'EOT'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/{phpunit_version}/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd https://schema.phpunit.de/{phpunit_version}/phpunit.xsd"
          bootstrap="{bootstrap_script}"
          cacheResultFile="{cache_directory}/test-results"
          executionOrder="depends,defects"

--- a/tests/unit/Util/ConfigurationGeneratorTest.php
+++ b/tests/unit/Util/ConfigurationGeneratorTest.php
@@ -26,7 +26,7 @@ final class ConfigurationGeneratorTest extends TestCase
         $this->assertEquals(
             '<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/X.Y.Z/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd https://schema.phpunit.de/X.Y.Z/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"


### PR DESCRIPTION
By default most IDEs don't support autocompletion and validation upon remote schemas, but all support multiple schema locations to be specified.

Since I guess almost all PHPUnit users nowadays install it by composer, that means that `vendor/phpunit/phpunit/phpunit.xsd` is always available as a primary source of truth.