### PR TITLE
Add stack trace for previous exceptions to bootstrap error message

### DIFF
--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -568,15 +568,30 @@ class Command
                 $this->exitWithErrorMessage($t->getMessage());
             }
 
-            $this->exitWithErrorMessage(
-                sprintf(
-                    'Error in bootstrap script: %s:%s%s%s%s',
+            $message = sprintf(
+                'Error in bootstrap script: %s:%s%s%s%s',
+                get_class($t),
+                PHP_EOL,
+                $t->getMessage(),
+                PHP_EOL,
+                $t->getTraceAsString()
+            );
+
+            while ($t = $t->getPrevious()) {
+                $message .= sprintf(
+                    '%s%sPrevious error: %s:%s%s%s%s',
+                    PHP_EOL,
+                    PHP_EOL,
                     get_class($t),
                     PHP_EOL,
                     $t->getMessage(),
                     PHP_EOL,
-                    $t->getTraceAsString()
-                )
+                    $t->getTraceAsString(),
+                );
+            }
+
+            $this->exitWithErrorMessage(
+                $message
             );
         }
     }

--- a/tests/end-to-end/regression/4620.phpt
+++ b/tests/end-to-end/regression/4620.phpt
@@ -19,3 +19,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Error in bootstrap script: PHPUnit\TestFixture\MyException:
 Big boom. Big bada boom.
 %a
+
+Previous error: Exception:
+Previous boom.
+%a

--- a/tests/end-to-end/regression/4620/bootstrap.php
+++ b/tests/end-to-end/regression/4620/bootstrap.php
@@ -15,4 +15,4 @@ final class MyException extends Exception
 {
 }
 
-throw new MyException('Big boom. Big bada boom.');
+throw new MyException('Big boom. Big bada boom.', 0, new Exception('Previous boom.'));


### PR DESCRIPTION
Addendum to #4620 and #4878.
Closes #5345

Adds previous exception stacktraces into the output, until there is no more left.
```shell
 Error in bootstrap script: PHPUnit\TestFixture\MyException:
 Big boom. Big bada boom.
 #0 /home/pniedzielski/PhpstormProjects/phpunit/src/Util/FileLoader.php(66): include_once()
 #1 /home/pniedzielski/PhpstormProjects/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load()
 #2 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(565): PHPUnit\Util\FileLoader::checkAndLoad()
 #3 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(402): PHPUnit\TextUI\Command->handleBootstrap()
 #4 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(112): PHPUnit\TextUI\Command->handleArguments()
 #5 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(97): PHPUnit\TextUI\Command->run()
 #6 Standard input code(11): PHPUnit\TextUI\Command::main()
 #7 {main}
 
 Previous exception: Exception:
 Previous boom.
 #0 /home/pniedzielski/PhpstormProjects/phpunit/src/Util/FileLoader.php(66): include_once()
 #1 /home/pniedzielski/PhpstormProjects/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load()
 #2 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(565): PHPUnit\Util\FileLoader::checkAndLoad()
 #3 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(402): PHPUnit\TextUI\Command->handleBootstrap()
 #4 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(112): PHPUnit\TextUI\Command->handleArguments()
 #5 /home/pniedzielski/PhpstormProjects/phpunit/src/TextUI/Command.php(97): PHPUnit\TextUI\Command->run()
 #6 Standard input code(11): PHPUnit\TextUI\Command::main()
 #7 {main}
```