### PR TITLE
Fix Psalm baseline issues

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -834,13 +834,6 @@
       <code><![CDATA[$this->stream]]></code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="src/Util/ExcludeList.php">
-    <InvalidPropertyAssignmentValue>
-      <code>self::$directories</code>
-      <code>self::$directories</code>
-      <code>self::$directories</code>
-    </InvalidPropertyAssignmentValue>
-  </file>
   <file src="src/Util/PHP/DefaultPhpProcess.php">
     <DocblockTypeContradiction>
       <code>is_array($envVar)</code>

--- a/src/Util/ExcludeList.php
+++ b/src/Util/ExcludeList.php
@@ -147,11 +147,11 @@ final class ExcludeList
      */
     public static function addDirectory(string $directory): void
     {
-        if (!is_dir($directory)) {
+        if (!is_dir($directory) || ($realPath = realpath($directory)) === false) {
             throw new InvalidDirectoryException($directory);
         }
 
-        self::$directories[] = realpath($directory);
+        self::$directories[] = $realPath;
     }
 
     public function __construct(?bool $enabled = null)
@@ -202,6 +202,9 @@ final class ExcludeList
             }
 
             $directory = (new ReflectionClass($className))->getFileName();
+            if ($directory === false) {
+                continue;
+            }
 
             for ($i = 0; $i < $parent; $i++) {
                 $directory = dirname($directory);


### PR DESCRIPTION
Fix the InvalidPropertyAssignmentValue psalm issue in the \PHPUnit\Util\ExcludeList class

For the #4093