### PR TITLE
Fail run with invalid data providers

### DIFF
--- a/tests/end-to-end/event/_files/InvalidDataProviderWithOneTestPassingTest.php
+++ b/tests/end-to-end/event/_files/InvalidDataProviderWithOneTestPassingTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event;
+
+use PHPUnit\Framework\TestCase;
+
+final class InvalidDataProviderWithOneTestPassingTest extends TestCase
+{
+    public static function provider(): array
+    {
+        return [0];
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
+++ b/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
@@ -1,0 +1,47 @@
+--TEST--
+The right events are emitted in the right order for a test that uses a data provider that returns an invalid array
+--SKIPIF--
+<?php declare(strict_types=1);
+if (DIRECTORY_SEPARATOR === '\\') {
+    print "skip: this test does not work on Windows / GitHub Actions\n";
+}
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = __DIR__ . '/_files/InvalidDataProviderWithOneTestPassingTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne)
+The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
+Data set #0 is invalid
+
+Test Suite Loaded (1 test)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testTwo)
+Test Prepared (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testTwo)
+Assertion Succeeded (Constraint: is true, Value: true)
+Test Passed (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testTwo)
+Test Finished (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testTwo)
+Test Suite Finished (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 1)


### PR DESCRIPTION
Before continuing with this, I assume the current behaviour is indeed wrong, @sebastianbergmann? This test currently fails with:
```diff
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 0)
```

What it means is, if you have a test with invalid/missing data provider and another one that is passing, the whole run is considered success.