### PR TITLE
Detail deprecations for 9.6.1 in the changelog

### DIFF
--- a/ChangeLog-9.6.md
+++ b/ChangeLog-9.6.md
@@ -19,7 +19,7 @@ All notable changes of the PHPUnit 9.6 release series are documented in this fil
 ### Fixed
 
 * [#5073](https://github.com/sebastianbergmann/phpunit/issues/5073): `--no-extensions` CLI option only prevents extension PHARs from being loaded
-* [#5160](https://github.com/sebastianbergmann/phpunit/issues/5160): PHPUnit 9.6 misses deprecations for assertions and constraints removed in PHPUnit 10
+* [#5160](https://github.com/sebastianbergmann/phpunit/issues/5160): Deprecate `assertClassHasAttribute()`, `assertClassNotHasAttribute()`, `assertClassHasStaticAttribute()`, `assertClassNotHasStaticAttribute()`, `assertObjectHasAttribute()`, `assertObjectNotHasAttribute()`, `classHasAttribute()`, `classHasStaticAttribute()`, and `objectHasAttribute()`
 
 ## [9.6.0] - 2023-02-03
 


### PR DESCRIPTION
The 9.6 branch adds several deprecations that aren't documented anywhere except in PRs from two years ago during planning for PHPUnit 11. This adds the method names to the changelog for 9.6.1 so at least they can be found there.