### PR TITLE
make attribute CoverFunction available for setting on methods

### DIFF
--- a/src/Framework/Attributes/CoversFunction.php
+++ b/src/Framework/Attributes/CoversFunction.php
@@ -16,7 +16,7 @@ use Attribute;
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
 final class CoversFunction
 {
     /**


### PR DESCRIPTION
```php
    #[CoversFunction('DummyClass::foo')]
    public function testSomething()
    {
        // ..
    }
```