### PR TITLE
Added TestData attribute with named data sets and variadic parameter support

### DIFF
--- a/src/Framework/Attributes/TestData.php
+++ b/src/Framework/Attributes/TestData.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Attributes;
+
+use function is_string;
+use Attribute;
+use PHPUnit\Event\InvalidArgumentException;
+
+/**
+ * @psalm-immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class TestData
+{
+    private readonly array $data;
+    private readonly ?string $name;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(mixed ...$data)
+    {
+        if (isset($data['name'])) {
+            if (!is_string($data['name'])) {
+                throw new InvalidArgumentException('Name must be of type string.');
+            }
+
+            $this->name = $data['name'];
+            unset($data['name']);
+        } else {
+            $this->name = null;
+        }
+
+        $this->data = $data;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    public function name(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/Framework/Attributes/TestData.php
+++ b/src/Framework/Attributes/TestData.php
@@ -9,9 +9,7 @@
  */
 namespace PHPUnit\Framework\Attributes;
 
-use function is_string;
 use Attribute;
-use PHPUnit\Event\InvalidArgumentException;
 
 /**
  * @psalm-immutable
@@ -24,22 +22,10 @@ final class TestData
     private readonly array $data;
     private readonly ?string $name;
 
-    /**
-     * @throws InvalidArgumentException
-     */
     public function __construct(mixed ...$data)
     {
-        if (isset($data['name'])) {
-            if (!is_string($data['name'])) {
-                throw new InvalidArgumentException('Name must be of type string.');
-            }
-
-            $this->name = $data['name'];
-            unset($data['name']);
-        } else {
-            $this->name = null;
-        }
-
+        $this->name = isset($data['name']) ? (string) $data['name'] : null;
+        unset($data['name']);
         $this->data = $data;
     }
 

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -9,7 +9,6 @@
  */
 namespace PHPUnit\Metadata\Api;
 
-use PHPUnit\Metadata\TestData;
 use function array_key_exists;
 use function array_merge;
 use function assert;
@@ -35,6 +34,7 @@ use PHPUnit\Framework\InvalidDataProviderException;
 use PHPUnit\Metadata\DataProvider as DataProviderMetadata;
 use PHPUnit\Metadata\MetadataCollection;
 use PHPUnit\Metadata\Parser\Registry;
+use PHPUnit\Metadata\TestData;
 use PHPUnit\Metadata\TestWith;
 use PHPUnit\Util\Reflection;
 use ReflectionClass;

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Metadata\Api;
 
+use PHPUnit\Metadata\TestData;
 use function array_key_exists;
 use function array_merge;
 use function assert;
@@ -193,9 +194,26 @@ final class DataProvider
         $result = [];
 
         foreach ($testWith as $_testWith) {
-            assert($_testWith instanceof TestWith);
+            assert($_testWith instanceof TestWith || $_testWith instanceof TestData);
 
-            $result[] = $_testWith->data();
+            if ($_testWith instanceof TestData) {
+                $key = $_testWith->name();
+            } else {
+                $key = null;
+            }
+
+            if (null === $key) {
+                $result[] = $_testWith->data();
+            } elseif (array_key_exists($key, $result)) {
+                throw new InvalidDataProviderException(
+                    sprintf(
+                        'The key "%s" has already been defined by a previous TestData attribute',
+                        $key
+                    )
+                );
+            } else {
+                $result[$key] = $_testWith->data();
+            }
         }
 
         return $result;

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -9,7 +9,6 @@
  */
 namespace PHPUnit\Metadata;
 
-use PHPUnit\Event\InvalidArgumentException;
 use PHPUnit\Metadata\Version\Requirement;
 
 /**
@@ -305,12 +304,12 @@ abstract class Metadata
         return new Test(self::METHOD_LEVEL);
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
     public static function testData(mixed ...$data): TestData
     {
-        return new TestData(self::METHOD_LEVEL, $data);
+        $name = isset($data['name']) ? (string) $data['name'] : null;
+        unset($data['name']);
+
+        return new TestData(self::METHOD_LEVEL, ...$data, name: $name);
     }
 
     public static function testDoxOnClass(string $text): TestDox
@@ -650,6 +649,7 @@ abstract class Metadata
 
     /**
      * @psalm-assert-if-true TestWith $this
+     * @psalm-assert-if-true TestData $this
      */
     public function isTestWith(): bool
     {

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Metadata;
 
+use PHPUnit\Event\InvalidArgumentException;
 use PHPUnit\Metadata\Version\Requirement;
 
 /**
@@ -302,6 +303,14 @@ abstract class Metadata
     public static function test(): Test
     {
         return new Test(self::METHOD_LEVEL);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public static function testData(mixed ...$data): TestData
+    {
+        return new TestData(self::METHOD_LEVEL, $data);
     }
 
     public static function testDoxOnClass(string $text): TestDox

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -56,6 +56,7 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestData;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\TestWithJson;
@@ -64,7 +65,6 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesFunction;
 use PHPUnit\Metadata\Metadata;
 use PHPUnit\Metadata\MetadataCollection;
-use PHPUnit\Metadata\TestData;
 use PHPUnit\Metadata\Version\ConstraintRequirement;
 use ReflectionClass;
 use ReflectionMethod;
@@ -578,7 +578,11 @@ final class AttributeParser implements Parser
                 case TestData::class:
                     assert($attributeInstance instanceof TestData);
 
-                    $result[] = Metadata::testData($attributeInstance->data(), name: $attributeInstance->name());
+                    if (null === $attributeInstance->name()) {
+                        $result[] = Metadata::testData(...$attributeInstance->data());
+                    } else {
+                        $result[] = Metadata::testData(...$attributeInstance->data(), name: $attributeInstance->name());
+                    }
 
                     break;
 

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -64,6 +64,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesFunction;
 use PHPUnit\Metadata\Metadata;
 use PHPUnit\Metadata\MetadataCollection;
+use PHPUnit\Metadata\TestData;
 use PHPUnit\Metadata\Version\ConstraintRequirement;
 use ReflectionClass;
 use ReflectionMethod;
@@ -571,6 +572,13 @@ final class AttributeParser implements Parser
 
                 case Test::class:
                     $result[] = Metadata::test();
+
+                    break;
+
+                case TestData::class:
+                    assert($attributeInstance instanceof TestData);
+
+                    $result[] = Metadata::testData($attributeInstance->data(), name: $attributeInstance->name());
 
                     break;
 

--- a/src/Metadata/TestData.php
+++ b/src/Metadata/TestData.php
@@ -9,9 +9,6 @@
  */
 namespace PHPUnit\Metadata;
 
-use function is_string;
-use PHPUnit\Event\InvalidArgumentException;
-
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  *
@@ -22,24 +19,12 @@ final class TestData extends Metadata
     private readonly array $data;
     private readonly ?string $name;
 
-    /**
-     * @throws InvalidArgumentException
-     */
     protected function __construct(int $level, mixed ...$data)
     {
         parent::__construct($level);
 
-        if (isset($data['name'])) {
-            if (!is_string($data['name'])) {
-                throw new InvalidArgumentException('Name must be of type string.');
-            }
-
-            $this->name = $data['name'];
-            unset($data['name']);
-        } else {
-            $this->name = null;
-        }
-
+        $this->name = isset($data['name']) ? (string) $data['name'] : null;
+        unset($data['name']);
         $this->data = $data;
     }
 

--- a/src/Metadata/TestData.php
+++ b/src/Metadata/TestData.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata;
+
+use function is_string;
+use PHPUnit\Event\InvalidArgumentException;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ *
+ * @psalm-immutable
+ */
+final class TestData extends Metadata
+{
+    private readonly array $data;
+    private readonly ?string $name;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function __construct(int $level, mixed ...$data)
+    {
+        parent::__construct($level);
+
+        if (isset($data['name'])) {
+            if (!is_string($data['name'])) {
+                throw new InvalidArgumentException('Name must be of type string.');
+            }
+
+            $this->name = $data['name'];
+            unset($data['name']);
+        } else {
+            $this->name = null;
+        }
+
+        $this->data = $data;
+    }
+
+    public function isTestWith(): bool
+    {
+        return true;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
+    }
+
+    public function name(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/tests/_files/Metadata/Attribute/tests/TestDataTest.php
+++ b/tests/_files/Metadata/Attribute/tests/TestDataTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Metadata\Attribute;
+
+use PHPUnit\Framework\Attributes\TestData;
+use PHPUnit\Framework\TestCase;
+
+final class TestDataTest extends TestCase
+{
+    #[TestData(1, 2, 3)]
+    public function testOne(): void
+    {
+    }
+
+    #[TestData(1, 2, 3, name: 'Name1')]
+    public function testOneWithName(): void
+    {
+    }
+}

--- a/tests/_files/TestDataAttributeDataProviderTest.php
+++ b/tests/_files/TestDataAttributeDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\TestData;
+use PHPUnit\Framework\TestCase;
+
+final class TestDataAttributeDataProviderTest extends TestCase
+{
+    #[TestData('a', 'b', name: 'foo')]
+    #[TestData('c', 'd', name: 'bar')]
+    #[TestData('e', 'f')]
+    #[TestData('g', 'h')]
+    public function testDataAttribute($one, $two): void
+    {
+    }
+
+    #[TestData('a', 'b', name: 'foo')]
+    #[TestData('c', 'd', name: 'foo')]
+    public function testDataDuplicateName($one, $two): void
+    {
+    }
+}

--- a/tests/unit/Metadata/Facade/DataProviderFacadeTest.php
+++ b/tests/unit/Metadata/Facade/DataProviderFacadeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\Api\DataProvider;
 use PHPUnit\TestFixture\DuplicateKeyDataProviderTest;
 use PHPUnit\TestFixture\MultipleDataProviderTest;
+use PHPUnit\TestFixture\TestDataAttributeDataProviderTest;
 use PHPUnit\TestFixture\VariousIterableDataProviderTest;
 
 #[\PHPUnit\Framework\Attributes\CoversClass(DataProvider::class)]
@@ -64,6 +65,27 @@ final class DataProviderFacadeTest extends TestCase
         $this->assertEquals(3, $aCount);
         $this->assertEquals(3, $bCount);
         $this->assertEquals(3, $cCount);
+    }
+
+    public function testTestDataAttribute(): void
+    {
+        $dataSets = (new DataProvider)->providedData(TestDataAttributeDataProviderTest::class, 'testDataAttribute');
+
+        $this->assertSame([
+            'foo' => ['a', 'b'],
+            'bar' => ['c', 'd'],
+            0     => ['e', 'f'],
+            1     => ['g', 'h'],
+        ], $dataSets);
+    }
+
+    public function testTestDataAttributeWithDuplicateKey(): void
+    {
+        $this->expectException(InvalidDataProviderException::class);
+        $this->expectExceptionMessage('The key "foo" has already been defined by a previous TestData attribute');
+
+        /* @noinspection UnusedFunctionResultInspection */
+        (new DataProvider)->providedData(TestDataAttributeDataProviderTest::class, 'testDataDuplicateName');
     }
 
     public function testWithVariousIterableDataProvidersFromParent(): void

--- a/tests/unit/Metadata/Parser/AttributeParserTest.php
+++ b/tests/unit/Metadata/Parser/AttributeParserTest.php
@@ -80,6 +80,7 @@ use PHPUnit\TestFixture\Metadata\Attribute\RequiresPhpTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresPhpunitTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresSettingTest;
 use PHPUnit\TestFixture\Metadata\Attribute\SmallTest;
+use PHPUnit\TestFixture\Metadata\Attribute\TestDataTest;
 use PHPUnit\TestFixture\Metadata\Attribute\TestDoxTest;
 use PHPUnit\TestFixture\Metadata\Attribute\TestWithTest;
 use PHPUnit\TestFixture\Metadata\Attribute\UsesTest;
@@ -912,6 +913,17 @@ final class AttributeParserTest extends TestCase
 
         $this->assertCount(1, $metadata);
         $this->assertTrue($metadata->asArray()[0]->isTest());
+    }
+
+    #[TestDox('Parses #[TestData] attribute with name on method')]
+    public function test_parses_TestData_attribute_with_name_on_method(): void
+    {
+        $metadata = (new AttributeParser)->forMethod(TestDataTest::class, 'testOneWithName')->isTestWith();
+
+        $this->assertCount(1, $metadata);
+        $this->assertTrue($metadata->asArray()[0]->isTestWith());
+        $this->assertSame([1, 2, 3], $metadata->asArray()[0]->data());
+        $this->assertSame('Name1', $metadata->asArray()[0]->name());
     }
 
     #[TestDox('Parses #[TestDox] attribute on method')]


### PR DESCRIPTION
This is meant to simplify how inline test data is passed into tests.  Rather than requiring everything to be wrapped in an array like 
```php
#[TestWith(['foo', 'bar'])]
public function testSomething(string $a, string $b): void
{
    // ...
}
```
You can now just pass in the parameters directly using the new `#[TestData]` attribute:
```php
#[TestData('foo', 'bar')]
public function testSomething(string $a, string $b): void
{
    // ...
}
```
which looks more like an invocation of the test method.  Additionally, this PR introduces support for naming data sets using a `name` parameter, eg
```php
#[TestData('foo', 'bar', name: 'Tests something with "foo" and "bar"')]
public function testSomething(string $a, string $b): void
{
    // ...
}
```
I have purposely not created an annotation version of this because PHPDoc is not a good place to define PHP values to pass into test methods.