### PR TITLE
Constraint/logicalNot: bug fix - prevent weird replacement

### DIFF
--- a/src/Framework/Constraint/LogicalNot.php
+++ b/src/Framework/Constraint/LogicalNot.php
@@ -29,7 +29,7 @@ final class LogicalNot extends Constraint
     {
         $positives = [
             'contains ',
-            'exists',
+            ' exists',
             'has ',
             'is ',
             'are ',
@@ -42,7 +42,7 @@ final class LogicalNot extends Constraint
 
         $negatives = [
             'does not contain ',
-            'does not exist',
+            ' does not exist',
             'does not have ',
             'is not ',
             'are not ',


### PR DESCRIPTION
If a value passed to an assertion would have `exists` in it, it would get replaced by `does not exist` leading to weird error messages.

Fixed now.

I have a test for this, but as this code isn't tested in the 8.5 branch, I will pull the test separately and to the `main` branch.