### PR TITLE
Enhancement: Enable `no_useless_concat_operator` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -187,6 +187,7 @@ $config->setFinder($finder)
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
+        'no_useless_concat_operator' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -565,7 +565,7 @@ final class DocBlock
     {
         //removing initial '   * ' for docComment
         $docComment = str_replace("\r\n", "\n", $docComment);
-        $docComment = preg_replace('/' . '\n' . '\s*' . '\*' . '\s?' . '/', "\n", $docComment);
+        $docComment = preg_replace('/\n\s*\*\s?/', "\n", $docComment);
         $docComment = (string) substr($docComment, 0, -1);
 
         return rtrim($docComment, "\n");


### PR DESCRIPTION
This pull request

- [x] enables the `no_useless_concat_operator` fixer
- [x] runs `tools/php-cs-fixer fix`


💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.12.0/doc/rules/operator/no_useless_concat_operator.rst.