### PR TITLE
Fix: Adjust order of values when assembling error message

### DIFF
--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -44,9 +44,9 @@ if ([] !== $unavailableExtensions) {
         STDERR,
         sprintf(
             'PHPUnit requires the "%s" extensions, but the "%s" %s not available.' . PHP_EOL,
-            count($unavailableExtensions) === 1 ? 'extension is' : 'extensions are',
             implode('", "', $requiredExtensions),
-            implode('", "', $unavailableExtensions)
+            implode('", "', $unavailableExtensions),
+            count($unavailableExtensions) === 1 ? 'extension is' : 'extensions are'
         )
     );
 

--- a/phpunit
+++ b/phpunit
@@ -52,9 +52,9 @@ if ([] !== $unavailableExtensions) {
         STDERR,
         sprintf(
             'PHPUnit requires the "%s" extensions, but the "%s" %s not available.' . PHP_EOL,
-            count($unavailableExtensions) === 1 ? 'extension is' : 'extensions are',
             implode('", "', $requiredExtensions),
-            implode('", "', $unavailableExtensions)
+            implode('", "', $unavailableExtensions),
+            count($unavailableExtensions) === 1 ? 'extension is' : 'extensions are'
         )
     );
 


### PR DESCRIPTION
This pull request

- [x] adjusts the order of values for assembling the error message when required extensions are unavailable

Fixes #5322.
Follows #5281.