### PR TITLE
Fix: Remove condition that always evaluates to `true`

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -562,12 +562,6 @@
       <code><![CDATA[$this->sortBySize($suite->tests())]]></code>
       <code><![CDATA[$this->sortDefectsFirst($suite->tests())]]></code>
     </ArgumentTypeCoercion>
-    <RedundantCondition>
-      <code><![CDATA[$order === self::ORDER_DURATION && $this->cache !== null]]></code>
-      <code><![CDATA[$orderDefects === self::ORDER_DEFECTS_FIRST && $this->cache !== null]]></code>
-      <code><![CDATA[$this->cache !== null]]></code>
-      <code><![CDATA[$this->cache !== null]]></code>
-    </RedundantCondition>
   </file>
   <file src="src/TextUI/Application.php">
     <InternalMethod>

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -156,13 +156,13 @@ final class TestSuiteSorter
             $suite->setTests($this->reverse($suite->tests()));
         } elseif ($order === self::ORDER_RANDOMIZED) {
             $suite->setTests($this->randomize($suite->tests()));
-        } elseif ($order === self::ORDER_DURATION && $this->cache !== null) {
+        } elseif ($order === self::ORDER_DURATION) {
             $suite->setTests($this->sortByDuration($suite->tests()));
         } elseif ($order === self::ORDER_SIZE) {
             $suite->setTests($this->sortBySize($suite->tests()));
         }
 
-        if ($orderDefects === self::ORDER_DEFECTS_FIRST && $this->cache !== null) {
+        if ($orderDefects === self::ORDER_DEFECTS_FIRST) {
             $suite->setTests($this->sortDefectsFirst($suite->tests()));
         }
 


### PR DESCRIPTION
This pull request

- [x] removes a condition that always evaluates to `true`

💁‍♂️ For reference, see the declaration of the `$cache` field in `TestSuiteSorter`:

https://github.com/sebastianbergmann/phpunit/blob/833302ab1daf9721bb13d76f71685075b8f8d1ee/src/Runner/TestSuiteSorter.php#L75