### PR TITLE
Control when PHP's garbage collector is triggered

### DIFF
--- a/ChangeLog-10.3.md
+++ b/ChangeLog-10.3.md
@@ -7,6 +7,7 @@ All notable changes of the PHPUnit 10.3 release series are documented in this fi
 ### Added
 
 * [#5428](https://github.com/sebastianbergmann/phpunit/issues/5428): Attribute `#[WithoutErrorHandler]` to disable PHPUnit's error handler for a test method
+* [#5368](https://github.com/sebastianbergmann/phpunit/pull/5368): Control when PHP's garbage collector is triggered
 * [#5431](https://github.com/sebastianbergmann/phpunit/pull/5431): Add more garbage collector details to event telemetry
 
 ### Changed

--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -172,6 +172,8 @@
         <xs:attribute name="cacheResultFile" type="xs:anyURI"/>
         <xs:attribute name="colors" type="xs:boolean" default="false"/>
         <xs:attribute name="columns" type="columnsType" default="80"/>
+        <xs:attribute name="controlGarbageCollector" type="xs:boolean" default="false"/>
+        <xs:attribute name="numberOfTestsBeforeGarbageCollection" type="xs:integer" default="100"/>
         <xs:attribute name="requireCoverageMetadata" type="xs:boolean" default="false"/>
         <xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
         <xs:attribute name="failOnDeprecation" type="xs:boolean" default="false"/>

--- a/src/Event/Emitter/DispatchingEmitter.php
+++ b/src/Event/Emitter/DispatchingEmitter.php
@@ -238,6 +238,28 @@ final class DispatchingEmitter implements Emitter
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
+    public function testRunnerDisabledGarbageCollection(): void
+    {
+        $this->dispatcher->dispatch(
+            new TestRunner\GarbageCollectionDisabled($this->telemetryInfo()),
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws UnknownEventTypeException
+     */
+    public function testRunnerTriggeredGarbageCollection(): void
+    {
+        $this->dispatcher->dispatch(
+            new TestRunner\GarbageCollectionTriggered($this->telemetryInfo()),
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws UnknownEventTypeException
+     */
     public function testSuiteSkipped(TestSuite $testSuite, string $message): void
     {
         $this->dispatcher->dispatch(
@@ -1054,6 +1076,17 @@ final class DispatchingEmitter implements Emitter
                 $this->telemetryInfo(),
                 $message,
             ),
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws UnknownEventTypeException
+     */
+    public function testRunnerEnabledGarbageCollection(): void
+    {
+        $this->dispatcher->dispatch(
+            new TestRunner\GarbageCollectionEnabled($this->telemetryInfo()),
         );
     }
 

--- a/src/Event/Emitter/Emitter.php
+++ b/src/Event/Emitter/Emitter.php
@@ -51,6 +51,10 @@ interface Emitter
 
     public function testRunnerExecutionStarted(TestSuite $testSuite): void;
 
+    public function testRunnerDisabledGarbageCollection(): void;
+
+    public function testRunnerTriggeredGarbageCollection(): void;
+
     public function testSuiteSkipped(TestSuite $testSuite, string $message): void;
 
     public function testSuiteStarted(TestSuite $testSuite): void;
@@ -223,6 +227,8 @@ interface Emitter
     public function testRunnerTriggeredDeprecation(string $message): void;
 
     public function testRunnerTriggeredWarning(string $message): void;
+
+    public function testRunnerEnabledGarbageCollection(): void;
 
     public function testRunnerExecutionAborted(): void;
 

--- a/src/Event/Events/TestRunner/GarbageCollectionDisabled.php
+++ b/src/Event/Events/TestRunner/GarbageCollectionDisabled.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Event;
+use PHPUnit\Event\Telemetry;
+
+/**
+ * @psalm-immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class GarbageCollectionDisabled implements Event
+{
+    private readonly Telemetry\Info $telemetryInfo;
+
+    public function __construct(Telemetry\Info $telemetryInfo)
+    {
+        $this->telemetryInfo = $telemetryInfo;
+    }
+
+    public function telemetryInfo(): Telemetry\Info
+    {
+        return $this->telemetryInfo;
+    }
+
+    public function asString(): string
+    {
+        return 'Test Runner Disabled Garbage Collection';
+    }
+}

--- a/src/Event/Events/TestRunner/GarbageCollectionDisabledSubscriber.php
+++ b/src/Event/Events/TestRunner/GarbageCollectionDisabledSubscriber.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Subscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface GarbageCollectionDisabledSubscriber extends Subscriber
+{
+    public function notify(GarbageCollectionDisabled $event): void;
+}

--- a/src/Event/Events/TestRunner/GarbageCollectionEnabled.php
+++ b/src/Event/Events/TestRunner/GarbageCollectionEnabled.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Event;
+use PHPUnit\Event\Telemetry;
+
+/**
+ * @psalm-immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class GarbageCollectionEnabled implements Event
+{
+    private readonly Telemetry\Info $telemetryInfo;
+
+    public function __construct(Telemetry\Info $telemetryInfo)
+    {
+        $this->telemetryInfo = $telemetryInfo;
+    }
+
+    public function telemetryInfo(): Telemetry\Info
+    {
+        return $this->telemetryInfo;
+    }
+
+    public function asString(): string
+    {
+        return 'Test Runner Enabled Garbage Collection';
+    }
+}

--- a/src/Event/Events/TestRunner/GarbageCollectionEnabledSubscriber.php
+++ b/src/Event/Events/TestRunner/GarbageCollectionEnabledSubscriber.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Subscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface GarbageCollectionEnabledSubscriber extends Subscriber
+{
+    public function notify(GarbageCollectionEnabled $event): void;
+}

--- a/src/Event/Events/TestRunner/GarbageCollectionTriggered.php
+++ b/src/Event/Events/TestRunner/GarbageCollectionTriggered.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Event;
+use PHPUnit\Event\Telemetry;
+
+/**
+ * @psalm-immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class GarbageCollectionTriggered implements Event
+{
+    private readonly Telemetry\Info $telemetryInfo;
+
+    public function __construct(Telemetry\Info $telemetryInfo)
+    {
+        $this->telemetryInfo = $telemetryInfo;
+    }
+
+    public function telemetryInfo(): Telemetry\Info
+    {
+        return $this->telemetryInfo;
+    }
+
+    public function asString(): string
+    {
+        return 'Test Runner Triggered Garbage Collection';
+    }
+}

--- a/src/Event/Events/TestRunner/GarbageCollectionTriggeredSubscriber.php
+++ b/src/Event/Events/TestRunner/GarbageCollectionTriggeredSubscriber.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Subscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface GarbageCollectionTriggeredSubscriber extends Subscriber
+{
+    public function notify(GarbageCollectionTriggered $event): void;
+}

--- a/src/Event/Facade.php
+++ b/src/Event/Facade.php
@@ -230,6 +230,9 @@ final class Facade
             TestRunner\Started::class,
             TestRunner\DeprecationTriggered::class,
             TestRunner\WarningTriggered::class,
+            TestRunner\GarbageCollectionDisabled::class,
+            TestRunner\GarbageCollectionTriggered::class,
+            TestRunner\GarbageCollectionEnabled::class,
 
             TestSuite\Filtered::class,
             TestSuite\Finished::class,

--- a/src/Runner/GarbageCollection/GarbageCollectionHandler.php
+++ b/src/Runner/GarbageCollection/GarbageCollectionHandler.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\GarbageCollection;
+
+use function gc_collect_cycles;
+use function gc_disable;
+use function gc_enable;
+use PHPUnit\Event\EventFacadeIsSealedException;
+use PHPUnit\Event\Facade;
+use PHPUnit\Event\UnknownSubscriberTypeException;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class GarbageCollectionHandler
+{
+    private readonly int $threshold;
+    private int $tests = 0;
+
+    /**
+     * @throws EventFacadeIsSealedException
+     * @throws UnknownSubscriberTypeException
+     */
+    public function __construct(Facade $facade, int $threshold)
+    {
+        $this->threshold = $threshold;
+
+        $this->registerSubscribers($facade);
+    }
+
+    public function executionStarted(): void
+    {
+        gc_disable();
+        gc_collect_cycles();
+    }
+
+    public function executionFinished(): void
+    {
+        gc_collect_cycles();
+        gc_enable();
+    }
+
+    public function testFinished(): void
+    {
+        $this->tests++;
+
+        if ($this->tests === $this->threshold) {
+            gc_collect_cycles();
+
+            $this->tests = 0;
+        }
+    }
+
+    /**
+     * @throws EventFacadeIsSealedException
+     * @throws UnknownSubscriberTypeException
+     */
+    private function registerSubscribers(Facade $facade): void
+    {
+        $facade->registerSubscribers(
+            new ExecutionStartedSubscriber($this),
+            new ExecutionFinishedSubscriber($this),
+            new TestFinishedSubscriber($this),
+        );
+    }
+}

--- a/src/Runner/GarbageCollection/GarbageCollectionHandler.php
+++ b/src/Runner/GarbageCollection/GarbageCollectionHandler.php
@@ -21,6 +21,7 @@ use PHPUnit\Event\UnknownSubscriberTypeException;
  */
 final class GarbageCollectionHandler
 {
+    private readonly Facade $facade;
     private readonly int $threshold;
     private int $tests = 0;
 
@@ -30,21 +31,32 @@ final class GarbageCollectionHandler
      */
     public function __construct(Facade $facade, int $threshold)
     {
+        $this->facade    = $facade;
         $this->threshold = $threshold;
 
-        $this->registerSubscribers($facade);
+        $this->registerSubscribers();
     }
 
     public function executionStarted(): void
     {
         gc_disable();
+
+        $this->facade->emitter()->testRunnerDisabledGarbageCollection();
+
         gc_collect_cycles();
+
+        $this->facade->emitter()->testRunnerTriggeredGarbageCollection();
     }
 
     public function executionFinished(): void
     {
         gc_collect_cycles();
+
+        $this->facade->emitter()->testRunnerTriggeredGarbageCollection();
+
         gc_enable();
+
+        $this->facade->emitter()->testRunnerEnabledGarbageCollection();
     }
 
     public function testFinished(): void
@@ -54,6 +66,8 @@ final class GarbageCollectionHandler
         if ($this->tests === $this->threshold) {
             gc_collect_cycles();
 
+            $this->facade->emitter()->testRunnerTriggeredGarbageCollection();
+
             $this->tests = 0;
         }
     }
@@ -62,9 +76,9 @@ final class GarbageCollectionHandler
      * @throws EventFacadeIsSealedException
      * @throws UnknownSubscriberTypeException
      */
-    private function registerSubscribers(Facade $facade): void
+    private function registerSubscribers(): void
     {
-        $facade->registerSubscribers(
+        $this->facade->registerSubscribers(
             new ExecutionStartedSubscriber($this),
             new ExecutionFinishedSubscriber($this),
             new TestFinishedSubscriber($this),

--- a/src/Runner/GarbageCollection/Subscriber/ExecutionFinishedSubscriber.php
+++ b/src/Runner/GarbageCollection/Subscriber/ExecutionFinishedSubscriber.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\GarbageCollection;
+
+use PHPUnit\Event\InvalidArgumentException;
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber as TestRunnerExecutionFinishedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ExecutionFinishedSubscriber extends Subscriber implements TestRunnerExecutionFinishedSubscriber
+{
+    /**
+     * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws InvalidArgumentException
+     */
+    public function notify(ExecutionFinished $event): void
+    {
+        $this->handler()->executionFinished();
+    }
+}

--- a/src/Runner/GarbageCollection/Subscriber/ExecutionStartedSubscriber.php
+++ b/src/Runner/GarbageCollection/Subscriber/ExecutionStartedSubscriber.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\GarbageCollection;
+
+use PHPUnit\Event\InvalidArgumentException;
+use PHPUnit\Event\TestRunner\ExecutionStarted;
+use PHPUnit\Event\TestRunner\ExecutionStartedSubscriber as TestRunnerExecutionStartedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ExecutionStartedSubscriber extends Subscriber implements TestRunnerExecutionStartedSubscriber
+{
+    /**
+     * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws InvalidArgumentException
+     */
+    public function notify(ExecutionStarted $event): void
+    {
+        $this->handler()->executionStarted();
+    }
+}

--- a/src/Runner/GarbageCollection/Subscriber/Subscriber.php
+++ b/src/Runner/GarbageCollection/Subscriber/Subscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\GarbageCollection;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+abstract class Subscriber
+{
+    private readonly GarbageCollectionHandler $handler;
+
+    public function __construct(GarbageCollectionHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    protected function handler(): GarbageCollectionHandler
+    {
+        return $this->handler;
+    }
+}

--- a/src/Runner/GarbageCollection/Subscriber/TestFinishedSubscriber.php
+++ b/src/Runner/GarbageCollection/Subscriber/TestFinishedSubscriber.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\GarbageCollection;
+
+use PHPUnit\Event\InvalidArgumentException;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class TestFinishedSubscriber extends Subscriber implements FinishedSubscriber
+{
+    /**
+     * @throws \PHPUnit\Framework\InvalidArgumentException
+     * @throws InvalidArgumentException
+     */
+    public function notify(Finished $event): void
+    {
+        $this->handler()->testFinished();
+    }
+}

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -32,6 +32,7 @@ use PHPUnit\Runner\CodeCoverage;
 use PHPUnit\Runner\Extension\ExtensionBootstrapper;
 use PHPUnit\Runner\Extension\Facade as ExtensionFacade;
 use PHPUnit\Runner\Extension\PharLoader;
+use PHPUnit\Runner\GarbageCollection\GarbageCollectionHandler;
 use PHPUnit\Runner\ResultCache\DefaultResultCache;
 use PHPUnit\Runner\ResultCache\NullResultCache;
 use PHPUnit\Runner\ResultCache\ResultCache;
@@ -157,6 +158,13 @@ final class Application
             TestResultFacade::init();
 
             $resultCache = $this->initializeTestResultCache($configuration);
+
+            if ($configuration->controlGarbageCollector()) {
+                new GarbageCollectionHandler(
+                    EventFacade::instance(),
+                    $configuration->numberOfTestsBeforeGarbageCollection(),
+                );
+            }
 
             EventFacade::instance()->seal();
 

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -127,12 +127,14 @@ final class Configuration
      */
     private readonly array $testSuffixes;
     private readonly Php $php;
+    private readonly bool $controlGarbageCollector;
+    private readonly int $numberOfTestsBeforeGarbageCollection;
 
     /**
      * @psalm-param non-empty-list<string> $testSuffixes
      * @psalm-param list<array{className: class-string, parameters: array<string, string>}> $extensionBootstrappers
      */
-    public function __construct(?string $cliArgument, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $registerMockObjectsFromTestArgumentsRecursively, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php)
+    public function __construct(?string $cliArgument, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $registerMockObjectsFromTestArgumentsRecursively, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection)
     {
         $this->cliArgument                                     = $cliArgument;
         $this->configurationFile                               = $configurationFile;
@@ -233,6 +235,9 @@ final class Configuration
         $this->defaultTestSuite                                = $defaultTestSuite;
         $this->testSuffixes                                    = $testSuffixes;
         $this->php                                             = $php;
+        $this->controlGarbageCollector                         = $controlGarbageCollector;
+        $this->numberOfTestsBeforeGarbageCollection            = $numberOfTestsBeforeGarbageCollection;
+
     }
 
     /**
@@ -1211,5 +1216,15 @@ final class Configuration
     public function php(): Php
     {
         return $this->php;
+    }
+
+    public function controlGarbageCollector(): bool
+    {
+        return $this->controlGarbageCollector;
+    }
+
+    public function numberOfTestsBeforeGarbageCollection(): int
+    {
+        return $this->numberOfTestsBeforeGarbageCollection;
     }
 }

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -838,6 +838,8 @@ final class Merger
                 $xmlConfiguration->php()->filesVariables(),
                 $xmlConfiguration->php()->requestVariables(),
             ),
+            $xmlConfiguration->phpunit()->controlGarbageCollector(),
+            $xmlConfiguration->phpunit()->numberOfTestsBeforeGarbageCollection(),
         );
     }
 }

--- a/src/TextUI/Configuration/Xml/DefaultConfiguration.php
+++ b/src/TextUI/Configuration/Xml/DefaultConfiguration.php
@@ -143,6 +143,8 @@ final class DefaultConfiguration extends Configuration
                 false,
                 false,
                 false,
+                false,
+                100,
             ),
             TestSuiteCollection::fromArray([]),
         );

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -821,6 +821,8 @@ final class Loader
             $backupStaticProperties,
             $this->getBooleanAttribute($document->documentElement, 'registerMockObjectsFromTestArgumentsRecursively', false),
             $this->getBooleanAttribute($document->documentElement, 'testdox', false),
+            $this->getBooleanAttribute($document->documentElement, 'controlGarbageCollector', false),
+            $this->getIntegerAttribute($document->documentElement, 'numberOfTestsBeforeGarbageCollection', 100),
         );
     }
 

--- a/src/TextUI/Configuration/Xml/PHPUnit.php
+++ b/src/TextUI/Configuration/Xml/PHPUnit.php
@@ -66,8 +66,10 @@ final class PHPUnit
     private readonly bool $backupStaticProperties;
     private readonly bool $registerMockObjectsFromTestArgumentsRecursively;
     private readonly bool $testdoxPrinter;
+    private readonly bool $controlGarbageCollector;
+    private readonly int $numberOfTestsBeforeGarbageCollection;
 
-    public function __construct(?string $cacheDirectory, bool $cacheResult, ?string $cacheResultFile, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $registerMockObjectsFromTestArgumentsRecursively, bool $testdoxPrinter)
+    public function __construct(?string $cacheDirectory, bool $cacheResult, ?string $cacheResultFile, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $registerMockObjectsFromTestArgumentsRecursively, bool $testdoxPrinter, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection)
     {
         $this->cacheDirectory                                  = $cacheDirectory;
         $this->cacheResult                                     = $cacheResult;
@@ -119,6 +121,8 @@ final class PHPUnit
         $this->backupStaticProperties                          = $backupStaticProperties;
         $this->registerMockObjectsFromTestArgumentsRecursively = $registerMockObjectsFromTestArgumentsRecursively;
         $this->testdoxPrinter                                  = $testdoxPrinter;
+        $this->controlGarbageCollector                         = $controlGarbageCollector;
+        $this->numberOfTestsBeforeGarbageCollection            = $numberOfTestsBeforeGarbageCollection;
     }
 
     /**
@@ -448,5 +452,15 @@ final class PHPUnit
     public function testdoxPrinter(): bool
     {
         return $this->testdoxPrinter;
+    }
+
+    public function controlGarbageCollector(): bool
+    {
+        return $this->controlGarbageCollector;
+    }
+
+    public function numberOfTestsBeforeGarbageCollection(): int
+    {
+        return $this->numberOfTestsBeforeGarbageCollection;
     }
 }

--- a/tests/_files/configuration.xml
+++ b/tests/_files/configuration.xml
@@ -28,7 +28,10 @@
          timeoutForSmallTests="1"
          timeoutForMediumTests="10"
          timeoutForLargeTests="60"
-         executionOrder="default">
+         executionOrder="default"
+         controlGarbageCollector="true"
+         numberOfTestsBeforeGarbageCollection="1000"
+>
     <testsuites>
         <testsuite name="My Test Suite">
             <directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">/path/to/files</directory>

--- a/tests/end-to-end/_files/controlled-garbage-collection/phpunit.xml
+++ b/tests/end-to-end/_files/controlled-garbage-collection/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+         controlGarbageCollector="true"
+         numberOfTestsBeforeGarbageCollection="1"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/_files/controlled-garbage-collection/tests/GarbageCollectionTest.php
+++ b/tests/end-to-end/_files/controlled-garbage-collection/tests/GarbageCollectionTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\GarbageCollection;
+
+use PHPUnit\Framework\TestCase;
+
+final class GarbageCollectionTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/generic/controlled-garbage-collection.phpt
+++ b/tests/end-to-end/generic/controlled-garbage-collection.phpt
@@ -1,0 +1,58 @@
+--TEST--
+phpunit --configuration=__DIR__.'/../_files/controlled-garbage-collection'
+--SKIPIF--
+<?php declare(strict_types=1);
+if (DIRECTORY_SEPARATOR === '\\') {
+    print "skip: this test does not work on Windows / GitHub Actions\n";
+}
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__.'/../_files/controlled-garbage-collection';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Test Suite Loaded (2 tests)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (2 tests)
+Test Runner Disabled Garbage Collection
+Test Runner Triggered Garbage Collection
+Test Suite Started (%s/phpunit.xml, 2 tests)
+Test Suite Started (default, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testOne)
+Test Prepared (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testOne)
+Assertion Succeeded (Constraint: is true, Value: true)
+Test Passed (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testOne)
+Test Finished (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testOne)
+Test Runner Triggered Garbage Collection
+Test Preparation Started (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testTwo)
+Test Prepared (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testTwo)
+Assertion Succeeded (Constraint: is true, Value: true)
+Test Passed (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testTwo)
+Test Finished (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testTwo)
+Test Runner Triggered Garbage Collection
+Test Suite Finished (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest, 2 tests)
+Test Suite Finished (default, 2 tests)
+Test Suite Finished (%s/phpunit.xml, 2 tests)
+Test Runner Execution Finished
+Test Runner Triggered Garbage Collection
+Test Runner Enabled Garbage Collection
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Event/Events/TestRunner/GarbageCollectionDisabledTest.php
+++ b/tests/unit/Event/Events/TestRunner/GarbageCollectionDisabledTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\AbstractEventTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+
+#[CoversClass(GarbageCollectionDisabled::class)]
+#[Small]
+final class GarbageCollectionDisabledTest extends AbstractEventTestCase
+{
+    public function testConstructorSetsValues(): void
+    {
+        $telemetryInfo = $this->telemetryInfo();
+
+        $event = new GarbageCollectionDisabled($telemetryInfo);
+
+        $this->assertSame($telemetryInfo, $event->telemetryInfo());
+    }
+
+    public function testCanBeRepresentedAsString(): void
+    {
+        $event = new GarbageCollectionDisabled($this->telemetryInfo());
+
+        $this->assertSame('Test Runner Disabled Garbage Collection', $event->asString());
+    }
+}

--- a/tests/unit/Event/Events/TestRunner/GarbageCollectionEnabledTest.php
+++ b/tests/unit/Event/Events/TestRunner/GarbageCollectionEnabledTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\AbstractEventTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+
+#[CoversClass(GarbageCollectionEnabled::class)]
+#[Small]
+final class GarbageCollectionEnabledTest extends AbstractEventTestCase
+{
+    public function testConstructorSetsValues(): void
+    {
+        $telemetryInfo = $this->telemetryInfo();
+
+        $event = new GarbageCollectionEnabled($telemetryInfo);
+
+        $this->assertSame($telemetryInfo, $event->telemetryInfo());
+    }
+
+    public function testCanBeRepresentedAsString(): void
+    {
+        $event = new GarbageCollectionEnabled($this->telemetryInfo());
+
+        $this->assertSame('Test Runner Enabled Garbage Collection', $event->asString());
+    }
+}

--- a/tests/unit/Event/Events/TestRunner/GarbageCollectionTriggeredTest.php
+++ b/tests/unit/Event/Events/TestRunner/GarbageCollectionTriggeredTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\AbstractEventTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+
+#[CoversClass(GarbageCollectionTriggered::class)]
+#[Small]
+final class GarbageCollectionTriggeredTest extends AbstractEventTestCase
+{
+    public function testConstructorSetsValues(): void
+    {
+        $telemetryInfo = $this->telemetryInfo();
+
+        $event = new GarbageCollectionTriggered($telemetryInfo);
+
+        $this->assertSame($telemetryInfo, $event->telemetryInfo());
+    }
+
+    public function testCanBeRepresentedAsString(): void
+    {
+        $event = new GarbageCollectionTriggered($this->telemetryInfo());
+
+        $this->assertSame('Test Runner Triggered Garbage Collection', $event->asString());
+    }
+}

--- a/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
@@ -342,6 +342,8 @@ final class LoaderTest extends TestCase
         $this->assertSame(TestSuiteSorter::ORDER_DEFAULT, $phpunit->executionOrder());
         $this->assertFalse($phpunit->defectsFirst());
         $this->assertTrue($phpunit->resolveDependencies());
+        $this->assertTrue($phpunit->controlGarbageCollector());
+        $this->assertSame(1000, $phpunit->numberOfTestsBeforeGarbageCollection());
     }
 
     public function test_TestDox_configuration_is_parsed_correctly(): void


### PR DESCRIPTION
When the PHP runtime automatically performs [garbage collection](https://www.php.net/manual/en/features.gc.php) then this may happen in the middle of the preparation (fixture setup) of a test or in the middle of the execution of a test. This can have a negative impact on test execution performance.

Solution proposed by @edorian in a conversation yesterday:

* Deactivate automatic garbage collection using `gc_disable()` before the first test is run
* Trigger garbage collection using `gc_collect_cycles()` before the first test is run
* Trigger garbage collection using `gc_collect_cycles()` after each n-th test
* Trigger garbage collection after using `gc_collect_cycles()` after the last test was run
* Activate automatic garbage collection using `gc_enable()` after the last test was run

- [X] Implement `GarbageCollectionHandler` that implements the above using PHPUnit's event system
- [x] Implement XML configuration file settings to configure this functionality
- [x] Register `GarbageCollectionHandler` when feature is enabled in XML configuration