### PR TITLE
Allow providing named arguments from a data provider

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1176,10 +1176,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      */
     final protected function runTest(): mixed
     {
-        $testArguments = array_merge($this->data, $this->dependencyInput);
+        $testArguments = array_merge($this->data, array_values($this->dependencyInput));
 
         try {
-            $testResult = $this->{$this->name}(...array_values($testArguments));
+            $testResult = $this->{$this->name}(...$testArguments);
         } catch (Throwable $exception) {
             if (!$this->shouldExceptionExpectationsBeVerified($exception)) {
                 throw $exception;

--- a/tests/_files/DataProviderNamedArgumentsTest.php
+++ b/tests/_files/DataProviderNamedArgumentsTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class DataProviderNamedArgumentsTest extends TestCase
+{
+    public static function providerMethod()
+    {
+        return [
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            ['c' => 3, 'a' => 2, 'b' => 1],
+        ];
+    }
+
+    #[DataProvider('providerMethod')]
+    public function testAdd($a, $b, $c): void
+    {
+        $this->assertEquals($c, $a + $b);
+    }
+}

--- a/tests/end-to-end/generic/dataprovider-named-arguments.phpt
+++ b/tests/end-to-end/generic/dataprovider-named-arguments.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit ../../_files/DataProviderNamedArgumentsTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderNamedArgumentsTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)


### PR DESCRIPTION
Resolves #5150

This PR aims to allow passing named arguments from a data provider, to have more flexibility in re-ordering arguments and skipping optional ones without having to provide a default value.

Note 1: I was not entirely sure on where to put the test; if there is a more suitable location to add this, let me know!

Note 2: Combining named arguments with input from a dependency is not supported, as providing positional arguments after named ones in an array is not supported, and data provider arguments will go first as [per doc description](https://docs.phpunit.de/en/10.0/writing-tests-for-phpunit.html#data-providers). I could not find a test to ensure this behavior, so made https://github.com/jnoordsij/phpunit/commit/ac028c8eb14da44268378a5a0fe0b9840aa67e2e this PR doesn't break existing behavior. I also created https://github.com/jnoordsij/phpunit/commit/f7e28c4c7a51c1f805d5ec94ae29feaa5acf63f4 to demonstrate the unsupported case. If wanted, I can add those tests to this PR or a new PR.