### PR TITLE
Enhancement: Enable `string_length_to_empty` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -294,6 +294,7 @@ $config->setFinder($finder)
         'statement_indentation' => true,
         'static_lambda' => true,
         'strict_param' => true,
+        'string_length_to_empty'=> true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/Framework/Constraint/StringStartsWith.php
+++ b/src/Framework/Constraint/StringStartsWith.php
@@ -9,7 +9,6 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use function strlen;
 use function strpos;
 use PHPUnit\Framework\InvalidArgumentException;
 
@@ -26,7 +25,7 @@ final class StringStartsWith extends Constraint
 
     public function __construct(string $prefix)
     {
-        if (strlen($prefix) === 0) {
+        if ($prefix === '') {
             throw InvalidArgumentException::create(1, 'non-empty string');
         }
 


### PR DESCRIPTION
This pull request

- [x] enables the `string_length_to_empty` fixer
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.2.0/doc/rules/string_notation/string_length_to_empty.rst.