### PR TITLE
Skip test with no pcov

### DIFF
--- a/tests/end-to-end/regression/5218.phpt
+++ b/tests/end-to-end/regression/5218.phpt
@@ -2,6 +2,11 @@
 https://github.com/sebastianbergmann/phpunit/issues/5218
 --INI--
 pcov.directory=tests/end-to-end/regression/5218/src/
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('pcov')) {
+    print "skip: this test requires pcov\n";
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';


### PR DESCRIPTION
Looks like my CI is useful to catch pcov-only tests ;-)

e.g.
https://revive.beccati.com/bamboo/browse/PHP-PHPUN-PHP82-3181/test/case/72181271

```
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 Time: 00:00.095, Memory: 8.00 MB
 
-OK (1 test, 1 assertion)
+There was 1 PHPUnit warning:
 
+1) No code coverage driver available
 
-Code Coverage Report:   
-  %s
-                        
- Summary:               
-  Classes: 100.00% (1/1)
-  Methods: 100.00% (1/1)
-  Lines:   100.00% (1/1)
-
-PHPUnit\TestFixture\Issue5218\Issue5218
-  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  1/  1)
+WARNINGS!
+Tests: 1, Assertions: 1, Warnings: 1.

/.../PHP-PHPUN-PHP82/tests/end-to-end/regression/5218.phpt:27
/.../PHP-PHPUN-PHP82/src/Framework/TestSuite.php:352
/.../PHP-PHPUN-PHP82/src/Framework/TestSuite.php:352
/.../PHP-PHPUN-PHP82/src/TextUI/TestRunner.php:63
/.../PHP-PHPUN-PHP82/src/TextUI/Application.php:141
```