### PR TITLE
Enhancement: Dump all required and unavailable extensions at once

### DIFF
--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -30,21 +30,27 @@ if (version_compare('7.3.0', PHP_VERSION, '>')) {
     die(1);
 }
 
-foreach (['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'] as $extension) {
-    if (extension_loaded($extension)) {
-        continue;
-    }
+$requiredExtensions = ['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
 
+$unavailableExtensions = array_filter($requiredExtensions, static function ($extension) {
+    return !extension_loaded($extension);
+});
+
+if ([] !== $unavailableExtensions) {
     fwrite(
         STDERR,
         sprintf(
-            'PHPUnit requires the "%s" extension.' . PHP_EOL,
-            $extension
+            'PHPUnit requires the "%s" extensions, but the "%s" %s not available.' . PHP_EOL,
+            count($unavailableExtensions) === 1 ? 'extension is' : 'extensions are',
+            implode('", "', $requiredExtensions),
+            implode('", "', $unavailableExtensions)
         )
     );
 
     die(1);
 }
+
+unset($requiredExtensions, $unavailableExtensions);
 
 if (__FILE__ === realpath($_SERVER['SCRIPT_NAME'])) {
     $execute = true;

--- a/phpunit
+++ b/phpunit
@@ -38,21 +38,27 @@ if (version_compare('7.3.0', PHP_VERSION, '>')) {
     die(1);
 }
 
-foreach (['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'] as $extension) {
-    if (extension_loaded($extension)) {
-        continue;
-    }
+$requiredExtensions = ['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
 
+$unavailableExtensions = array_filter($requiredExtensions, static function ($extension) {
+    return !extension_loaded($extension);
+});
+
+if ([] !== $unavailableExtensions) {
     fwrite(
         STDERR,
         sprintf(
-            'PHPUnit requires the "%s" extension.' . PHP_EOL,
-            $extension
+            'PHPUnit requires the "%s" extensions, but the "%s" %s not available.' . PHP_EOL,
+            count($unavailableExtensions) === 1 ? 'extension is' : 'extensions are',
+            implode('", "', $requiredExtensions),
+            implode('", "', $unavailableExtensions)
         )
     );
 
     die(1);
 }
+
+unset($requiredExtensions, $unavailableExtensions);
 
 if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');


### PR DESCRIPTION
This pull request

- [x] dumps all required and unavailable extensions at once

💁‍♂️ This could be helpful, for example, when using GitHub Actions and setting up PHP with `shivammathur/setup-php` and disabling all extensions except for those that are actually required, as you can identify all unavailable extensions in one go.