### PR TITLE
Fix: Continue on error when running tests on PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,13 @@ jobs:
       - name: Install dependencies with Composer
         run: ./tools/composer update --no-ansi --no-interaction --no-progress
 
-      - name: Run tests with PHPUnit
+      - name: Run tests with PHPUnit on stable PHP version
+        if: matrix.php-version != '8.3'
+        run: ./phpunit --testsuite unit
+
+      - name: Run tests with PHPUnit on unstable PHP version
+        if: matrix.php-version == '8.3'
+        continue-on-error: true
         run: ./phpunit --testsuite unit
 
   end-to-end-tests:
@@ -153,7 +159,13 @@ jobs:
       - name: Install dependencies with Composer
         run: ./tools/composer update --no-ansi --no-interaction --no-progress
 
-      - name: Run tests with PHPUnit
+      - name: Run tests with PHPUnit on stable PHP version
+        if: matrix.php-version != '8.3'
+        run: ./phpunit --testsuite end-to-end
+
+      - name: Run tests with PHPUnit on unstable PHP version
+        if: matrix.php-version == '8.3'
+        continue-on-error: true
         run: ./phpunit --testsuite end-to-end
 
   code-coverage:


### PR DESCRIPTION
This pull request

- [x] use a combination of [`if`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif) and [`the continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) to prevent unit tests failing on PHP 8.3 to fail the build

Somewhat related to https://github.com/shivammathur/setup-php/issues/692.