### PR TITLE
Enhancement: Enable `phpdoc_param_order` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -248,6 +248,7 @@ $config->setFinder($finder)
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => true,
+        'phpdoc_param_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',


### PR DESCRIPTION
This pull request

- [x] enables the `phpdoc_param_order` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.17.0/doc/rules/phpdoc/phpdoc_param_order.rst.