### PR TITLE
Enhancement: Configure `blank_line_before_statement` fixer to include more statements

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -40,6 +40,7 @@ $config->setFinder($finder)
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -51,6 +52,7 @@ $config->setFinder($finder)
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -59,6 +61,7 @@ $config->setFinder($finder)
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [

--- a/src/Framework/Constraint/JsonMatchesErrorMessageProvider.php
+++ b/src/Framework/Constraint/JsonMatchesErrorMessageProvider.php
@@ -30,14 +30,19 @@ final class JsonMatchesErrorMessageProvider
         switch ($error) {
             case JSON_ERROR_NONE:
                 return null;
+
             case JSON_ERROR_DEPTH:
                 return $prefix . 'Maximum stack depth exceeded';
+
             case JSON_ERROR_STATE_MISMATCH:
                 return $prefix . 'Underflow or the modes mismatch';
+
             case JSON_ERROR_CTRL_CHAR:
                 return $prefix . 'Unexpected control character found';
+
             case JSON_ERROR_SYNTAX:
                 return $prefix . 'Syntax error, malformed JSON';
+
             case JSON_ERROR_UTF8:
                 return $prefix . 'Malformed UTF-8 characters, possibly incorrectly encoded';
 
@@ -56,6 +61,7 @@ final class JsonMatchesErrorMessageProvider
                 $prefix = 'Expected value JSON decode error - ';
 
                 break;
+
             case 'actual':
                 $prefix = 'Actual value JSON decode error - ';
 


### PR DESCRIPTION
This pull request

- [x] configures the `blank_line_before_statement` fixer to include more statements
- [x] runs `tools/php-cs-fixer fix`