### PR TITLE
Fix: Add test asserting that running empty test suite does not fail

### DIFF
--- a/tests/end-to-end/regression/5192.phpt
+++ b/tests/end-to-end/regression/5192.phpt
@@ -1,0 +1,14 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/5192
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/5192/phpunit.xml';
+
+require_once __DIR__ . '/../../bootstrap.php';
+PHPUnit\TextUI\Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+No tests executed!

--- a/tests/end-to-end/regression/5192/phpunit.xml
+++ b/tests/end-to-end/regression/5192/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+>
+<testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
This pull request

- [x] adds a test asserting that running an empty test suite does not fail

Related to #5192.