### PR TITLE
Use different exit codes for different failuretypes when exiting for these is requested

### DIFF
--- a/src/TextUI/ShellExitCodeCalculator.php
+++ b/src/TextUI/ShellExitCodeCalculator.php
@@ -19,6 +19,14 @@ final class ShellExitCodeCalculator
     private const SUCCESS_EXIT   = 0;
     private const FAILURE_EXIT   = 1;
     private const EXCEPTION_EXIT = 2;
+    private const FAILURE_EXIT_DEPRECATIONS = 101;
+    private const FAILURE_EXIT_INCOMPLETE = 102;
+    private const FAILURE_EXIT_NOTICE = 103;
+    private const FAILURE_EXIT_RISKY = 104;
+    private const FAILURE_EXIT_SKIPPED = 105;
+    private const FAILURE_EXIT_WARNING = 106;
+
+
 
     public function calculate(bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, TestResult $result): int
     {
@@ -34,27 +42,27 @@ final class ShellExitCodeCalculator
 
         if ($result->wasSuccessfulIgnoringPhpunitWarnings()) {
             if ($failOnDeprecation && ($result->hasTestTriggeredDeprecationEvents() || $result->hasTestTriggeredPhpDeprecationEvents() || $result->hasTestTriggeredPhpunitDeprecationEvents())) {
-                $returnCode = self::FAILURE_EXIT;
+                $returnCode = self::FAILURE_EXIT_DEPRECATIONS;
             }
 
             if ($failOnIncomplete && $result->hasTestMarkedIncompleteEvents()) {
-                $returnCode = self::FAILURE_EXIT;
+                $returnCode = self::FAILURE_EXIT_INCOMPLETE;
             }
 
             if ($failOnNotice && ($result->hasTestTriggeredNoticeEvents() || $result->hasTestTriggeredPhpNoticeEvents())) {
-                $returnCode = self::FAILURE_EXIT;
+                $returnCode = self::FAILURE_EXIT_NOTICE;
             }
 
             if ($failOnRisky && $result->hasTestConsideredRiskyEvents()) {
-                $returnCode = self::FAILURE_EXIT;
+                $returnCode = self::FAILURE_EXIT_RISKY;
             }
 
             if ($failOnSkipped && $result->hasTestSkippedEvents()) {
-                $returnCode = self::FAILURE_EXIT;
+                $returnCode = self::FAILURE_EXIT_SKIPPED;
             }
 
             if ($failOnWarning && $result->hasWarningEvents()) {
-                $returnCode = self::FAILURE_EXIT;
+                $returnCode = self::FAILURE_EXIT_WARNING;
             }
         }
 

--- a/src/TextUI/ShellExitCodeCalculator.php
+++ b/src/TextUI/ShellExitCodeCalculator.php
@@ -16,17 +16,15 @@ use PHPUnit\TestRunner\TestResult\TestResult;
  */
 final class ShellExitCodeCalculator
 {
-    private const SUCCESS_EXIT   = 0;
-    private const FAILURE_EXIT   = 1;
-    private const EXCEPTION_EXIT = 2;
+    private const SUCCESS_EXIT              = 0;
+    private const FAILURE_EXIT              = 1;
+    private const EXCEPTION_EXIT            = 2;
     private const FAILURE_EXIT_DEPRECATIONS = 101;
-    private const FAILURE_EXIT_INCOMPLETE = 102;
-    private const FAILURE_EXIT_NOTICE = 103;
-    private const FAILURE_EXIT_RISKY = 104;
-    private const FAILURE_EXIT_SKIPPED = 105;
-    private const FAILURE_EXIT_WARNING = 106;
-
-
+    private const FAILURE_EXIT_INCOMPLETE   = 102;
+    private const FAILURE_EXIT_NOTICE       = 103;
+    private const FAILURE_EXIT_RISKY        = 104;
+    private const FAILURE_EXIT_SKIPPED      = 105;
+    private const FAILURE_EXIT_WARNING      = 106;
 
     public function calculate(bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, TestResult $result): int
     {

--- a/tests/end-to-end/cli/fail-on/fail-on-deprecation.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-deprecation.phpt
@@ -48,4 +48,4 @@ Test Finished (PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest::testTwo)
 Test Suite Finished (PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 101)

--- a/tests/end-to-end/cli/fail-on/fail-on-incomplete.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-incomplete.phpt
@@ -46,4 +46,4 @@ Test Finished (PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest::testTwo)
 Test Suite Finished (PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 102)

--- a/tests/end-to-end/cli/fail-on/fail-on-notice.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-notice.phpt
@@ -48,4 +48,4 @@ Test Finished (PHPUnit\TestFixture\TestRunnerStopping\NoticeTest::testTwo)
 Test Suite Finished (PHPUnit\TestFixture\TestRunnerStopping\NoticeTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 103)

--- a/tests/end-to-end/cli/fail-on/fail-on-risky.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-risky.phpt
@@ -47,4 +47,4 @@ Test Finished (PHPUnit\TestFixture\TestRunnerStopping\RiskyTest::testTwo)
 Test Suite Finished (PHPUnit\TestFixture\TestRunnerStopping\RiskyTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 104)

--- a/tests/end-to-end/cli/fail-on/fail-on-skipped.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-skipped.phpt
@@ -46,4 +46,4 @@ Test Finished (PHPUnit\TestFixture\TestRunnerStopping\SkippedTest::testTwo)
 Test Suite Finished (PHPUnit\TestFixture\TestRunnerStopping\SkippedTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 105)

--- a/tests/end-to-end/cli/fail-on/fail-on-warning.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-warning.phpt
@@ -48,4 +48,4 @@ Test Finished (PHPUnit\TestFixture\TestRunnerStopping\WarningTest::testTwo)
 Test Suite Finished (PHPUnit\TestFixture\TestRunnerStopping\WarningTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 106)

--- a/tests/end-to-end/event/php-deprecated.phpt
+++ b/tests/end-to-end/event/php-deprecated.phpt
@@ -51,4 +51,4 @@ Test Finished (PHPUnit\TestFixture\Event\DeprecatedPhpFeatureTest::testDeprecate
 Test Suite Finished (PHPUnit\TestFixture\Event\DeprecatedPhpFeatureTest, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 101)

--- a/tests/end-to-end/event/php-notice.phpt
+++ b/tests/end-to-end/event/php-notice.phpt
@@ -45,4 +45,4 @@ Test Finished (PHPUnit\TestFixture\Event\PhpNoticeTest::testPhpNotice)
 Test Suite Finished (PHPUnit\TestFixture\Event\PhpNoticeTest, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 103)

--- a/tests/end-to-end/event/php-warning.phpt
+++ b/tests/end-to-end/event/php-warning.phpt
@@ -45,4 +45,4 @@ Test Finished (PHPUnit\TestFixture\Event\PhpWarningTest::testPhpWarning)
 Test Suite Finished (PHPUnit\TestFixture\Event\PhpWarningTest, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 1)
+PHPUnit Finished (Shell Exit Code: 106)


### PR DESCRIPTION
This PR implements an enhancement to ShellExitCodeCalculator to have different exit codes for different failure types