### PR TITLE
Fix: Use DocBlock to suppress inspections

### DIFF
--- a/src/Framework/Constraint/TraversableContains.php
+++ b/src/Framework/Constraint/TraversableContains.php
@@ -78,7 +78,7 @@ final class TraversableContains extends Constraint
                     return true;
                 }
 
-                /* @noinspection TypeUnsafeComparisonInspection */
+                /** @noinspection TypeUnsafeComparisonInspection */
                 if (!$this->checkForObjectIdentity && $element == $this->value) {
                     return true;
                 }
@@ -89,7 +89,7 @@ final class TraversableContains extends Constraint
                     return true;
                 }
 
-                /* @noinspection TypeUnsafeComparisonInspection */
+                /** @noinspection TypeUnsafeComparisonInspection */
                 if (!$this->checkForNonObjectIdentity && $element == $this->value) {
                     return true;
                 }

--- a/src/Framework/Constraint/TraversableContainsEqual.php
+++ b/src/Framework/Constraint/TraversableContainsEqual.php
@@ -58,7 +58,7 @@ final class TraversableContainsEqual extends Constraint
         }
 
         foreach ($other as $element) {
-            /* @noinspection TypeUnsafeComparisonInspection */
+            /** @noinspection TypeUnsafeComparisonInspection */
             if ($this->value == $element) {
                 return true;
             }

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -668,7 +668,7 @@ final class TestResult implements Countable
             function_exists('xdebug_start_function_monitor');
 
         if ($monitorFunctions) {
-            /* @noinspection ForgottenDebugOutputInspection */
+            /** @noinspection ForgottenDebugOutputInspection */
             xdebug_start_function_monitor(ResourceOperations::getFunctions());
         }
 
@@ -762,7 +762,7 @@ final class TestResult implements Countable
             /** @noinspection ForgottenDebugOutputInspection */
             $functions = xdebug_get_monitored_functions();
 
-            /* @noinspection ForgottenDebugOutputInspection */
+            /** @noinspection ForgottenDebugOutputInspection */
             xdebug_stop_function_monitor();
 
             foreach ($functions as $function) {

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -206,7 +206,7 @@ final class TestRunner extends BaseTestRunner
         if (is_int($arguments['repeat']) && $arguments['repeat'] > 0) {
             $_suite = new TestSuite;
 
-            /* @noinspection PhpUnusedLocalVariableInspection */
+            /** @noinspection PhpUnusedLocalVariableInspection */
             foreach (range(1, $arguments['repeat']) as $step) {
                 $_suite->addTest($suite);
             }

--- a/src/Util/Getopt.php
+++ b/src/Util/Getopt.php
@@ -56,7 +56,7 @@ final class Getopt
 
         $args = array_map('trim', $args);
 
-        /* @noinspection ComparisonOperandsOrderInspection */
+        /** @noinspection ComparisonOperandsOrderInspection */
         while (false !== $arg = current($args)) {
             $i = key($args);
             next($args);
@@ -122,7 +122,7 @@ final class Getopt
                 }
 
                 if (!(strlen($spec) > 2 && $spec[2] === ':')) {
-                    /* @noinspection ComparisonOperandsOrderInspection */
+                    /** @noinspection ComparisonOperandsOrderInspection */
                     if (false === $opt_arg = current($args)) {
                         throw new Exception(
                             "option requires an argument -- {$opt}"
@@ -169,9 +169,9 @@ final class Getopt
             }
 
             if (substr($long_opt, -1) === '=') {
-                /* @noinspection StrlenInEmptyStringCheckContextInspection */
+                /** @noinspection StrlenInEmptyStringCheckContextInspection */
                 if (substr($long_opt, -2) !== '==' && !strlen((string) $opt_arg)) {
-                    /* @noinspection ComparisonOperandsOrderInspection */
+                    /** @noinspection ComparisonOperandsOrderInspection */
                     if (false === $opt_arg = current($args)) {
                         throw new Exception(
                             "option --{$opt} requires an argument"


### PR DESCRIPTION
This pull request

- [x] uses DocBlocks to suppress inspections

💁‍♂️ For reference, see https://www.jetbrains.com/help/phpstorm/disabling-and-enabling-inspections.html#suppress-inspections.