### PR TITLE
Use temporary file (instead of STDOUT) to communicate result from child process to parent process

### DIFF
--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -300,12 +300,13 @@ final class TestRunner
         $includePath     = var_export(get_include_path(), true);
         // must do these fixes because TestCaseMethod.tpl has unserialize('{data}') in it, and we can't break BC
         // the lines above used to use addcslashes() rather than var_export(), which breaks null byte escape sequences
-        $data                    = "'." . $data . ".'";
-        $dataName                = "'.(" . $dataName . ").'";
-        $dependencyInput         = "'." . $dependencyInput . ".'";
-        $includePath             = "'." . $includePath . ".'";
-        $offset                  = hrtime();
-        $serializedConfiguration = $this->saveConfigurationForChildProcess();
+        $data                          = "'." . $data . ".'";
+        $dataName                      = "'.(" . $dataName . ").'";
+        $dependencyInput               = "'." . $dependencyInput . ".'";
+        $includePath                   = "'." . $includePath . ".'";
+        $offset                        = hrtime();
+        $serializedConfiguration       = $this->saveConfigurationForChildProcess();
+        $fileWithSerializedChildResult = tempnam(sys_get_temp_dir(), 'phpunit_');
 
         $var = [
             'bootstrap'                      => $bootstrap,
@@ -327,6 +328,7 @@ final class TestRunner
             'offsetSeconds'                  => $offset[0],
             'offsetNanoseconds'              => $offset[1],
             'serializedConfiguration'        => $serializedConfiguration,
+            'fileWithSerializedChildResult'  => $fileWithSerializedChildResult,
         ];
 
         if (!$runEntireClass) {
@@ -336,7 +338,7 @@ final class TestRunner
         $template->setVar($var);
 
         $php = AbstractPhpProcess::factory();
-        $php->runTestJob($template->render(), $test);
+        $php->runTestJob($template->render(), $test, $fileWithSerializedChildResult);
 
         @unlink($serializedConfiguration);
     }

--- a/src/Util/PHP/Template/TestCaseMethod.tpl
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl
@@ -21,8 +21,6 @@ set_include_path('{include_path}');
 $composerAutoload = {composerAutoload};
 $phar             = {phar};
 
-ob_start();
-
 if ($composerAutoload) {
     require_once $composerAutoload;
 
@@ -53,17 +51,11 @@ function __phpunit_run_isolated_test()
     $test->setDependencyInput(unserialize('{dependencyInput}'));
     $test->setInIsolation(true);
 
-    ob_end_clean();
-
     $test->run();
 
-    $output = '';
-
-    if (!$test->hasExpectationOnOutput()) {
-        $output = $test->output();
-    }
-
     ini_set('xdebug.scream', '0');
+
+    $output = $test->hasUnexpectedOutput() ? $test->output() : '';
 
     // Not every STDOUT target stream is rewindable
     @rewind(STDOUT);
@@ -78,15 +70,18 @@ function __phpunit_run_isolated_test()
         }
     }
 
-    print serialize(
-        [
-            'testResult'    => $test->result(),
-            'codeCoverage'  => {collectCodeCoverageInformation} ? CodeCoverage::instance()->codeCoverage() : null,
-            'numAssertions' => $test->numberOfAssertionsPerformed(),
-            'output'        => $output,
-            'events'        => $dispatcher->flush(),
-            'passedTests'   => PassedTests::instance()
-        ]
+    file_put_contents(
+        '{fileWithSerializedChildResult}',
+        serialize(
+            [
+                'testResult'    => $test->result(),
+                'output'        => $output,
+                'codeCoverage'  => {collectCodeCoverageInformation} ? CodeCoverage::instance()->codeCoverage() : null,
+                'numAssertions' => $test->numberOfAssertionsPerformed(),
+                'events'        => $dispatcher->flush(),
+                'passedTests'   => PassedTests::instance()
+            ]
+        )
     );
 }
 


### PR DESCRIPTION
I recently worked with an application that used an unusual combination of [output buffering](https://www.php.net/manual/en/book.outcontrol.php), [custom error handling](https://www.php.net/manual/de/function.set-error-handler.php), [custom exception handling](https://www.php.net/manual/de/function.set-exception-handler.php), and [custom shutdown handling](https://www.php.net/manual/de/function.register-shutdown-function.php).

The way this application works got in the way of writing edge-to-edge [characterization tests](https://thephp.cc/topics/characterization-tests) for the application: trying to run such a test in a separate PHP process (using PHPUnit's process isolation functionality) did not work.

The application's custom error handler acted on `E_DEPRECATED` events emitted by the PHP interpreter for code generated by PHPUnit. This was taken care of in #5270.

The application's use of output buffering interfered with the way that PHPUnit currently communicated results from a child process to the parent process.

These changes made PHPUnit's process isolation functionality work in the context of that application. They also do not break any existing test. However, they feel like a short-term solution for an edge case problem.

Considering other problems such as #5230, I would much rather completely rethink how process isolation should work.