### PR TITLE
Add test for bug: JUnit doesn't log error, and it doesn't appear in DefaultPrinter

### DIFF
--- a/tests/end-to-end/logging/_files/TypeErrorTest.php
+++ b/tests/end-to-end/logging/_files/TypeErrorTest.php
@@ -9,19 +9,21 @@
  */
 namespace PHPUnit\TestFixture;
 
+use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 final class TypeErrorTest extends TestCase
 {
-    private \DateTimeImmutable $dateTime;
+    private DateTimeImmutable $dateTime;
 
     protected function setUp(): void
     {
-        $this->dateTime = new \DateTime();
+        $this->dateTime = new DateTime;
     }
 
     public function testMe(): void
     {
-        self::assertTrue(true);
+        $this->assertTrue(true);
     }
 }

--- a/tests/end-to-end/logging/_files/TypeErrorTest.php
+++ b/tests/end-to-end/logging/_files/TypeErrorTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class TypeErrorTest extends TestCase
+{
+    private \DateTimeImmutable $dateTime;
+
+    protected function setUp(): void
+    {
+        $this->dateTime = new \DateTime();
+    }
+
+    public function testMe(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/log-junit-with-progress-with-errors.phpt
+++ b/tests/end-to-end/logging/log-junit-with-progress-with-errors.phpt
@@ -1,0 +1,54 @@
+--TEST--
+phpunit --log-junit php://stdout _files/TypeErrorTest.php
+--SKIPIF--
+<?php declare(strict_types=1);
+if (DIRECTORY_SEPARATOR === '\\') {
+    print "skip: this test does not work on Windows / GitHub Actions\n";
+}
+--FILE--
+<?php declare(strict_types=1);
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--log-junit';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/TypeErrorTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($logfile);
+
+unlink($logfile);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) PHPUnit\TestFixture\TypeErrorTest::testMe
+TypeError: Cannot assign DateTime to property PHPUnit\TestFixture\TypeErrorTest::$dateTime of type DateTimeImmutable
+
+%sTypeErrorTest.php:%d
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.
+
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="PHPUnit\TestFixture\TypeErrorTest" file="%sTypeErrorTest.php" tests="1" assertions="0" errors="1" warnings="0" failures="0" skipped="0" time="%f">
+    <testcase name="testMe" class="PHPUnit\TestFixture\TypeErrorTest" classname="PHPUnit.TestFixture.TypeErrorTest" file="%sTypeErrorTest.php" line="%d" assertions="0" time="%f">
+      <error type="TypeError">PHPUnit\TestFixture\TypeErrorTest::testMe
+TypeError: Cannot assign DateTime to property PHPUnit\TestFixture\TypeErrorTest::$dateTime of type DateTimeImmutable
+
+%sTypeErrorTest.php:%s</error>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/end-to-end/logging/log-junit-with-progress-with-errors.phpt
+++ b/tests/end-to-end/logging/log-junit-with-progress-with-errors.phpt
@@ -22,6 +22,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 print file_get_contents($logfile);
 
 unlink($logfile);
+--XFAIL--
+https://github.com/sebastianbergmann/phpunit/pull/5188
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 


### PR DESCRIPTION
This test passes on `9.6` (with proper, minor adjustments of the `--FILE--` section of course).

Basically in `10.0` when:

* The test errors in the `setUp`
* The `JUnit` logger is active

The following unexpected behaviours happen all at once:

1. The output is truncated after progress:
`E                                                                   1 / 1 (100%)No tests executed!`
2. The junit log file reports that the test passed
3. The exit status is `0`