### PR TITLE
[#5258] Fix JunitXmlLogger prepared state after each test's finish

### DIFF
--- a/src/Logging/JUnit/JunitXmlLogger.php
+++ b/src/Logging/JUnit/JunitXmlLogger.php
@@ -261,6 +261,7 @@ final class JunitXmlLogger
 
         $this->currentTestCase = null;
         $this->time            = null;
+        $this->prepared        = false;
     }
 
     /**

--- a/tests/end-to-end/logging/log-junit-to-file.phpt
+++ b/tests/end-to-end/logging/log-junit-to-file.phpt
@@ -26,7 +26,7 @@ unlink($logfile);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="PHPUnit\SelfTest\Basic\StatusTest" file="%sStatusTest.php" tests="12" assertions="4" errors="2" failures="2" skipped="4" time="%f">
+  <testsuite name="PHPUnit\SelfTest\Basic\StatusTest" file="%sStatusTest.php" tests="13" assertions="4" errors="2" failures="2" skipped="5" time="%f">
     <testcase name="testSuccess" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="1" time="%f"/>
     <testcase name="testFailure" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="1" time="%f">
       <failure type="PHPUnit\Framework\ExpectationFailedException">PHPUnit\SelfTest\Basic\StatusTest::testFailure%A
@@ -62,6 +62,9 @@ RuntimeException: error with custom message
 %sStatusTest.php:%d</error>
     </testcase>
     <testcase name="testIncompleteWithMessage" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="0" time="%f">
+      <skipped/>
+    </testcase>
+    <testcase name="testSkippedByMetadata" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="0" time="%f">
       <skipped/>
     </testcase>
     <testcase name="testSkippedWithMessage" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="0" time="%f">

--- a/tests/end-to-end/logging/log-junit-to-stdout.phpt
+++ b/tests/end-to-end/logging/log-junit-to-stdout.phpt
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../../bootstrap.php';
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite name="PHPUnit\SelfTest\Basic\StatusTest" file="%sStatusTest.php" tests="12" assertions="4" errors="2" failures="2" skipped="4" time="%f">
+  <testsuite name="PHPUnit\SelfTest\Basic\StatusTest" file="%sStatusTest.php" tests="13" assertions="4" errors="2" failures="2" skipped="5" time="%f">
     <testcase name="testSuccess" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="1" time="%f"/>
     <testcase name="testFailure" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="1" time="%f">
       <failure type="PHPUnit\Framework\ExpectationFailedException">PHPUnit\SelfTest\Basic\StatusTest::testFailure%A
@@ -51,6 +51,9 @@ RuntimeException: error with custom message
 %sStatusTest.php:%d</error>
     </testcase>
     <testcase name="testIncompleteWithMessage" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="0" time="%f">
+      <skipped/>
+    </testcase>
+    <testcase name="testSkippedByMetadata" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="0" time="%f">
       <skipped/>
     </testcase>
     <testcase name="testSkippedWithMessage" file="%sStatusTest.php" line="%d" class="PHPUnit\SelfTest\Basic\StatusTest" classname="PHPUnit.SelfTest.Basic.StatusTest" assertions="0" time="%f">

--- a/tests/end-to-end/regression/5258.phpt
+++ b/tests/end-to-end/regression/5258.phpt
@@ -2,17 +2,21 @@
 https://github.com/sebastianbergmann/phpunit/issues/5258
 --FILE--
 <?php declare(strict_types=1);
+$junitFile = tempnam(sys_get_temp_dir(), __FILE__);
+
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--log-junit';
-$_SERVER['argv'][] = '/dev/null';
+$_SERVER['argv'][] = $junitFile;
 $_SERVER['argv'][] = __DIR__ . '/5258/Issue5258Test.php';
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
---XFAIL--
-https://github.com/sebastianbergmann/phpunit/issues/5258
+
+print file_get_contents($junitFile);
+
+unlink($junitFile);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
@@ -24,3 +28,12 @@ Time: %s, Memory: %s MB
 
 OK, but some tests were skipped!
 Tests: 2, Assertions: 1, Skipped: 1.
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="PHPUnit\TestFixture\Issue5258\Issue5258Test" file="%sIssue5258Test.php" tests="2" assertions="1" errors="0" failures="0" skipped="1" time="%f">
+    <testcase name="testOne" file="%sIssue5258Test.php" line="%d" class="PHPUnit\TestFixture\Issue5258\Issue5258Test" classname="PHPUnit.TestFixture.Issue5258.Issue5258Test" assertions="1" time="%f"/>
+    <testcase name="testTwo" file="%sIssue5258Test.php" line="%d" class="PHPUnit\TestFixture\Issue5258\Issue5258Test" classname="PHPUnit.TestFixture.Issue5258.Issue5258Test" assertions="0" time="0.000000">
+      <skipped/>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Fix #5258 