### PR TITLE
MockObject can be used to test consecutive method calls.

### DIFF
--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException;
 use PHPUnit\Framework\MockObject\MethodNameNotConfiguredException;
 use PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException;
 use PHPUnit\Framework\MockObject\Rule;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls;
 use PHPUnit\Framework\MockObject\Stub\Exception;
 use PHPUnit\Framework\MockObject\Stub\ReturnArgument;
@@ -162,6 +163,37 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
         $this->matcher->setAfterMatchBuilderId($id);
 
         return $this;
+    }
+
+    /**
+     * @throws MatcherAlreadyRegisteredException
+     * @throws MethodNameNotConfiguredException
+     */
+    public function orThen(InvocationOrder $rule): self
+    {
+        if (!$this->matcher->hasMethodNameRule()) {
+            throw new MethodNameNotConfiguredException;
+        }
+
+        if (!$this->matcher->isConsecutiveCall()) {
+            $this->matcher->setConsecutiveCall(1);
+        }
+
+        $rule->setMatcher($this->matcher);
+        $this->id($this->matcher->getConsecutiveId());
+
+        return $this->invocationHandler->expects($rule);
+    }
+
+    /**
+     * @throws MatcherAlreadyRegisteredException
+     * @throws MethodNameNotConfiguredException
+     */
+    public function andThen(InvocationOrder $rule): self
+    {
+        $this->matcher->setCheckOrder(true);
+
+        return $this->orThen($rule);
     }
 
     /**

--- a/src/Framework/MockObject/Rule/AnyParameters.php
+++ b/src/Framework/MockObject/Rule/AnyParameters.php
@@ -28,4 +28,9 @@ final class AnyParameters implements ParametersRule
     public function verify(): void
     {
     }
+
+    public function match(BaseInvocation $invocation): bool
+    {
+        return true;
+    }
 }

--- a/src/Framework/MockObject/Rule/InvocationOrder.php
+++ b/src/Framework/MockObject/Rule/InvocationOrder.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Framework\MockObject\Rule;
 
 use function count;
 use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
+use PHPUnit\Framework\MockObject\Matcher;
 use PHPUnit\Framework\MockObject\Verifiable;
 use PHPUnit\Framework\SelfDescribing;
 
@@ -23,6 +24,7 @@ abstract class InvocationOrder implements SelfDescribing, Verifiable
      * @psalm-var list<BaseInvocation>
      */
     private array $invocations = [];
+    private ?Matcher $matcher  = null;
 
     public function numberOfInvocations(): int
     {
@@ -39,6 +41,16 @@ abstract class InvocationOrder implements SelfDescribing, Verifiable
         $this->invocations[] = $invocation;
 
         $this->invokedDo($invocation);
+    }
+
+    final public function getMatcher(): ?Matcher
+    {
+        return $this->matcher;
+    }
+
+    final public function setMatcher(Matcher $matcher): void
+    {
+        $this->matcher = $matcher;
     }
 
     abstract public function matches(BaseInvocation $invocation): bool;

--- a/src/Framework/MockObject/Rule/ParametersRule.php
+++ b/src/Framework/MockObject/Rule/ParametersRule.php
@@ -25,4 +25,9 @@ interface ParametersRule extends SelfDescribing, Verifiable
     public function apply(BaseInvocation $invocation): void;
 
     public function verify(): void;
+
+    /**
+     * Returns boolean case the Parameters matches Invocation.
+     */
+    public function match(BaseInvocation $invocation): bool;
 }

--- a/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\Foo;
 use PHPUnit\TestFixture\MockObject\ClassWithAllPossibleReturnTypes;
 use PHPUnit\TestFixture\MockObject\ClassWithImplicitProtocol;
+use PHPUnit\TestFixture\MockObject\ClassWithVariadicArgumentMethod;
 use stdClass;
 
 #[CoversClass(InvocationMocker::class)]
@@ -242,5 +243,38 @@ final class InvocationMockerTest extends TestCase
 
         $this->assertSame('foo', $mock->foo());
         $this->assertSame($mock, $mock->bar());
+    }
+
+    public function testConsecutiveCallsInOrder(): void
+    {
+        $mock = $this->createMock(ClassWithVariadicArgumentMethod::class);
+        $mock->expects($this->exactly(2))
+            ->method('foo')
+            ->with(1)
+            ->willReturn('first')
+            ->andThen($this->once())
+            ->with(2)
+            ->willReturn('second');
+
+        $this->assertNull($mock->foo(2));
+        $this->assertSame('first', $mock->foo(1));
+        $this->assertSame('second', $mock->foo(2));
+        $this->assertSame('first', $mock->foo(1));
+    }
+
+    public function testConsecutiveCalls(): void
+    {
+        $mock = $this->createMock(ClassWithVariadicArgumentMethod::class);
+        $mock->expects($this->exactly(2))
+            ->method('foo')
+            ->with(1)
+            ->willReturn('first')
+            ->orThen($this->once())
+            ->with(2)
+            ->willReturn('second');
+
+        $this->assertSame('second', $mock->foo(2));
+        $this->assertSame('first', $mock->foo(1));
+        $this->assertSame('first', $mock->foo(1));
     }
 }


### PR DESCRIPTION
Allow mock object to be used to mock methods with same name, but with different parameters.
Addresses #4255 and #4026.

This can be easily ported to 9.6. Just let me know if i need to target 9.6.