### PR TITLE
Enhancement: Enable `single_line_comment_spacing` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -289,6 +289,7 @@ $config->setFinder($finder)
         'single_class_element_per_statement' => true,
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
+        'single_line_comment_spacing' => true,
         'single_quote' => true,
         'single_space_around_construct' => true,
         'single_trait_insert_per_statement' => true,

--- a/src/Framework/Constraint/ArraySubset.php
+++ b/src/Framework/Constraint/ArraySubset.php
@@ -61,8 +61,8 @@ final class ArraySubset extends Constraint
      */
     public function evaluate($other, string $description = '', bool $returnResult = false)
     {
-        //type cast $other & $this->subset as an array to allow
-        //support in standard array functions.
+        // type cast $other & $this->subset as an array to allow
+        // support in standard array functions.
         $other        = $this->toArray($other);
         $this->subset = $this->toArray($this->subset);
 

--- a/src/Framework/MockObject/Builder/InvocationStubber.php
+++ b/src/Framework/MockObject/Builder/InvocationStubber.php
@@ -17,46 +17,46 @@ interface InvocationStubber
     public function will(Stub $stub): Identity;
 
     /** @return self */
-    public function willReturn($value, ...$nextValues)/*: self */;
+    public function willReturn($value, ...$nextValues)/* : self */;
 
     /**
      * @param mixed $reference
      *
      * @return self
      */
-    public function willReturnReference(&$reference)/*: self */;
+    public function willReturnReference(&$reference)/* : self */;
 
     /**
      * @param array<int, array<int, mixed>> $valueMap
      *
      * @return self
      */
-    public function willReturnMap(array $valueMap)/*: self */;
+    public function willReturnMap(array $valueMap)/* : self */;
 
     /**
      * @param int $argumentIndex
      *
      * @return self
      */
-    public function willReturnArgument($argumentIndex)/*: self */;
+    public function willReturnArgument($argumentIndex)/* : self */;
 
     /**
      * @param callable $callback
      *
      * @return self
      */
-    public function willReturnCallback($callback)/*: self */;
+    public function willReturnCallback($callback)/* : self */;
 
     /** @return self */
-    public function willReturnSelf()/*: self */;
+    public function willReturnSelf()/* : self */;
 
     /**
      * @param mixed $values
      *
      * @return self
      */
-    public function willReturnOnConsecutiveCalls(...$values)/*: self */;
+    public function willReturnOnConsecutiveCalls(...$values)/* : self */;
 
     /** @return self */
-    public function willThrowException(Throwable $exception)/*: self */;
+    public function willThrowException(Throwable $exception)/* : self */;
 }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1947,7 +1947,7 @@ abstract class TestCase extends Assert implements SelfDescribing, Test
      *
      * @return object
      */
-    protected function getObjectForTrait($traitName, array $arguments = [], $traitClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true)/*: object*/
+    protected function getObjectForTrait($traitName, array $arguments = [], $traitClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true)/* : object */
     {
         $this->recordDoubledType($traitName);
 

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -563,7 +563,7 @@ final class DocBlock
 
     private function cleanUpMultiLineAnnotation(string $docComment): string
     {
-        //removing initial '   * ' for docComment
+        // removing initial '   * ' for docComment
         $docComment = str_replace("\r\n", "\n", $docComment);
         $docComment = preg_replace('/' . '\n' . '\s*' . '\*' . '\s?' . '/', "\n", $docComment);
         $docComment = (string) substr($docComment, 0, -1);

--- a/tests/end-to-end/regression/1337/Issue1337Test.php
+++ b/tests/end-to-end/regression/1337/Issue1337Test.php
@@ -24,7 +24,7 @@ class Issue1337Test extends TestCase
         return [
             'c:\\' => [true],
             // The following is commented out because it no longer works in PHP >= 8.1
-            //0.9    => [true],
+            // 0.9    => [true],
         ];
     }
 }

--- a/tests/end-to-end/regression/2137/Issue2137Test.php
+++ b/tests/end-to-end/regression/2137/Issue2137Test.php
@@ -24,7 +24,7 @@ class Issue2137Test extends PHPUnit\Framework\TestCase
     public function provideBrandService()
     {
         return [
-            //[true, true]
+            // [true, true]
             new stdClass, // not valid
         ];
     }

--- a/tests/end-to-end/regression/498/Issue498Test.php
+++ b/tests/end-to-end/regression/498/Issue498Test.php
@@ -37,7 +37,7 @@ class Issue498Test extends TestCase
 
     public function shouldBeTrueDataProvider()
     {
-        //throw new Exception("Can't create the data");
+        // throw new Exception("Can't create the data");
         return [
             [true],
             [false],

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -2569,7 +2569,7 @@ XML;
                 new DateTime('2013-03-29T05:13:35-0500'),
             ],
             // Exception
-            //array(new Exception('Exception 1'), new Exception('Exception 2')),
+            // array(new Exception('Exception 1'), new Exception('Exception 2')),
             // different types
             [new SampleClass(4, 8, 15), false],
             [false, new SampleClass(4, 8, 15)],
@@ -2654,7 +2654,7 @@ XML;
                 new DateTime('2013-03-29T04:13:35-0600'),
             ],
             // Exception
-            //array(new Exception('Exception 1'), new Exception('Exception 1')),
+            // array(new Exception('Exception 1'), new Exception('Exception 1')),
             // mixed types
             [0, '0'],
             ['0', 0],


### PR DESCRIPTION
This pull request

- [x] enables the `single_line_comment_spacing` fixer
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.7.0/doc/rules/comment/single_line_comment_spacing.rst.