### PR TITLE
Enhancement: Enable `no_space_around_double_colon` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -166,6 +166,7 @@ $config->setFinder($finder)
         'no_php4_constructor' => true,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_space_around_double_colon` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.2.0/doc/rules/operator/no_space_around_double_colon.rst.