### PR TITLE
Fix TestCase::onNotSuccessfulTest() PHP 8.0 and lower BC

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1383,9 +1383,11 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * This method is called when a test method did not execute successfully.
      *
+     * @return never
+     *
      * @throws Throwable
      */
-    protected function onNotSuccessfulTest(Throwable $t): never
+    protected function onNotSuccessfulTest(Throwable $t): void
     {
         throw $t;
     }


### PR DESCRIPTION
introduced in https://github.com/sebastianbergmann/phpunit/commit/b61f014f0896ac75b3f7711a95c6fd0a5fa575fa

In PHP 8.0 and lower there is no `never` native type.

PHP projects overriding `TestCase::onNotSuccessfulTest()` method like:

```php
<?php

class MyTest extends TestCase {
    protected function onNotSuccessfulTest(Throwable $t): void
    {
        throw $t;
    }
}
```

should still be able to run the tests on PHP 8.0 and lower (with phpunit 9.x).

This PR loosen the return type requirement from `never` to `void`. PHP 8.1 and higher only projects can use the native `never` return type already - https://3v4l.org/gjAI0.