### PR TITLE
Fix possibly negative str_repeat argument in ProgressPrinter

### DIFF
--- a/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php
+++ b/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php
@@ -54,8 +54,10 @@ final class ProgressPrinter
 
     public function testRunnerExecutionStarted(ExecutionStarted $event): void
     {
+        $this->numberOfTestsRun   = 0;
         $this->numberOfTests      = $event->testSuite()->count();
         $this->numberOfTestsWidth = strlen((string) $this->numberOfTests);
+        $this->column             = 0;
         $this->maxColumn          = $this->numberOfColumns - strlen('  /  (XXX%)') - (2 * $this->numberOfTestsWidth);
     }
 


### PR DESCRIPTION
```
  str_repeat(): Argument #2 ($times) must be greater than or equal to 0        
    at vendor/phpunit/phpunit/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php:256    
```