### PR TITLE
chore: Remove check on static attribute always set to false

### DIFF
--- a/src/Util/ExcludeList.php
+++ b/src/Util/ExcludeList.php
@@ -137,7 +137,6 @@ final class ExcludeList
      * @psalm-var list<string>
      */
     private static array $directories = [];
-    private static bool $initialized  = false;
 
     /**
      * @psalm-param non-empty-string $directory
@@ -182,10 +181,6 @@ final class ExcludeList
 
     private static function initialize(): void
     {
-        if (self::$initialized) {
-            return;
-        }
-
         foreach (self::EXCLUDED_CLASS_NAMES as $className => $parent) {
             if (!class_exists($className)) {
                 continue;


### PR DESCRIPTION
Signed-off-by: codisart <louis.celier@gmail.com>

It seems to me that the "self::$initialized" was never updated from its default value of false. 
So the check in the self::initialize() method was useless.