### PR TITLE
Enhancement: Enable `method_chaining_indentation` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -128,6 +128,7 @@ $config->setFinder($finder)
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
         ],
+        'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => true,

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -117,8 +117,8 @@ final class Matcher
 
         if ($this->afterMatchBuilderId !== null) {
             $matcher = $invocation->getObject()
-                                  ->__phpunit_getInvocationHandler()
-                                  ->lookupMatcher($this->afterMatchBuilderId);
+                ->__phpunit_getInvocationHandler()
+                ->lookupMatcher($this->afterMatchBuilderId);
 
             if (!$matcher) {
                 throw new RuntimeException(
@@ -169,8 +169,8 @@ final class Matcher
     {
         if ($this->afterMatchBuilderId !== null) {
             $matcher = $invocation->getObject()
-                                  ->__phpunit_getInvocationHandler()
-                                  ->lookupMatcher($this->afterMatchBuilderId);
+                ->__phpunit_getInvocationHandler()
+                ->lookupMatcher($this->afterMatchBuilderId);
 
             if (!$matcher) {
                 throw new RuntimeException(

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1682,11 +1682,11 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
         }
 
         return $this->getMockBuilder($originalClassName)
-                    ->disableOriginalConstructor()
-                    ->disableOriginalClone()
-                    ->disableArgumentCloning()
-                    ->disallowMockingUnknownTypes()
-                    ->getMock();
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
     }
 
     /**
@@ -1754,12 +1754,12 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
         }
 
         return $this->getMockBuilder($originalClassName)
-                    ->disableOriginalConstructor()
-                    ->disableOriginalClone()
-                    ->disableArgumentCloning()
-                    ->disallowMockingUnknownTypes()
-                    ->setMethods(empty($methods) ? null : $methods)
-                    ->getMock();
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->setMethods(empty($methods) ? null : $methods)
+            ->getMock();
     }
 
     /**
@@ -1774,9 +1774,9 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
     protected function createTestProxy(string $originalClassName, array $constructorArguments = []): MockObject
     {
         return $this->getMockBuilder($originalClassName)
-                    ->setConstructorArgs($constructorArguments)
-                    ->enableProxyingToOriginalMethods()
-                    ->getMock();
+            ->setConstructorArgs($constructorArguments)
+            ->enableProxyingToOriginalMethods()
+            ->getMock();
     }
 
     /**

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -567,7 +567,7 @@ final class Test
                 $method->getDeclaringClass()->getName(),
                 $method->getName()
             )
-            ->symbolAnnotations()
+                ->symbolAnnotations()
         );
     }
 

--- a/tests/unit/Framework/MockObject/ConfigurableMethodTest.php
+++ b/tests/unit/Framework/MockObject/ConfigurableMethodTest.php
@@ -19,7 +19,7 @@ final class ConfigurableMethodTest extends TestCase
         $type = $this->createMock(Type::class);
 
         $type->method('isAssignable')
-             ->willReturn(true);
+            ->willReturn(true);
 
         $method = new ConfigurableMethod('foo', $type);
 
@@ -31,7 +31,7 @@ final class ConfigurableMethodTest extends TestCase
         $type = $this->createMock(Type::class);
 
         $type->method('isAssignable')
-             ->willReturn(false);
+            ->willReturn(false);
 
         $method = new ConfigurableMethod('foo', $type);
 

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -158,8 +158,8 @@ final class GeneratorTest extends TestCase
         $mock = $this->generator->getMockForAbstractClass(AbstractMockTestClass::class);
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturn('testing');
+            ->method('doSomething')
+            ->willReturn('testing');
 
         $this->assertEquals('testing', $mock->doSomething());
         $this->assertEquals(1, $mock->returnAnything());

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -22,15 +22,15 @@ final class ConsecutiveParametersTest extends TestCase
     public function testIntegration(): void
     {
         $mock = $this->getMockBuilder(stdClass::class)
-                     ->setMethods(['foo'])
-                     ->getMock();
+            ->setMethods(['foo'])
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('foo')
-             ->withConsecutive(
-                 ['bar'],
-                 [21, 42]
-             );
+            ->method('foo')
+            ->withConsecutive(
+                ['bar'],
+                [21, 42]
+            );
 
         $this->assertNull($mock->foo('bar'));
         $this->assertNull($mock->foo(21, 42));
@@ -39,14 +39,14 @@ final class ConsecutiveParametersTest extends TestCase
     public function testIntegrationWithLessAssertionsThanMethodCalls(): void
     {
         $mock = $this->getMockBuilder(stdClass::class)
-                     ->setMethods(['foo'])
-                     ->getMock();
+            ->setMethods(['foo'])
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('foo')
-             ->withConsecutive(
-                 ['bar']
-             );
+            ->method('foo')
+            ->withConsecutive(
+                ['bar']
+            );
 
         $this->assertNull($mock->foo('bar'));
         $this->assertNull($mock->foo(21, 42));
@@ -55,15 +55,15 @@ final class ConsecutiveParametersTest extends TestCase
     public function testIntegrationExpectingException(): void
     {
         $mock = $this->getMockBuilder(stdClass::class)
-                     ->setMethods(['foo'])
-                     ->getMock();
+            ->setMethods(['foo'])
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('foo')
-             ->withConsecutive(
-                 ['bar'],
-                 [21, 42]
-             );
+            ->method('foo')
+            ->withConsecutive(
+                ['bar'],
+                [21, 42]
+            );
 
         $mock->foo('bar');
 

--- a/tests/unit/Framework/MockObject/MatcherTest.php
+++ b/tests/unit/Framework/MockObject/MatcherTest.php
@@ -125,8 +125,8 @@ class MatcherTest extends TestCase
 
         $stub = $this->createMock(Stub\Stub::class);
         $stub->expects($this->atMost(1))
-             ->method('invoke')
-             ->with($invocation);
+            ->method('invoke')
+            ->with($invocation);
 
         $parameterRule = $this->createStub(ParametersRule::class);
 

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -37,8 +37,8 @@ final class MockBuilderTest extends TestCase
     public function testMethodsToMockCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethod'])
-                     ->getMock();
+            ->setMethods(['mockableMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertTrue($mock->anotherMockableMethod());
@@ -47,8 +47,8 @@ final class MockBuilderTest extends TestCase
     public function testMethodExceptionsToMockCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethodsExcept(['mockableMethod'])
-                     ->getMock();
+            ->setMethodsExcept(['mockableMethod'])
+            ->getMock();
 
         $this->assertTrue($mock->mockableMethod());
         $this->assertNull($mock->anotherMockableMethod());
@@ -57,8 +57,8 @@ final class MockBuilderTest extends TestCase
     public function testSetMethodsAllowsNonExistentMethodNames(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethodWithCrazyName'])
-                     ->getMock();
+            ->setMethods(['mockableMethodWithCrazyName'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethodWithCrazyName());
     }
@@ -72,15 +72,15 @@ final class MockBuilderTest extends TestCase
         ));
 
         $this->getMockBuilder(Mockable::class)
-             ->onlyMethods(['mockableMethodWithCrazyName'])
-             ->getMock();
+            ->onlyMethods(['mockableMethodWithCrazyName'])
+            ->getMock();
     }
 
     public function testOnlyMethodsWithExistingMethodNames(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->onlyMethods(['mockableMethod'])
-                     ->getMock();
+            ->onlyMethods(['mockableMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertTrue($mock->anotherMockableMethod());
@@ -89,8 +89,8 @@ final class MockBuilderTest extends TestCase
     public function testOnlyMethodsWithEmptyArray(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->onlyMethods([])
-                     ->getMock();
+            ->onlyMethods([])
+            ->getMock();
 
         $this->assertTrue($mock->mockableMethod());
     }
@@ -104,15 +104,15 @@ final class MockBuilderTest extends TestCase
         ));
 
         $this->getMockBuilder(Mockable::class)
-             ->addMethods(['mockableMethod'])
-             ->getMock();
+            ->addMethods(['mockableMethod'])
+            ->getMock();
     }
 
     public function testAddMethodsWithExistingMethodNames(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->getMock();
+            ->addMethods(['mockableMethodWithFakeMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethodWithFakeMethod());
         $this->assertTrue($mock->anotherMockableMethod());
@@ -121,8 +121,8 @@ final class MockBuilderTest extends TestCase
     public function testAddMethodsWithEmptyArray(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->addMethods([])
-                     ->getMock();
+            ->addMethods([])
+            ->getMock();
 
         $this->assertTrue($mock->mockableMethod());
     }
@@ -130,8 +130,8 @@ final class MockBuilderTest extends TestCase
     public function testEmptyMethodExceptionsToMockCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethodsExcept()
-                     ->getMock();
+            ->setMethodsExcept()
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->anotherMockableMethod());
@@ -140,9 +140,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseAddMethodsAfterOnlyMethods(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->onlyMethods(['mockableMethod'])
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->getMock();
+            ->onlyMethods(['mockableMethod'])
+            ->addMethods(['mockableMethodWithFakeMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->mockableMethodWithFakeMethod());
@@ -151,9 +151,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseOnlyMethodsAfterAddMethods(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->onlyMethods(['mockableMethod'])
-                     ->getMock();
+            ->addMethods(['mockableMethodWithFakeMethod'])
+            ->onlyMethods(['mockableMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethodWithFakeMethod());
         $this->assertNull($mock->mockableMethod());
@@ -162,9 +162,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseSetMethodsAfterOnlyMethods(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->onlyMethods(['mockableMethod'])
-                     ->setMethods(['mockableMethodWithCrazyName'])
-                     ->getMock();
+            ->onlyMethods(['mockableMethod'])
+            ->setMethods(['mockableMethodWithCrazyName'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethodWithCrazyName());
     }
@@ -172,9 +172,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseSetMethodsAfterAddMethods(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->addMethods(['notAMethod'])
-                     ->setMethods(['mockableMethodWithCrazyName'])
-                     ->getMock();
+            ->addMethods(['notAMethod'])
+            ->setMethods(['mockableMethodWithCrazyName'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethodWithCrazyName());
     }
@@ -182,9 +182,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseAddMethodsAfterSetMethods(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethod'])
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->getMock();
+            ->setMethods(['mockableMethod'])
+            ->addMethods(['mockableMethodWithFakeMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->mockableMethodWithFakeMethod());
@@ -193,9 +193,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseOnlyMethodsAfterSetMethods(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethodWithFakeMethod'])
-                     ->onlyMethods(['mockableMethod'])
-                     ->getMock();
+            ->setMethods(['mockableMethodWithFakeMethod'])
+            ->onlyMethods(['mockableMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethod());
         $this->assertNull($mock->mockableMethodWithFakeMethod());
@@ -204,9 +204,9 @@ final class MockBuilderTest extends TestCase
     public function testAbleToUseAddMethodsAfterSetMethodsWithNull(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMethods()
-                     ->addMethods(['mockableMethodWithFakeMethod'])
-                     ->getMock();
+            ->setMethods()
+            ->addMethods(['mockableMethodWithFakeMethod'])
+            ->getMock();
 
         $this->assertNull($mock->mockableMethodWithFakeMethod());
     }
@@ -221,8 +221,8 @@ final class MockBuilderTest extends TestCase
     public function testMockClassNameCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setMockClassName(ACustomClassName::class)
-                     ->getMock();
+            ->setMockClassName(ACustomClassName::class)
+            ->getMock();
 
         $this->assertInstanceOf(ACustomClassName::class, $mock);
     }
@@ -230,8 +230,8 @@ final class MockBuilderTest extends TestCase
     public function testConstructorArgumentsCanBeSpecified(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->setConstructorArgs([23, 42])
-                     ->getMock();
+            ->setConstructorArgs([23, 42])
+            ->getMock();
 
         $this->assertEquals([23, 42], $mock->constructorArgs);
     }
@@ -239,8 +239,8 @@ final class MockBuilderTest extends TestCase
     public function testOriginalConstructorCanBeDisabled(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->disableOriginalConstructor()
-                     ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->assertNull($mock->constructorArgs);
     }
@@ -248,7 +248,7 @@ final class MockBuilderTest extends TestCase
     public function testByDefaultOriginalCloneIsPreserved(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->getMock();
+            ->getMock();
 
         $cloned = clone $mock;
 
@@ -258,8 +258,8 @@ final class MockBuilderTest extends TestCase
     public function testOriginalCloneCanBeDisabled(): void
     {
         $mock = $this->getMockBuilder(Mockable::class)
-                     ->disableOriginalClone()
-                     ->getMock();
+            ->disableOriginalClone()
+            ->getMock();
 
         $mock->cloned = false;
         $cloned       = clone $mock;
@@ -270,12 +270,12 @@ final class MockBuilderTest extends TestCase
     public function testProvidesAFluentInterface(): void
     {
         $spec = $this->getMockBuilder(Mockable::class)
-                     ->setMethods(['mockableMethod'])
-                     ->setConstructorArgs([])
-                     ->setMockClassName('DummyClassName')
-                     ->disableOriginalConstructor()
-                     ->disableOriginalClone()
-                     ->disableAutoload();
+            ->setMethods(['mockableMethod'])
+            ->setConstructorArgs([])
+            ->setMockClassName('DummyClassName')
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableAutoload();
 
         $this->assertInstanceOf(MockBuilder::class, $spec);
     }

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -46,20 +46,20 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsNeverCalled(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->never())
-             ->method('doSomething');
+            ->method('doSomething');
     }
 
     public function testMockedMethodIsNeverCalledWithParameter(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->never())
-             ->method('doSomething')
-             ->with('someArg');
+            ->method('doSomething')
+            ->with('someArg');
     }
 
     /**
@@ -68,11 +68,11 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsNotCalledWhenExpectsAnyWithParameter(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomethingElse')
-             ->with('someArg');
+            ->method('doSomethingElse')
+            ->with('someArg');
     }
 
     /**
@@ -81,19 +81,19 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsNotCalledWhenMethodSpecifiedDirectlyWithParameter(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->method('doSomethingElse')
-             ->with('someArg');
+            ->with('someArg');
     }
 
     public function testMockedMethodIsCalledAtLeastOnce(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->atLeastOnce())
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
     }
@@ -101,10 +101,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledAtLeastOnce2(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->atLeastOnce())
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
         $mock->doSomething();
@@ -113,10 +113,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledAtLeastTwice(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->atLeast(2))
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
         $mock->doSomething();
@@ -125,10 +125,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledAtLeastTwice2(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->atLeast(2))
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
         $mock->doSomething();
@@ -138,10 +138,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledAtMostTwice(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->atMost(2))
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
         $mock->doSomething();
@@ -150,10 +150,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledAtMosttTwice2(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->atMost(2))
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
     }
@@ -161,10 +161,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledOnce(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
     }
@@ -172,11 +172,11 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledOnceWithParameter(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('doSomethingElse')
-             ->with($this->equalTo('something'));
+            ->method('doSomethingElse')
+            ->with($this->equalTo('something'));
 
         $mock->doSomethingElse('something');
     }
@@ -184,10 +184,10 @@ final class MockObjectTest extends TestCase
     public function testMockedMethodIsCalledExactly(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->exactly(2))
-             ->method('doSomething');
+            ->method('doSomething');
 
         $mock->doSomething();
         $mock->doSomething();
@@ -196,11 +196,11 @@ final class MockObjectTest extends TestCase
     public function testStubbedException(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->throwException(new Exception));
+            ->method('doSomething')
+            ->will($this->throwException(new Exception));
 
         $this->expectException(Exception::class);
 
@@ -210,11 +210,11 @@ final class MockObjectTest extends TestCase
     public function testStubbedWillThrowException(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willThrowException(new Exception);
+            ->method('doSomething')
+            ->willThrowException(new Exception);
 
         $this->expectException(Exception::class);
 
@@ -224,20 +224,20 @@ final class MockObjectTest extends TestCase
     public function testStubbedReturnValue(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->returnValue('something'));
+            ->method('doSomething')
+            ->will($this->returnValue('something'));
 
         $this->assertEquals('something', $mock->doSomething());
 
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturn('something');
+            ->method('doSomething')
+            ->willReturn('something');
 
         $this->assertEquals('something', $mock->doSomething());
     }
@@ -250,22 +250,22 @@ final class MockObjectTest extends TestCase
         ];
 
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->returnValueMap($map));
+            ->method('doSomething')
+            ->will($this->returnValueMap($map));
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
         $this->assertNull($mock->doSomething('foo', 'bar'));
 
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturnMap($map);
+            ->method('doSomething')
+            ->willReturnMap($map);
 
         $this->assertEquals('d', $mock->doSomething('a', 'b', 'c'));
         $this->assertEquals('h', $mock->doSomething('e', 'f', 'g'));
@@ -275,20 +275,20 @@ final class MockObjectTest extends TestCase
     public function testStubbedReturnArgument(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->returnArgument(1));
+            ->method('doSomething')
+            ->will($this->returnArgument(1));
 
         $this->assertEquals('b', $mock->doSomething('a', 'b'));
 
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturnArgument(1);
+            ->method('doSomething')
+            ->willReturnArgument(1);
 
         $this->assertEquals('b', $mock->doSomething('a', 'b'));
     }
@@ -296,28 +296,28 @@ final class MockObjectTest extends TestCase
     public function testFunctionCallback(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['doSomething'])
-                     ->getMock();
+            ->setMethods(['doSomething'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('doSomething')
-             ->will($this->returnCallback(sprintf(
-                 '%s::functionCallback',
-                 FunctionCallbackWrapper::class
-             )));
+            ->method('doSomething')
+            ->will($this->returnCallback(sprintf(
+                '%s::functionCallback',
+                FunctionCallbackWrapper::class
+            )));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
 
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['doSomething'])
-                     ->getMock();
+            ->setMethods(['doSomething'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('doSomething')
-             ->willReturnCallback(sprintf(
-                 '%s::functionCallback',
-                 FunctionCallbackWrapper::class
-             ));
+            ->method('doSomething')
+            ->willReturnCallback(sprintf(
+                '%s::functionCallback',
+                FunctionCallbackWrapper::class
+            ));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
     }
@@ -325,20 +325,20 @@ final class MockObjectTest extends TestCase
     public function testStubbedReturnSelf(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->returnSelf());
+            ->method('doSomething')
+            ->will($this->returnSelf());
 
         $this->assertEquals($mock, $mock->doSomething());
 
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturnSelf();
+            ->method('doSomething')
+            ->willReturnSelf();
 
         $this->assertEquals($mock, $mock->doSomething());
     }
@@ -346,22 +346,22 @@ final class MockObjectTest extends TestCase
     public function testStubbedReturnOnConsecutiveCalls(): void
     {
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->will($this->onConsecutiveCalls('a', 'b', 'c'));
+            ->method('doSomething')
+            ->will($this->onConsecutiveCalls('a', 'b', 'c'));
 
         $this->assertEquals('a', $mock->doSomething());
         $this->assertEquals('b', $mock->doSomething());
         $this->assertEquals('c', $mock->doSomething());
 
         $mock = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->any())
-             ->method('doSomething')
-             ->willReturnOnConsecutiveCalls('a', 'b', 'c');
+            ->method('doSomething')
+            ->willReturnOnConsecutiveCalls('a', 'b', 'c');
 
         $this->assertEquals('a', $mock->doSomething());
         $this->assertEquals('b', $mock->doSomething());
@@ -371,12 +371,12 @@ final class MockObjectTest extends TestCase
     public function testStaticMethodCallback(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['doSomething'])
-                     ->getMock();
+            ->setMethods(['doSomething'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('doSomething')
-             ->will($this->returnCallback([MethodCallback::class, 'staticCallback']));
+            ->method('doSomething')
+            ->will($this->returnCallback([MethodCallback::class, 'staticCallback']));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
     }
@@ -384,12 +384,12 @@ final class MockObjectTest extends TestCase
     public function testPublicMethodCallback(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['doSomething'])
-                     ->getMock();
+            ->setMethods(['doSomething'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('doSomething')
-             ->will($this->returnCallback([new MethodCallback, 'nonStaticCallback']));
+            ->method('doSomething')
+            ->will($this->returnCallback([new MethodCallback, 'nonStaticCallback']));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
     }
@@ -397,10 +397,10 @@ final class MockObjectTest extends TestCase
     public function testMockClassOnlyGeneratedOnce(): void
     {
         $mock1 = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $mock2 = $this->getMockBuilder(AnInterface::class)
-                     ->getMock();
+            ->getMock();
 
         $this->assertEquals(get_class($mock1), get_class($mock2));
     }
@@ -408,23 +408,23 @@ final class MockObjectTest extends TestCase
     public function testMockClassDifferentForPartialMocks(): void
     {
         $mock1 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->getMock();
+            ->getMock();
 
         $mock2 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMethods(['doSomething'])
-                      ->getMock();
+            ->setMethods(['doSomething'])
+            ->getMock();
 
         $mock3 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMethods(['doSomething'])
-                      ->getMock();
+            ->setMethods(['doSomething'])
+            ->getMock();
 
         $mock4 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMethods(['doAnotherThing'])
-                      ->getMock();
+            ->setMethods(['doAnotherThing'])
+            ->getMock();
 
         $mock5 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMethods(['doAnotherThing'])
-                      ->getMock();
+            ->setMethods(['doAnotherThing'])
+            ->getMock();
 
         $this->assertNotEquals(get_class($mock1), get_class($mock2));
         $this->assertNotEquals(get_class($mock1), get_class($mock3));
@@ -439,23 +439,23 @@ final class MockObjectTest extends TestCase
     public function testMockClassStoreOverrulable(): void
     {
         $mock1 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->getMock();
+            ->getMock();
 
         $mock2 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMockClassName('MyMockClassNameForPartialMockTestClass1')
-                      ->getMock();
+            ->setMockClassName('MyMockClassNameForPartialMockTestClass1')
+            ->getMock();
 
         $mock3 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->getMock();
+            ->getMock();
 
         $mock4 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMethods(['doSomething'])
-                      ->setMockClassName('AnotherMockClassNameForPartialMockTestClass')
-                      ->getMock();
+            ->setMethods(['doSomething'])
+            ->setMockClassName('AnotherMockClassNameForPartialMockTestClass')
+            ->getMock();
 
         $mock5 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->setMockClassName('MyMockClassNameForPartialMockTestClass2')
-                      ->getMock();
+            ->setMockClassName('MyMockClassNameForPartialMockTestClass2')
+            ->getMock();
 
         $this->assertNotEquals(get_class($mock1), get_class($mock2));
         $this->assertEquals(get_class($mock1), get_class($mock3));
@@ -477,11 +477,11 @@ final class MockObjectTest extends TestCase
     public function testOriginalConstructorSettingConsidered(): void
     {
         $mock1 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->getMock();
+            ->getMock();
 
         $mock2 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->disableOriginalConstructor()
-                      ->getMock();
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->assertTrue($mock1->constructorCalled);
         $this->assertFalse($mock2->constructorCalled);
@@ -490,11 +490,11 @@ final class MockObjectTest extends TestCase
     public function testOriginalCloneSettingConsidered(): void
     {
         $mock1 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->getMock();
+            ->getMock();
 
         $mock2 = $this->getMockBuilder(PartialMockTestClass::class)
-                      ->disableOriginalClone()
-                      ->getMock();
+            ->disableOriginalClone()
+            ->getMock();
 
         $this->assertNotEquals(get_class($mock1), get_class($mock2));
     }
@@ -505,10 +505,10 @@ final class MockObjectTest extends TestCase
     public function testGetMockForAbstractClass(): void
     {
         $mock = $this->getMockBuilder(AbstractMockTestClass::class)
-                     ->getMock();
+            ->getMock();
 
         $mock->expects($this->never())
-             ->method('doSomething');
+            ->method('doSomething');
     }
 
     /**
@@ -519,7 +519,7 @@ final class MockObjectTest extends TestCase
     public function testGetMockForTraversable($type): void
     {
         $mock = $this->getMockBuilder($type)
-                     ->getMock();
+            ->getMock();
 
         $this->assertInstanceOf(Traversable::class, $mock);
     }
@@ -532,7 +532,7 @@ final class MockObjectTest extends TestCase
         $mock = $this->getMockForTrait(AbstractTrait::class);
 
         $mock->expects($this->never())
-             ->method('doSomething');
+            ->method('doSomething');
 
         $parent = get_parent_class($mock);
         $traits = class_uses($parent, false);
@@ -543,7 +543,7 @@ final class MockObjectTest extends TestCase
     public function testClonedMockObjectShouldStillEqualTheOriginal(): void
     {
         $a = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $b = clone $a;
 
@@ -553,10 +553,10 @@ final class MockObjectTest extends TestCase
     public function testMockObjectsConstructedIndepentantlyShouldBeEqual(): void
     {
         $a = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $b = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $this->assertEquals($a, $b);
     }
@@ -564,10 +564,10 @@ final class MockObjectTest extends TestCase
     public function testMockObjectsConstructedIndepentantlyShouldNotBeTheSame(): void
     {
         $a = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $b = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $this->assertNotSame($a, $b);
     }
@@ -575,17 +575,17 @@ final class MockObjectTest extends TestCase
     public function testClonedMockObjectCanBeUsedInPlaceOfOriginalOne(): void
     {
         $x = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $y = clone $x;
 
         $mock = $this->getMockBuilder(stdClass::class)
-                     ->setMethods(['foo'])
-                     ->getMock();
+            ->setMethods(['foo'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('foo')
-             ->with($this->equalTo($x));
+            ->method('foo')
+            ->with($this->equalTo($x));
 
         $mock->foo($y);
     }
@@ -593,17 +593,17 @@ final class MockObjectTest extends TestCase
     public function testClonedMockObjectIsNotIdenticalToOriginalOne(): void
     {
         $x = $this->getMockBuilder(stdClass::class)
-                  ->getMock();
+            ->getMock();
 
         $y = clone $x;
 
         $mock = $this->getMockBuilder(stdClass::class)
-                     ->setMethods(['foo'])
-                     ->getMock();
+            ->setMethods(['foo'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('foo')
-             ->with($this->logicalNot($this->identicalTo($x)));
+            ->method('foo')
+            ->with($this->logicalNot($this->identicalTo($x)));
 
         $mock->foo($y);
     }
@@ -613,22 +613,22 @@ final class MockObjectTest extends TestCase
         $expectedObject = new stdClass;
 
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['doSomethingElse'])
-                     ->enableArgumentCloning()
-                     ->getMock();
+            ->setMethods(['doSomethingElse'])
+            ->enableArgumentCloning()
+            ->getMock();
 
         $actualArguments = [];
 
         $mock->expects($this->any())
-             ->method('doSomethingElse')
-             ->will(
-                 $this->returnCallback(
-                     static function () use (&$actualArguments): void
-                     {
-                         $actualArguments = func_get_args();
-                     }
-                 )
-             );
+            ->method('doSomethingElse')
+            ->will(
+                $this->returnCallback(
+                    static function () use (&$actualArguments): void
+                    {
+                        $actualArguments = func_get_args();
+                    }
+                )
+            );
 
         $mock->doSomethingElse($expectedObject);
 
@@ -642,22 +642,22 @@ final class MockObjectTest extends TestCase
         $expectedObject = new stdClass;
 
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['doSomethingElse'])
-                     ->disableArgumentCloning()
-                     ->getMock();
+            ->setMethods(['doSomethingElse'])
+            ->disableArgumentCloning()
+            ->getMock();
 
         $actualArguments = [];
 
         $mock->expects($this->any())
-             ->method('doSomethingElse')
-             ->will(
-                 $this->returnCallback(
-                     static function () use (&$actualArguments): void
-                     {
-                         $actualArguments = func_get_args();
-                     }
-                 )
-             );
+            ->method('doSomethingElse')
+            ->will(
+                $this->returnCallback(
+                    static function () use (&$actualArguments): void
+                    {
+                        $actualArguments = func_get_args();
+                    }
+                )
+            );
 
         $mock->doSomethingElse($expectedObject);
 
@@ -668,14 +668,14 @@ final class MockObjectTest extends TestCase
     public function testArgumentCloningOptionGeneratesUniqueMock(): void
     {
         $mockWithCloning = $this->getMockBuilder(SomeClass::class)
-                                ->setMethods(['doSomethingElse'])
-                                ->enableArgumentCloning()
-                                ->getMock();
+            ->setMethods(['doSomethingElse'])
+            ->enableArgumentCloning()
+            ->getMock();
 
         $mockWithoutCloning = $this->getMockBuilder(SomeClass::class)
-                                   ->setMethods(['doSomethingElse'])
-                                   ->disableArgumentCloning()
-                                   ->getMock();
+            ->setMethods(['doSomethingElse'])
+            ->disableArgumentCloning()
+            ->getMock();
 
         $this->assertNotEquals($mockWithCloning, $mockWithoutCloning);
     }
@@ -683,11 +683,11 @@ final class MockObjectTest extends TestCase
     public function testVerificationOfMethodNameFailsWithoutParameters(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['right', 'wrong'])
-                     ->getMock();
+            ->setMethods(['right', 'wrong'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('right');
+            ->method('right');
 
         $mock->wrong();
 
@@ -708,11 +708,11 @@ final class MockObjectTest extends TestCase
     public function testVerificationOfMethodNameFailsWithParameters(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['right', 'wrong'])
-                     ->getMock();
+            ->setMethods(['right', 'wrong'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('right');
+            ->method('right');
 
         $mock->wrong();
 
@@ -733,12 +733,12 @@ final class MockObjectTest extends TestCase
     public function testVerificationOfMethodNameFailsWithWrongParameters(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['right', 'wrong'])
-                     ->getMock();
+            ->setMethods(['right', 'wrong'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('right')
-             ->with(['first', 'second']);
+            ->method('right')
+            ->with(['first', 'second']);
 
         try {
             $mock->right(['second']);
@@ -792,12 +792,12 @@ EOF
     public function testVerificationOfNeverFailsWithEmptyParameters(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['right', 'wrong'])
-                     ->getMock();
+            ->setMethods(['right', 'wrong'])
+            ->getMock();
 
         $mock->expects($this->never())
-             ->method('right')
-             ->with();
+            ->method('right')
+            ->with();
 
         try {
             $mock->right();
@@ -818,12 +818,12 @@ EOF
     public function testVerificationOfNeverFailsWithAnyParameters(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['right', 'wrong'])
-                     ->getMock();
+            ->setMethods(['right', 'wrong'])
+            ->getMock();
 
         $mock->expects($this->never())
-             ->method('right')
-             ->withAnyParameters();
+            ->method('right')
+            ->withAnyParameters();
 
         try {
             $mock->right();
@@ -844,12 +844,12 @@ EOF
     public function testWithAnythingInsteadOfWithAnyParameters(): void
     {
         $mock = $this->getMockBuilder(SomeClass::class)
-                     ->setMethods(['right', 'wrong'])
-                     ->getMock();
+            ->setMethods(['right', 'wrong'])
+            ->getMock();
 
         $mock->expects($this->once())
-             ->method('right')
-             ->with($this->anything());
+            ->method('right')
+            ->with($this->anything());
 
         try {
             $mock->right();
@@ -878,10 +878,10 @@ EOF
     public function testMockArgumentsPassedByReference(): void
     {
         $foo = $this->getMockBuilder(MethodCallbackByReference::class)
-                    ->setMethods(['bar'])
-                    ->disableOriginalConstructor()
-                    ->disableArgumentCloning()
-                    ->getMock();
+            ->setMethods(['bar'])
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->getMock();
 
         $foo->expects($this->any())
             ->method('bar')
@@ -900,9 +900,9 @@ EOF
     public function testMockArgumentsPassedByReference2(): void
     {
         $foo = $this->getMockBuilder(MethodCallbackByReference::class)
-                    ->disableOriginalConstructor()
-                    ->disableArgumentCloning()
-                    ->getMock();
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->getMock();
 
         $foo->expects($this->any())
             ->method('bar')
@@ -926,10 +926,10 @@ EOF
     public function testMockArgumentsPassedByReference3(): void
     {
         $foo = $this->getMockBuilder(MethodCallbackByReference::class)
-                    ->setMethods(['bar'])
-                    ->disableOriginalConstructor()
-                    ->disableArgumentCloning()
-                    ->getMock();
+            ->setMethods(['bar'])
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->getMock();
 
         $a = new stdClass;
         $b = $c = 0;
@@ -948,10 +948,10 @@ EOF
     public function testMockArgumentsPassedByReference4(): void
     {
         $foo = $this->getMockBuilder(MethodCallbackByReference::class)
-                    ->setMethods(['bar'])
-                    ->disableOriginalConstructor()
-                    ->disableArgumentCloning()
-                    ->getMock();
+            ->setMethods(['bar'])
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->getMock();
 
         $a = new stdClass;
         $b = $c = 0;
@@ -1050,8 +1050,8 @@ EOF
         $this->assertInstanceOf(
             ClassThatImplementsSerializable::class,
             $this->getMockBuilder(ClassThatImplementsSerializable::class)
-                 ->disableOriginalConstructor()
-                 ->getMock()
+                ->disableOriginalConstructor()
+                ->getMock()
         );
     }
 

--- a/tests/unit/Framework/MockObject/ProxyObjectTest.php
+++ b/tests/unit/Framework/MockObject/ProxyObjectTest.php
@@ -23,7 +23,7 @@ final class ProxyObjectTest extends TestCase
         $proxy = $this->createTestProxy(TestProxyFixture::class);
 
         $proxy->expects($this->once())
-              ->method('returnString');
+            ->method('returnString');
 
         assert($proxy instanceof MockObject);
         assert($proxy instanceof TestProxyFixture);
@@ -36,7 +36,7 @@ final class ProxyObjectTest extends TestCase
         $proxy = $this->createTestProxy(TestProxyFixture::class);
 
         $proxy->expects($this->once())
-              ->method('returnTypedString');
+            ->method('returnTypedString');
 
         assert($proxy instanceof MockObject);
         assert($proxy instanceof TestProxyFixture);
@@ -49,7 +49,7 @@ final class ProxyObjectTest extends TestCase
         $proxy = $this->createTestProxy(TestProxyFixture::class);
 
         $proxy->expects($this->once())
-              ->method('returnObject');
+            ->method('returnObject');
 
         assert($proxy instanceof MockObject);
         assert($proxy instanceof TestProxyFixture);
@@ -62,7 +62,7 @@ final class ProxyObjectTest extends TestCase
         $proxy = $this->createTestProxy(TestProxyFixture::class);
 
         $proxy->expects($this->once())
-              ->method('returnTypedObject');
+            ->method('returnTypedObject');
 
         assert($proxy instanceof MockObject);
         assert($proxy instanceof TestProxyFixture);
@@ -75,7 +75,7 @@ final class ProxyObjectTest extends TestCase
         $proxy = $this->createTestProxy(TestProxyFixture::class);
 
         $proxy->expects($this->once())
-              ->method('returnObjectOfFinalClass');
+            ->method('returnObjectOfFinalClass');
 
         assert($proxy instanceof MockObject);
         assert($proxy instanceof TestProxyFixture);
@@ -88,7 +88,7 @@ final class ProxyObjectTest extends TestCase
         $proxy = $this->createTestProxy(TestProxyFixture::class);
 
         $proxy->expects($this->once())
-              ->method('returnTypedObjectOfFinalClass');
+            ->method('returnTypedObjectOfFinalClass');
 
         assert($proxy instanceof MockObject);
         assert($proxy instanceof TestProxyFixture);

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -107,10 +107,10 @@ EOF;
         $fileSection = '<?php echo "Hello PHPUnit!"; ?>' . PHP_EOL;
 
         $this->phpProcess
-             ->expects($this->once())
-             ->method('runJob')
-             ->with($fileSection)
-             ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
+            ->expects($this->once())
+            ->method('runJob')
+            ->with($fileSection)
+            ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
 
         $this->testCase->run();
     }
@@ -131,10 +131,10 @@ EOF
         $renderedCode = "<?php echo '" . $this->dirname . "' . '" . $this->filename . "'; ?>" . PHP_EOL;
 
         $this->phpProcess
-             ->expects($this->once())
-             ->method('runJob')
-             ->with($renderedCode)
-             ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
+            ->expects($this->once())
+            ->method('runJob')
+            ->with($renderedCode)
+            ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
 
         $this->testCase->run();
     }
@@ -150,10 +150,10 @@ EOF
         $renderedCode = "<?php echo 'skip: ' . '" . $this->filename . "'; ?>" . PHP_EOL;
 
         $this->phpProcess
-             ->expects($this->at(0))
-             ->method('runJob')
-             ->with($renderedCode)
-             ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
+            ->expects($this->at(0))
+            ->method('runJob')
+            ->with($renderedCode)
+            ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
 
         $this->testCase->run();
     }
@@ -169,10 +169,10 @@ EOF
         $this->setPhpContent($phptContent);
 
         $this->phpProcess
-             ->expects($this->at(0))
-             ->method('runJob')
-             ->with($skipifSection)
-             ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
+            ->expects($this->at(0))
+            ->method('runJob')
+            ->with($skipifSection)
+            ->will($this->returnValue(['stdout' => '', 'stderr' => '']));
 
         $this->testCase->run();
     }
@@ -188,10 +188,10 @@ EOF
         $this->setPhpContent($phptContent);
 
         $this->phpProcess
-             ->expects($this->once())
-             ->method('runJob')
-             ->with($skipifSection)
-             ->will($this->returnValue(['stdout' => 'skip: Reason', 'stderr' => '']));
+            ->expects($this->once())
+            ->method('runJob')
+            ->with($skipifSection)
+            ->will($this->returnValue(['stdout' => 'skip: Reason', 'stderr' => '']));
 
         $this->testCase->run();
     }
@@ -207,9 +207,9 @@ EOF
         $this->setPhpContent($phptContent);
 
         $this->phpProcess
-             ->expects($this->at(1))
-             ->method('runJob')
-             ->with($cleanSection);
+            ->expects($this->at(1))
+            ->method('runJob')
+            ->with($cleanSection);
 
         $this->testCase->run();
     }
@@ -284,10 +284,10 @@ EOF
         $this->setPhpContent(self::EXPECT_CONTENT);
 
         $this->phpProcess
-             ->expects($this->once())
-             ->method('runJob')
-             ->with(self::FILE_SECTION)
-             ->will($this->returnValue(['stdout' => 'Hello PHPUnit!', 'stderr' => '']));
+            ->expects($this->once())
+            ->method('runJob')
+            ->with(self::FILE_SECTION)
+            ->will($this->returnValue(['stdout' => 'Hello PHPUnit!', 'stderr' => '']));
 
         $result = $this->testCase->run();
 
@@ -299,10 +299,10 @@ EOF
         $this->setPhpContent(self::EXPECTF_CONTENT);
 
         $this->phpProcess
-             ->expects($this->once())
-             ->method('runJob')
-             ->with(self::FILE_SECTION)
-             ->will($this->returnValue(['stdout' => 'Hello PHPUnit!', 'stderr' => '']));
+            ->expects($this->once())
+            ->method('runJob')
+            ->with(self::FILE_SECTION)
+            ->will($this->returnValue(['stdout' => 'Hello PHPUnit!', 'stderr' => '']));
 
         $result = $this->testCase->run();
 
@@ -314,10 +314,10 @@ EOF
         $this->setPhpContent(self::EXPECTREGEX_CONTENT);
 
         $this->phpProcess
-             ->expects($this->once())
-             ->method('runJob')
-             ->with(self::FILE_SECTION)
-             ->will($this->returnValue(['stdout' => 'Hello PHPUnit!', 'stderr' => '']));
+            ->expects($this->once())
+            ->method('runJob')
+            ->with(self::FILE_SECTION)
+            ->will($this->returnValue(['stdout' => 'Hello PHPUnit!', 'stderr' => '']));
 
         $result = $this->testCase->run();
 


### PR DESCRIPTION
This pull request

- [x] enables the `method_chaining_indentation` fixer
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v2.17.0/doc/rules/whitespace/method_chaining_indentation.rst.