### PR TITLE
Enhancement: Enable `no_useless_nullsafe_operator` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -186,6 +186,7 @@ $config->setFinder($finder)
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
+        'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_useless_nullsafe_operator` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.9.1/doc/rules/operator/no_useless_nullsafe_operator.rst.