### PR TITLE
Enhancement: Enable `integer_literal_case` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -115,6 +115,7 @@ $config->setFinder($finder)
             'style' => PhpCsFixer\Fixer\Operator\IncrementStyleFixer::STYLE_POST,
         ],
         'indentation_type' => true,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `integer_literal_case` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.2.0/doc/rules/casing/integer_literal_case.rst. 