### PR TITLE
Enhancement: Enable `ordered_types` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -233,6 +233,7 @@ $config->setFinder($finder)
             'order' => 'alpha',
         ],
         'ordered_traits' => true,
+        'ordered_types' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'this',


### PR DESCRIPTION
This pull request

- [x] enables the `ordered_types` fixer


💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.17.0/doc/rules/class_notation/ordered_types.rst.