### PR TITLE
StringContains: bug fix for ignoring line endings

### DIFF
--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -27,6 +27,10 @@ final class StringContains extends Constraint
 
     public function __construct(string $string, bool $ignoreCase = false, bool $ignoreLineEndings = false)
     {
+        if ($ignoreLineEndings) {
+            $string = $this->normalizeLineEndings($string);
+        }
+
         $this->string            = $string;
         $this->ignoreCase        = $ignoreCase;
         $this->ignoreLineEndings = $ignoreLineEndings;
@@ -41,10 +45,6 @@ final class StringContains extends Constraint
 
         if ($this->ignoreCase) {
             $string = mb_strtolower($this->string, 'UTF-8');
-        }
-
-        if ($this->ignoreLineEndings) {
-            $string = $this->normalizeLineEndings($string);
         }
 
         return sprintf(

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -62,10 +62,37 @@ final class StringContainsTest extends TestCase
             [
                 true,
                 '',
+                true,
+                false,
+                'SUBSTRING',
+                'prefix substring suffix',
+            ],
+
+            [
+                true,
+                '',
                 false,
                 true,
                 "substring\n",
                 "prefix substring\r\n suffix",
+            ],
+
+            [
+                true,
+                '',
+                false,
+                true,
+                "substring\r suffix",
+                "prefix substring\n suffix",
+            ],
+
+            [
+                true,
+                '',
+                false,
+                true,
+                "substring\r\n suffix",
+                "prefix substring\r suffix",
             ],
 
             [


### PR DESCRIPTION
As things were, at the time of the comparison, only the line endings of the `$haystack` were normalized, not the line endings of the `$needle`, which led to false negatives.

Fixed now.

Includes additional tests demonstrating the issue and safeguarding the fix.

Includes a similar additional test for the case-insensitivity check, which did not have this issue, but wasn't being safeguarded against it either.