### PR TITLE
Fixed #5146: Properly honors the phpunit.xml for textdox="true".

### DIFF
--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -541,8 +541,7 @@ final class Merger
         }
 
         $testDoxOutput = false;
-
-        if ($cliConfiguration->hasTestDoxPrinter() && $cliConfiguration->testdoxPrinter()) {
+        if (($cliConfiguration->hasTestDoxPrinter() && $cliConfiguration->testdoxPrinter() || $xmlConfiguration->phpunit()->testdoxPrinter())) {
             $testDoxOutput = true;
         }
 


### PR DESCRIPTION
This pull request causes PHPUnit to honor the `testdox="true"` configuration in the `phpunit.xml`, making PHPUnit v10's behavior identical to PHPUnit v9's.

See [Issue #5146: PHPUnit v10 does not honor the testdox="true" of phpunit.xml](https://github.com/sebastianbergmann/phpunit/issues/5146).