### PR TITLE
Enhancement: Enable `octal_notation` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -193,6 +193,7 @@ $config->setFinder($finder)
         'non_printable_character' => true,
         'normalize_index_brace' => true,
         'object_operator_without_whitespace' => true,
+        'octal_notation' => true,
         'operator_linebreak' => [
             'only_booleans' => true,
             'position' => 'end',

--- a/src/Event/Value/Telemetry/Duration.php
+++ b/src/Event/Value/Telemetry/Duration.php
@@ -65,8 +65,8 @@ final class Duration
     public function asString(): string
     {
         $seconds = $this->seconds();
-        $minutes = 00;
-        $hours   = 00;
+        $minutes = 0;
+        $hours   = 0;
 
         if ($seconds > 60 * 60) {
             $hours = floor($seconds / 60 / 60);

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -19,6 +19,6 @@ final class Filesystem
 {
     public static function createDirectory(string $directory): bool
     {
-        return !(!is_dir($directory) && !@mkdir($directory, 0777, true) && !is_dir($directory));
+        return !(!is_dir($directory) && !@mkdir($directory, 0o777, true) && !is_dir($directory));
     }
 }


### PR DESCRIPTION
This pull request

- [x] enables the `octal_notation` fixer
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.2.0/doc/rules/basic/octal_notation.rst.