### PR TITLE
CodeCoverage: refactor to pure Singleton

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -440,6 +440,18 @@
       <code>\SebastianBergmann\CodeCoverage\CodeCoverage</code>
     </InvalidNullableReturnType>
     <MissingThrowsDocblock>
+      <code>codeCoverageGenerationFailed</code>
+      <code>codeCoverageGenerationFailed</code>
+      <code>codeCoverageGenerationFailed</code>
+      <code>codeCoverageGenerationFailed</code>
+      <code>codeCoverageGenerationFailed</code>
+      <code>codeCoverageGenerationFailed</code>
+      <code>codeCoverageGenerationSucceeded</code>
+      <code>codeCoverageGenerationSucceeded</code>
+      <code>codeCoverageGenerationSucceeded</code>
+      <code>codeCoverageGenerationSucceeded</code>
+      <code>codeCoverageGenerationSucceeded</code>
+      <code>codeCoverageGenerationSucceeded</code>
       <code>coverageCacheDirectory</code>
       <code>coverageClover</code>
       <code>coverageCobertura</code>
@@ -450,22 +462,10 @@
       <code>coverageText</code>
       <code>coverageText</code>
       <code>coverageXml</code>
-      <code>self::codeCoverageGenerationFailed($printer, $e)</code>
-      <code>self::codeCoverageGenerationFailed($printer, $e)</code>
-      <code>self::codeCoverageGenerationFailed($printer, $e)</code>
-      <code>self::codeCoverageGenerationFailed($printer, $e)</code>
-      <code>self::codeCoverageGenerationFailed($printer, $e)</code>
-      <code>self::codeCoverageGenerationFailed($printer, $e)</code>
-      <code>self::codeCoverageGenerationSucceeded($printer)</code>
-      <code>self::codeCoverageGenerationSucceeded($printer)</code>
-      <code>self::codeCoverageGenerationSucceeded($printer)</code>
-      <code>self::codeCoverageGenerationSucceeded($printer)</code>
-      <code>self::codeCoverageGenerationSucceeded($printer)</code>
-      <code>self::codeCoverageGenerationSucceeded($printer)</code>
     </MissingThrowsDocblock>
     <NullableReturnStatement>
-      <code>self::$driver</code>
-      <code>self::$instance</code>
+      <code>$this-&gt;codeCoverage</code>
+      <code>$this-&gt;driver</code>
     </NullableReturnStatement>
     <PossiblyNullReference>
       <code>start</code>

--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -86,11 +86,11 @@ final class TestRunner
 
         ErrorHandler::instance()->enable();
 
-        $collectCodeCoverage = CodeCoverage::isActive() &&
+        $collectCodeCoverage = CodeCoverage::instance()->isActive() &&
                                $shouldCodeCoverageBeCollected;
 
         if ($collectCodeCoverage) {
-            CodeCoverage::start($test);
+            CodeCoverage::instance()->start($test);
         }
 
         try {
@@ -172,7 +172,7 @@ final class TestRunner
             }
 
             try {
-                CodeCoverage::stop(
+                CodeCoverage::instance()->stop(
                     $append,
                     $linesToBeCovered,
                     $linesToBeUsed
@@ -283,7 +283,7 @@ final class TestRunner
             $iniSettings   = GlobalState::getIniSettingsAsString();
         }
 
-        $coverage = CodeCoverage::isActive() ? 'true' : 'false';
+        $coverage = CodeCoverage::instance()->isActive() ? 'true' : 'false';
 
         if (defined('PHPUNIT_COMPOSER_INSTALL')) {
             $composerAutoload = var_export(PHPUNIT_COMPOSER_INSTALL, true);

--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -59,15 +59,15 @@ final class CodeCoverage
         return self::$instance;
     }
 
-    public function init(Configuration $configuration): void
+    public function init(Configuration $configuration, CodeCoverageFilterRegistry $codeCoverageFilterRegistry): void
     {
-        CodeCoverageFilterRegistry::instance()->init($configuration);
+        $codeCoverageFilterRegistry->init($configuration);
 
         if (!$configuration->hasCoverageReport()) {
             return;
         }
 
-        $this->activate(CodeCoverageFilterRegistry::instance()->get(), $configuration->pathCoverage());
+        $this->activate($codeCoverageFilterRegistry->get(), $configuration->pathCoverage());
 
         if (!$this->isActive()) {
             return;
@@ -101,8 +101,8 @@ final class CodeCoverage
             $this->codeCoverage()->excludeUncoveredFiles();
         }
 
-        if (CodeCoverageFilterRegistry::instance()->get()->isEmpty()) {
-            if (!CodeCoverageFilterRegistry::instance()->configured()) {
+        if ($codeCoverageFilterRegistry->get()->isEmpty()) {
+            if (!$codeCoverageFilterRegistry->configured()) {
                 EventFacade::emitter()->testRunnerTriggeredWarning(
                     'No filter is configured, code coverage will not be processed'
                 );

--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -51,13 +51,13 @@ final class CodeCoverage
 
     public static function init(Configuration $configuration): void
     {
-        CodeCoverageFilterRegistry::init($configuration);
+        CodeCoverageFilterRegistry::instance()->init($configuration);
 
         if (!$configuration->hasCoverageReport()) {
             return;
         }
 
-        self::activate(CodeCoverageFilterRegistry::get(), $configuration->pathCoverage());
+        self::activate(CodeCoverageFilterRegistry::instance()->get(), $configuration->pathCoverage());
 
         if (!self::isActive()) {
             return;
@@ -91,8 +91,8 @@ final class CodeCoverage
             self::instance()->excludeUncoveredFiles();
         }
 
-        if (CodeCoverageFilterRegistry::get()->isEmpty()) {
-            if (!CodeCoverageFilterRegistry::configured()) {
+        if (CodeCoverageFilterRegistry::instance()->get()->isEmpty()) {
+            if (!CodeCoverageFilterRegistry::instance()->configured()) {
                 EventFacade::emitter()->testRunnerTriggeredWarning(
                     'No filter is configured, code coverage will not be processed'
                 );

--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -43,13 +43,23 @@ use SebastianBergmann\Timer\Timer;
  */
 final class CodeCoverage
 {
-    private static ?\SebastianBergmann\CodeCoverage\CodeCoverage $instance = null;
-    private static ?Driver $driver                                         = null;
-    private static bool $collecting                                        = false;
-    private static ?TestCase $test                                         = null;
-    private static ?Timer $timer                                           = null;
+    private static self $instance;
+    private ?\SebastianBergmann\CodeCoverage\CodeCoverage $codeCoverage = null;
+    private ?Driver $driver                                             = null;
+    private bool $collecting                                            = false;
+    private ?TestCase $test                                             = null;
+    private ?Timer $timer                                               = null;
 
-    public static function init(Configuration $configuration): void
+    public static function instance(): self
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self;
+        }
+
+        return self::$instance;
+    }
+
+    public function init(Configuration $configuration): void
     {
         CodeCoverageFilterRegistry::instance()->init($configuration);
 
@@ -57,38 +67,38 @@ final class CodeCoverage
             return;
         }
 
-        self::activate(CodeCoverageFilterRegistry::instance()->get(), $configuration->pathCoverage());
+        $this->activate(CodeCoverageFilterRegistry::instance()->get(), $configuration->pathCoverage());
 
-        if (!self::isActive()) {
+        if (!$this->isActive()) {
             return;
         }
 
         if ($configuration->hasCoverageCacheDirectory()) {
-            self::codeCoverage()->cacheStaticAnalysis($configuration->coverageCacheDirectory());
+            $this->codeCoverage()->cacheStaticAnalysis($configuration->coverageCacheDirectory());
         }
 
-        self::codeCoverage()->excludeSubclassesOfThisClassFromUnintentionallyCoveredCodeCheck(Comparator::class);
+        $this->codeCoverage()->excludeSubclassesOfThisClassFromUnintentionallyCoveredCodeCheck(Comparator::class);
 
         if ($configuration->strictCoverage()) {
-            self::codeCoverage()->enableCheckForUnintentionallyCoveredCode();
+            $this->codeCoverage()->enableCheckForUnintentionallyCoveredCode();
         }
 
         if ($configuration->ignoreDeprecatedCodeUnitsFromCodeCoverage()) {
-            self::codeCoverage()->ignoreDeprecatedCode();
+            $this->codeCoverage()->ignoreDeprecatedCode();
         } else {
-            self::codeCoverage()->doNotIgnoreDeprecatedCode();
+            $this->codeCoverage()->doNotIgnoreDeprecatedCode();
         }
 
         if ($configuration->disableCodeCoverageIgnore()) {
-            self::codeCoverage()->disableAnnotationsForIgnoringCode();
+            $this->codeCoverage()->disableAnnotationsForIgnoringCode();
         } else {
-            self::codeCoverage()->enableAnnotationsForIgnoringCode();
+            $this->codeCoverage()->enableAnnotationsForIgnoringCode();
         }
 
         if ($configuration->includeUncoveredFiles()) {
-            self::codeCoverage()->includeUncoveredFiles();
+            $this->codeCoverage()->includeUncoveredFiles();
         } else {
-            self::codeCoverage()->excludeUncoveredFiles();
+            $this->codeCoverage()->excludeUncoveredFiles();
         }
 
         if (CodeCoverageFilterRegistry::instance()->get()->isEmpty()) {
@@ -102,35 +112,35 @@ final class CodeCoverage
                 );
             }
 
-            self::deactivate();
+            $this->deactivate();
         }
     }
 
     /**
-     * @psalm-assert-if-true !null self::$instance
+     * @psalm-assert-if-true !null $this->instance
      */
-    public static function isActive(): bool
+    public function isActive(): bool
     {
-        return self::$instance !== null;
+        return $this->codeCoverage !== null;
     }
 
-    public static function codeCoverage(): \SebastianBergmann\CodeCoverage\CodeCoverage
+    public function codeCoverage(): \SebastianBergmann\CodeCoverage\CodeCoverage
     {
-        return self::$instance;
+        return $this->codeCoverage;
     }
 
-    public static function driver(): Driver
+    public function driver(): Driver
     {
-        return self::$driver;
+        return $this->driver;
     }
 
     /**
      * @throws MoreThanOneDataSetFromDataProviderException
      * @throws NoDataSetFromDataProviderException
      */
-    public static function start(TestCase $test): void
+    public function start(TestCase $test): void
     {
-        if (self::$collecting) {
+        if ($this->collecting) {
             return;
         }
 
@@ -144,26 +154,26 @@ final class CodeCoverage
             $size = TestSize::large();
         }
 
-        self::$test = $test;
+        $this->test = $test;
 
-        self::$instance->start(
+        $this->codeCoverage->start(
             $test->valueObjectForEvents()->id(),
             $size
         );
 
-        self::$collecting = true;
+        $this->collecting = true;
     }
 
-    public static function stop(bool $append = true, array|false $linesToBeCovered = [], array $linesToBeUsed = []): void
+    public function stop(bool $append = true, array|false $linesToBeCovered = [], array $linesToBeUsed = []): void
     {
-        if (!self::$collecting) {
+        if (!$this->collecting) {
             return;
         }
 
         $status = TestStatus::unknown();
 
-        if (self::$test !== null) {
-            if (self::$test->status()->isSuccess()) {
+        if ($this->test !== null) {
+            if ($this->test->status()->isSuccess()) {
                 $status = TestStatus::success();
             } else {
                 $status = TestStatus::failure();
@@ -171,72 +181,72 @@ final class CodeCoverage
         }
 
         /* @noinspection UnusedFunctionResultInspection */
-        self::$instance->stop($append, $status, $linesToBeCovered, $linesToBeUsed);
+        $this->codeCoverage->stop($append, $status, $linesToBeCovered, $linesToBeUsed);
 
-        self::$test       = null;
-        self::$collecting = false;
+        $this->test       = null;
+        $this->collecting = false;
     }
 
-    public static function deactivate(): void
+    public function deactivate(): void
     {
-        self::$driver   = null;
-        self::$instance = null;
-        self::$test     = null;
+        $this->driver       = null;
+        $this->codeCoverage = null;
+        $this->test         = null;
     }
 
-    public static function generateReports(Printer $printer, Configuration $configuration): void
+    public function generateReports(Printer $printer, Configuration $configuration): void
     {
-        if (!self::isActive()) {
+        if (!$this->isActive()) {
             return;
         }
 
         if ($configuration->hasCoverageClover()) {
-            self::codeCoverageGenerationStart($printer, 'Clover XML');
+            $this->codeCoverageGenerationStart($printer, 'Clover XML');
 
             try {
                 $writer = new CloverReport;
-                $writer->process(self::codeCoverage(), $configuration->coverageClover());
+                $writer->process($this->codeCoverage(), $configuration->coverageClover());
 
-                self::codeCoverageGenerationSucceeded($printer);
+                $this->codeCoverageGenerationSucceeded($printer);
 
                 unset($writer);
             } catch (CodeCoverageException $e) {
-                self::codeCoverageGenerationFailed($printer, $e);
+                $this->codeCoverageGenerationFailed($printer, $e);
             }
         }
 
         if ($configuration->hasCoverageCobertura()) {
-            self::codeCoverageGenerationStart($printer, 'Cobertura XML');
+            $this->codeCoverageGenerationStart($printer, 'Cobertura XML');
 
             try {
                 $writer = new CoberturaReport;
-                $writer->process(self::codeCoverage(), $configuration->coverageCobertura());
+                $writer->process($this->codeCoverage(), $configuration->coverageCobertura());
 
-                self::codeCoverageGenerationSucceeded($printer);
+                $this->codeCoverageGenerationSucceeded($printer);
 
                 unset($writer);
             } catch (CodeCoverageException $e) {
-                self::codeCoverageGenerationFailed($printer, $e);
+                $this->codeCoverageGenerationFailed($printer, $e);
             }
         }
 
         if ($configuration->hasCoverageCrap4j()) {
-            self::codeCoverageGenerationStart($printer, 'Crap4J XML');
+            $this->codeCoverageGenerationStart($printer, 'Crap4J XML');
 
             try {
                 $writer = new Crap4jReport($configuration->coverageCrap4jThreshold());
-                $writer->process(self::codeCoverage(), $configuration->coverageCrap4j());
+                $writer->process($this->codeCoverage(), $configuration->coverageCrap4j());
 
-                self::codeCoverageGenerationSucceeded($printer);
+                $this->codeCoverageGenerationSucceeded($printer);
 
                 unset($writer);
             } catch (CodeCoverageException $e) {
-                self::codeCoverageGenerationFailed($printer, $e);
+                $this->codeCoverageGenerationFailed($printer, $e);
             }
         }
 
         if ($configuration->hasCoverageHtml()) {
-            self::codeCoverageGenerationStart($printer, 'HTML');
+            $this->codeCoverageGenerationStart($printer, 'HTML');
 
             try {
                 $customCssFile = CustomCssFile::default();
@@ -264,28 +274,28 @@ final class CodeCoverage
                     $customCssFile
                 );
 
-                $writer->process(self::codeCoverage(), $configuration->coverageHtml());
+                $writer->process($this->codeCoverage(), $configuration->coverageHtml());
 
-                self::codeCoverageGenerationSucceeded($printer);
+                $this->codeCoverageGenerationSucceeded($printer);
 
                 unset($writer);
             } catch (CodeCoverageException $e) {
-                self::codeCoverageGenerationFailed($printer, $e);
+                $this->codeCoverageGenerationFailed($printer, $e);
             }
         }
 
         if ($configuration->hasCoveragePhp()) {
-            self::codeCoverageGenerationStart($printer, 'PHP');
+            $this->codeCoverageGenerationStart($printer, 'PHP');
 
             try {
                 $writer = new PhpReport;
-                $writer->process(self::codeCoverage(), $configuration->coveragePhp());
+                $writer->process($this->codeCoverage(), $configuration->coveragePhp());
 
-                self::codeCoverageGenerationSucceeded($printer);
+                $this->codeCoverageGenerationSucceeded($printer);
 
                 unset($writer);
             } catch (CodeCoverageException $e) {
-                self::codeCoverageGenerationFailed($printer, $e);
+                $this->codeCoverageGenerationFailed($printer, $e);
             }
         }
 
@@ -296,7 +306,7 @@ final class CodeCoverage
                 $configuration->coverageTextShowOnlySummary()
             );
 
-            $textReport = $processor->process(self::codeCoverage(), $configuration->colors());
+            $textReport = $processor->process($this->codeCoverage(), $configuration->colors());
 
             if ($configuration->coverageText() === 'php://stdout') {
                 $printer->print($textReport);
@@ -306,32 +316,32 @@ final class CodeCoverage
         }
 
         if ($configuration->hasCoverageXml()) {
-            self::codeCoverageGenerationStart($printer, 'PHPUnit XML');
+            $this->codeCoverageGenerationStart($printer, 'PHPUnit XML');
 
             try {
                 $writer = new XmlReport(Version::id());
-                $writer->process(self::codeCoverage(), $configuration->coverageXml());
+                $writer->process($this->codeCoverage(), $configuration->coverageXml());
 
-                self::codeCoverageGenerationSucceeded($printer);
+                $this->codeCoverageGenerationSucceeded($printer);
 
                 unset($writer);
             } catch (CodeCoverageException $e) {
-                self::codeCoverageGenerationFailed($printer, $e);
+                $this->codeCoverageGenerationFailed($printer, $e);
             }
         }
     }
 
-    private static function activate(Filter $filter, bool $pathCoverage): void
+    private function activate(Filter $filter, bool $pathCoverage): void
     {
         try {
             if ($pathCoverage) {
-                self::$driver = (new Selector)->forLineAndPathCoverage($filter);
+                $this->driver = (new Selector)->forLineAndPathCoverage($filter);
             } else {
-                self::$driver = (new Selector)->forLineCoverage($filter);
+                $this->driver = (new Selector)->forLineCoverage($filter);
             }
 
-            self::$instance = new \SebastianBergmann\CodeCoverage\CodeCoverage(
-                self::$driver,
+            $this->codeCoverage = new \SebastianBergmann\CodeCoverage\CodeCoverage(
+                $this->driver,
                 $filter
             );
         } catch (CodeCoverageException $e) {
@@ -341,7 +351,7 @@ final class CodeCoverage
         }
     }
 
-    private static function codeCoverageGenerationStart(Printer $printer, string $format): void
+    private function codeCoverageGenerationStart(Printer $printer, string $format): void
     {
         $printer->print(
             sprintf(
@@ -350,18 +360,18 @@ final class CodeCoverage
             )
         );
 
-        self::timer()->start();
+        $this->timer()->start();
     }
 
     /**
      * @throws NoActiveTimerException
      */
-    private static function codeCoverageGenerationSucceeded(Printer $printer): void
+    private function codeCoverageGenerationSucceeded(Printer $printer): void
     {
         $printer->print(
             sprintf(
                 "done [%s]\n",
-                self::timer()->stop()->asString()
+                $this->timer()->stop()->asString()
             )
         );
     }
@@ -369,23 +379,23 @@ final class CodeCoverage
     /**
      * @throws NoActiveTimerException
      */
-    private static function codeCoverageGenerationFailed(Printer $printer, CodeCoverageException $e): void
+    private function codeCoverageGenerationFailed(Printer $printer, CodeCoverageException $e): void
     {
         $printer->print(
             sprintf(
                 "failed [%s]\n%s\n",
-                self::timer()->stop()->asString(),
+                $this->timer()->stop()->asString(),
                 $e->getMessage()
             )
         );
     }
 
-    private static function timer(): Timer
+    private function timer(): Timer
     {
-        if (self::$timer === null) {
-            self::$timer = new Timer;
+        if ($this->timer === null) {
+            $this->timer = new Timer;
         }
 
-        return self::$timer;
+        return $this->timer;
     }
 }

--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -64,31 +64,31 @@ final class CodeCoverage
         }
 
         if ($configuration->hasCoverageCacheDirectory()) {
-            self::instance()->cacheStaticAnalysis($configuration->coverageCacheDirectory());
+            self::codeCoverage()->cacheStaticAnalysis($configuration->coverageCacheDirectory());
         }
 
-        self::instance()->excludeSubclassesOfThisClassFromUnintentionallyCoveredCodeCheck(Comparator::class);
+        self::codeCoverage()->excludeSubclassesOfThisClassFromUnintentionallyCoveredCodeCheck(Comparator::class);
 
         if ($configuration->strictCoverage()) {
-            self::instance()->enableCheckForUnintentionallyCoveredCode();
+            self::codeCoverage()->enableCheckForUnintentionallyCoveredCode();
         }
 
         if ($configuration->ignoreDeprecatedCodeUnitsFromCodeCoverage()) {
-            self::instance()->ignoreDeprecatedCode();
+            self::codeCoverage()->ignoreDeprecatedCode();
         } else {
-            self::instance()->doNotIgnoreDeprecatedCode();
+            self::codeCoverage()->doNotIgnoreDeprecatedCode();
         }
 
         if ($configuration->disableCodeCoverageIgnore()) {
-            self::instance()->disableAnnotationsForIgnoringCode();
+            self::codeCoverage()->disableAnnotationsForIgnoringCode();
         } else {
-            self::instance()->enableAnnotationsForIgnoringCode();
+            self::codeCoverage()->enableAnnotationsForIgnoringCode();
         }
 
         if ($configuration->includeUncoveredFiles()) {
-            self::instance()->includeUncoveredFiles();
+            self::codeCoverage()->includeUncoveredFiles();
         } else {
-            self::instance()->excludeUncoveredFiles();
+            self::codeCoverage()->excludeUncoveredFiles();
         }
 
         if (CodeCoverageFilterRegistry::instance()->get()->isEmpty()) {
@@ -114,7 +114,7 @@ final class CodeCoverage
         return self::$instance !== null;
     }
 
-    public static function instance(): \SebastianBergmann\CodeCoverage\CodeCoverage
+    public static function codeCoverage(): \SebastianBergmann\CodeCoverage\CodeCoverage
     {
         return self::$instance;
     }
@@ -195,7 +195,7 @@ final class CodeCoverage
 
             try {
                 $writer = new CloverReport;
-                $writer->process(self::instance(), $configuration->coverageClover());
+                $writer->process(self::codeCoverage(), $configuration->coverageClover());
 
                 self::codeCoverageGenerationSucceeded($printer);
 
@@ -210,7 +210,7 @@ final class CodeCoverage
 
             try {
                 $writer = new CoberturaReport;
-                $writer->process(self::instance(), $configuration->coverageCobertura());
+                $writer->process(self::codeCoverage(), $configuration->coverageCobertura());
 
                 self::codeCoverageGenerationSucceeded($printer);
 
@@ -225,7 +225,7 @@ final class CodeCoverage
 
             try {
                 $writer = new Crap4jReport($configuration->coverageCrap4jThreshold());
-                $writer->process(self::instance(), $configuration->coverageCrap4j());
+                $writer->process(self::codeCoverage(), $configuration->coverageCrap4j());
 
                 self::codeCoverageGenerationSucceeded($printer);
 
@@ -264,7 +264,7 @@ final class CodeCoverage
                     $customCssFile
                 );
 
-                $writer->process(self::instance(), $configuration->coverageHtml());
+                $writer->process(self::codeCoverage(), $configuration->coverageHtml());
 
                 self::codeCoverageGenerationSucceeded($printer);
 
@@ -279,7 +279,7 @@ final class CodeCoverage
 
             try {
                 $writer = new PhpReport;
-                $writer->process(self::instance(), $configuration->coveragePhp());
+                $writer->process(self::codeCoverage(), $configuration->coveragePhp());
 
                 self::codeCoverageGenerationSucceeded($printer);
 
@@ -296,7 +296,7 @@ final class CodeCoverage
                 $configuration->coverageTextShowOnlySummary()
             );
 
-            $textReport = $processor->process(self::instance(), $configuration->colors());
+            $textReport = $processor->process(self::codeCoverage(), $configuration->colors());
 
             if ($configuration->coverageText() === 'php://stdout') {
                 $printer->print($textReport);
@@ -310,7 +310,7 @@ final class CodeCoverage
 
             try {
                 $writer = new XmlReport(Version::id());
-                $writer->process(self::instance(), $configuration->coverageXml());
+                $writer->process(self::codeCoverage(), $configuration->coverageXml());
 
                 self::codeCoverageGenerationSucceeded($printer);
 

--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -43,7 +43,7 @@ use SebastianBergmann\Timer\Timer;
  */
 final class CodeCoverage
 {
-    private static self $instance;
+    private static ?self $instance                                      = null;
     private ?\SebastianBergmann\CodeCoverage\CodeCoverage $codeCoverage = null;
     private ?Driver $driver                                             = null;
     private bool $collecting                                            = false;
@@ -52,7 +52,7 @@ final class CodeCoverage
 
     public static function instance(): self
     {
-        if (!isset(self::$instance)) {
+        if (self::$instance === null) {
             self::$instance = new self;
         }
 

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -170,13 +170,13 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         if (CodeCoverage::isActive()) {
             $codeCoverageCacheDirectory = null;
 
-            if (CodeCoverage::instance()->cachesStaticAnalysis()) {
-                $codeCoverageCacheDirectory = CodeCoverage::instance()->cacheDirectory();
+            if (CodeCoverage::codeCoverage()->cachesStaticAnalysis()) {
+                $codeCoverageCacheDirectory = CodeCoverage::codeCoverage()->cacheDirectory();
             }
 
             $this->renderForCoverage(
                 $code,
-                CodeCoverage::instance()->collectsBranchAndPathCoverage(),
+                CodeCoverage::codeCoverage()->collectsBranchAndPathCoverage(),
                 $codeCoverageCacheDirectory
             );
         }
@@ -185,9 +185,9 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         $this->output = $jobResult['stdout'] ?? '';
 
         if (CodeCoverage::isActive() && ($coverage = $this->cleanupForCoverage())) {
-            CodeCoverage::instance()->start($this->filename, TestSize::large());
+            CodeCoverage::codeCoverage()->start($this->filename, TestSize::large());
 
-            CodeCoverage::instance()->append(
+            CodeCoverage::codeCoverage()->append(
                 $coverage,
                 $this->filename,
                 true,

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -132,7 +132,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
 
         $code     = $this->render($sections['FILE']);
         $xfail    = false;
-        $settings = $this->parseIniSection($this->settings(CodeCoverage::isActive()));
+        $settings = $this->parseIniSection($this->settings(CodeCoverage::instance()->isActive()));
 
         $emitter->testPrepared($this->valueObjectForEvents());
 
@@ -167,16 +167,16 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
             $this->phpUtil->setArgs($sections['ARGS']);
         }
 
-        if (CodeCoverage::isActive()) {
+        if (CodeCoverage::instance()->isActive()) {
             $codeCoverageCacheDirectory = null;
 
-            if (CodeCoverage::codeCoverage()->cachesStaticAnalysis()) {
-                $codeCoverageCacheDirectory = CodeCoverage::codeCoverage()->cacheDirectory();
+            if (CodeCoverage::instance()->codeCoverage()->cachesStaticAnalysis()) {
+                $codeCoverageCacheDirectory = CodeCoverage::instance()->codeCoverage()->cacheDirectory();
             }
 
             $this->renderForCoverage(
                 $code,
-                CodeCoverage::codeCoverage()->collectsBranchAndPathCoverage(),
+                CodeCoverage::instance()->codeCoverage()->collectsBranchAndPathCoverage(),
                 $codeCoverageCacheDirectory
             );
         }
@@ -184,10 +184,10 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         $jobResult    = $this->phpUtil->runJob($code, $this->stringifyIni($settings));
         $this->output = $jobResult['stdout'] ?? '';
 
-        if (CodeCoverage::isActive() && ($coverage = $this->cleanupForCoverage())) {
-            CodeCoverage::codeCoverage()->start($this->filename, TestSize::large());
+        if (CodeCoverage::instance()->isActive() && ($coverage = $this->cleanupForCoverage())) {
+            CodeCoverage::instance()->codeCoverage()->start($this->filename, TestSize::large());
 
-            CodeCoverage::codeCoverage()->append(
+            CodeCoverage::instance()->codeCoverage()->append(
                 $coverage,
                 $this->filename,
                 true,
@@ -234,7 +234,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
             $emitter->testErrored($this->valueObjectForEvents(), EventThrowable::from($t));
         }
 
-        $this->runClean($sections, CodeCoverage::isActive());
+        $this->runClean($sections, CodeCoverage::instance()->isActive());
 
         $emitter->testFinished($this->valueObjectForEvents(), 1);
     }

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -52,6 +52,7 @@ use PHPUnit\TextUI\Command\ShowHelpCommand;
 use PHPUnit\TextUI\Command\ShowVersionCommand;
 use PHPUnit\TextUI\Command\VersionCheckCommand;
 use PHPUnit\TextUI\Command\WarmCodeCoverageCacheCommand;
+use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use PHPUnit\TextUI\Configuration\Configuration;
 use PHPUnit\TextUI\Configuration\PhpHandler;
 use PHPUnit\TextUI\Configuration\Registry;
@@ -111,7 +112,7 @@ final class Application
                 $this->bootstrapExtensions($configuration);
             }
 
-            CodeCoverage::instance()->init($configuration);
+            CodeCoverage::instance()->init($configuration, CodeCoverageFilterRegistry::instance());
 
             $printer = OutputFacade::init($configuration);
 
@@ -370,7 +371,7 @@ final class Application
         }
 
         if ($cliConfiguration->warmCoverageCache()) {
-            $this->execute(new WarmCodeCoverageCacheCommand($configuration));
+            $this->execute(new WarmCodeCoverageCacheCommand($configuration, CodeCoverageFilterRegistry::instance()));
         }
     }
 

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -111,7 +111,7 @@ final class Application
                 $this->bootstrapExtensions($configuration);
             }
 
-            CodeCoverage::init($configuration);
+            CodeCoverage::instance()->init($configuration);
 
             $printer = OutputFacade::init($configuration);
 
@@ -162,7 +162,7 @@ final class Application
             $result = TestResultFacade::result();
 
             OutputFacade::printResult($result, $testDoxResult);
-            CodeCoverage::generateReports($printer, $configuration);
+            CodeCoverage::instance()->generateReports($printer, $configuration);
 
             $shellExitCode = (new ShellExitCodeCalculator)->calculate(
                 $configuration->failOnEmptyTestSuite(),
@@ -387,8 +387,8 @@ final class Application
 
         $runtime = 'PHP ' . PHP_VERSION;
 
-        if (CodeCoverage::isActive()) {
-            $runtime .= ' with ' . CodeCoverage::driver()->nameAndVersion();
+        if (CodeCoverage::instance()->isActive()) {
+            $runtime .= ' with ' . CodeCoverage::instance()->driver()->nameAndVersion();
         }
 
         $this->writeMessage($printer, 'Runtime', $runtime);

--- a/src/TextUI/Command/Commands/WarmCodeCoverageCacheCommand.php
+++ b/src/TextUI/Command/Commands/WarmCodeCoverageCacheCommand.php
@@ -42,9 +42,9 @@ final class WarmCodeCoverageCacheCommand implements Command
             );
         }
 
-        CodeCoverageFilterRegistry::init($this->configuration);
+        CodeCoverageFilterRegistry::instance()->init($this->configuration);
 
-        if (!CodeCoverageFilterRegistry::configured()) {
+        if (!CodeCoverageFilterRegistry::instance()->configured()) {
             return Result::from(
                 'Filter for code coverage has not been configured' . PHP_EOL,
                 Result::FAILURE
@@ -60,7 +60,7 @@ final class WarmCodeCoverageCacheCommand implements Command
             $this->configuration->coverageCacheDirectory(),
             !$this->configuration->disableCodeCoverageIgnore(),
             $this->configuration->ignoreDeprecatedCodeUnitsFromCodeCoverage(),
-            CodeCoverageFilterRegistry::get()
+            CodeCoverageFilterRegistry::instance()->get()
         );
 
         printf(

--- a/src/TextUI/Command/Commands/WarmCodeCoverageCacheCommand.php
+++ b/src/TextUI/Command/Commands/WarmCodeCoverageCacheCommand.php
@@ -23,10 +23,12 @@ use SebastianBergmann\Timer\Timer;
 final class WarmCodeCoverageCacheCommand implements Command
 {
     private readonly Configuration $configuration;
+    private readonly CodeCoverageFilterRegistry $codeCoverageFilterRegistry;
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, CodeCoverageFilterRegistry $codeCoverageFilterRegistry)
     {
-        $this->configuration = $configuration;
+        $this->configuration              = $configuration;
+        $this->codeCoverageFilterRegistry = $codeCoverageFilterRegistry;
     }
 
     /**
@@ -42,9 +44,9 @@ final class WarmCodeCoverageCacheCommand implements Command
             );
         }
 
-        CodeCoverageFilterRegistry::instance()->init($this->configuration);
+        $this->codeCoverageFilterRegistry->init($this->configuration);
 
-        if (!CodeCoverageFilterRegistry::instance()->configured()) {
+        if (!$this->codeCoverageFilterRegistry->configured()) {
             return Result::from(
                 'Filter for code coverage has not been configured' . PHP_EOL,
                 Result::FAILURE
@@ -60,7 +62,7 @@ final class WarmCodeCoverageCacheCommand implements Command
             $this->configuration->coverageCacheDirectory(),
             !$this->configuration->disableCodeCoverageIgnore(),
             $this->configuration->ignoreDeprecatedCodeUnitsFromCodeCoverage(),
-            CodeCoverageFilterRegistry::instance()->get()
+            $this->codeCoverageFilterRegistry->get()
         );
 
         printf(

--- a/src/TextUI/Configuration/CodeCoverageFilterRegistry.php
+++ b/src/TextUI/Configuration/CodeCoverageFilterRegistry.php
@@ -20,13 +20,13 @@ use SebastianBergmann\CodeCoverage\Filter;
  */
 final class CodeCoverageFilterRegistry
 {
-    private static self $instance;
-    private ?Filter $filter  = null;
-    private bool $configured = false;
+    private static ?self $instance = null;
+    private ?Filter $filter        = null;
+    private bool $configured       = false;
 
     public static function instance(): self
     {
-        if (!isset(self::$instance)) {
+        if (self::$instance === null) {
             self::$instance = new self;
         }
 

--- a/src/TextUI/Configuration/CodeCoverageFilterRegistry.php
+++ b/src/TextUI/Configuration/CodeCoverageFilterRegistry.php
@@ -20,31 +20,41 @@ use SebastianBergmann\CodeCoverage\Filter;
  */
 final class CodeCoverageFilterRegistry
 {
-    private static ?Filter $filter  = null;
-    private static bool $configured = false;
+    private static self $instance;
+    private ?Filter $filter  = null;
+    private bool $configured = false;
 
-    public static function get(): Filter
+    public static function instance(): self
     {
-        assert(self::$filter !== null);
+        if (!isset(self::$instance)) {
+            self::$instance = new self;
+        }
 
-        return self::$filter;
+        return self::$instance;
     }
 
-    public static function init(Configuration $configuration): void
+    public function get(): Filter
+    {
+        assert($this->filter !== null);
+
+        return $this->filter;
+    }
+
+    public function init(Configuration $configuration): void
     {
         if (!$configuration->hasCoverageReport()) {
             return;
         }
 
-        if (self::$configured) {
+        if ($this->configured) {
             return;
         }
 
-        self::$filter = new Filter;
+        $this->filter = new Filter;
 
         if ($configuration->hasNonEmptyListOfFilesToBeIncludedInCodeCoverageReport()) {
             foreach ($configuration->coverageIncludeDirectories() as $directory) {
-                self::$filter->includeDirectory(
+                $this->filter->includeDirectory(
                     $directory->path(),
                     $directory->suffix(),
                     $directory->prefix()
@@ -52,11 +62,11 @@ final class CodeCoverageFilterRegistry
             }
 
             foreach ($configuration->coverageIncludeFiles() as $file) {
-                self::$filter->includeFile($file->path());
+                $this->filter->includeFile($file->path());
             }
 
             foreach ($configuration->coverageExcludeDirectories() as $directory) {
-                self::$filter->excludeDirectory(
+                $this->filter->excludeDirectory(
                     $directory->path(),
                     $directory->suffix(),
                     $directory->prefix()
@@ -64,15 +74,15 @@ final class CodeCoverageFilterRegistry
             }
 
             foreach ($configuration->coverageExcludeFiles() as $file) {
-                self::$filter->excludeFile($file->path());
+                $this->filter->excludeFile($file->path());
             }
 
-            self::$configured = true;
+            $this->configured = true;
         }
     }
 
-    public static function configured(): bool
+    public function configured(): bool
     {
-        return self::$configured;
+        return $this->configured;
     }
 }

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -319,7 +319,7 @@ abstract class AbstractPhpProcess
             $test->addToAssertionCount($childResult['numAssertions']);
 
             if (CodeCoverage::isActive() && $childResult['codeCoverage'] instanceof \SebastianBergmann\CodeCoverage\CodeCoverage) {
-                CodeCoverage::instance()->merge(
+                CodeCoverage::codeCoverage()->merge(
                     $childResult['codeCoverage']
                 );
             }

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -318,8 +318,8 @@ abstract class AbstractPhpProcess
             $test->setResult($childResult['testResult']);
             $test->addToAssertionCount($childResult['numAssertions']);
 
-            if (CodeCoverage::isActive() && $childResult['codeCoverage'] instanceof \SebastianBergmann\CodeCoverage\CodeCoverage) {
-                CodeCoverage::codeCoverage()->merge(
+            if (CodeCoverage::instance()->isActive() && $childResult['codeCoverage'] instanceof \SebastianBergmann\CodeCoverage\CodeCoverage) {
+                CodeCoverage::instance()->codeCoverage()->merge(
                     $childResult['codeCoverage']
                 );
             }

--- a/src/Util/PHP/Template/TestCaseClass.tpl
+++ b/src/Util/PHP/Template/TestCaseClass.tpl
@@ -43,8 +43,7 @@ function __phpunit_run_isolated_test()
     require_once '{filename}';
 
     if ({collectCodeCoverageInformation}) {
-        CodeCoverageFilterRegistry::init(ConfigurationRegistry::get());
-        CodeCoverage::init(ConfigurationRegistry::get());
+        CodeCoverage::instance()->init(ConfigurationRegistry::get(), CodeCoverageFilterRegistry::instance());
     }
 
     $test = new {className}('{name}');

--- a/src/Util/PHP/Template/TestCaseMethod.tpl
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl
@@ -44,8 +44,7 @@ function __phpunit_run_isolated_test()
     require_once '{filename}';
 
     if ({collectCodeCoverageInformation}) {
-        CodeCoverageFilterRegistry::init(ConfigurationRegistry::get());
-        CodeCoverage::init(ConfigurationRegistry::get());
+        CodeCoverage::instance()->init(ConfigurationRegistry::get(), CodeCoverageFilterRegistry::instance());
     }
 
     $test = new {className}('{methodName}');


### PR DESCRIPTION
Hi, this PR sets a clear line between the Singleton instance and its behaviour for:

1. `\PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry`
2. `\PHPUnit\Runner\CodeCoverage`

Allowing to have local instances that do not interfere with active PHPUnit run.

For PHPUnit the benefit is that these classes become now unit-testable, if needed.
For external project like ParaTest (I'm *aware* that I'm dealing with `@internal` classes) this means these classes can be used without mangling PHPUnit internal state.