### PR TITLE
[bug] fix empty ExecutionStarted->testSuite()->name() string

### DIFF
--- a/src/TextUI/Configuration/Xml/TestSuiteMapper.php
+++ b/src/TextUI/Configuration/Xml/TestSuiteMapper.php
@@ -39,7 +39,7 @@ final class TestSuiteMapper
         try {
             $filterAsArray         = $filter ? explode(',', $filter) : [];
             $excludedFilterAsArray = $excludedTestSuites ? explode(',', $excludedTestSuites) : [];
-            $result                = TestSuiteObject::empty();
+            $result                = TestSuiteObject::empty($filter);
 
             foreach ($configuration as $testSuiteConfiguration) {
                 if (!empty($filterAsArray) && !in_array($testSuiteConfiguration->name(), $filterAsArray, true)) {


### PR DESCRIPTION
when relying on `defaultTestSuite` in `phpunit.xml` or `--testsuite=` command line arg

fixes #5208