### PR TITLE
Provide distinct messages when a test is considered risky due to output buffering level mismatch

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1655,8 +1655,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         if ($bufferingLevel !== $this->outputBufferingLevel) {
             if ($bufferingLevel > $this->outputBufferingLevel) {
                 $message = 'Test code or tested code did not close its own output buffers';
-            }
-            else {
+            } else {
                 $message = 'Test code or tested code closed output buffers other than its own';
             }
 

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1650,12 +1650,19 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      */
     private function stopOutputBuffering(): bool
     {
-        if (ob_get_level() !== $this->outputBufferingLevel) {
+        $bufferingLevel = ob_get_level();
+
+        if ($bufferingLevel !== $this->outputBufferingLevel) {
+            if ($bufferingLevel > $this->outputBufferingLevel) {
+                $message = 'Test code or tested code did not close its own output buffers';
+            }
+            else {
+                $message = 'Test code or tested code closed output buffers other than its own';
+            }
+
             while (ob_get_level() >= $this->outputBufferingLevel) {
                 ob_end_clean();
             }
-
-            $message = 'Test code or tested code did not (only) close its own output buffers';
 
             Event\Facade::emitter()->testConsideredRisky(
                 $this->valueObjectForEvents(),

--- a/tests/end-to-end/regression/1437.phpt
+++ b/tests/end-to-end/regression/1437.phpt
@@ -29,7 +29,7 @@ Failed asserting that false is true.
 There was 1 risky test:
 
 1) PHPUnit\TestFixture\Issue1437Test::testFailure
-Test code or tested code did not (only) close its own output buffers
+Test code or tested code did not close its own output buffers
 
 %sIssue1437Test.php:%i
 

--- a/tests/end-to-end/regression/5342.phpt
+++ b/tests/end-to-end/regression/5342.phpt
@@ -1,0 +1,37 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/1437
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/5342/Issue5342Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+F                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 failure:
+
+1) PHPUnit\TestFixture\Issue5342Test::testFailure
+Failed asserting that false is true.
+
+%sIssue5342Test.php:%i
+
+--
+
+There was 1 risky test:
+
+1) PHPUnit\TestFixture\Issue5342Test::testFailure
+Test code or tested code closed output buffers other than its own
+
+%sIssue5342Test.php:%i
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1, Risky: 1.

--- a/tests/end-to-end/regression/5342/Issue5342Test.php
+++ b/tests/end-to-end/regression/5342/Issue5342Test.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\TestFixture;
 
-use function ob_start;
+use function ob_end_clean;
 use PHPUnit\Framework\TestCase;
 
 class Issue5342Test extends TestCase

--- a/tests/end-to-end/regression/5342/Issue5342Test.php
+++ b/tests/end-to-end/regression/5342/Issue5342Test.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use function ob_start;
+use PHPUnit\Framework\TestCase;
+
+class Issue5342Test extends TestCase
+{
+    public function testFailure(): void
+    {
+        ob_end_clean();
+        $this->assertTrue(false);
+    }
+}


### PR DESCRIPTION
Currently, a test is marked risky if it didn't close its output buffer OR if it closed additional output buffers.

This PR will give the developer granularity to see which of the two cases caused the issue.