### PR TITLE
[Postponed] Add option to ignore covers annotation

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -83,6 +83,10 @@ final class CodeCoverage
             $this->codeCoverage()->enableCheckForUnintentionallyCoveredCode();
         }
 
+        if ($configuration->ignoreCoversAnnotation()) {
+            $this->codeCoverage()->ignoreCoversAnnotation();
+        }
+
         if ($configuration->ignoreDeprecatedCodeUnitsFromCodeCoverage()) {
             $this->codeCoverage()->ignoreDeprecatedCode();
         } else {

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -100,6 +100,7 @@ final class Builder
         'fail-on-skipped',
         'fail-on-warning',
         'strict-coverage',
+        'ignore-covers-annotation',
         'disable-coverage-ignore',
         'strict-global-state',
         'teamcity',
@@ -206,6 +207,7 @@ final class Builder
         $reverseList                       = null;
         $stderr                            = null;
         $strictCoverage                    = null;
+        $ignoreCoversAnnotation            = null;
         $stopOnDefect                      = null;
         $stopOnError                       = null;
         $stopOnFailure                     = null;
@@ -649,6 +651,11 @@ final class Builder
 
                     break;
 
+                case '--ignore-covers-annotation':
+                    $ignoreCoversAnnotation = true;
+
+                    break;
+
                 case '--disable-coverage-ignore':
                     $disableCodeCoverageIgnore = true;
 
@@ -833,6 +840,7 @@ final class Builder
             $reverseList,
             $stderr,
             $strictCoverage,
+            $ignoreCoversAnnotation,
             $stopOnDefect,
             $stopOnError,
             $stopOnFailure,

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -81,6 +81,7 @@ final class Configuration
     private readonly ?bool $reverseList;
     private readonly ?bool $stderr;
     private readonly ?bool $strictCoverage;
+    private readonly ?bool $ignoreCoversAnnotation;
     private readonly ?bool $stopOnDefect;
     private readonly ?bool $stopOnError;
     private readonly ?bool $stopOnFailure;
@@ -114,7 +115,7 @@ final class Configuration
     /**
      * @psalm-param ?non-empty-list<string> $testSuffixes
      */
-    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox)
+    public function __construct(?string $argument, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, ?string $cacheResultFile, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, ?string $coverageCacheDirectory, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?string $filter, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?bool $ignoreCoversAnnotation, ?bool $stopOnDefect, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox)
     {
         $this->argument                                     = $argument;
         $this->atLeastVersion                               = $atLeastVersion;
@@ -181,6 +182,7 @@ final class Configuration
         $this->reverseList                                  = $reverseList;
         $this->stderr                                       = $stderr;
         $this->strictCoverage                               = $strictCoverage;
+        $this->ignoreCoversAnnotation                       = $ignoreCoversAnnotation;
         $this->stopOnDefect                                 = $stopOnDefect;
         $this->stopOnError                                  = $stopOnError;
         $this->stopOnFailure                                = $stopOnFailure;
@@ -1377,6 +1379,14 @@ final class Configuration
     }
 
     /**
+     * @psalm-assert-if-true !null $this->ignoreCoversAnnotation
+     */
+    public function hasIgnoreCoversAnnotation(): bool
+    {
+        return $this->ignoreCoversAnnotation !== null;
+    }
+
+    /**
      * @throws Exception
      */
     public function strictCoverage(): bool
@@ -1386,6 +1396,18 @@ final class Configuration
         }
 
         return $this->strictCoverage;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function ignoreCoversAnnotation(): bool
+    {
+        if (!$this->hasIgnoreCoversAnnotation()) {
+            throw new Exception;
+        }
+
+        return $this->ignoreCoversAnnotation;
     }
 
     /**

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -88,6 +88,7 @@ final class Configuration
     private readonly int $timeoutForLargeTests;
     private readonly bool $reportUselessTests;
     private readonly bool $strictCoverage;
+    private readonly bool $ignoreCoversAnnotation;
     private readonly bool $disallowTestOutput;
     private readonly bool $displayDetailsOnIncompleteTests;
     private readonly bool $displayDetailsOnSkippedTests;
@@ -134,7 +135,7 @@ final class Configuration
      * @psalm-param non-empty-list<string> $testSuffixes
      * @psalm-param list<array{className: class-string, parameters: array<string, string>}> $extensionBootstrappers
      */
-    public function __construct(?string $cliArgument, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, FilterDirectoryCollection $coverageIncludeDirectories, FileCollection $coverageIncludeFiles, FilterDirectoryCollection $coverageExcludeDirectories, FileCollection $coverageExcludeFiles, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $registerMockObjectsFromTestArgumentsRecursively, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php)
+    public function __construct(?string $cliArgument, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, FilterDirectoryCollection $coverageIncludeDirectories, FileCollection $coverageIncludeFiles, FilterDirectoryCollection $coverageExcludeDirectories, FileCollection $coverageExcludeFiles, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $ignoreCoversAnnotation, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $registerMockObjectsFromTestArgumentsRecursively, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php)
     {
         $this->cliArgument                                     = $cliArgument;
         $this->configurationFile                               = $configurationFile;
@@ -197,6 +198,7 @@ final class Configuration
         $this->timeoutForLargeTests                            = $timeoutForLargeTests;
         $this->reportUselessTests                              = $reportUselessTests;
         $this->strictCoverage                                  = $strictCoverage;
+        $this->ignoreCoversAnnotation                          = $ignoreCoversAnnotation;
         $this->disallowTestOutput                              = $disallowTestOutput;
         $this->displayDetailsOnIncompleteTests                 = $displayDetailsOnIncompleteTests;
         $this->displayDetailsOnSkippedTests                    = $displayDetailsOnSkippedTests;
@@ -776,6 +778,11 @@ final class Configuration
     public function strictCoverage(): bool
     {
         return $this->strictCoverage;
+    }
+
+    public function ignoreCoversAnnotation(): bool
+    {
+        return $this->ignoreCoversAnnotation;
     }
 
     public function disallowTestOutput(): bool

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -402,6 +402,12 @@ final class Merger
             $strictCoverage = $xmlConfiguration->phpunit()->beStrictAboutCoverageMetadata();
         }
 
+        if ($cliConfiguration->hasIgnoreCoversAnnotation()) {
+            $ignoreCoversAnnotation = $cliConfiguration->ignoreCoversAnnotation();
+        } else {
+            $ignoreCoversAnnotation = $xmlConfiguration->phpunit()->beIgnoreCoversAnnotation();
+        }
+
         if ($cliConfiguration->hasDisallowTestOutput()) {
             $disallowTestOutput = $cliConfiguration->disallowTestOutput();
         } else {
@@ -735,6 +741,7 @@ final class Merger
             $timeoutForLargeTests,
             $reportUselessTests,
             $strictCoverage,
+            $ignoreCoversAnnotation,
             $disallowTestOutput,
             $displayDetailsOnIncompleteTests,
             $displayDetailsOnSkippedTests,

--- a/src/TextUI/Configuration/Xml/DefaultConfiguration.php
+++ b/src/TextUI/Configuration/Xml/DefaultConfiguration.php
@@ -110,6 +110,7 @@ final class DefaultConfiguration extends Configuration
                 true,
                 false,
                 false,
+                false,
                 1,
                 1,
                 10,

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -767,6 +767,7 @@ final class Loader
             $this->getBooleanAttribute($document->documentElement, 'beStrictAboutOutputDuringTests', false),
             $this->getBooleanAttribute($document->documentElement, 'beStrictAboutTestsThatDoNotTestAnything', true),
             $beStrictAboutCoverageMetadata,
+            $this->getBooleanAttribute($document->documentElement, 'beIgnoreCoversAttribute', false),
             $this->getBooleanAttribute($document->documentElement, 'enforceTimeLimit', false),
             $this->getIntegerAttribute($document->documentElement, 'defaultTimeLimit', 1),
             $this->getIntegerAttribute($document->documentElement, 'timeoutForSmallTests', 1),

--- a/src/TextUI/Configuration/Xml/PHPUnit.php
+++ b/src/TextUI/Configuration/Xml/PHPUnit.php
@@ -49,6 +49,7 @@ final class PHPUnit
     private readonly bool $beStrictAboutOutputDuringTests;
     private readonly bool $beStrictAboutTestsThatDoNotTestAnything;
     private readonly bool $beStrictAboutCoverageMetadata;
+    private readonly bool $beIgnoreCoversAnnotation;
     private readonly bool $enforceTimeLimit;
     private readonly int $defaultTimeLimit;
     private readonly int $timeoutForSmallTests;
@@ -63,7 +64,7 @@ final class PHPUnit
     private readonly bool $registerMockObjectsFromTestArgumentsRecursively;
     private readonly bool $testdoxPrinter;
 
-    public function __construct(?string $cacheDirectory, bool $cacheResult, ?string $cacheResultFile, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $registerMockObjectsFromTestArgumentsRecursively, bool $testdoxPrinter)
+    public function __construct(?string $cacheDirectory, bool $cacheResult, ?string $cacheResultFile, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnError, bool $stopOnFailure, bool $stopOnWarning, bool $stopOnIncomplete, bool $stopOnRisky, bool $stopOnSkipped, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $beIgnoreCoversAnnotation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $registerMockObjectsFromTestArgumentsRecursively, bool $testdoxPrinter)
     {
         $this->cacheDirectory                                  = $cacheDirectory;
         $this->cacheResult                                     = $cacheResult;
@@ -98,6 +99,7 @@ final class PHPUnit
         $this->beStrictAboutOutputDuringTests                  = $beStrictAboutOutputDuringTests;
         $this->beStrictAboutTestsThatDoNotTestAnything         = $beStrictAboutTestsThatDoNotTestAnything;
         $this->beStrictAboutCoverageMetadata                   = $beStrictAboutCoverageMetadata;
+        $this->beIgnoreCoversAnnotation                        = $beIgnoreCoversAnnotation;
         $this->enforceTimeLimit                                = $enforceTimeLimit;
         $this->defaultTimeLimit                                = $defaultTimeLimit;
         $this->timeoutForSmallTests                            = $timeoutForSmallTests;
@@ -340,6 +342,11 @@ final class PHPUnit
     public function beStrictAboutCoverageMetadata(): bool
     {
         return $this->beStrictAboutCoverageMetadata;
+    }
+
+    public function beIgnoreCoversAnnotation(): bool
+    {
+        return $this->beIgnoreCoversAnnotation;
     }
 
     public function enforceTimeLimit(): bool

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -68,6 +68,7 @@ final class Help
             ['spacer' => ''],
 
             ['arg'    => '--strict-coverage', 'desc' => 'Be strict about code coverage metadata'],
+            ['arg'    => '--ignore-covers-annotation', 'desc' => 'Be ignore covers annotation'],
             ['arg'    => '--strict-global-state', 'desc' => 'Be strict about changes to global state'],
             ['arg'    => '--disallow-test-output', 'desc' => 'Be strict about output during tests'],
             ['arg'    => '--enforce-time-limit', 'desc' => 'Enforce time limit based on test size'],

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -44,6 +44,7 @@
                                    each test
 
   [32m--strict-coverage               [0m Be strict about code coverage metadata
+  [32m--ignore-covers-annotation      [0m Be ignore covers annotation
   [32m--strict-global-state           [0m Be strict about changes to global state
   [32m--disallow-test-output          [0m Be strict about output during tests
   [32m--enforce-time-limit            [0m Enforce time limit based on test size

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -38,6 +38,7 @@ Execution:
   --static-backup                  Backup and restore static properties for each test
 
   --strict-coverage                Be strict about code coverage metadata
+  --ignore-covers-annotation       Be ignore covers annotation
   --strict-global-state            Be strict about changes to global state
   --disallow-test-output           Be strict about output during tests
   --enforce-time-limit             Enforce time limit based on test size


### PR DESCRIPTION
Option to ignore [@covers](https://docs.phpunit.de/en/9.5/annotations.html#covers) annotation.

Postponed by https://github.com/sebastianbergmann/php-code-coverage/pull/986