### PR TITLE
Fix: Continue entire job when running on PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       PHP_EXTENSIONS: none, curl, dom, json, libxml, mbstring, openssl, phar, soap, tokenizer, xml, xmlwriter
       PHP_INI_VALUES: memory_limit=-1, assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +80,18 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
-          - "8.3"
+
+        experimental:
+          - false
+
+        include:
+          - os: ubuntu-latest
+            php-version: "8.3"
+            experimental: true
+
+          - os: windows-latest
+            php-version: "8.3"
+            experimental: true
 
     steps:
       - name: Configure Git to avoid issues with line endings
@@ -99,13 +112,7 @@ jobs:
       - name: Install dependencies with Composer
         run: ./tools/composer update --no-ansi --no-interaction --no-progress
 
-      - name: Run tests with PHPUnit on stable PHP version
-        if: matrix.php-version != '8.3'
-        run: ./phpunit --testsuite unit
-
-      - name: Run tests with PHPUnit on unstable PHP version
-        if: matrix.php-version == '8.3'
-        continue-on-error: true
+      - name: Run tests with PHPUnit
         run: ./phpunit --testsuite unit
 
   end-to-end-tests:
@@ -120,6 +127,8 @@ jobs:
       PHP_EXTENSIONS: none, curl, dom, json, libxml, mbstring, openssl, phar, soap, tokenizer, xml, xmlwriter
       PHP_INI_VALUES: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -130,7 +139,18 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
-          - "8.3"
+
+        experimental:
+          - false
+
+        include:
+          - os: ubuntu-latest
+            php-version: "8.3"
+            experimental: true
+
+          - os: windows-latest
+            php-version: "8.3"
+            experimental: true
 
     steps:
       - name: Configure Git to avoid issues with line endings
@@ -152,14 +172,7 @@ jobs:
       - name: Install dependencies with Composer
         run: ./tools/composer update --no-ansi --no-interaction --no-progress
 
-      - name: Run tests with PHPUnit on stable PHP version
-        if: matrix.php-version != '8.3'
-        run: ./phpunit --testsuite end-to-end
-
-      - name: Run tests with PHPUnit on unstable PHP version
-        if: matrix.php-version == '8.3'
-        continue-on-error: true
-
+      - name: Run tests with PHPUnit
         run: ./phpunit --testsuite end-to-end
 
   code-coverage:


### PR DESCRIPTION
This pull request

- [x] uses a combination of [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) and [`include`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude) to allow an entire job to fail when running it on an unstable PHP version

Follows #5152.
Follows #5154.