### PR TITLE
Update deprecation notices for assertObject[Not]HasAttribute() in PHPUnit 9.6 once PHPUnit 10.1 has been released

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1304,7 +1304,7 @@ abstract class Assert
      */
     public static function assertObjectHasAttribute(string $attributeName, $object, string $message = ''): void
     {
-        self::createWarning('assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10.');
+        self::createWarning('assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectHasProperty() (PHPUnit 10.1.0+) instead.');
 
         if (!self::isValidObjectAttributeName($attributeName)) {
             throw InvalidArgumentException::create(1, 'valid attribute name');
@@ -1334,7 +1334,7 @@ abstract class Assert
      */
     public static function assertObjectNotHasAttribute(string $attributeName, $object, string $message = ''): void
     {
-        self::createWarning('assertObjectNotHasAttribute() is deprecated and will be removed in PHPUnit 10.');
+        self::createWarning('assertObjectNotHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectNotHasProperty() (PHPUnit 10.1.0+) instead.');
 
         if (!self::isValidObjectAttributeName($attributeName)) {
             throw InvalidArgumentException::create(1, 'valid attribute name');


### PR DESCRIPTION
... now PHPUnit 10.1.0 introduces the `assertObjectHasProperty()` and `assertObjectNotHasProperty()` methods.

Refs:
* https://github.com/sebastianbergmann/phpunit/pull/5231
* https://github.com/sebastianbergmann/phpunit/commit/f18856ceaffe531e45668f13ac926ad84b75a790


---

Note: probably best to merge just before the 10.1.0 release ?