### PR TITLE
Constraint/ObjectHasProperty: improve non-object handling in failure description

### DIFF
--- a/src/Framework/Constraint/Object/ObjectHasProperty.php
+++ b/src/Framework/Constraint/Object/ObjectHasProperty.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
+use function gettype;
 use function is_object;
 use function sprintf;
 use ReflectionObject;
@@ -61,10 +62,18 @@ final class ObjectHasProperty extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
+        if (is_object($other)) {
+            return sprintf(
+                'object of class "%s" %s',
+                $other::class,
+                $this->toString()
+            );
+        }
+
         return sprintf(
-            '%sclass "%s" %s',
-            is_object($other) ? 'object of ' : '',
-            is_object($other) ? $other::class : $other,
+            '"%s" (%s) %s',
+            $other,
+            gettype($other),
             $this->toString()
         );
     }

--- a/tests/unit/Framework/Constraint/Object/ObjectHasPropertyTest.php
+++ b/tests/unit/Framework/Constraint/Object/ObjectHasPropertyTest.php
@@ -36,6 +36,16 @@ final class ObjectHasPropertyTest extends TestCase
         $constraint->evaluate(new stdClass);
     }
 
+    public function testHandlesNonObjectsGracefully(): void
+    {
+        $constraint = new ObjectHasProperty('theProperty');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that "non-object" (string) has property "theProperty".');
+
+        $constraint->evaluate('non-object');
+    }
+
     public function testCanBeRepresentedAsString(): void
     {
         $constraint = new ObjectHasProperty('theProperty');


### PR DESCRIPTION
Fixes occurrences of "Failed asserting that class "non-object" has property "theProperty"." and makes the description more descriptive for non-objects.

Includes test safeguarding the change.