### PR TITLE
Enhancement: Add `arguments` to `elements` option of `trailing_comma_in_multiline` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -308,6 +308,7 @@ $config->setFinder($finder)
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline' => [
             'elements' => [
+                'arguments',
                 'arrays'
             ]
         ],

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -28,7 +28,7 @@
                 $expectedElement->childNodes->item($i),
                 $actualElement->childNodes->item($i),
                 $checkAttributes,
-                $message
+                $message,
             )]]></code>
     </DeprecatedMethod>
     <DocblockTypeContradiction>
@@ -161,22 +161,22 @@
       <code>new IsType(IsType::TYPE_STRING)</code>
       <code>new TraversableContainsOnly(
                     $type,
-                    $isNativeType
+                    $isNativeType,
                 )</code>
       <code>new TraversableContainsOnly(
                 $className,
-                false
+                false,
             )</code>
       <code>new TraversableContainsOnly(
                 $type,
-                $isNativeType
+                $isNativeType,
             )</code>
       <code>new TraversableContainsOnly($className, false)</code>
       <code>new TraversableContainsOnly($type)</code>
       <code>static::assertThat(
             $actual,
             static::objectEquals($expected, $method),
-            $message
+            $message,
         )</code>
       <code>static::assertThat($haystack, $constraint, $message)</code>
       <code>static::assertThat($haystack, $constraint, $message)</code>
@@ -408,7 +408,7 @@
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
   </file>
@@ -420,7 +420,7 @@
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
   </file>
@@ -573,7 +573,7 @@
                 $callOriginalConstructor,
                 $callOriginalClone,
                 $callAutoload,
-                $cloneArguments
+                $cloneArguments,
             )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
@@ -668,11 +668,11 @@
                 substr(
                     substr(
                         $parameterAsString,
-                        strpos($parameterAsString, '<optional> ') + strlen('<optional> ')
+                        strpos($parameterAsString, '<optional> ') + strlen('<optional> '),
                     ),
                     0,
-                    -2
-                )
+                    -2,
+                ),
             )[1]]]></code>
       <code>(string) var_export($defaultValue, true)</code>
     </RedundantCastGivenDocblockType>
@@ -777,7 +777,7 @@
       <code>Filter::getFilteredStacktrace($t)</code>
       <code>Filter::getFilteredStacktrace($t)</code>
       <code><![CDATA[new DataProviderTestSuite(
-            $className . '::' . $methodName
+            $className . '::' . $methodName,
         )]]></code>
       <code><![CDATA[throw new Exception('No valid test provided.');]]></code>
     </MissingThrowsDocblock>
@@ -831,7 +831,7 @@
     <MissingThrowsDocblock>
       <code><![CDATA[TestUtil::getMissingRequirements(
             static::class,
-            $this->name
+            $this->name,
         )]]></code>
       <code>cacheDirectory</code>
       <code>endTest</code>
@@ -917,20 +917,20 @@
       <code>getObjectForTrait</code>
       <code>new Differ($header)</code>
       <code><![CDATA[new Template(
-                    __DIR__ . '/../Util/PHP/Template/TestCaseClass.tpl'
+                    __DIR__ . '/../Util/PHP/Template/TestCaseClass.tpl',
                 )]]></code>
       <code><![CDATA[new Template(
-                    __DIR__ . '/../Util/PHP/Template/TestCaseMethod.tpl'
+                    __DIR__ . '/../Util/PHP/Template/TestCaseMethod.tpl',
                 )]]></code>
       <code><![CDATA[throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );]]></code>
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
       <code><![CDATA[throw new Exception('This test uses TestCase::prophesize(), but phpspec/prophecy is not installed. Please run "composer require --dev phpspec/prophecy".');]]></code>
     </MissingThrowsDocblock>
@@ -1008,12 +1008,12 @@
       <code><![CDATA[throw new Exception(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );]]></code>
       <code><![CDATA[throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );]]></code>
     </MissingThrowsDocblock>
     <PossiblyInvalidArgument>
@@ -1067,7 +1067,7 @@
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
     <PropertyNotSetInConstructor>
@@ -1150,7 +1150,7 @@
     <MissingThrowsDocblock>
       <code>cacheDirectory</code>
       <code><![CDATA[new Template(
-            __DIR__ . '/../Util/PHP/Template/PhptTestCase.tpl'
+            __DIR__ . '/../Util/PHP/Template/PhptTestCase.tpl',
         )]]></code>
       <code>stop</code>
     </MissingThrowsDocblock>
@@ -1194,7 +1194,7 @@
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
   </file>
@@ -1247,12 +1247,12 @@
       <code><![CDATA[throw new ReflectionException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );]]></code>
       <code><![CDATA[throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
       <code>unrecognizedOrderBy</code>
     </MissingThrowsDocblock>
@@ -1335,7 +1335,7 @@
             $arguments['colors'],
             $arguments['debug'],
             $arguments['columns'],
-            $arguments['reverseList']
+            $arguments['reverseList'],
         )]]></code>
     </InvalidStringClass>
     <MissingThrowsDocblock>
@@ -1578,7 +1578,7 @@
             array_filter([
                 'setting'            => $recordedSettings,
                 'extension_versions' => $extensionVersions,
-            ])
+            ]),
         )]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
@@ -1588,7 +1588,7 @@
             array_filter([
                 'setting'            => $recordedSettings,
                 'extension_versions' => $extensionVersions,
-            ])
+            ]),
         )]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
@@ -1628,8 +1628,8 @@
       <code><![CDATA[throw new Exception(
                 sprintf(
                     '"%s" is not a directory',
-                    $directory
-                )
+                    $directory,
+                ),
             );]]></code>
     </MissingThrowsDocblock>
   </file>
@@ -1668,12 +1668,12 @@
       <code><![CDATA[throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );]]></code>
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
     <PossiblyNullPropertyAssignmentValue>
@@ -1706,7 +1706,7 @@
       <code><![CDATA[throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
     <PropertyNotSetInConstructor>
@@ -1844,7 +1844,7 @@
       <code><![CDATA[throw new UtilException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );]]></code>
     </MissingThrowsDocblock>
     <RedundantConditionGivenDocblockType>
@@ -1894,7 +1894,7 @@
       <code><![CDATA[throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );]]></code>
     </MissingThrowsDocblock>
   </file>
@@ -1925,7 +1925,7 @@
       <code><![CDATA[throw new Exception(
                             $e->getMessage(),
                             $e->getCode(),
-                            $e
+                            $e,
                         );]]></code>
     </MissingThrowsDocblock>
     <MoreSpecificReturnType>

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -111,14 +111,14 @@ abstract class Assert
         if (!(is_int($key) || is_string($key))) {
             throw InvalidArgumentException::create(
                 1,
-                'integer or string'
+                'integer or string',
             );
         }
 
         if (!(is_array($array) || $array instanceof ArrayAccess)) {
             throw InvalidArgumentException::create(
                 2,
-                'array or ArrayAccess'
+                'array or ArrayAccess',
             );
         }
 
@@ -142,19 +142,19 @@ abstract class Assert
         if (!(is_int($key) || is_string($key))) {
             throw InvalidArgumentException::create(
                 1,
-                'integer or string'
+                'integer or string',
             );
         }
 
         if (!(is_array($array) || $array instanceof ArrayAccess)) {
             throw InvalidArgumentException::create(
                 2,
-                'array or ArrayAccess'
+                'array or ArrayAccess',
             );
         }
 
         $constraint = new LogicalNot(
-            new ArrayHasKey($key)
+            new ArrayHasKey($key),
         );
 
         static::assertThat($array, $constraint, $message);
@@ -191,7 +191,7 @@ abstract class Assert
     public static function assertNotContains($needle, iterable $haystack, string $message = ''): void
     {
         $constraint = new LogicalNot(
-            new TraversableContainsIdentical($needle)
+            new TraversableContainsIdentical($needle),
         );
 
         static::assertThat($haystack, $constraint, $message);
@@ -220,9 +220,9 @@ abstract class Assert
             $haystack,
             new TraversableContainsOnly(
                 $type,
-                $isNativeType
+                $isNativeType,
             ),
-            $message
+            $message,
         );
     }
 
@@ -238,9 +238,9 @@ abstract class Assert
             $haystack,
             new TraversableContainsOnly(
                 $className,
-                false
+                false,
             ),
-            $message
+            $message,
         );
     }
 
@@ -261,10 +261,10 @@ abstract class Assert
             new LogicalNot(
                 new TraversableContainsOnly(
                     $type,
-                    $isNativeType
-                )
+                    $isNativeType,
+                ),
             ),
-            $message
+            $message,
         );
     }
 
@@ -290,7 +290,7 @@ abstract class Assert
         static::assertThat(
             $haystack,
             new Count($expectedCount),
-            $message
+            $message,
         );
     }
 
@@ -314,7 +314,7 @@ abstract class Assert
         }
 
         $constraint = new LogicalNot(
-            new Count($expectedCount)
+            new Count($expectedCount),
         );
 
         static::assertThat($haystack, $constraint, $message);
@@ -369,7 +369,7 @@ abstract class Assert
     {
         $constraint = new IsEqualWithDelta(
             $expected,
-            $delta
+            $delta,
         );
 
         static::assertThat($actual, $constraint, $message);
@@ -384,7 +384,7 @@ abstract class Assert
     public static function assertNotEquals($expected, $actual, string $message = ''): void
     {
         $constraint = new LogicalNot(
-            new IsEqual($expected)
+            new IsEqual($expected),
         );
 
         static::assertThat($actual, $constraint, $message);
@@ -399,7 +399,7 @@ abstract class Assert
     public static function assertNotEqualsCanonicalizing($expected, $actual, string $message = ''): void
     {
         $constraint = new LogicalNot(
-            new IsEqualCanonicalizing($expected)
+            new IsEqualCanonicalizing($expected),
         );
 
         static::assertThat($actual, $constraint, $message);
@@ -414,7 +414,7 @@ abstract class Assert
     public static function assertNotEqualsIgnoringCase($expected, $actual, string $message = ''): void
     {
         $constraint = new LogicalNot(
-            new IsEqualIgnoringCase($expected)
+            new IsEqualIgnoringCase($expected),
         );
 
         static::assertThat($actual, $constraint, $message);
@@ -431,8 +431,8 @@ abstract class Assert
         $constraint = new LogicalNot(
             new IsEqualWithDelta(
                 $expected,
-                $delta
-            )
+                $delta,
+            ),
         );
 
         static::assertThat($actual, $constraint, $message);
@@ -446,7 +446,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             static::objectEquals($expected, $method),
-            $message
+            $message,
         );
     }
 
@@ -506,7 +506,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             static::greaterThanOrEqual($expected),
-            $message
+            $message,
         );
     }
 
@@ -562,7 +562,7 @@ abstract class Assert
         static::assertFileExists($actual, $message);
 
         $constraint = new IsEqualCanonicalizing(
-            file_get_contents($expected)
+            file_get_contents($expected),
         );
 
         static::assertThat(file_get_contents($actual), $constraint, $message);
@@ -598,7 +598,7 @@ abstract class Assert
         static::assertFileExists($actual, $message);
 
         $constraint = new LogicalNot(
-            new IsEqual(file_get_contents($expected))
+            new IsEqual(file_get_contents($expected)),
         );
 
         static::assertThat(file_get_contents($actual), $constraint, $message);
@@ -617,7 +617,7 @@ abstract class Assert
         static::assertFileExists($actual, $message);
 
         $constraint = new LogicalNot(
-            new IsEqualCanonicalizing(file_get_contents($expected))
+            new IsEqualCanonicalizing(file_get_contents($expected)),
         );
 
         static::assertThat(file_get_contents($actual), $constraint, $message);
@@ -636,7 +636,7 @@ abstract class Assert
         static::assertFileExists($actual, $message);
 
         $constraint = new LogicalNot(
-            new IsEqualIgnoringCase(file_get_contents($expected))
+            new IsEqualIgnoringCase(file_get_contents($expected)),
         );
 
         static::assertThat(file_get_contents($actual), $constraint, $message);
@@ -702,7 +702,7 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
 
         $constraint = new LogicalNot(
-            new IsEqual(file_get_contents($expectedFile))
+            new IsEqual(file_get_contents($expectedFile)),
         );
 
         static::assertThat($actualString, $constraint, $message);
@@ -720,7 +720,7 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
 
         $constraint = new LogicalNot(
-            new IsEqualCanonicalizing(file_get_contents($expectedFile))
+            new IsEqualCanonicalizing(file_get_contents($expectedFile)),
         );
 
         static::assertThat($actualString, $constraint, $message);
@@ -738,7 +738,7 @@ abstract class Assert
         static::assertFileExists($expectedFile, $message);
 
         $constraint = new LogicalNot(
-            new IsEqualIgnoringCase(file_get_contents($expectedFile))
+            new IsEqualIgnoringCase(file_get_contents($expectedFile)),
         );
 
         static::assertThat($actualString, $constraint, $message);
@@ -1227,9 +1227,9 @@ abstract class Assert
         static::assertThat(
             $className,
             new LogicalNot(
-                new ClassHasAttribute($attributeName)
+                new ClassHasAttribute($attributeName),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1257,7 +1257,7 @@ abstract class Assert
         static::assertThat(
             $className,
             new ClassHasStaticAttribute($attributeName),
-            $message
+            $message,
         );
     }
 
@@ -1285,9 +1285,9 @@ abstract class Assert
         static::assertThat(
             $className,
             new LogicalNot(
-                new ClassHasStaticAttribute($attributeName)
+                new ClassHasStaticAttribute($attributeName),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1317,7 +1317,7 @@ abstract class Assert
         static::assertThat(
             $object,
             new ObjectHasAttribute($attributeName),
-            $message
+            $message,
         );
     }
 
@@ -1347,9 +1347,9 @@ abstract class Assert
         static::assertThat(
             $object,
             new LogicalNot(
-                new ObjectHasAttribute($attributeName)
+                new ObjectHasAttribute($attributeName),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1372,7 +1372,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsIdentical($expected),
-            $message
+            $message,
         );
     }
 
@@ -1393,9 +1393,9 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(
-                new IsIdentical($expected)
+                new IsIdentical($expected),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1421,7 +1421,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsInstanceOf($expected),
-            $message
+            $message,
         );
     }
 
@@ -1447,9 +1447,9 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(
-                new IsInstanceOf($expected)
+                new IsInstanceOf($expected),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1466,7 +1466,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_ARRAY),
-            $message
+            $message,
         );
     }
 
@@ -1483,7 +1483,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_BOOL),
-            $message
+            $message,
         );
     }
 
@@ -1500,7 +1500,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_FLOAT),
-            $message
+            $message,
         );
     }
 
@@ -1517,7 +1517,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_INT),
-            $message
+            $message,
         );
     }
 
@@ -1534,7 +1534,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_NUMERIC),
-            $message
+            $message,
         );
     }
 
@@ -1551,7 +1551,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_OBJECT),
-            $message
+            $message,
         );
     }
 
@@ -1568,7 +1568,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_RESOURCE),
-            $message
+            $message,
         );
     }
 
@@ -1585,7 +1585,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_CLOSED_RESOURCE),
-            $message
+            $message,
         );
     }
 
@@ -1602,7 +1602,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_STRING),
-            $message
+            $message,
         );
     }
 
@@ -1619,7 +1619,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_SCALAR),
-            $message
+            $message,
         );
     }
 
@@ -1636,7 +1636,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_CALLABLE),
-            $message
+            $message,
         );
     }
 
@@ -1653,7 +1653,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new IsType(IsType::TYPE_ITERABLE),
-            $message
+            $message,
         );
     }
 
@@ -1670,7 +1670,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_ARRAY)),
-            $message
+            $message,
         );
     }
 
@@ -1687,7 +1687,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_BOOL)),
-            $message
+            $message,
         );
     }
 
@@ -1704,7 +1704,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_FLOAT)),
-            $message
+            $message,
         );
     }
 
@@ -1721,7 +1721,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_INT)),
-            $message
+            $message,
         );
     }
 
@@ -1738,7 +1738,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_NUMERIC)),
-            $message
+            $message,
         );
     }
 
@@ -1755,7 +1755,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_OBJECT)),
-            $message
+            $message,
         );
     }
 
@@ -1772,7 +1772,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_RESOURCE)),
-            $message
+            $message,
         );
     }
 
@@ -1789,7 +1789,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_CLOSED_RESOURCE)),
-            $message
+            $message,
         );
     }
 
@@ -1806,7 +1806,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_STRING)),
-            $message
+            $message,
         );
     }
 
@@ -1823,7 +1823,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_SCALAR)),
-            $message
+            $message,
         );
     }
 
@@ -1840,7 +1840,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_CALLABLE)),
-            $message
+            $message,
         );
     }
 
@@ -1857,7 +1857,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(new IsType(IsType::TYPE_ITERABLE)),
-            $message
+            $message,
         );
     }
 
@@ -1900,9 +1900,9 @@ abstract class Assert
         static::assertThat(
             $string,
             new LogicalNot(
-                new RegularExpression($pattern)
+                new RegularExpression($pattern),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1923,9 +1923,9 @@ abstract class Assert
         static::assertThat(
             $string,
             new LogicalNot(
-                new RegularExpression($pattern)
+                new RegularExpression($pattern),
             ),
-            $message
+            $message,
         );
     }
 
@@ -1961,7 +1961,7 @@ abstract class Assert
         static::assertThat(
             $actual,
             new SameSize($expected),
-            $message
+            $message,
         );
     }
 
@@ -1997,9 +1997,9 @@ abstract class Assert
         static::assertThat(
             $actual,
             new LogicalNot(
-                new SameSize($expected)
+                new SameSize($expected),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2025,9 +2025,9 @@ abstract class Assert
         static::assertThat(
             $string,
             new LogicalNot(
-                new StringMatchesFormatDescription($format)
+                new StringMatchesFormatDescription($format),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2044,9 +2044,9 @@ abstract class Assert
         static::assertThat(
             $string,
             new StringMatchesFormatDescription(
-                file_get_contents($formatFile)
+                file_get_contents($formatFile),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2064,10 +2064,10 @@ abstract class Assert
             $string,
             new LogicalNot(
                 new StringMatchesFormatDescription(
-                    file_get_contents($formatFile)
-                )
+                    file_get_contents($formatFile),
+                ),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2096,9 +2096,9 @@ abstract class Assert
         static::assertThat(
             $string,
             new LogicalNot(
-                new StringStartsWith($prefix)
+                new StringStartsWith($prefix),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2168,9 +2168,9 @@ abstract class Assert
         static::assertThat(
             $string,
             new LogicalNot(
-                new StringEndsWith($suffix)
+                new StringEndsWith($suffix),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2335,7 +2335,7 @@ abstract class Assert
         static::assertSame(
             $expectedElement->tagName,
             $actualElement->tagName,
-            $message
+            $message,
         );
 
         if ($checkAttributes) {
@@ -2346,8 +2346,8 @@ abstract class Assert
                     '%s%sNumber of attributes on node "%s" does not match',
                     $message,
                     !empty($message) ? "\n" : '',
-                    $expectedElement->tagName
-                )
+                    $expectedElement->tagName,
+                ),
             );
 
             for ($i = 0; $i < $expectedElement->attributes->length; $i++) {
@@ -2363,8 +2363,8 @@ abstract class Assert
                             $message,
                             !empty($message) ? "\n" : '',
                             $expectedAttribute->name,
-                            $expectedElement->tagName
-                        )
+                            $expectedElement->tagName,
+                        ),
                     );
                 }
             }
@@ -2380,8 +2380,8 @@ abstract class Assert
                 '%s%sNumber of child nodes of "%s" differs',
                 $message,
                 !empty($message) ? "\n" : '',
-                $expectedElement->tagName
-            )
+                $expectedElement->tagName,
+            ),
         );
 
         for ($i = 0; $i < $expectedElement->childNodes->length; $i++) {
@@ -2389,7 +2389,7 @@ abstract class Assert
                 $expectedElement->childNodes->item($i),
                 $actualElement->childNodes->item($i),
                 $checkAttributes,
-                $message
+                $message,
             );
         }
     }
@@ -2449,9 +2449,9 @@ abstract class Assert
         static::assertThat(
             $actualJson,
             new LogicalNot(
-                new JsonMatches($expectedJson)
+                new JsonMatches($expectedJson),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2489,9 +2489,9 @@ abstract class Assert
         static::assertThat(
             $actualJson,
             new LogicalNot(
-                new JsonMatches($expectedJson)
+                new JsonMatches($expectedJson),
             ),
-            $message
+            $message,
         );
     }
 
@@ -2513,7 +2513,7 @@ abstract class Assert
         static::assertJson($actualJson, $message);
 
         $constraintExpected = new JsonMatches(
-            $expectedJson
+            $expectedJson,
         );
 
         $constraintActual = new JsonMatches($actualJson);
@@ -2540,7 +2540,7 @@ abstract class Assert
         static::assertJson($actualJson, $message);
 
         $constraintExpected = new JsonMatches(
-            $expectedJson
+            $expectedJson,
         );
 
         $constraintActual = new JsonMatches($actualJson);
@@ -2721,7 +2721,7 @@ abstract class Assert
     {
         return static::logicalOr(
             new IsEqual($value),
-            new GreaterThan($value)
+            new GreaterThan($value),
         );
     }
 
@@ -2779,7 +2779,7 @@ abstract class Assert
     {
         return static::logicalOr(
             new IsEqual($value),
-            new LessThan($value)
+            new LessThan($value),
         );
     }
 

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -2927,7 +2927,7 @@ if (!function_exists('PHPUnit\Framework\atLeast')) {
     function atLeast(int $requiredInvocations): InvokedAtLeastCountMatcher
     {
         return new InvokedAtLeastCountMatcher(
-            $requiredInvocations
+            $requiredInvocations,
         );
     }
 }

--- a/src/Framework/Constraint/Cardinality/Count.php
+++ b/src/Framework/Constraint/Cardinality/Count.php
@@ -40,7 +40,7 @@ class Count extends Constraint
     {
         return sprintf(
             'count matches %d',
-            $this->expectedCount
+            $this->expectedCount,
         );
     }
 
@@ -76,7 +76,7 @@ class Count extends Constraint
                     throw new Exception(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
             }
@@ -136,7 +136,7 @@ class Count extends Constraint
         return sprintf(
             'actual size %d matches expected size %d',
             (int) $this->getCountOf($other),
-            $this->expectedCount
+            $this->expectedCount,
         );
     }
 }

--- a/src/Framework/Constraint/Cardinality/IsEmpty.php
+++ b/src/Framework/Constraint/Cardinality/IsEmpty.php
@@ -64,7 +64,7 @@ final class IsEmpty extends Constraint
             '%s %s %s',
             strpos($type, 'a') === 0 || strpos($type, 'o') === 0 ? 'an' : 'a',
             $type,
-            $this->toString()
+            $this->toString(),
         );
     }
 }

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -106,7 +106,7 @@ abstract class Constraint implements Countable, SelfDescribing
     {
         $failureDescription = sprintf(
             'Failed asserting that %s.',
-            $this->failureDescription($other)
+            $this->failureDescription($other),
         );
 
         $additionalFailureDescription = $this->additionalFailureDescription($other);
@@ -121,7 +121,7 @@ abstract class Constraint implements Countable, SelfDescribing
 
         throw new ExpectationFailedException(
             $failureDescription,
-            $comparisonFailure
+            $comparisonFailure,
         );
     }
 

--- a/src/Framework/Constraint/Equality/IsEqual.php
+++ b/src/Framework/Constraint/Equality/IsEqual.php
@@ -78,7 +78,7 @@ final class IsEqual extends Constraint
         try {
             $comparator = $comparatorFactory->getComparatorFor(
                 $this->value,
-                $other
+                $other,
             );
 
             $comparator->assertEquals(
@@ -86,7 +86,7 @@ final class IsEqual extends Constraint
                 $other,
                 $this->delta,
                 $this->canonicalize,
-                $this->ignoreCase
+                $this->ignoreCase,
             );
         } catch (ComparisonFailure $f) {
             if ($returnResult) {
@@ -95,7 +95,7 @@ final class IsEqual extends Constraint
 
             throw new ExpectationFailedException(
                 trim($description . "\n" . $f->getMessage()),
-                $f
+                $f,
             );
         }
 
@@ -118,21 +118,21 @@ final class IsEqual extends Constraint
 
             return sprintf(
                 "is equal to '%s'",
-                $this->value
+                $this->value,
             );
         }
 
         if ($this->delta != 0) {
             $delta = sprintf(
                 ' with delta <%F>',
-                $this->delta
+                $this->delta,
             );
         }
 
         return sprintf(
             'is equal to %s%s',
             $this->exporter()->export($this->value),
-            $delta
+            $delta,
         );
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
+++ b/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
@@ -58,7 +58,7 @@ final class IsEqualCanonicalizing extends Constraint
         try {
             $comparator = $comparatorFactory->getComparatorFor(
                 $this->value,
-                $other
+                $other,
             );
 
             $comparator->assertEquals(
@@ -66,7 +66,7 @@ final class IsEqualCanonicalizing extends Constraint
                 $other,
                 0.0,
                 true,
-                false
+                false,
             );
         } catch (ComparisonFailure $f) {
             if ($returnResult) {
@@ -75,7 +75,7 @@ final class IsEqualCanonicalizing extends Constraint
 
             throw new ExpectationFailedException(
                 trim($description . "\n" . $f->getMessage()),
-                $f
+                $f,
             );
         }
 
@@ -96,13 +96,13 @@ final class IsEqualCanonicalizing extends Constraint
 
             return sprintf(
                 "is equal to '%s'",
-                $this->value
+                $this->value,
             );
         }
 
         return sprintf(
             'is equal to %s',
-            $this->exporter()->export($this->value)
+            $this->exporter()->export($this->value),
         );
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
+++ b/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
@@ -58,7 +58,7 @@ final class IsEqualIgnoringCase extends Constraint
         try {
             $comparator = $comparatorFactory->getComparatorFor(
                 $this->value,
-                $other
+                $other,
             );
 
             $comparator->assertEquals(
@@ -66,7 +66,7 @@ final class IsEqualIgnoringCase extends Constraint
                 $other,
                 0.0,
                 false,
-                true
+                true,
             );
         } catch (ComparisonFailure $f) {
             if ($returnResult) {
@@ -75,7 +75,7 @@ final class IsEqualIgnoringCase extends Constraint
 
             throw new ExpectationFailedException(
                 trim($description . "\n" . $f->getMessage()),
-                $f
+                $f,
             );
         }
 
@@ -96,13 +96,13 @@ final class IsEqualIgnoringCase extends Constraint
 
             return sprintf(
                 "is equal to '%s'",
-                $this->value
+                $this->value,
             );
         }
 
         return sprintf(
             'is equal to %s',
-            $this->exporter()->export($this->value)
+            $this->exporter()->export($this->value),
         );
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualWithDelta.php
+++ b/src/Framework/Constraint/Equality/IsEqualWithDelta.php
@@ -62,13 +62,13 @@ final class IsEqualWithDelta extends Constraint
         try {
             $comparator = $comparatorFactory->getComparatorFor(
                 $this->value,
-                $other
+                $other,
             );
 
             $comparator->assertEquals(
                 $this->value,
                 $other,
-                $this->delta
+                $this->delta,
             );
         } catch (ComparisonFailure $f) {
             if ($returnResult) {
@@ -77,7 +77,7 @@ final class IsEqualWithDelta extends Constraint
 
             throw new ExpectationFailedException(
                 trim($description . "\n" . $f->getMessage()),
-                $f
+                $f,
             );
         }
 
@@ -94,7 +94,7 @@ final class IsEqualWithDelta extends Constraint
         return sprintf(
             'is equal to %s with delta <%F>',
             $this->exporter()->export($this->value),
-            $this->delta
+            $this->delta,
         );
     }
 }

--- a/src/Framework/Constraint/Exception/Exception.php
+++ b/src/Framework/Constraint/Exception/Exception.php
@@ -36,7 +36,7 @@ final class Exception extends Constraint
     {
         return sprintf(
             'exception of type "%s"',
-            $this->className
+            $this->className,
         );
     }
 
@@ -73,13 +73,13 @@ final class Exception extends Constraint
                 'exception of type "%s" matches expected exception "%s"%s',
                 get_class($other),
                 $this->className,
-                $message
+                $message,
             );
         }
 
         return sprintf(
             'exception of type "%s" is thrown',
-            $this->className
+            $this->className,
         );
     }
 }

--- a/src/Framework/Constraint/Exception/ExceptionCode.php
+++ b/src/Framework/Constraint/Exception/ExceptionCode.php
@@ -61,7 +61,7 @@ final class ExceptionCode extends Constraint
         return sprintf(
             '%s is equal to expected exception code %s',
             $this->exporter()->export($other->getCode()),
-            $this->exporter()->export($this->expectedCode)
+            $this->exporter()->export($this->expectedCode),
         );
     }
 }

--- a/src/Framework/Constraint/Exception/ExceptionMessage.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessage.php
@@ -65,14 +65,14 @@ final class ExceptionMessage extends Constraint
         if ($this->expectedMessage === '') {
             return sprintf(
                 "exception message is empty but is '%s'",
-                $other->getMessage()
+                $other->getMessage(),
             );
         }
 
         return sprintf(
             "exception message '%s' contains '%s'",
             $other->getMessage(),
-            $this->expectedMessage
+            $this->expectedMessage,
         );
     }
 }

--- a/src/Framework/Constraint/Exception/ExceptionMessageRegularExpression.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessageRegularExpression.php
@@ -48,7 +48,7 @@ final class ExceptionMessageRegularExpression extends Constraint
 
         if ($match === false) {
             throw new \PHPUnit\Framework\Exception(
-                "Invalid expected exception message regex given: '{$this->expectedMessageRegExp}'"
+                "Invalid expected exception message regex given: '{$this->expectedMessageRegExp}'",
             );
         }
 
@@ -68,7 +68,7 @@ final class ExceptionMessageRegularExpression extends Constraint
         return sprintf(
             "exception message '%s' matches '%s'",
             $other->getMessage(),
-            $this->expectedMessageRegExp
+            $this->expectedMessageRegExp,
         );
     }
 }

--- a/src/Framework/Constraint/Filesystem/DirectoryExists.php
+++ b/src/Framework/Constraint/Filesystem/DirectoryExists.php
@@ -48,7 +48,7 @@ final class DirectoryExists extends Constraint
     {
         return sprintf(
             'directory "%s" exists',
-            $other
+            $other,
         );
     }
 }

--- a/src/Framework/Constraint/Filesystem/FileExists.php
+++ b/src/Framework/Constraint/Filesystem/FileExists.php
@@ -48,7 +48,7 @@ final class FileExists extends Constraint
     {
         return sprintf(
             'file "%s" exists',
-            $other
+            $other,
         );
     }
 }

--- a/src/Framework/Constraint/Filesystem/IsReadable.php
+++ b/src/Framework/Constraint/Filesystem/IsReadable.php
@@ -48,7 +48,7 @@ final class IsReadable extends Constraint
     {
         return sprintf(
             '"%s" is readable',
-            $other
+            $other,
         );
     }
 }

--- a/src/Framework/Constraint/Filesystem/IsWritable.php
+++ b/src/Framework/Constraint/Filesystem/IsWritable.php
@@ -48,7 +48,7 @@ final class IsWritable extends Constraint
     {
         return sprintf(
             '"%s" is writable',
-            $other
+            $other,
         );
     }
 }

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -62,7 +62,7 @@ final class IsIdentical extends Constraint
                     $this->value,
                     $other,
                     sprintf("'%s'", $this->value),
-                    sprintf("'%s'", $other)
+                    sprintf("'%s'", $other),
                 );
             }
 
@@ -72,7 +72,7 @@ final class IsIdentical extends Constraint
                     $this->value,
                     $other,
                     $this->exporter()->export($this->value),
-                    $this->exporter()->export($other)
+                    $this->exporter()->export($other),
                 );
             }
 

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -37,7 +37,7 @@ final class JsonMatches extends Constraint
     {
         return sprintf(
             'matches JSON string "%s"',
-            $this->value
+            $this->value,
         );
     }
 
@@ -100,7 +100,7 @@ final class JsonMatches extends Constraint
                 Json::prettify($recodedValue),
                 Json::prettify($recodedOther),
                 false,
-                'Failed asserting that two json values are equal.'
+                'Failed asserting that two json values are equal.',
             );
         }
 

--- a/src/Framework/Constraint/Object/ClassHasAttribute.php
+++ b/src/Framework/Constraint/Object/ClassHasAttribute.php
@@ -40,7 +40,7 @@ class ClassHasAttribute extends Constraint
     {
         return sprintf(
             'has attribute "%s"',
-            $this->attributeName
+            $this->attributeName,
         );
     }
 
@@ -59,7 +59,7 @@ class ClassHasAttribute extends Constraint
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -79,7 +79,7 @@ class ClassHasAttribute extends Constraint
             '%sclass "%s" %s',
             is_object($other) ? 'object of ' : '',
             is_object($other) ? get_class($other) : $other,
-            $this->toString()
+            $this->toString(),
         );
     }
 

--- a/src/Framework/Constraint/Object/ClassHasStaticAttribute.php
+++ b/src/Framework/Constraint/Object/ClassHasStaticAttribute.php
@@ -28,7 +28,7 @@ final class ClassHasStaticAttribute extends ClassHasAttribute
     {
         return sprintf(
             'has static attribute "%s"',
-            $this->attributeName()
+            $this->attributeName(),
         );
     }
 
@@ -51,7 +51,7 @@ final class ClassHasStaticAttribute extends ClassHasAttribute
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd

--- a/src/Framework/Constraint/Object/ObjectEquals.php
+++ b/src/Framework/Constraint/Object/ObjectEquals.php
@@ -65,7 +65,7 @@ final class ObjectEquals extends Constraint
         if (!$object->hasMethod($this->method)) {
             throw new ComparisonMethodDoesNotExistException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
@@ -75,7 +75,7 @@ final class ObjectEquals extends Constraint
         if (!$method->hasReturnType()) {
             throw new ComparisonMethodDoesNotDeclareBoolReturnTypeException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
@@ -84,28 +84,28 @@ final class ObjectEquals extends Constraint
         if (!$returnType instanceof ReflectionNamedType) {
             throw new ComparisonMethodDoesNotDeclareBoolReturnTypeException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
         if ($returnType->allowsNull()) {
             throw new ComparisonMethodDoesNotDeclareBoolReturnTypeException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
         if ($returnType->getName() !== 'bool') {
             throw new ComparisonMethodDoesNotDeclareBoolReturnTypeException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
         if ($method->getNumberOfParameters() !== 1 || $method->getNumberOfRequiredParameters() !== 1) {
             throw new ComparisonMethodDoesNotDeclareExactlyOneParameterException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
@@ -114,7 +114,7 @@ final class ObjectEquals extends Constraint
         if (!$parameter->hasType()) {
             throw new ComparisonMethodDoesNotDeclareParameterTypeException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
@@ -123,7 +123,7 @@ final class ObjectEquals extends Constraint
         if (!$type instanceof ReflectionNamedType) {
             throw new ComparisonMethodDoesNotDeclareParameterTypeException(
                 get_class($other),
-                $this->method
+                $this->method,
             );
         }
 
@@ -137,7 +137,7 @@ final class ObjectEquals extends Constraint
             throw new ComparisonMethodDoesNotAcceptParameterTypeException(
                 get_class($other),
                 $this->method,
-                get_class($this->expected)
+                get_class($this->expected),
             );
         }
 

--- a/src/Framework/Constraint/Operator/LogicalNot.php
+++ b/src/Framework/Constraint/Operator/LogicalNot.php
@@ -63,15 +63,15 @@ final class LogicalNot extends UnaryOperator
                 preg_replace(
                     $positives,
                     $negatives,
-                    $nonInput
+                    $nonInput,
                 ),
-                $string
+                $string,
             );
         } else {
             $negatedString = preg_replace(
                 $positives,
                 $negatives,
-                $string
+                $string,
             );
         }
 

--- a/src/Framework/Constraint/Operator/LogicalXor.php
+++ b/src/Framework/Constraint/Operator/LogicalXor.php
@@ -57,7 +57,7 @@ final class LogicalXor extends BinaryOperator
             {
                 return $matches xor $constraint->evaluate($other, '', true);
             },
-            $initial->evaluate($other, '', true)
+            $initial->evaluate($other, '', true),
         );
     }
 }

--- a/src/Framework/Constraint/String/IsJson.php
+++ b/src/Framework/Constraint/String/IsJson.php
@@ -65,13 +65,13 @@ final class IsJson extends Constraint
 
         json_decode($other);
         $error = (string) JsonMatchesErrorMessageProvider::determineJsonError(
-            (string) json_last_error()
+            (string) json_last_error(),
         );
 
         return sprintf(
             '%s is valid JSON (%s)',
             $this->exporter()->shortenedExport($other),
-            $error
+            $error,
         );
     }
 }

--- a/src/Framework/Constraint/String/RegularExpression.php
+++ b/src/Framework/Constraint/String/RegularExpression.php
@@ -34,7 +34,7 @@ class RegularExpression extends Constraint
     {
         return sprintf(
             'matches PCRE pattern "%s"',
-            $this->pattern
+            $this->pattern,
         );
     }
 

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -48,7 +48,7 @@ final class StringContains extends Constraint
 
         return sprintf(
             'contains "%s"',
-            $string
+            $string,
         );
     }
 

--- a/src/Framework/Constraint/String/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/String/StringMatchesFormatDescription.php
@@ -33,8 +33,8 @@ final class StringMatchesFormatDescription extends RegularExpression
     {
         parent::__construct(
             $this->createPatternFromFormat(
-                $this->convertNewlines($string)
-            )
+                $this->convertNewlines($string),
+            ),
         );
 
         $this->string = $string;
@@ -49,7 +49,7 @@ final class StringMatchesFormatDescription extends RegularExpression
     protected function matches($other): bool
     {
         return parent::matches(
-            $this->convertNewlines($other)
+            $this->convertNewlines($other),
         );
     }
 
@@ -96,7 +96,7 @@ final class StringMatchesFormatDescription extends RegularExpression
                 '%x' => '[0-9a-fA-F]+',
                 '%f' => '[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?',
                 '%c' => '.',
-            ]
+            ],
         );
 
         return '/^' . $string . '$/s';

--- a/src/Framework/Constraint/Traversable/TraversableContains.php
+++ b/src/Framework/Constraint/Traversable/TraversableContains.php
@@ -52,7 +52,7 @@ abstract class TraversableContains extends Constraint
         return sprintf(
             '%s %s',
             is_array($other) ? 'an array' : 'a traversable',
-            $this->toString()
+            $this->toString(),
         );
     }
 

--- a/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
+++ b/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
@@ -36,7 +36,7 @@ final class TraversableContainsOnly extends Constraint
             $this->constraint = new IsType($type);
         } else {
             $this->constraint = new IsInstanceOf(
-                $type
+                $type,
             );
         }
 

--- a/src/Framework/Constraint/Type/IsInstanceOf.php
+++ b/src/Framework/Constraint/Type/IsInstanceOf.php
@@ -36,7 +36,7 @@ final class IsInstanceOf extends Constraint
         return sprintf(
             'is instance of %s "%s"',
             $this->getType(),
-            $this->className
+            $this->className,
         );
     }
 
@@ -67,7 +67,7 @@ final class IsInstanceOf extends Constraint
             '%s is an instance of %s "%s"',
             $this->exporter()->shortenedExport($other),
             $this->getType(),
-            $this->className
+            $this->className,
         );
     }
 

--- a/src/Framework/Constraint/Type/IsType.php
+++ b/src/Framework/Constraint/Type/IsType.php
@@ -130,8 +130,8 @@ final class IsType extends Constraint
                 sprintf(
                     'Type specified for PHPUnit\Framework\Constraint\IsType <%s> ' .
                     'is not a valid type.',
-                    $type
-                )
+                    $type,
+                ),
             );
         }
 
@@ -145,7 +145,7 @@ final class IsType extends Constraint
     {
         return sprintf(
             'is of type "%s"',
-            $this->type
+            $this->type,
         );
     }
 

--- a/src/Framework/Exception/ActualValueIsNotAnObjectException.php
+++ b/src/Framework/Exception/ActualValueIsNotAnObjectException.php
@@ -21,7 +21,7 @@ final class ActualValueIsNotAnObjectException extends Exception
         parent::__construct(
             'Actual value is not an object',
             0,
-            null
+            null,
         );
     }
 

--- a/src/Framework/Exception/ComparisonMethodDoesNotAcceptParameterTypeException.php
+++ b/src/Framework/Exception/ComparisonMethodDoesNotAcceptParameterTypeException.php
@@ -24,10 +24,10 @@ final class ComparisonMethodDoesNotAcceptParameterTypeException extends Exceptio
                 '%s is not an accepted argument type for comparison method %s::%s().',
                 $type,
                 $className,
-                $methodName
+                $methodName,
             ),
             0,
-            null
+            null,
         );
     }
 

--- a/src/Framework/Exception/ComparisonMethodDoesNotDeclareBoolReturnTypeException.php
+++ b/src/Framework/Exception/ComparisonMethodDoesNotDeclareBoolReturnTypeException.php
@@ -23,10 +23,10 @@ final class ComparisonMethodDoesNotDeclareBoolReturnTypeException extends Except
             sprintf(
                 'Comparison method %s::%s() does not declare bool return type.',
                 $className,
-                $methodName
+                $methodName,
             ),
             0,
-            null
+            null,
         );
     }
 

--- a/src/Framework/Exception/ComparisonMethodDoesNotDeclareExactlyOneParameterException.php
+++ b/src/Framework/Exception/ComparisonMethodDoesNotDeclareExactlyOneParameterException.php
@@ -23,10 +23,10 @@ final class ComparisonMethodDoesNotDeclareExactlyOneParameterException extends E
             sprintf(
                 'Comparison method %s::%s() does not declare exactly one parameter.',
                 $className,
-                $methodName
+                $methodName,
             ),
             0,
-            null
+            null,
         );
     }
 

--- a/src/Framework/Exception/ComparisonMethodDoesNotDeclareParameterTypeException.php
+++ b/src/Framework/Exception/ComparisonMethodDoesNotDeclareParameterTypeException.php
@@ -23,10 +23,10 @@ final class ComparisonMethodDoesNotDeclareParameterTypeException extends Excepti
             sprintf(
                 'Parameter of comparison method %s::%s() does not have a declared type.',
                 $className,
-                $methodName
+                $methodName,
             ),
             0,
-            null
+            null,
         );
     }
 

--- a/src/Framework/Exception/ComparisonMethodDoesNotExistException.php
+++ b/src/Framework/Exception/ComparisonMethodDoesNotExistException.php
@@ -23,10 +23,10 @@ final class ComparisonMethodDoesNotExistException extends Exception
             sprintf(
                 'Comparison method %s::%s() does not exist.',
                 $className,
-                $methodName
+                $methodName,
             ),
             0,
-            null
+            null,
         );
     }
 

--- a/src/Framework/Exception/InvalidArgumentException.php
+++ b/src/Framework/Exception/InvalidArgumentException.php
@@ -34,8 +34,8 @@ final class InvalidArgumentException extends Exception
                 $argument,
                 $function,
                 in_array(lcfirst($type)[0], ['a', 'e', 'i', 'o', 'u'], true) ? 'an' : 'a',
-                $type
-            )
+                $type,
+            ),
         );
     }
 

--- a/src/Framework/ExecutionOrderDependency.php
+++ b/src/Framework/ExecutionOrderDependency.php
@@ -77,8 +77,8 @@ final class ExecutionOrderDependency
                 static function (self $d)
                 {
                     return $d->isValid();
-                }
-            )
+                },
+            ),
         );
     }
 
@@ -95,7 +95,7 @@ final class ExecutionOrderDependency
             {
                 return $dependency->getTarget();
             },
-            $existing
+            $existing,
         );
 
         foreach ($additional as $dependency) {
@@ -132,7 +132,7 @@ final class ExecutionOrderDependency
             {
                 return $dependency->getTarget();
             },
-            $right
+            $right,
         );
 
         foreach ($left as $dependency) {

--- a/src/Framework/MockObject/Api/Api.php
+++ b/src/Framework/MockObject/Api/Api.php
@@ -42,7 +42,7 @@ trait Api
     {
         if (isset(static::$__phpunit_configurableMethods)) {
             throw new ConfigurableMethodsAlreadyInitializedException(
-                'Configurable methods is already initialized and can not be reinitialized'
+                'Configurable methods is already initialized and can not be reinitialized',
             );
         }
 
@@ -67,7 +67,7 @@ trait Api
         if ($this->__phpunit_invocationMocker === null) {
             $this->__phpunit_invocationMocker = new InvocationHandler(
                 static::$__phpunit_configurableMethods,
-                $this->__phpunit_returnValueGeneration
+                $this->__phpunit_returnValueGeneration,
             );
         }
 

--- a/src/Framework/MockObject/Api/Method.php
+++ b/src/Framework/MockObject/Api/Method.php
@@ -24,7 +24,7 @@ trait Method
 
         return call_user_func_array(
             [$expects, 'method'],
-            func_get_args()
+            func_get_args(),
         );
     }
 }

--- a/src/Framework/MockObject/Builder/InvocationMocker.php
+++ b/src/Framework/MockObject/Builder/InvocationMocker.php
@@ -241,7 +241,7 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
             {
                 return strtolower($configurable->getName());
             },
-            $this->configurableMethods
+            $this->configurableMethods,
         );
 
         if (is_string($constraint) && !in_array(strtolower($constraint), $configurableMethodNames, true)) {
@@ -300,7 +300,7 @@ final class InvocationMocker implements InvocationStubber, MethodNameMatch
             if (!$configuredMethod->mayReturn($value)) {
                 throw new IncompatibleReturnValueException(
                     $configuredMethod,
-                    $value
+                    $value,
                 );
             }
         }

--- a/src/Framework/MockObject/Exception/CannotUseAddMethodsException.php
+++ b/src/Framework/MockObject/Exception/CannotUseAddMethodsException.php
@@ -22,8 +22,8 @@ final class CannotUseAddMethodsException extends \PHPUnit\Framework\Exception im
             sprintf(
                 'Trying to configure method "%s" with addMethods(), but it exists in class "%s". Use onlyMethods() for methods that exist in the class',
                 $methodName,
-                $type
-            )
+                $type,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/CannotUseOnlyMethodsException.php
+++ b/src/Framework/MockObject/Exception/CannotUseOnlyMethodsException.php
@@ -22,8 +22,8 @@ final class CannotUseOnlyMethodsException extends \PHPUnit\Framework\Exception i
             sprintf(
                 'Trying to configure method "%s" with onlyMethods(), but it does not exist in class "%s". Use addMethods() for methods that do not exist in the class',
                 $methodName,
-                $type
-            )
+                $type,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/ClassAlreadyExistsException.php
+++ b/src/Framework/MockObject/Exception/ClassAlreadyExistsException.php
@@ -21,8 +21,8 @@ final class ClassAlreadyExistsException extends \PHPUnit\Framework\Exception imp
         parent::__construct(
             sprintf(
                 'Class "%s" already exists',
-                $className
-            )
+                $className,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/ClassIsFinalException.php
+++ b/src/Framework/MockObject/Exception/ClassIsFinalException.php
@@ -21,8 +21,8 @@ final class ClassIsFinalException extends \PHPUnit\Framework\Exception implement
         parent::__construct(
             sprintf(
                 'Class "%s" is declared "final" and cannot be doubled',
-                $className
-            )
+                $className,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/ClassIsReadonlyException.php
+++ b/src/Framework/MockObject/Exception/ClassIsReadonlyException.php
@@ -21,8 +21,8 @@ final class ClassIsReadonlyException extends \PHPUnit\Framework\Exception implem
         parent::__construct(
             sprintf(
                 'Class "%s" is declared "readonly" and cannot be doubled',
-                $className
-            )
+                $className,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/DuplicateMethodException.php
+++ b/src/Framework/MockObject/Exception/DuplicateMethodException.php
@@ -28,8 +28,8 @@ final class DuplicateMethodException extends \PHPUnit\Framework\Exception implem
             sprintf(
                 'Cannot double using a method list that contains duplicates: "%s" (duplicate: "%s")',
                 implode(', ', $methods),
-                implode(', ', array_unique(array_diff_assoc($methods, array_unique($methods))))
-            )
+                implode(', ', array_unique(array_diff_assoc($methods, array_unique($methods)))),
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/IncompatibleReturnValueException.php
+++ b/src/Framework/MockObject/Exception/IncompatibleReturnValueException.php
@@ -29,8 +29,8 @@ final class IncompatibleReturnValueException extends \PHPUnit\Framework\Exceptio
                 'Method %s may not return value of type %s, its declared return type is "%s"',
                 $method->getName(),
                 is_object($value) ? get_class($value) : gettype($value),
-                $method->getReturnTypeDeclaration()
-            )
+                $method->getReturnTypeDeclaration(),
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/InvalidMethodNameException.php
+++ b/src/Framework/MockObject/Exception/InvalidMethodNameException.php
@@ -21,8 +21,8 @@ final class InvalidMethodNameException extends \PHPUnit\Framework\Exception impl
         parent::__construct(
             sprintf(
                 'Cannot double method with invalid name "%s"',
-                $method
-            )
+                $method,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/MatchBuilderNotFoundException.php
+++ b/src/Framework/MockObject/Exception/MatchBuilderNotFoundException.php
@@ -21,8 +21,8 @@ final class MatchBuilderNotFoundException extends \PHPUnit\Framework\Exception i
         parent::__construct(
             sprintf(
                 'No builder found for match builder identification <%s>',
-                $id
-            )
+                $id,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/MatcherAlreadyRegisteredException.php
+++ b/src/Framework/MockObject/Exception/MatcherAlreadyRegisteredException.php
@@ -21,8 +21,8 @@ final class MatcherAlreadyRegisteredException extends \PHPUnit\Framework\Excepti
         parent::__construct(
             sprintf(
                 'Matcher with id <%s> is already registered',
-                $id
-            )
+                $id,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/MethodCannotBeConfiguredException.php
+++ b/src/Framework/MockObject/Exception/MethodCannotBeConfiguredException.php
@@ -21,8 +21,8 @@ final class MethodCannotBeConfiguredException extends \PHPUnit\Framework\Excepti
         parent::__construct(
             sprintf(
                 'Trying to configure method "%s" which cannot be configured because it does not exist, has not been specified, is final, or is static',
-                $method
-            )
+                $method,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/ReturnValueNotConfiguredException.php
+++ b/src/Framework/MockObject/Exception/ReturnValueNotConfiguredException.php
@@ -22,8 +22,8 @@ final class ReturnValueNotConfiguredException extends \PHPUnit\Framework\Excepti
             sprintf(
                 'Return value inference disabled and no expectation set up for %s::%s()',
                 $invocation->getClassName(),
-                $invocation->getMethodName()
-            )
+                $invocation->getMethodName(),
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/SoapExtensionNotAvailableException.php
+++ b/src/Framework/MockObject/Exception/SoapExtensionNotAvailableException.php
@@ -17,7 +17,7 @@ final class SoapExtensionNotAvailableException extends \PHPUnit\Framework\Except
     public function __construct()
     {
         parent::__construct(
-            'The SOAP extension is required to generate a test double from WSDL'
+            'The SOAP extension is required to generate a test double from WSDL',
         );
     }
 }

--- a/src/Framework/MockObject/Exception/UnknownClassException.php
+++ b/src/Framework/MockObject/Exception/UnknownClassException.php
@@ -21,8 +21,8 @@ final class UnknownClassException extends \PHPUnit\Framework\Exception implement
         parent::__construct(
             sprintf(
                 'Class "%s" does not exist',
-                $className
-            )
+                $className,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/UnknownTraitException.php
+++ b/src/Framework/MockObject/Exception/UnknownTraitException.php
@@ -21,8 +21,8 @@ final class UnknownTraitException extends \PHPUnit\Framework\Exception implement
         parent::__construct(
             sprintf(
                 'Trait "%s" does not exist',
-                $traitName
-            )
+                $traitName,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Exception/UnknownTypeException.php
+++ b/src/Framework/MockObject/Exception/UnknownTypeException.php
@@ -21,8 +21,8 @@ final class UnknownTypeException extends \PHPUnit\Framework\Exception implements
         parent::__construct(
             sprintf(
                 'Class or interface "%s" does not exist',
-                $type
-            )
+                $type,
+            ),
         );
     }
 }

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -186,7 +186,7 @@ EOT;
                 throw new ReflectionException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -207,7 +207,7 @@ EOT;
             $callOriginalClone,
             $callAutoload,
             $cloneArguments,
-            $callOriginalMethods
+            $callOriginalMethods,
         );
 
         return $this->getObject(
@@ -218,7 +218,7 @@ EOT;
             $arguments,
             $callOriginalMethods,
             $proxyTarget,
-            $returnValueGeneration
+            $returnValueGeneration,
         );
     }
 
@@ -265,7 +265,7 @@ EOT;
             $intersectionName = sprintf(
                 'Intersection_%s_%s',
                 implode('_', $unqualifiedNames),
-                substr(md5((string) mt_rand()), 0, 8)
+                substr(md5((string) mt_rand()), 0, 8),
             );
         } while (interface_exists($intersectionName, false));
 
@@ -275,7 +275,7 @@ EOT;
             [
                 'intersection' => $intersectionName,
                 'interfaces'   => implode(', ', $interfaces),
-            ]
+            ],
         );
 
         eval($template->render());
@@ -318,7 +318,7 @@ EOT;
                 throw new ReflectionException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -343,7 +343,7 @@ EOT;
                 $callOriginalConstructor,
                 $callOriginalClone,
                 $callAutoload,
-                $cloneArguments
+                $cloneArguments,
             );
         }
 
@@ -379,7 +379,7 @@ EOT;
         $className = $this->generateClassName(
             $traitName,
             '',
-            'Trait_'
+            'Trait_',
         );
 
         $classTemplate = $this->getTemplate('trait_class.tpl');
@@ -389,7 +389,7 @@ EOT;
                 'prologue'   => 'abstract ',
                 'class_name' => $className['className'],
                 'trait_name' => $traitName,
-            ]
+            ],
         );
 
         $mockTrait = new MockTrait($classTemplate->render(), $className['className']);
@@ -416,7 +416,7 @@ EOT;
         $className = $this->generateClassName(
             $traitName,
             $traitClassName,
-            'Trait_'
+            'Trait_',
         );
 
         $classTemplate = $this->getTemplate('trait_class.tpl');
@@ -426,18 +426,18 @@ EOT;
                 'prologue'   => '',
                 'class_name' => $className['className'],
                 'trait_name' => $traitName,
-            ]
+            ],
         );
 
         return $this->getObject(
             new MockTrait(
                 $classTemplate->render(),
-                $className['className']
+                $className['className'],
             ),
             '',
             $callOriginalConstructor,
             $callAutoload,
-            $arguments
+            $arguments,
         );
     }
 
@@ -457,7 +457,7 @@ EOT;
                 $callOriginalClone,
                 $callAutoload,
                 $cloneArguments,
-                $callOriginalMethods
+                $callOriginalMethods,
             );
         }
 
@@ -466,7 +466,7 @@ EOT;
             serialize($methods) .
             serialize($callOriginalClone) .
             serialize($cloneArguments) .
-            serialize($callOriginalMethods)
+            serialize($callOriginalMethods),
         );
 
         if (!isset(self::$cache[$key])) {
@@ -477,7 +477,7 @@ EOT;
                 $callOriginalClone,
                 $callAutoload,
                 $cloneArguments,
-                $callOriginalMethods
+                $callOriginalMethods,
             );
         }
 
@@ -504,7 +504,7 @@ EOT;
             throw new RuntimeException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
 
@@ -523,7 +523,7 @@ EOT;
             if (empty($methods) || in_array($name, $methods, true)) {
                 $args = explode(
                     ',',
-                    str_replace(')', '', substr($method, $nameEnd + 1))
+                    str_replace(')', '', substr($method, $nameEnd + 1)),
                 );
 
                 foreach (range(0, count($args) - 1) as $i) {
@@ -540,7 +540,7 @@ EOT;
                     [
                         'method_name' => $name,
                         'arguments'   => implode(', ', $args),
-                    ]
+                    ],
                 );
 
                 $methodsBuffer .= $methodTemplate->render();
@@ -571,7 +571,7 @@ EOT;
                 'wsdl'       => $wsdlFile,
                 'options'    => $optionsBuffer,
                 'methods'    => $methodsBuffer,
-            ]
+            ],
         );
 
         return $classTemplate->render();
@@ -591,7 +591,7 @@ EOT;
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -621,7 +621,7 @@ EOT;
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -651,7 +651,7 @@ EOT;
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -681,7 +681,7 @@ EOT;
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -718,7 +718,7 @@ EOT;
                     throw new ReflectionException(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
@@ -745,7 +745,7 @@ EOT;
                         throw new ReflectionException(
                             $e->getMessage(),
                             $e->getCode(),
-                            $e
+                            $e,
                         );
                     }
                     // @codeCoverageIgnoreEnd
@@ -784,7 +784,7 @@ EOT;
         $_mockClassName = $this->generateClassName(
             $type,
             $mockClassName,
-            'Mock_'
+            'Mock_',
         );
 
         if (class_exists($_mockClassName['fullClassName'], $callAutoload)) {
@@ -813,7 +813,7 @@ EOT;
                 throw new ReflectionException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -839,7 +839,7 @@ EOT;
                     throw new ReflectionException(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
@@ -855,7 +855,7 @@ EOT;
                             throw new ReflectionException(
                                 $e->getMessage(),
                                 $e->getCode(),
-                                $e
+                                $e,
                             );
                         }
                         // @codeCoverageIgnoreEnd
@@ -866,14 +866,14 @@ EOT;
                     }
 
                     $mockMethods->addMethods(
-                        MockMethod::fromReflection($method, $callOriginalMethods, $cloneArguments)
+                        MockMethod::fromReflection($method, $callOriginalMethods, $cloneArguments),
                     );
                 }
 
                 $_mockClassName = $this->generateClassName(
                     $actualClassName,
                     $_mockClassName['className'],
-                    'Mock_'
+                    'Mock_',
                 );
             }
 
@@ -884,7 +884,7 @@ EOT;
                 $additionalInterfaces[] = Iterator::class;
 
                 $mockMethods->addMethods(
-                    ...$this->mockClassMethods(Iterator::class, $callOriginalMethods, $cloneArguments)
+                    ...$this->mockClassMethods(Iterator::class, $callOriginalMethods, $cloneArguments),
                 );
             }
 
@@ -896,7 +896,7 @@ EOT;
                     throw new ReflectionException(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
@@ -915,13 +915,13 @@ EOT;
 
         if ($isClass && $explicitMethods === []) {
             $mockMethods->addMethods(
-                ...$this->mockClassMethods($_mockClassName['fullClassName'], $callOriginalMethods, $cloneArguments)
+                ...$this->mockClassMethods($_mockClassName['fullClassName'], $callOriginalMethods, $cloneArguments),
             );
         }
 
         if ($isInterface && ($explicitMethods === [] || $explicitMethods === null)) {
             $mockMethods->addMethods(
-                ...$this->mockInterfaceMethods($_mockClassName['fullClassName'], $cloneArguments)
+                ...$this->mockInterfaceMethods($_mockClassName['fullClassName'], $cloneArguments),
             );
         }
 
@@ -935,14 +935,14 @@ EOT;
                         throw new ReflectionException(
                             $e->getMessage(),
                             $e->getCode(),
-                            $e
+                            $e,
                         );
                     }
                     // @codeCoverageIgnoreEnd
 
                     if ($this->canMockMethod($method)) {
                         $mockMethods->addMethods(
-                            MockMethod::fromReflection($method, $callOriginalMethods, $cloneArguments)
+                            MockMethod::fromReflection($method, $callOriginalMethods, $cloneArguments),
                         );
                     }
                 } else {
@@ -950,8 +950,8 @@ EOT;
                         MockMethod::fromName(
                             $_mockClassName['fullClassName'],
                             $methodName,
-                            $cloneArguments
-                        )
+                            $cloneArguments,
+                        ),
                     );
                 }
             }
@@ -988,19 +988,19 @@ EOT;
                 'class_declaration' => $this->generateMockClassDeclaration(
                     $_mockClassName,
                     $isInterface,
-                    $additionalInterfaces
+                    $additionalInterfaces,
                 ),
                 'clone'           => $cloneTrait,
                 'mock_class_name' => $_mockClassName['className'],
                 'mocked_methods'  => $mockedMethods,
                 'method'          => $method,
-            ]
+            ],
         );
 
         return new MockClass(
             $classTemplate->render(),
             $_mockClassName['className'],
-            $configurable
+            $configurable,
         );
     }
 
@@ -1047,7 +1047,7 @@ EOT;
             $buffer .= sprintf(
                 '%s implements %s',
                 $mockClassName['className'],
-                $interfaces
+                $interfaces,
             );
 
             if (!in_array($mockClassName['originalClassName'], $additionalInterfaces, true)) {
@@ -1065,7 +1065,7 @@ EOT;
                 $mockClassName['className'],
                 !empty($mockClassName['namespaceName']) ? $mockClassName['namespaceName'] . '\\' : '',
                 $mockClassName['originalClassName'],
-                $interfaces
+                $interfaces,
             );
         }
 
@@ -1096,7 +1096,7 @@ EOT;
                 throw new RuntimeException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
         }

--- a/src/Framework/MockObject/Invocation.php
+++ b/src/Framework/MockObject/Invocation.php
@@ -183,7 +183,7 @@ final class Invocation implements SelfDescribing
                     throw new RuntimeException(
                         $t->getMessage(),
                         (int) $t->getCode(),
-                        $t
+                        $t,
                     );
                 }
             }
@@ -221,7 +221,7 @@ final class Invocation implements SelfDescribing
                     throw new RuntimeException(
                         $t->getMessage(),
                         (int) $t->getCode(),
-                        $t
+                        $t,
                     );
                 }
             }
@@ -256,8 +256,8 @@ final class Invocation implements SelfDescribing
                 'Return value for %s::%s() cannot be generated%s, please configure a return value for this method',
                 $this->className,
                 $this->methodName,
-                $reason
-            )
+                $reason,
+            ),
         );
     }
 
@@ -273,10 +273,10 @@ final class Invocation implements SelfDescribing
                 ', ',
                 array_map(
                     [$exporter, 'shortenedExport'],
-                    $this->parameters
-                )
+                    $this->parameters,
+                ),
             ),
-            $this->returnType ? sprintf(': %s', $this->returnType) : ''
+            $this->returnType ? sprintf(': %s', $this->returnType) : '',
         );
     }
 

--- a/src/Framework/MockObject/InvocationHandler.php
+++ b/src/Framework/MockObject/InvocationHandler.php
@@ -102,7 +102,7 @@ final class InvocationHandler
         return new InvocationMocker(
             $this,
             $matcher,
-            ...$this->configurableMethods
+            ...$this->configurableMethods,
         );
     }
 

--- a/src/Framework/MockObject/Matcher.php
+++ b/src/Framework/MockObject/Matcher.php
@@ -143,9 +143,9 @@ final class Matcher
                     "Expectation failed for %s when %s\n%s",
                     $this->methodNameRule->toString(),
                     $this->invocationRule->toString(),
-                    $e->getMessage()
+                    $e->getMessage(),
                 ),
-                $e->getComparisonFailure()
+                $e->getComparisonFailure(),
             );
         }
 
@@ -199,9 +199,9 @@ final class Matcher
                     "Expectation failed for %s when %s\n%s",
                     $this->methodNameRule->toString(),
                     $this->invocationRule->toString(),
-                    $e->getMessage()
+                    $e->getMessage(),
                 ),
-                $e->getComparisonFailure()
+                $e->getComparisonFailure(),
             );
         }
 
@@ -239,8 +239,8 @@ final class Matcher
                     "Expectation failed for %s when %s.\n%s",
                     $this->methodNameRule->toString(),
                     $this->invocationRule->toString(),
-                    TestFailure::exceptionToString($e)
-                )
+                    TestFailure::exceptionToString($e),
+                ),
             );
         }
     }

--- a/src/Framework/MockObject/MethodNameConstraint.php
+++ b/src/Framework/MockObject/MethodNameConstraint.php
@@ -33,7 +33,7 @@ final class MethodNameConstraint extends Constraint
     {
         return sprintf(
             'is "%s"',
-            $this->methodName
+            $this->methodName,
         );
     }
 

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -138,7 +138,7 @@ final class MockBuilder
             $this->callOriginalMethods,
             $this->proxyTarget,
             $this->allowMockingUnknownTypes,
-            $this->returnValueGeneration
+            $this->returnValueGeneration,
         );
 
         $this->testCase->registerMockObject($object);
@@ -165,7 +165,7 @@ final class MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments
+            $this->cloneArguments,
         );
 
         $this->testCase->registerMockObject($object);
@@ -192,7 +192,7 @@ final class MockBuilder
             $this->originalClone,
             $this->autoload,
             $this->methods,
-            $this->cloneArguments
+            $this->cloneArguments,
         );
 
         $this->testCase->registerMockObject($object);
@@ -243,7 +243,7 @@ final class MockBuilder
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -285,7 +285,7 @@ final class MockBuilder
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -313,8 +313,8 @@ final class MockBuilder
         return $this->setMethods(
             array_diff(
                 $this->generator->getClassMethods($this->type),
-                $methods
-            )
+                $methods,
+            ),
         );
     }
 

--- a/src/Framework/MockObject/MockClass.php
+++ b/src/Framework/MockObject/MockClass.php
@@ -55,7 +55,7 @@ final class MockClass implements MockType
                     $this->mockName,
                     '__phpunit_initConfigurableMethods',
                 ],
-                ...$this->configurableMethods
+                ...$this->configurableMethods,
             );
         }
 

--- a/src/Framework/MockObject/MockMethod.php
+++ b/src/Framework/MockObject/MockMethod.php
@@ -140,7 +140,7 @@ final class MockMethod
             $reference,
             $callOriginalMethod,
             $method->isStatic(),
-            $deprecation
+            $deprecation,
         );
     }
 
@@ -157,7 +157,7 @@ final class MockMethod
             '',
             false,
             false,
-            null
+            null,
         );
     }
 
@@ -191,12 +191,12 @@ final class MockMethod
         } elseif ($this->returnType->isNever() || $this->returnType->isVoid()) {
             $templateFile = sprintf(
                 '%s_method_never_or_void.tpl',
-                $this->callOriginalMethod ? 'proxied' : 'mocked'
+                $this->callOriginalMethod ? 'proxied' : 'mocked',
             );
         } else {
             $templateFile = sprintf(
                 '%s_method.tpl',
-                $this->callOriginalMethod ? 'proxied' : 'mocked'
+                $this->callOriginalMethod ? 'proxied' : 'mocked',
             );
         }
 
@@ -209,7 +209,7 @@ final class MockMethod
             $deprecationTemplate->setVar(
                 [
                     'deprecation' => var_export($deprecation, true),
-                ]
+                ],
             );
 
             $deprecation = $deprecationTemplate->render();
@@ -230,7 +230,7 @@ final class MockMethod
                 'reference'          => $this->reference,
                 'clone_arguments'    => $this->cloneArguments ? 'true' : 'false',
                 'deprecation'        => $deprecation,
-            ]
+            ],
         );
 
         return $template->render();
@@ -255,7 +255,7 @@ final class MockMethod
                 throw new RuntimeException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
         }
@@ -361,18 +361,18 @@ final class MockMethod
                 substr(
                     substr(
                         $parameterAsString,
-                        strpos($parameterAsString, '<optional> ') + strlen('<optional> ')
+                        strpos($parameterAsString, '<optional> ') + strlen('<optional> '),
                     ),
                     0,
-                    -2
-                )
+                    -2,
+                ),
             )[1];
             // @codeCoverageIgnoreStart
         } catch (\ReflectionException $e) {
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd

--- a/src/Framework/MockObject/Rule/ConsecutiveParameters.php
+++ b/src/Framework/MockObject/Rule/ConsecutiveParameters.php
@@ -47,8 +47,8 @@ final class ConsecutiveParameters implements ParametersRule
                     sprintf(
                         'Parameter group #%d must be an array or Traversable, got %s',
                         $index,
-                        gettype($parameters)
-                    )
+                        gettype($parameters),
+                    ),
                 );
             }
 
@@ -111,8 +111,8 @@ final class ConsecutiveParameters implements ParametersRule
             throw new ExpectationFailedException(
                 sprintf(
                     'Parameter count for invocation %s is too low.',
-                    $invocation->toString()
-                )
+                    $invocation->toString(),
+                ),
             );
         }
 
@@ -124,8 +124,8 @@ final class ConsecutiveParameters implements ParametersRule
                     'value.',
                     $i,
                     $callIndex,
-                    $invocation->toString()
-                )
+                    $invocation->toString(),
+                ),
             );
         }
     }

--- a/src/Framework/MockObject/Rule/InvokedAtIndex.php
+++ b/src/Framework/MockObject/Rule/InvokedAtIndex.php
@@ -64,8 +64,8 @@ final class InvokedAtIndex extends InvocationOrder
             throw new ExpectationFailedException(
                 sprintf(
                     'The expected invocation at index %s was never reached.',
-                    $this->sequenceIndex
-                )
+                    $this->sequenceIndex,
+                ),
             );
         }
     }

--- a/src/Framework/MockObject/Rule/InvokedAtLeastCount.php
+++ b/src/Framework/MockObject/Rule/InvokedAtLeastCount.php
@@ -48,7 +48,7 @@ final class InvokedAtLeastCount extends InvocationOrder
         if ($count < $this->requiredInvocations) {
             throw new ExpectationFailedException(
                 'Expected invocation at least ' . $this->requiredInvocations .
-                ' times but it occurred ' . $count . ' time(s).'
+                ' times but it occurred ' . $count . ' time(s).',
             );
         }
     }

--- a/src/Framework/MockObject/Rule/InvokedAtLeastOnce.php
+++ b/src/Framework/MockObject/Rule/InvokedAtLeastOnce.php
@@ -34,7 +34,7 @@ final class InvokedAtLeastOnce extends InvocationOrder
 
         if ($count < 1) {
             throw new ExpectationFailedException(
-                'Expected invocation at least once but it never occurred.'
+                'Expected invocation at least once but it never occurred.',
             );
         }
     }

--- a/src/Framework/MockObject/Rule/InvokedAtMostCount.php
+++ b/src/Framework/MockObject/Rule/InvokedAtMostCount.php
@@ -48,7 +48,7 @@ final class InvokedAtMostCount extends InvocationOrder
         if ($count > $this->allowedInvocations) {
             throw new ExpectationFailedException(
                 'Expected invocation at most ' . $this->allowedInvocations .
-                ' times but it occurred ' . $count . ' time(s).'
+                ' times but it occurred ' . $count . ' time(s).',
             );
         }
     }

--- a/src/Framework/MockObject/Rule/InvokedCount.php
+++ b/src/Framework/MockObject/Rule/InvokedCount.php
@@ -62,8 +62,8 @@ final class InvokedCount extends InvocationOrder
                     'Method was expected to be called %d times, ' .
                     'actually called %d times.',
                     $this->expectedCount,
-                    $count
-                )
+                    $count,
+                ),
             );
         }
     }
@@ -92,7 +92,7 @@ final class InvokedCount extends InvocationOrder
                 default:
                     $message .= sprintf(
                         'was not expected to be called more than %d times.',
-                        $this->expectedCount
+                        $this->expectedCount,
                     );
             }
 

--- a/src/Framework/MockObject/Rule/Parameters.php
+++ b/src/Framework/MockObject/Rule/Parameters.php
@@ -47,7 +47,7 @@ final class Parameters implements ParametersRule
         foreach ($parameters as $parameter) {
             if (!($parameter instanceof Constraint)) {
                 $parameter = new IsEqual(
-                    $parameter
+                    $parameter,
                 );
             }
 
@@ -127,7 +127,7 @@ final class Parameters implements ParametersRule
             }
 
             throw new ExpectationFailedException(
-                sprintf($message, $this->invocation->toString())
+                sprintf($message, $this->invocation->toString()),
             );
         }
 
@@ -138,8 +138,8 @@ final class Parameters implements ParametersRule
                     'Parameter %s for invocation %s does not match expected ' .
                     'value.',
                     $i,
-                    $this->invocation->toString()
-                )
+                    $this->invocation->toString(),
+                ),
             );
         }
 

--- a/src/Framework/MockObject/Stub/ConsecutiveCalls.php
+++ b/src/Framework/MockObject/Stub/ConsecutiveCalls.php
@@ -51,7 +51,7 @@ final class ConsecutiveCalls implements Stub
 
         return sprintf(
             'return user-specified value %s',
-            $exporter->export($this->value)
+            $exporter->export($this->value),
         );
     }
 }

--- a/src/Framework/MockObject/Stub/Exception.php
+++ b/src/Framework/MockObject/Stub/Exception.php
@@ -40,7 +40,7 @@ final class Exception implements Stub
 
         return sprintf(
             'raise user-specified exception %s',
-            $exporter->export($this->exception)
+            $exporter->export($this->exception),
         );
     }
 }

--- a/src/Framework/MockObject/Stub/ReturnCallback.php
+++ b/src/Framework/MockObject/Stub/ReturnCallback.php
@@ -49,7 +49,7 @@ final class ReturnCallback implements Stub
                 'passed arguments',
                 $class,
                 $type,
-                $this->callback[1]
+                $this->callback[1],
             );
         }
 

--- a/src/Framework/MockObject/Stub/ReturnReference.php
+++ b/src/Framework/MockObject/Stub/ReturnReference.php
@@ -39,7 +39,7 @@ final class ReturnReference implements Stub
 
         return sprintf(
             'return user-specified reference %s',
-            $exporter->export($this->reference)
+            $exporter->export($this->reference),
         );
     }
 }

--- a/src/Framework/MockObject/Stub/ReturnStub.php
+++ b/src/Framework/MockObject/Stub/ReturnStub.php
@@ -39,7 +39,7 @@ final class ReturnStub implements Stub
 
         return sprintf(
             'return user-specified value %s',
-            $exporter->export($this->value)
+            $exporter->export($this->value),
         );
     }
 }

--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -31,28 +31,28 @@ final class TestBuilder
 
         if (!$theClass->isInstantiable()) {
             return new ErrorTestCase(
-                sprintf('Cannot instantiate class "%s".', $className)
+                sprintf('Cannot instantiate class "%s".', $className),
             );
         }
 
         $backupSettings = TestUtil::getBackupSettings(
             $className,
-            $methodName
+            $methodName,
         );
 
         $preserveGlobalState = TestUtil::getPreserveGlobalStateSettings(
             $className,
-            $methodName
+            $methodName,
         );
 
         $runTestInSeparateProcess = TestUtil::getProcessIsolationSettings(
             $className,
-            $methodName
+            $methodName,
         );
 
         $runClassInSeparateProcess = TestUtil::getClassProcessIsolationSettings(
             $className,
-            $methodName
+            $methodName,
         );
 
         $constructor = $theClass->getConstructor();
@@ -71,14 +71,14 @@ final class TestBuilder
             try {
                 $data = TestUtil::getProvidedData(
                     $className,
-                    $methodName
+                    $methodName,
                 );
             } catch (IncompleteTestError $e) {
                 $message = sprintf(
                     "Test for %s::%s marked incomplete by data provider\n%s",
                     $className,
                     $methodName,
-                    $this->throwableToString($e)
+                    $this->throwableToString($e),
                 );
 
                 $data = new IncompleteTestCase($className, $methodName, $message);
@@ -87,7 +87,7 @@ final class TestBuilder
                     "Test for %s::%s skipped by data provider\n%s",
                     $className,
                     $methodName,
-                    $this->throwableToString($e)
+                    $this->throwableToString($e),
                 );
 
                 $data = new SkippedTestCase($className, $methodName, $message);
@@ -96,7 +96,7 @@ final class TestBuilder
                     "The data provider specified for %s::%s is invalid.\n%s",
                     $className,
                     $methodName,
-                    $this->throwableToString($t)
+                    $this->throwableToString($t),
                 );
 
                 $data = new ErrorTestCase($message);
@@ -111,7 +111,7 @@ final class TestBuilder
                     $runTestInSeparateProcess,
                     $preserveGlobalState,
                     $runClassInSeparateProcess,
-                    $backupSettings
+                    $backupSettings,
                 );
             } else {
                 $test = $this->buildTestWithoutData($className);
@@ -125,7 +125,7 @@ final class TestBuilder
                 $runTestInSeparateProcess,
                 $preserveGlobalState,
                 $runClassInSeparateProcess,
-                $backupSettings
+                $backupSettings,
             );
         }
 
@@ -149,7 +149,7 @@ final class TestBuilder
         array $backupSettings
     ): DataProviderTestSuite {
         $dataProviderTestSuite = new DataProviderTestSuite(
-            $className . '::' . $methodName
+            $className . '::' . $methodName,
         );
 
         $groups = TestUtil::getGroups($className, $methodName);
@@ -169,7 +169,7 @@ final class TestBuilder
                     $runTestInSeparateProcess,
                     $preserveGlobalState,
                     $runClassInSeparateProcess,
-                    $backupSettings
+                    $backupSettings,
                 );
 
                 $dataProviderTestSuite->addTest($_test, $groups);
@@ -208,7 +208,7 @@ final class TestBuilder
 
         if ($backupSettings['backupStaticAttributes'] !== null) {
             $test->setBackupStaticAttributes(
-                $backupSettings['backupStaticAttributes']
+                $backupSettings['backupStaticAttributes'],
             );
         }
     }
@@ -225,7 +225,7 @@ final class TestBuilder
             return sprintf(
                 "%s\n%s",
                 $message,
-                Filter::getFilteredStacktrace($t)
+                Filter::getFilteredStacktrace($t),
             );
         }
 
@@ -233,7 +233,7 @@ final class TestBuilder
             "%s: %s\n%s",
             get_class($t),
             $message,
-            Filter::getFilteredStacktrace($t)
+            Filter::getFilteredStacktrace($t),
         );
     }
 }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -374,7 +374,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     public static function atLeast(int $requiredInvocations): InvokedAtLeastCountMatcher
     {
         return new InvokedAtLeastCountMatcher(
-            $requiredInvocations
+            $requiredInvocations,
         );
     }
 
@@ -429,7 +429,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
             if (isset($frame['object']) && $frame['object'] instanceof self) {
                 $frame['object']->addWarning(
-                    'The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.'
+                    'The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.',
                 );
 
                 break;
@@ -555,7 +555,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -563,7 +563,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         $buffer = sprintf(
             '%s::%s',
             $class->name,
-            $this->getName(false)
+            $this->getName(false),
         );
 
         return $buffer . $this->getDataSetAsString();
@@ -837,18 +837,18 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
 
             if ($runEntireClass) {
                 $template = new Template(
-                    __DIR__ . '/../Util/PHP/Template/TestCaseClass.tpl'
+                    __DIR__ . '/../Util/PHP/Template/TestCaseClass.tpl',
                 );
             } else {
                 $template = new Template(
-                    __DIR__ . '/../Util/PHP/Template/TestCaseMethod.tpl'
+                    __DIR__ . '/../Util/PHP/Template/TestCaseMethod.tpl',
                 );
             }
 
@@ -1043,7 +1043,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         return TestUtil::getSize(
             static::class,
-            $this->getName(false)
+            $this->getName(false),
         );
     }
 
@@ -1222,8 +1222,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 throw new Warning(
                     implode(
                         "\n",
-                        array_unique($this->warnings)
-                    )
+                        array_unique($this->warnings),
+                    ),
                 );
             }
 
@@ -1596,7 +1596,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         if (trim($this->name) === '') {
             throw new Exception(
-                'PHPUnit\Framework\TestCase::$name must be a non-blank string.'
+                'PHPUnit\Framework\TestCase::$name must be a non-blank string.',
             );
         }
 
@@ -1617,15 +1617,15 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                         $exception,
                         LogicalOr::fromConstraints(
                             new ExceptionConstraint(Error::class),
-                            new ExceptionConstraint(\Error::class)
-                        )
+                            new ExceptionConstraint(\Error::class),
+                        ),
                     );
                 } else {
                     $this->assertThat(
                         $exception,
                         new ExceptionConstraint(
-                            $this->expectedException
-                        )
+                            $this->expectedException,
+                        ),
                     );
                 }
             }
@@ -1634,8 +1634,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 $this->assertThat(
                     $exception,
                     new ExceptionMessage(
-                        $this->expectedExceptionMessage
-                    )
+                        $this->expectedExceptionMessage,
+                    ),
                 );
             }
 
@@ -1643,8 +1643,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 $this->assertThat(
                     $exception,
                     new ExceptionMessageRegularExpression(
-                        $this->expectedExceptionMessageRegExp
-                    )
+                        $this->expectedExceptionMessageRegExp,
+                    ),
                 );
             }
 
@@ -1652,8 +1652,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 $this->assertThat(
                     $exception,
                     new ExceptionCode(
-                        $this->expectedExceptionCode
-                    )
+                        $this->expectedExceptionCode,
+                    ),
                 );
             }
 
@@ -1664,8 +1664,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $this->assertThat(
                 null,
                 new ExceptionConstraint(
-                    $this->expectedException
-                )
+                    $this->expectedException,
+                ),
             );
         } elseif ($this->expectedExceptionMessage !== null) {
             $this->numAssertions++;
@@ -1673,8 +1673,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             throw new AssertionFailedError(
                 sprintf(
                     'Failed asserting that exception with message "%s" is thrown',
-                    $this->expectedExceptionMessage
-                )
+                    $this->expectedExceptionMessage,
+                ),
             );
         } elseif ($this->expectedExceptionMessageRegExp !== null) {
             $this->numAssertions++;
@@ -1682,8 +1682,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             throw new AssertionFailedError(
                 sprintf(
                     'Failed asserting that exception with message matching "%s" is thrown',
-                    $this->expectedExceptionMessageRegExp
-                )
+                    $this->expectedExceptionMessageRegExp,
+                ),
             );
         } elseif ($this->expectedExceptionCode !== null) {
             $this->numAssertions++;
@@ -1691,8 +1691,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             throw new AssertionFailedError(
                 sprintf(
                     'Failed asserting that exception with code "%s" is thrown',
-                    $this->expectedExceptionCode
-                )
+                    $this->expectedExceptionCode,
+                ),
             );
         }
 
@@ -1717,8 +1717,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 sprintf(
                     'INI setting "%s" could not be set to "%s".',
                     $varName,
-                    $newValue
-                )
+                    $newValue,
+                ),
             );
         }
     }
@@ -1753,7 +1753,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             throw new Exception(
                 'The locale functionality is not implemented on your platform, ' .
                 'the specified locale does not exist or the category name is ' .
-                'invalid.'
+                'invalid.',
             );
         }
     }
@@ -1826,7 +1826,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -1836,7 +1836,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             static function (string $method) use ($reflector)
             {
                 return !$reflector->hasMethod($method);
-            }
+            },
         );
 
         if ($mockedMethodsThatDontExist) {
@@ -1844,8 +1844,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 sprintf(
                     'createPartialMock() called with method(s) %s that do not exist in %s. This will not be allowed in future versions of PHPUnit.',
                     implode(', ', $mockedMethodsThatDontExist),
-                    $originalClassName
-                )
+                    $originalClassName,
+                ),
             );
         }
 
@@ -1902,7 +1902,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $callOriginalConstructor,
             $callOriginalClone,
             $callAutoload,
-            $cloneArguments
+            $cloneArguments,
         );
 
         return get_class($mock);
@@ -1931,7 +1931,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $callOriginalClone,
             $callAutoload,
             $mockedMethods,
-            $cloneArguments
+            $cloneArguments,
         );
 
         $this->registerMockObject($mockObject);
@@ -1963,7 +1963,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                     $wsdlFile,
                     $originalClassName,
                     $methods,
-                    $options
+                    $options,
                 )
             );
         }
@@ -1975,7 +1975,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $mockClassName,
             $callOriginalConstructor,
             false,
-            false
+            false,
         );
 
         $this->registerMockObject($mockObject);
@@ -2002,7 +2002,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $callOriginalClone,
             $callAutoload,
             $mockedMethods,
-            $cloneArguments
+            $cloneArguments,
         );
 
         $this->registerMockObject($mockObject);
@@ -2024,7 +2024,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $traitClassName,
             $callAutoload,
             $callOriginalConstructor,
-            $arguments
+            $arguments,
         );
     }
 
@@ -2088,7 +2088,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             }
 
             $mockObject->__phpunit_verify(
-                $this->shouldInvocationMockerBeReset($mockObject)
+                $this->shouldInvocationMockerBeReset($mockObject),
             );
         }
 
@@ -2121,7 +2121,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
         $missingRequirements = TestUtil::getMissingRequirements(
             static::class,
-            $this->name
+            $this->name,
         );
 
         if (!empty($missingRequirements)) {
@@ -2187,9 +2187,9 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                     $this->result->addError(
                         $this,
                         new SkippedTestError(
-                            'This test depends on a test that is larger than itself.'
+                            'This test depends on a test that is larger than itself.',
                         ),
-                        0
+                        0,
                     );
 
                     return false;
@@ -2222,9 +2222,9 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         $this->result->addError(
             $this,
             new SkippedTestError(
-                'This method has an invalid @depends annotation.'
+                'This method has an invalid @depends annotation.',
             ),
-            0
+            0,
         );
 
         $this->result->endTest($this, 0);
@@ -2241,10 +2241,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             new SkippedTestError(
                 sprintf(
                     'This test depends on "%s" to pass.',
-                    $dependency->getTarget()
-                )
+                    $dependency->getTarget(),
+                ),
             ),
-            0
+            0,
         );
 
         $this->result->endTest($this, 0);
@@ -2261,10 +2261,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             new Warning(
                 sprintf(
                     'This test depends on "%s" which does not exist.',
-                    $dependency->getTarget()
-                )
+                    $dependency->getTarget(),
+                ),
             ),
-            0
+            0,
         );
 
         $this->result->endTest($this, 0);
@@ -2301,7 +2301,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             }
 
             throw new RiskyTestError(
-                'Test code or tested code did not (only) close its own output buffers'
+                'Test code or tested code did not (only) close its own output buffers',
             );
         }
 
@@ -2341,7 +2341,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             try {
                 $this->compareGlobalStateSnapshots(
                     $this->snapshot,
-                    $this->createGlobalStateSnapshot($this->backupGlobals === true)
+                    $this->createGlobalStateSnapshot($this->backupGlobals === true),
                 );
             } catch (RiskyTestError $rte) {
                 // Intentionally left empty
@@ -2419,7 +2419,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             false,
             false,
             false,
-            false
+            false,
         );
     }
 
@@ -2435,13 +2435,13 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $this->compareGlobalStateSnapshotPart(
                 $before->globalVariables(),
                 $after->globalVariables(),
-                "--- Global variables before the test\n+++ Global variables after the test\n"
+                "--- Global variables before the test\n+++ Global variables after the test\n",
             );
 
             $this->compareGlobalStateSnapshotPart(
                 $before->superGlobalVariables(),
                 $after->superGlobalVariables(),
-                "--- Super-global variables before the test\n+++ Super-global variables after the test\n"
+                "--- Super-global variables before the test\n+++ Super-global variables after the test\n",
             );
         }
 
@@ -2449,7 +2449,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             $this->compareGlobalStateSnapshotPart(
                 $before->staticAttributes(),
                 $after->staticAttributes(),
-                "--- Static attributes before the test\n+++ Static attributes after the test\n"
+                "--- Static attributes before the test\n+++ Static attributes after the test\n",
             );
         }
     }
@@ -2465,11 +2465,11 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
             $diff = $differ->diff(
                 $exporter->export($before),
-                $exporter->export($after)
+                $exporter->export($after),
             );
 
             throw new RiskyTestError(
-                $diff
+                $diff,
             );
         }
     }
@@ -2527,7 +2527,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
                     $this->registerMockObjectsFromTestArguments(
                         $testArgument,
-                        $visited
+                        $visited,
                     );
                 }
             }
@@ -2538,7 +2538,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         $annotations = TestUtil::parseTestMethodAnnotations(
             static::class,
-            $this->name
+            $this->name,
         );
 
         if (isset($annotations['method']['doesNotPerformAssertions'])) {
@@ -2598,7 +2598,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd

--- a/src/Framework/TestFailure.php
+++ b/src/Framework/TestFailure.php
@@ -95,7 +95,7 @@ final class TestFailure
         return sprintf(
             '%s: %s',
             $this->testName,
-            $this->thrownException->getMessage()
+            $this->thrownException->getMessage(),
         );
     }
 

--- a/src/Framework/TestResult.php
+++ b/src/Framework/TestResult.php
@@ -460,7 +460,7 @@ final class TestResult implements Countable
                 'result' => $test->getResult(),
                 'size'   => TestUtil::getSize(
                     $class,
-                    $test->getName(false)
+                    $test->getName(false),
                 ),
             ];
 
@@ -646,7 +646,7 @@ final class TestResult implements Countable
 
         if ($test instanceof TestCase) {
             $test->setRegisterMockObjectsFromTestArgumentsRecursively(
-                $this->registerMockObjectsFromTestArgumentsRecursively
+                $this->registerMockObjectsFromTestArgumentsRecursively,
             );
 
             $isAnyCoverageRequired = TestUtil::requiresCodeCoverageDataCollection($test);
@@ -667,7 +667,7 @@ final class TestResult implements Countable
                 $this->convertDeprecationsToExceptions,
                 $this->convertErrorsToExceptions,
                 $this->convertNoticesToExceptions,
-                $this->convertWarningsToExceptions
+                $this->convertWarningsToExceptions,
             );
 
             $errorHandler->register();
@@ -731,9 +731,9 @@ final class TestResult implements Countable
             $this->addFailure(
                 $test,
                 new RiskyTestError(
-                    $e->getMessage()
+                    $e->getMessage(),
                 ),
-                $_timeout
+                $_timeout,
             );
 
             $risky = true;
@@ -758,10 +758,10 @@ final class TestResult implements Countable
                     '%s in %s:%s',
                     $e->getMessage(),
                     $frame['file'] ?? $e->getFile(),
-                    $frame['line'] ?? $e->getLine()
+                    $frame['line'] ?? $e->getLine(),
                 ),
                 0,
-                $e
+                $e,
             );
         } catch (Warning $e) {
             $warning = true;
@@ -794,10 +794,10 @@ final class TestResult implements Countable
                                 '%s() used in %s:%s',
                                 $function['function'],
                                 $function['filename'],
-                                $function['lineno']
-                            )
+                                $function['lineno'],
+                            ),
                         ),
-                        $time
+                        $time,
                     );
                 }
             }
@@ -812,7 +812,7 @@ final class TestResult implements Countable
         if ($this->forceCoversAnnotation && !$error && !$failure && !$warning && !$incomplete && !$skipped && !$risky) {
             $annotations = TestUtil::parseTestMethodAnnotations(
                 get_class($test),
-                $test->getName(false)
+                $test->getName(false),
             );
 
             if (!isset($annotations['class']['covers']) &&
@@ -822,9 +822,9 @@ final class TestResult implements Countable
                 $this->addFailure(
                     $test,
                     new MissingCoversAnnotationException(
-                        'This test does not have a @covers annotation but is expected to have one'
+                        'This test does not have a @covers annotation but is expected to have one',
                     ),
-                    $time
+                    $time,
                 );
 
                 $risky = true;
@@ -840,20 +840,20 @@ final class TestResult implements Countable
                 try {
                     $linesToBeCovered = TestUtil::getLinesToBeCovered(
                         get_class($test),
-                        $test->getName(false)
+                        $test->getName(false),
                     );
 
                     $linesToBeUsed = TestUtil::getLinesToBeUsed(
                         get_class($test),
-                        $test->getName(false)
+                        $test->getName(false),
                     );
                 } catch (InvalidCoversTargetException $cce) {
                     $this->addWarning(
                         $test,
                         new Warning(
-                            $cce->getMessage()
+                            $cce->getMessage(),
                         ),
-                        $time
+                        $time,
                     );
                 }
             }
@@ -862,12 +862,12 @@ final class TestResult implements Countable
                 $this->codeCoverage->stop(
                     $append,
                     $linesToBeCovered,
-                    $linesToBeUsed
+                    $linesToBeUsed,
                 );
             } catch (UnintentionallyCoveredCodeException $cce) {
                 $unintentionallyCoveredCodeError = new UnintentionallyCoveredCodeError(
                     'This test executed code that is not listed as code to be covered or used:' .
-                    PHP_EOL . $cce->getMessage()
+                    PHP_EOL . $cce->getMessage(),
                 );
             } catch (OriginalCodeCoverageException $cce) {
                 $error = true;
@@ -892,7 +892,7 @@ final class TestResult implements Countable
             $this->addFailure(
                 $test,
                 $unintentionallyCoveredCodeError,
-                $time
+                $time,
             );
         } elseif ($this->beStrictAboutTestsThatDoNotTestAnything &&
             !$test->doesNotPerformAssertions() &&
@@ -904,7 +904,7 @@ final class TestResult implements Countable
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -919,7 +919,7 @@ final class TestResult implements Countable
                     throw new Exception(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
@@ -931,10 +931,10 @@ final class TestResult implements Countable
                     sprintf(
                         "This test did not perform any assertions\n\n%s:%d",
                         $reflected->getFileName(),
-                        $reflected->getStartLine()
-                    )
+                        $reflected->getStartLine(),
+                    ),
                 ),
-                $time
+                $time,
             );
         } elseif ($this->beStrictAboutTestsThatDoNotTestAnything &&
             $test->doesNotPerformAssertions() &&
@@ -944,10 +944,10 @@ final class TestResult implements Countable
                 new RiskyTestError(
                     sprintf(
                         'This test is annotated with "@doesNotPerformAssertions" but performed %d assertions',
-                        $test->getNumAssertions()
-                    )
+                        $test->getNumAssertions(),
+                    ),
                 ),
-                $time
+                $time,
             );
         } elseif ($this->beStrictAboutOutputDuringTests && $test->hasOutput()) {
             $this->addFailure(
@@ -955,24 +955,24 @@ final class TestResult implements Countable
                 new OutputError(
                     sprintf(
                         'This test printed output: %s',
-                        $test->getActualOutput()
-                    )
+                        $test->getActualOutput(),
+                    ),
                 ),
-                $time
+                $time,
             );
         } elseif ($this->beStrictAboutTodoAnnotatedTests && $test instanceof TestCase) {
             $annotations = TestUtil::parseTestMethodAnnotations(
                 get_class($test),
-                $test->getName(false)
+                $test->getName(false),
             );
 
             if (isset($annotations['method']['todo'])) {
                 $this->addFailure(
                     $test,
                     new RiskyTestError(
-                        'Test method is annotated with @todo'
+                        'Test method is annotated with @todo',
                     ),
-                    $time
+                    $time,
                 );
             }
         }

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -166,7 +166,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
         if (!is_string($theClass) && !$theClass instanceof ReflectionClass) {
             throw InvalidArgumentException::create(
                 1,
-                'ReflectionClass object or string'
+                'ReflectionClass object or string',
             );
         }
 
@@ -184,7 +184,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                     throw new Exception(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
@@ -215,9 +215,9 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 new WarningTestCase(
                     sprintf(
                         'Class "%s" has no public constructor.',
-                        $theClass->getName()
-                    )
-                )
+                        $theClass->getName(),
+                    ),
+                ),
             );
 
             return;
@@ -236,9 +236,9 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 new WarningTestCase(
                     sprintf(
                         'No tests found in class "%s".',
-                        $theClass->getName()
-                    )
-                )
+                        $theClass->getName(),
+                    ),
+                ),
             );
         }
 
@@ -267,7 +267,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -310,7 +310,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
         if (!(is_object($testClass) || (is_string($testClass) && class_exists($testClass)))) {
             throw InvalidArgumentException::create(
                 1,
-                'class name or object'
+                'class name or object',
             );
         }
 
@@ -322,7 +322,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -336,21 +336,21 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             if (!$testClass->isAbstract() && $testClass->hasMethod(BaseTestRunner::SUITE_METHODNAME)) {
                 try {
                     $method = $testClass->getMethod(
-                        BaseTestRunner::SUITE_METHODNAME
+                        BaseTestRunner::SUITE_METHODNAME,
                     );
                     // @codeCoverageIgnoreStart
                 } catch (ReflectionException $e) {
                     throw new Exception(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
 
                 if ($method->isStatic()) {
                     $this->addTest(
-                        $method->invoke(null, $testClass->getName())
+                        $method->invoke(null, $testClass->getName()),
                     );
 
                     $suiteMethod = true;
@@ -425,7 +425,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                     throw new Exception(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd
@@ -447,7 +447,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -460,8 +460,8 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 $this->addWarning(
                     sprintf(
                         'Abstract test case classes with "Test" suffix are deprecated (%s)',
-                        $class->getName()
-                    )
+                        $class->getName(),
+                    ),
                 );
             }
 
@@ -469,14 +469,14 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 if ($class->hasMethod(BaseTestRunner::SUITE_METHODNAME)) {
                     try {
                         $method = $class->getMethod(
-                            BaseTestRunner::SUITE_METHODNAME
+                            BaseTestRunner::SUITE_METHODNAME,
                         );
                         // @codeCoverageIgnoreStart
                     } catch (ReflectionException $e) {
                         throw new Exception(
                             $e->getMessage(),
                             $e->getCode(),
-                            $e
+                            $e,
                         );
                     }
                     // @codeCoverageIgnoreEnd
@@ -493,7 +493,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                         $expectedClassName = substr(
                             $expectedClassName,
                             0,
-                            $pos
+                            $pos,
                         );
                     }
 
@@ -503,8 +503,8 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                                 "Test case class not matching filename is deprecated\n               in %s\n               Class name was '%s', expected '%s'",
                                 $filename,
                                 $class->getShortName(),
-                                $expectedClassName
-                            )
+                                $expectedClassName,
+                            ),
                         );
                     }
 
@@ -517,8 +517,8 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             $this->addWarning(
                 sprintf(
                     "Multiple test case classes per file is deprecated\n               in %s",
-                    $filename
-                )
+                    $filename,
+                ),
             );
         }
 
@@ -573,7 +573,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             {
                 return (string) $key;
             },
-            array_keys($this->groups)
+            array_keys($this->groups),
         );
     }
 
@@ -656,7 +656,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                         $result->addFailure(
                             $test,
                             new SkippedTestError('Test skipped because of an error in hook method'),
-                            0
+                            0,
                         );
                     }
 
@@ -857,7 +857,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
                 }
                 $this->requiredTests = ExecutionOrderDependency::mergeUnique(
                     ExecutionOrderDependency::filterInvalid($this->requiredTests),
-                    $test->requires()
+                    $test->requires(),
                 );
             }
 
@@ -891,13 +891,13 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
 
         if ($test instanceof TestCase || $test instanceof DataProviderTestSuite) {
             $test->setDependencies(
-                TestUtil::getDependencies($class->getName(), $methodName)
+                TestUtil::getDependencies($class->getName(), $methodName),
             );
         }
 
         $this->addTest(
             $test,
-            TestUtil::getGroups($class->getName(), $methodName)
+            TestUtil::getGroups($class->getName(), $methodName),
         );
     }
 

--- a/src/Framework/TestSuiteIterator.php
+++ b/src/Framework/TestSuiteIterator.php
@@ -67,7 +67,7 @@ final class TestSuiteIterator implements RecursiveIterator
     {
         if (!$this->hasChildren()) {
             throw new NoChildTestSuiteException(
-                'The current item is not a TestSuite instance and therefore does not have any children.'
+                'The current item is not a TestSuite instance and therefore does not have any children.',
             );
         }
 

--- a/src/Runner/BaseTestRunner.php
+++ b/src/Runner/BaseTestRunner.php
@@ -91,7 +91,7 @@ abstract class BaseTestRunner
             /** @var string[] $files */
             $files = (new FileIteratorFacade)->getFilesAsArray(
                 $suiteClassFile,
-                $suffixes
+                $suffixes,
             );
 
             $suite = new TestSuite($suiteClassFile);
@@ -109,7 +109,7 @@ abstract class BaseTestRunner
 
         try {
             $testClass = $this->loadSuiteClass(
-                $suiteClassFile
+                $suiteClassFile,
             );
         } catch (\PHPUnit\Exception $e) {
             $this->runFailed($e->getMessage());
@@ -122,7 +122,7 @@ abstract class BaseTestRunner
 
             if (!$suiteMethod->isStatic()) {
                 $this->runFailed(
-                    'suite() method must be static.'
+                    'suite() method must be static.',
                 );
 
                 return null;

--- a/src/Runner/DefaultTestResultCache.php
+++ b/src/Runner/DefaultTestResultCache.php
@@ -107,7 +107,7 @@ final class DefaultTestResultCache implements TestResultCache
 
         $data = json_decode(
             file_get_contents($this->cacheFilename),
-            true
+            true,
         );
 
         if ($data === null) {
@@ -138,8 +138,8 @@ final class DefaultTestResultCache implements TestResultCache
             throw new Exception(
                 sprintf(
                     'Cannot create directory "%s" for result cache file',
-                    $this->cacheFilename
-                )
+                    $this->cacheFilename,
+                ),
             );
         }
 
@@ -150,9 +150,9 @@ final class DefaultTestResultCache implements TestResultCache
                     'version' => self::VERSION,
                     'defects' => $this->defects,
                     'times'   => $this->times,
-                ]
+                ],
             ),
-            LOCK_EX
+            LOCK_EX,
         );
     }
 }

--- a/src/Runner/Extension/ExtensionHandler.php
+++ b/src/Runner/Extension/ExtensionHandler.php
@@ -35,8 +35,8 @@ final class ExtensionHandler
             throw new Exception(
                 sprintf(
                     'Class "%s" does not implement a PHPUnit\Runner\Hook interface',
-                    $extensionConfiguration->className()
-                )
+                    $extensionConfiguration->className(),
+                ),
             );
         }
 
@@ -56,8 +56,8 @@ final class ExtensionHandler
             throw new Exception(
                 sprintf(
                     'Class "%s" does not implement the PHPUnit\Framework\TestListener interface',
-                    $listenerConfiguration->className()
-                )
+                    $listenerConfiguration->className(),
+                ),
             );
         }
 
@@ -77,7 +77,7 @@ final class ExtensionHandler
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
 
@@ -110,8 +110,8 @@ final class ExtensionHandler
             throw new Exception(
                 sprintf(
                     'Class "%s" does not exist',
-                    $extensionConfiguration->className()
-                )
+                    $extensionConfiguration->className(),
+                ),
             );
         }
     }

--- a/src/Runner/Filter/Factory.php
+++ b/src/Runner/Filter/Factory.php
@@ -39,8 +39,8 @@ final class Factory
             throw new Exception(
                 sprintf(
                     'Class "%s" does not extend RecursiveFilterIterator',
-                    $filter->name
-                )
+                    $filter->name,
+                ),
             );
         }
 

--- a/src/Runner/Filter/GroupFilterIterator.php
+++ b/src/Runner/Filter/GroupFilterIterator.php
@@ -35,7 +35,7 @@ abstract class GroupFilterIterator extends RecursiveFilterIterator
             if (in_array((string) $group, $groups, true)) {
                 $testHashes = array_map(
                     'spl_object_hash',
-                    $tests
+                    $tests,
                 );
 
                 $this->groupTests = array_merge($this->groupTests, $testHashes);

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -96,7 +96,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
                 if (isset($matches[3]) && $matches[2] < $matches[3]) {
                     $filter = sprintf(
                         '%s.*with data set #(\d+)$',
-                        $matches[1]
+                        $matches[1],
                     );
 
                     $this->filterMin = (int) $matches[2];
@@ -105,7 +105,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
                     $filter = sprintf(
                         '%s.*with data set #%s$',
                         $matches[1],
-                        $matches[2]
+                        $matches[2],
                     );
                 }
             } // Handles:
@@ -115,7 +115,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
                 $filter = sprintf(
                     '%s.*with data set "%s"$',
                     $matches[1],
-                    $matches[2]
+                    $matches[2],
                 );
             }
 
@@ -126,8 +126,8 @@ final class NameFilterIterator extends RecursiveFilterIterator
                 str_replace(
                     '/',
                     '\\/',
-                    $filter
-                )
+                    $filter,
+                ),
             );
         }
 

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -91,8 +91,8 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
             throw new Exception(
                 sprintf(
                     'File "%s" does not exist.',
-                    $filename
-                )
+                    $filename,
+                ),
             );
         }
 
@@ -223,7 +223,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                     $trace[0]['file'],
                     $trace[0]['line'],
                     $trace,
-                    $comparisonFailure ? $diff : ''
+                    $comparisonFailure ? $diff : '',
                 );
             }
 
@@ -408,7 +408,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
             $result->addFailure(
                 $this,
                 new SyntheticSkippedError($message, 0, $trace[0]['file'], $trace[0]['line'], $trace),
-                0
+                0,
             );
             $result->endTest($this, 0);
 
@@ -489,7 +489,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         foreach ($unsupportedSections as $section) {
             if (isset($sections[$section])) {
                 throw new Exception(
-                    "PHPUnit does not support PHPT {$section} sections"
+                    "PHPUnit does not support PHPT {$section} sections",
                 );
             }
         }
@@ -520,8 +520,8 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                         sprintf(
                             'Could not load --%s-- %s for PHPT file',
                             $section . '_EXTERNAL',
-                            $testDirectory . $externalFilename
-                        )
+                            $testDirectory . $externalFilename,
+                        ),
                     );
                 }
 
@@ -579,7 +579,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                 "'" . dirname($this->filename) . "'",
                 "'" . $this->filename . "'",
             ],
-            $code
+            $code,
         );
     }
 
@@ -599,7 +599,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         $files = $this->getCoverageFiles();
 
         $template = new Template(
-            __DIR__ . '/../Util/PHP/Template/PhptTestCase.tpl'
+            __DIR__ . '/../Util/PHP/Template/PhptTestCase.tpl',
         );
 
         $composerAutoload = '\'\'';
@@ -619,7 +619,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         if (!empty($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
             $globals = '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = ' . var_export(
                 $GLOBALS['__PHPUNIT_BOOTSTRAP'],
-                true
+                true,
             ) . ";\n";
         }
 
@@ -638,7 +638,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                 'coverageFile'               => $files['coverage'],
                 'driverMethod'               => $pathCoverage ? 'forLineAndPathCoverage' : 'forLineCoverage',
                 'codeCoverageCacheDirectory' => $codeCoverageCacheDirectory,
-            ]
+            ],
         );
 
         file_put_contents($files['job'], $job);

--- a/src/Runner/StandardTestSuiteLoader.php
+++ b/src/Runner/StandardTestSuiteLoader.php
@@ -43,7 +43,7 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
             FileLoader::checkAndLoad($suiteClassFile);
 
             $loadedClasses = array_values(
-                array_diff(get_declared_classes(), $loadedClasses)
+                array_diff(get_declared_classes(), $loadedClasses),
             );
 
             if (empty($loadedClasses)) {
@@ -51,8 +51,8 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
                     sprintf(
                         'Class %s could not be found in %s',
                         $suiteClassName,
-                        $suiteClassFile
-                    )
+                        $suiteClassFile,
+                    ),
                 );
             }
         }
@@ -76,8 +76,8 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
                 sprintf(
                     'Class %s could not be found in %s',
                     $suiteClassName,
-                    $suiteClassFile
-                )
+                    $suiteClassFile,
+                ),
             );
         }
 
@@ -88,7 +88,7 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -99,8 +99,8 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
                     sprintf(
                         'Class %s declared in %s is abstract',
                         $suiteClassName,
-                        $suiteClassFile
-                    )
+                        $suiteClassFile,
+                    ),
                 );
             }
 
@@ -116,8 +116,8 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
                     sprintf(
                         'Method %s::suite() declared in %s is abstract',
                         $suiteClassName,
-                        $suiteClassFile
-                    )
+                        $suiteClassFile,
+                    ),
                 );
             }
 
@@ -126,8 +126,8 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
                     sprintf(
                         'Method %s::suite() declared in %s is not public',
                         $suiteClassName,
-                        $suiteClassFile
-                    )
+                        $suiteClassFile,
+                    ),
                 );
             }
 
@@ -136,8 +136,8 @@ final class StandardTestSuiteLoader implements TestSuiteLoader
                     sprintf(
                         'Method %s::suite() declared in %s is not static',
                         $suiteClassName,
-                        $suiteClassFile
-                    )
+                        $suiteClassFile,
+                    ),
                 );
             }
         }

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -123,7 +123,7 @@ final class TestSuiteSorter
 
         if (!in_array($order, $allowedOrders, true)) {
             throw new Exception(
-                '$order must be one of TestSuiteSorter::ORDER_[DEFAULT|REVERSED|RANDOMIZED|DURATION|SIZE]'
+                '$order must be one of TestSuiteSorter::ORDER_[DEFAULT|REVERSED|RANDOMIZED|DURATION|SIZE]',
             );
         }
 
@@ -134,7 +134,7 @@ final class TestSuiteSorter
 
         if (!in_array($orderDefects, $allowedOrderDefects, true)) {
             throw new Exception(
-                '$orderDefects must be one of TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_DEFECTS_FIRST'
+                '$orderDefects must be one of TestSuiteSorter::ORDER_DEFAULT, TestSuiteSorter::ORDER_DEFECTS_FIRST',
             );
         }
 
@@ -240,7 +240,7 @@ final class TestSuiteSorter
             function ($left, $right)
             {
                 return $this->cmpDefectPriorityAndTime($left, $right);
-            }
+            },
         );
 
         return $tests;
@@ -256,7 +256,7 @@ final class TestSuiteSorter
             function ($left, $right)
             {
                 return $this->cmpDuration($left, $right);
-            }
+            },
         );
 
         return $tests;
@@ -272,7 +272,7 @@ final class TestSuiteSorter
             function ($left, $right)
             {
                 return $this->cmpSize($left, $right);
-            }
+            },
         );
 
         return $tests;

--- a/src/TextUI/CliArguments/Builder.php
+++ b/src/TextUI/CliArguments/Builder.php
@@ -129,13 +129,13 @@ final class Builder
             $options = (new CliParser)->parse(
                 $parameters,
                 self::SHORT_OPTIONS,
-                array_merge(self::LONG_OPTIONS, $additionalLongOptions)
+                array_merge(self::LONG_OPTIONS, $additionalLongOptions),
             );
         } catch (CliParserException $e) {
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
 
@@ -880,7 +880,7 @@ final class Builder
             $verbose,
             $version,
             $coverageFilter,
-            $xdebugFilterFile
+            $xdebugFilterFile,
         );
     }
 }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -99,7 +99,7 @@ class Command
             throw new RuntimeException(
                 $t->getMessage(),
                 (int) $t->getCode(),
-                $t
+                $t,
             );
         }
     }
@@ -118,7 +118,7 @@ class Command
         } else {
             $suite = $runner->getTest(
                 $this->arguments['test'],
-                $this->arguments['testSuffixes']
+                $this->arguments['testSuffixes'],
             );
         }
 
@@ -256,8 +256,8 @@ class Command
             $this->exitWithErrorMessage(
                 sprintf(
                     'unrecognized --order-by option: %s',
-                    $arguments->unrecognizedOrderBy()
-                )
+                    $arguments->unrecognizedOrderBy(),
+                ),
             );
         }
 
@@ -270,7 +270,7 @@ class Command
         if ($arguments->hasIncludePath()) {
             ini_set(
                 'include_path',
-                $arguments->includePath() . PATH_SEPARATOR . ini_get('include_path')
+                $arguments->includePath() . PATH_SEPARATOR . ini_get('include_path'),
             );
         }
 
@@ -290,8 +290,8 @@ class Command
                 $this->exitWithErrorMessage(
                     sprintf(
                         'Cannot open file "%s".',
-                        $arguments->argument()
-                    )
+                        $arguments->argument(),
+                    ),
                 );
             }
         }
@@ -367,7 +367,7 @@ class Command
 
                 $this->arguments['printer'] = $this->handlePrinter(
                     $phpunitConfiguration->printerClass(),
-                    $file
+                    $file,
                 );
             }
 
@@ -376,7 +376,7 @@ class Command
 
                 $this->arguments['loader'] = $this->handleLoader(
                     $phpunitConfiguration->testSuiteLoaderClass(),
-                    $file
+                    $file,
                 );
             }
 
@@ -388,7 +388,7 @@ class Command
                 try {
                     $this->arguments['test'] = (new TestSuiteMapper)->map(
                         $this->arguments['configurationObject']->testSuite(),
-                        $this->arguments['testsuite'] ?? ''
+                        $this->arguments['testsuite'] ?? '',
                     );
                 } catch (Exception $e) {
                     $this->printVersionString();
@@ -429,7 +429,7 @@ class Command
         if (!class_exists($loaderClass, false)) {
             if ($loaderFile == '') {
                 $loaderFile = Filesystem::classNameToFilename(
-                    $loaderClass
+                    $loaderClass,
                 );
             }
 
@@ -453,7 +453,7 @@ class Command
                 throw new ReflectionException(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -474,8 +474,8 @@ class Command
         $this->exitWithErrorMessage(
             sprintf(
                 'Could not use "%s" as loader.',
-                $loaderClass
-            )
+                $loaderClass,
+            ),
         );
 
         return null;
@@ -491,7 +491,7 @@ class Command
         if (!class_exists($printerClass, false)) {
             if ($printerFile === '') {
                 $printerFile = Filesystem::classNameToFilename(
-                    $printerClass
+                    $printerClass,
                 );
             }
 
@@ -511,8 +511,8 @@ class Command
             $this->exitWithErrorMessage(
                 sprintf(
                     'Could not use "%s" as printer: class does not exist',
-                    $printerClass
-                )
+                    $printerClass,
+                ),
             );
         }
 
@@ -523,7 +523,7 @@ class Command
             throw new ReflectionException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
             // @codeCoverageIgnoreEnd
         }
@@ -533,8 +533,8 @@ class Command
                 sprintf(
                     'Could not use "%s" as printer: class does not implement %s',
                     $printerClass,
-                    ResultPrinter::class
-                )
+                    ResultPrinter::class,
+                ),
             );
         }
 
@@ -542,8 +542,8 @@ class Command
             $this->exitWithErrorMessage(
                 sprintf(
                     'Could not use "%s" as printer: class cannot be instantiated',
-                    $printerClass
-                )
+                    $printerClass,
+                ),
             );
         }
 
@@ -574,7 +574,7 @@ class Command
                 PHP_EOL,
                 $t->getMessage(),
                 PHP_EOL,
-                $t->getTraceAsString()
+                $t->getTraceAsString(),
             );
 
             while ($t = $t->getPrevious()) {
@@ -605,7 +605,7 @@ class Command
             printf(
                 'You are not using the latest version of PHPUnit.' . PHP_EOL .
                 'The latest version is PHPUnit %s.' . PHP_EOL,
-                $latestVersion
+                $latestVersion,
             );
         } else {
             print 'You are using the latest version of PHPUnit.' . PHP_EOL;
@@ -661,7 +661,7 @@ class Command
                 'groups',
                 'excludeGroups',
                 'testsuite',
-            ]
+            ],
         );
 
         print 'Available test group(s):' . PHP_EOL;
@@ -676,7 +676,7 @@ class Command
 
             printf(
                 ' - %s' . PHP_EOL,
-                $group
+                $group,
             );
         }
 
@@ -702,7 +702,7 @@ class Command
                 'groups',
                 'excludeGroups',
                 'testsuite',
-            ]
+            ],
         );
 
         print 'Available test suite(s):' . PHP_EOL;
@@ -710,7 +710,7 @@ class Command
         foreach ($this->arguments['configurationObject']->testSuite() as $testSuite) {
             printf(
                 ' - %s' . PHP_EOL,
-                $testSuite->name()
+                $testSuite->name(),
             );
         }
 
@@ -734,7 +734,7 @@ class Command
                 'filter',
                 'groups',
                 'excludeGroups',
-            ]
+            ],
         );
 
         $renderer = new TextTestListRenderer;
@@ -761,7 +761,7 @@ class Command
                 'filter',
                 'groups',
                 'excludeGroups',
-            ]
+            ],
         );
 
         $renderer = new XmlTestListRenderer;
@@ -770,7 +770,7 @@ class Command
 
         printf(
             'Wrote list of tests that would have been run to %s' . PHP_EOL,
-            $target
+            $target,
         );
 
         if ($exit) {
@@ -826,8 +826,8 @@ class Command
                 $bootstrapScript,
                 $testsDirectory,
                 $src,
-                $cacheDirectory
-            )
+                $cacheDirectory,
+            ),
         );
 
         print PHP_EOL . 'Generated phpunit.xml in ' . getcwd() . '.' . PHP_EOL;
@@ -853,7 +853,7 @@ class Command
         try {
             file_put_contents(
                 $filename,
-                (new Migrator)->migrate($filename)
+                (new Migrator)->migrate($filename),
             );
 
             print 'Migrated configuration: ' . $filename . PHP_EOL;
@@ -906,7 +906,7 @@ class Command
         if ($configuration->codeCoverage()->hasNonEmptyListOfFilesToBeIncludedInCodeCoverageReport()) {
             (new FilterMapper)->map(
                 $filter,
-                $configuration->codeCoverage()
+                $configuration->codeCoverage(),
             );
         } elseif (isset($this->arguments['coverageFilter'])) {
             if (!is_array($this->arguments['coverageFilter'])) {
@@ -933,7 +933,7 @@ class Command
             $cacheDirectory,
             !$configuration->codeCoverage()->disableCodeCoverageIgnore(),
             $configuration->codeCoverage()->ignoreDeprecatedCodeUnits(),
-            $filter
+            $filter,
         );
 
         print 'done [' . $timer->stop()->asString() . ']' . PHP_EOL;
@@ -971,7 +971,7 @@ class Command
                     'The %s and %s options cannot be combined, %s is ignored' . PHP_EOL,
                     $this->mapKeyToOptionForWarning($_key),
                     $this->mapKeyToOptionForWarning($key),
-                    $this->mapKeyToOptionForWarning($_key)
+                    $this->mapKeyToOptionForWarning($_key),
                 );
 
                 $warningPrinted = true;

--- a/src/TextUI/DefaultResultPrinter.php
+++ b/src/TextUI/DefaultResultPrinter.php
@@ -142,7 +142,7 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
         if (!in_array($colors, self::AVAILABLE_COLORS, true)) {
             throw InvalidArgumentException::create(
                 3,
-                vsprintf('value from "%s", "%s" or "%s"', self::AVAILABLE_COLORS)
+                vsprintf('value from "%s", "%s" or "%s"', self::AVAILABLE_COLORS),
             );
         }
 
@@ -271,8 +271,8 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
             $this->write(
                 sprintf(
                     "Test '%s' started\n",
-                    \PHPUnit\Util\Test::describeAsString($test)
-                )
+                    \PHPUnit\Util\Test::describeAsString($test),
+                ),
             );
         }
     }
@@ -286,8 +286,8 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
             $this->write(
                 sprintf(
                     "Test '%s' ended\n",
-                    \PHPUnit\Util\Test::describeAsString($test)
-                )
+                    \PHPUnit\Util\Test::describeAsString($test),
+                ),
             );
         }
 
@@ -326,8 +326,8 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
                 ($count == 1) ? 'was' : 'were',
                 $count,
                 $type,
-                ($count == 1) ? '' : 's'
-            )
+                ($count == 1) ? '' : 's',
+            ),
         );
 
         $i = 1;
@@ -355,8 +355,8 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
             sprintf(
                 "\n%d) %s\n",
                 $count,
-                $defect->getTestName()
-            )
+                $defect->getTestName(),
+            ),
         );
     }
 
@@ -413,7 +413,7 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
         if (count($result) === 0) {
             $this->writeWithColor(
                 'fg-black, bg-yellow',
-                'No tests executed!'
+                'No tests executed!',
             );
 
             return;
@@ -427,8 +427,8 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
                     count($result),
                     (count($result) === 1) ? '' : 's',
                     $this->numAssertions,
-                    ($this->numAssertions === 1) ? '' : 's'
-                )
+                    ($this->numAssertions === 1) ? '' : 's',
+                ),
             );
 
             return;
@@ -443,7 +443,7 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
 
             $this->writeWithColor(
                 $color,
-                'OK, but incomplete, skipped, or risky tests!'
+                'OK, but incomplete, skipped, or risky tests!',
             );
         } else {
             $this->write("\n");
@@ -453,21 +453,21 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
 
                 $this->writeWithColor(
                     $color,
-                    'ERRORS!'
+                    'ERRORS!',
                 );
             } elseif ($result->failureCount()) {
                 $color = 'fg-white, bg-red';
 
                 $this->writeWithColor(
                     $color,
-                    'FAILURES!'
+                    'FAILURES!',
                 );
             } elseif ($result->warningCount()) {
                 $color = 'fg-black, bg-yellow';
 
                 $this->writeWithColor(
                     $color,
-                    'WARNINGS!'
+                    'WARNINGS!',
                 );
             }
         }
@@ -504,8 +504,8 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
                     $this->numTestsWidth . 'd (%3s%%)',
                     $this->numTestsRun,
                     $this->numTests,
-                    floor(($this->numTestsRun / $this->numTests) * 100)
-                )
+                    floor(($this->numTestsRun / $this->numTests) * 100),
+                ),
             );
 
             if ($this->column == $this->maxColumn) {
@@ -574,9 +574,9 @@ class DefaultResultPrinter extends Printer implements ResultPrinter
                     '%s%s: %d',
                     !$first ? ', ' : '',
                     $name,
-                    $count
+                    $count,
                 ),
-                false
+                false,
             );
 
             $first = false;

--- a/src/TextUI/Exception/TestDirectoryNotFoundException.php
+++ b/src/TextUI/Exception/TestDirectoryNotFoundException.php
@@ -22,8 +22,8 @@ final class TestDirectoryNotFoundException extends RuntimeException implements E
         parent::__construct(
             sprintf(
                 'Test directory "%s" not found',
-                $path
-            )
+                $path,
+            ),
         );
     }
 }

--- a/src/TextUI/Exception/TestFileNotFoundException.php
+++ b/src/TextUI/Exception/TestFileNotFoundException.php
@@ -22,8 +22,8 @@ final class TestFileNotFoundException extends RuntimeException implements Except
         parent::__construct(
             sprintf(
                 'Test file "%s" not found',
-                $path
-            )
+                $path,
+            ),
         );
     }
 }

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -246,7 +246,7 @@ final class Help
                         {
                             return Color::colorize('fg-cyan', $matches[0]);
                         },
-                        $arg
+                        $arg,
                     );
                     $desc = explode(PHP_EOL, wordwrap($option['desc'], $this->maxDescLength, PHP_EOL));
 

--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -307,7 +307,7 @@ final class TestRunner extends BaseTestRunner
                         throw new Exception(
                             $e->getMessage(),
                             $e->getCode(),
-                            $e
+                            $e,
                         );
                     }
                     // @codeCoverageIgnoreEnd
@@ -341,8 +341,8 @@ final class TestRunner extends BaseTestRunner
                 new HtmlResultPrinter(
                     $arguments['testdoxHTMLFile'],
                     $arguments['testdoxGroups'],
-                    $arguments['testdoxExcludeGroups']
-                )
+                    $arguments['testdoxExcludeGroups'],
+                ),
             );
         }
 
@@ -351,22 +351,22 @@ final class TestRunner extends BaseTestRunner
                 new TextResultPrinter(
                     $arguments['testdoxTextFile'],
                     $arguments['testdoxGroups'],
-                    $arguments['testdoxExcludeGroups']
-                )
+                    $arguments['testdoxExcludeGroups'],
+                ),
             );
         }
 
         if (isset($arguments['testdoxXMLFile'])) {
             $result->addListener(
                 new XmlResultPrinter(
-                    $arguments['testdoxXMLFile']
-                )
+                    $arguments['testdoxXMLFile'],
+                ),
             );
         }
 
         if (isset($arguments['teamcityLogfile'])) {
             $result->addListener(
-                new TeamCity($arguments['teamcityLogfile'])
+                new TeamCity($arguments['teamcityLogfile']),
             );
         }
 
@@ -374,8 +374,8 @@ final class TestRunner extends BaseTestRunner
             $result->addListener(
                 new JUnit(
                     $arguments['junitLogfile'],
-                    $arguments['reportUselessTests']
-                )
+                    $arguments['reportUselessTests'],
+                ),
             );
         }
 
@@ -432,7 +432,7 @@ final class TestRunner extends BaseTestRunner
 
                     (new FilterMapper)->map(
                         $this->codeCoverageFilter,
-                        $codeCoverageConfiguration
+                        $codeCoverageConfiguration,
                     );
                 }
             }
@@ -449,7 +449,7 @@ final class TestRunner extends BaseTestRunner
 
                 $codeCoverage = new CodeCoverage(
                     $codeCoverageDriver,
-                    $this->codeCoverageFilter
+                    $this->codeCoverageFilter,
                 );
 
                 if (isset($codeCoverageConfiguration) && $codeCoverageConfiguration->hasCacheDirectory()) {
@@ -532,21 +532,21 @@ final class TestRunner extends BaseTestRunner
 
                 $this->writeMessage(
                     'Configuration',
-                    $arguments['configurationObject']->filename()
+                    $arguments['configurationObject']->filename(),
                 );
             }
 
             foreach ($arguments['loadedExtensions'] as $extension) {
                 $this->writeMessage(
                     'Extension',
-                    $extension
+                    $extension,
                 );
             }
 
             foreach ($arguments['notLoadedExtensions'] as $extension) {
                 $this->writeMessage(
                     'Extension',
-                    $extension
+                    $extension,
                 );
             }
         }
@@ -554,7 +554,7 @@ final class TestRunner extends BaseTestRunner
         if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
             $this->writeMessage(
                 'Random Seed',
-                (string) $arguments['randomOrderSeed']
+                (string) $arguments['randomOrderSeed'],
             );
         }
 
@@ -586,7 +586,7 @@ final class TestRunner extends BaseTestRunner
                     $this->writeMessage('Suggestion', 'Migrate your XML configuration using "--migrate-configuration"!');
                 } else {
                     $this->write(
-                        "\n  Warning - The configuration file did not pass validation!\n  The following problems have been detected:\n"
+                        "\n  Warning - The configuration file did not pass validation!\n  The following problems have been detected:\n",
                     );
 
                     $this->write($arguments['configurationObject']->validationErrors());
@@ -714,8 +714,8 @@ final class TestRunner extends BaseTestRunner
                         $arguments['reportHighLowerBound'],
                         sprintf(
                             ' and <a href="https://phpunit.de/">PHPUnit %s</a>',
-                            Version::id()
-                        )
+                            Version::id(),
+                        ),
                     );
 
                     $writer->process($codeCoverage, $arguments['coverageHtml']);
@@ -756,11 +756,11 @@ final class TestRunner extends BaseTestRunner
                     $arguments['reportLowUpperBound'],
                     $arguments['reportHighLowerBound'],
                     $arguments['coverageTextShowUncoveredFiles'],
-                    $arguments['coverageTextShowOnlySummary']
+                    $arguments['coverageTextShowOnlySummary'],
                 );
 
                 $outputStream->write(
-                    $processor->process($codeCoverage, $colors)
+                    $processor->process($codeCoverage, $colors),
                 );
             }
 
@@ -1023,7 +1023,7 @@ final class TestRunner extends BaseTestRunner
             foreach ($arguments['unavailableExtensions'] as $extension) {
                 $arguments['warnings'][] = sprintf(
                     'Extension "%s" is not available',
-                    $extension
+                    $extension,
                 );
             }
 
@@ -1033,7 +1033,7 @@ final class TestRunner extends BaseTestRunner
                 if ($loggingConfiguration->hasText()) {
                     $arguments['listeners'][] = new DefaultResultPrinter(
                         $loggingConfiguration->text()->target()->path(),
-                        true
+                        true,
                     );
                 }
 
@@ -1147,14 +1147,14 @@ final class TestRunner extends BaseTestRunner
         if (!empty($arguments['excludeGroups'])) {
             $filterFactory->addFilter(
                 new ReflectionClass(ExcludeGroupFilterIterator::class),
-                $arguments['excludeGroups']
+                $arguments['excludeGroups'],
             );
         }
 
         if (!empty($arguments['groups'])) {
             $filterFactory->addFilter(
                 new ReflectionClass(IncludeGroupFilterIterator::class),
-                $arguments['groups']
+                $arguments['groups'],
             );
         }
 
@@ -1166,8 +1166,8 @@ final class TestRunner extends BaseTestRunner
                     {
                         return '__phpunit_covers_' . $name;
                     },
-                    $arguments['testsCovering']
-                )
+                    $arguments['testsCovering'],
+                ),
             );
         }
 
@@ -1179,15 +1179,15 @@ final class TestRunner extends BaseTestRunner
                     {
                         return '__phpunit_uses_' . $name;
                     },
-                    $arguments['testsUsing']
-                )
+                    $arguments['testsUsing'],
+                ),
             );
         }
 
         if ($arguments['filter']) {
             $filterFactory->addFilter(
                 new ReflectionClass(NameFilterIterator::class),
-                $arguments['filter']
+                $arguments['filter'],
             );
         }
 
@@ -1204,8 +1204,8 @@ final class TestRunner extends BaseTestRunner
             sprintf(
                 "%-15s%s\n",
                 $type . ':',
-                $message
-            )
+                $message,
+            ),
         );
 
         $this->messagePrinted = true;
@@ -1219,7 +1219,7 @@ final class TestRunner extends BaseTestRunner
             $arguments['colors'],
             $arguments['debug'],
             $arguments['columns'],
-            $arguments['reverseList']
+            $arguments['reverseList'],
         );
 
         assert($object instanceof ResultPrinter);
@@ -1232,8 +1232,8 @@ final class TestRunner extends BaseTestRunner
         $this->write(
             sprintf(
                 "\nGenerating code coverage report in %s format ... ",
-                $format
-            )
+                $format,
+            ),
         );
 
         $this->timer->start();
@@ -1244,8 +1244,8 @@ final class TestRunner extends BaseTestRunner
         $this->write(
             sprintf(
                 "done [%s]\n",
-                $this->timer->stop()->asString()
-            )
+                $this->timer->stop()->asString(),
+            ),
         );
     }
 
@@ -1255,8 +1255,8 @@ final class TestRunner extends BaseTestRunner
             sprintf(
                 "failed [%s]\n%s\n",
                 $this->timer->stop()->asString(),
-                $e->getMessage()
-            )
+                $e->getMessage(),
+            ),
         );
     }
 }

--- a/src/TextUI/TestSuiteMapper.php
+++ b/src/TextUI/TestSuiteMapper.php
@@ -60,7 +60,7 @@ final class TestSuiteMapper
                         $directory->path(),
                         $directory->suffix(),
                         $directory->prefix(),
-                        $exclude
+                        $exclude,
                     );
 
                     if (!empty($files)) {
@@ -96,7 +96,7 @@ final class TestSuiteMapper
             throw new RuntimeException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
     }

--- a/src/TextUI/XmlConfiguration/CodeCoverage/CodeCoverage.php
+++ b/src/TextUI/XmlConfiguration/CodeCoverage/CodeCoverage.php
@@ -150,7 +150,7 @@ final class CodeCoverage
     {
         if (!$this->hasCacheDirectory()) {
             throw new Exception(
-                'No cache directory has been configured'
+                'No cache directory has been configured',
             );
         }
 
@@ -222,7 +222,7 @@ final class CodeCoverage
     {
         if (!$this->hasClover()) {
             throw new Exception(
-                'Code Coverage report "Clover XML" has not been configured'
+                'Code Coverage report "Clover XML" has not been configured',
             );
         }
 
@@ -244,7 +244,7 @@ final class CodeCoverage
     {
         if (!$this->hasCobertura()) {
             throw new Exception(
-                'Code Coverage report "Cobertura XML" has not been configured'
+                'Code Coverage report "Cobertura XML" has not been configured',
             );
         }
 
@@ -266,7 +266,7 @@ final class CodeCoverage
     {
         if (!$this->hasCrap4j()) {
             throw new Exception(
-                'Code Coverage report "Crap4J" has not been configured'
+                'Code Coverage report "Crap4J" has not been configured',
             );
         }
 
@@ -288,7 +288,7 @@ final class CodeCoverage
     {
         if (!$this->hasHtml()) {
             throw new Exception(
-                'Code Coverage report "HTML" has not been configured'
+                'Code Coverage report "HTML" has not been configured',
             );
         }
 
@@ -310,7 +310,7 @@ final class CodeCoverage
     {
         if (!$this->hasPhp()) {
             throw new Exception(
-                'Code Coverage report "PHP" has not been configured'
+                'Code Coverage report "PHP" has not been configured',
             );
         }
 
@@ -332,7 +332,7 @@ final class CodeCoverage
     {
         if (!$this->hasText()) {
             throw new Exception(
-                'Code Coverage report "Text" has not been configured'
+                'Code Coverage report "Text" has not been configured',
             );
         }
 
@@ -354,7 +354,7 @@ final class CodeCoverage
     {
         if (!$this->hasXml()) {
             throw new Exception(
-                'Code Coverage report "XML" has not been configured'
+                'Code Coverage report "XML" has not been configured',
             );
         }
 

--- a/src/TextUI/XmlConfiguration/CodeCoverage/FilterMapper.php
+++ b/src/TextUI/XmlConfiguration/CodeCoverage/FilterMapper.php
@@ -22,7 +22,7 @@ final class FilterMapper
             $filter->includeDirectory(
                 $directory->path(),
                 $directory->suffix(),
-                $directory->prefix()
+                $directory->prefix(),
             );
         }
 
@@ -34,7 +34,7 @@ final class FilterMapper
             $filter->excludeDirectory(
                 $directory->path(),
                 $directory->suffix(),
-                $directory->prefix()
+                $directory->prefix(),
             );
         }
 

--- a/src/TextUI/XmlConfiguration/Generator.php
+++ b/src/TextUI/XmlConfiguration/Generator.php
@@ -67,7 +67,7 @@ EOT;
                 $srcDirectory,
                 $cacheDirectory,
             ],
-            self::TEMPLATE
+            self::TEMPLATE,
         );
     }
 }

--- a/src/TextUI/XmlConfiguration/Loader.php
+++ b/src/TextUI/XmlConfiguration/Loader.php
@@ -73,7 +73,7 @@ final class Loader
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
 
@@ -85,7 +85,7 @@ final class Loader
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
 
@@ -100,7 +100,7 @@ final class Loader
             $this->logging($filename, $xpath),
             $this->php($filename, $xpath),
             $this->phpunit($filename, $document),
-            $this->testSuite($filename, $xpath)
+            $this->testSuite($filename, $xpath),
         );
     }
 
@@ -118,9 +118,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -132,9 +132,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -146,9 +146,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -160,9 +160,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -174,9 +174,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -188,9 +188,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -200,7 +200,7 @@ final class Loader
             $teamCity,
             $testDoxHtml,
             $testDoxText,
-            $testDoxXml
+            $testDoxXml,
         );
     }
 
@@ -228,42 +228,42 @@ final class Loader
             switch ($type) {
                 case 'plain':
                     $text = new Text(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
 
                 case 'junit':
                     $junit = new Junit(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
 
                 case 'teamcity':
                     $teamCity = new TeamCity(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
 
                 case 'testdox-html':
                     $testDoxHtml = new TestDoxHtml(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
 
                 case 'testdox-text':
                     $testDoxText = new TestDoxText(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
 
                 case 'testdox-xml':
                     $testDoxXml = new TestDoxXml(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
@@ -276,7 +276,7 @@ final class Loader
             $teamCity,
             $testDoxHtml,
             $testDoxText,
-            $testDoxXml
+            $testDoxXml,
         );
     }
 
@@ -304,7 +304,7 @@ final class Loader
             $file = $this->toAbsolutePath(
                 $filename,
                 (string) $element->getAttribute('file'),
-                true
+                true,
             );
         }
 
@@ -402,38 +402,38 @@ final class Loader
 
             if ($cacheDirectory !== null) {
                 $cacheDirectory = new Directory(
-                    $this->toAbsolutePath($filename, $cacheDirectory)
+                    $this->toAbsolutePath($filename, $cacheDirectory),
                 );
             }
 
             $pathCoverage = $this->getBooleanAttribute(
                 $element,
                 'pathCoverage',
-                false
+                false,
             );
 
             $includeUncoveredFiles = $this->getBooleanAttribute(
                 $element,
                 'includeUncoveredFiles',
-                true
+                true,
             );
 
             $processUncoveredFiles = $this->getBooleanAttribute(
                 $element,
                 'processUncoveredFiles',
-                false
+                false,
             );
 
             $ignoreDeprecatedCodeUnits = $this->getBooleanAttribute(
                 $element,
                 'ignoreDeprecatedCodeUnits',
-                false
+                false,
             );
 
             $disableCodeCoverageIgnore = $this->getBooleanAttribute(
                 $element,
                 'disableCodeCoverageIgnore',
-                false
+                false,
             );
         }
 
@@ -445,9 +445,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -459,9 +459,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -473,10 +473,10 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
                 ),
-                $this->getIntegerAttribute($element, 'threshold', 30)
+                $this->getIntegerAttribute($element, 'threshold', 30),
             );
         }
 
@@ -488,11 +488,11 @@ final class Loader
                 new Directory(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputDirectory')
-                    )
+                        (string) $this->getStringAttribute($element, 'outputDirectory'),
+                    ),
                 ),
                 $this->getIntegerAttribute($element, 'lowUpperBound', 50),
-                $this->getIntegerAttribute($element, 'highLowerBound', 90)
+                $this->getIntegerAttribute($element, 'highLowerBound', 90),
             );
         }
 
@@ -504,9 +504,9 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
             );
         }
 
@@ -518,11 +518,11 @@ final class Loader
                 new File(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputFile')
-                    )
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
                 ),
                 $this->getBooleanAttribute($element, 'showUncoveredFiles', false),
-                $this->getBooleanAttribute($element, 'showOnlySummary', false)
+                $this->getBooleanAttribute($element, 'showOnlySummary', false),
             );
         }
 
@@ -534,9 +534,9 @@ final class Loader
                 new Directory(
                     $this->toAbsolutePath(
                         $filename,
-                        (string) $this->getStringAttribute($element, 'outputDirectory')
-                    )
-                )
+                        (string) $this->getStringAttribute($element, 'outputDirectory'),
+                    ),
+                ),
             );
         }
 
@@ -557,7 +557,7 @@ final class Loader
             $html,
             $php,
             $text,
-            $xml
+            $xml,
         );
     }
 
@@ -569,13 +569,13 @@ final class Loader
         $ignoreDeprecatedCodeUnits = $this->getBooleanAttribute(
             $document->documentElement,
             'ignoreDeprecatedCodeUnitsFromCodeCoverage',
-            false
+            false,
         );
 
         $disableCodeCoverageIgnore = $this->getBooleanAttribute(
             $document->documentElement,
             'disableCodeCoverageIgnore',
-            false
+            false,
         );
 
         $includeUncoveredFiles = true;
@@ -587,14 +587,14 @@ final class Loader
             if ($element->hasAttribute('addUncoveredFilesFromWhitelist')) {
                 $includeUncoveredFiles = (bool) $this->getBoolean(
                     (string) $element->getAttribute('addUncoveredFilesFromWhitelist'),
-                    true
+                    true,
                 );
             }
 
             if ($element->hasAttribute('processUncoveredFilesFromWhitelist')) {
                 $processUncoveredFiles = (bool) $this->getBoolean(
                     (string) $element->getAttribute('processUncoveredFilesFromWhitelist'),
-                    false
+                    false,
                 );
             }
         }
@@ -622,14 +622,14 @@ final class Loader
             switch ($type) {
                 case 'coverage-clover':
                     $clover = new Clover(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
 
                 case 'coverage-cobertura':
                     $cobertura = new Cobertura(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
@@ -637,7 +637,7 @@ final class Loader
                 case 'coverage-crap4j':
                     $crap4j = new Crap4j(
                         new File($target),
-                        $this->getIntegerAttribute($log, 'threshold', 30)
+                        $this->getIntegerAttribute($log, 'threshold', 30),
                     );
 
                     break;
@@ -646,14 +646,14 @@ final class Loader
                     $html = new CodeCoverageHtml(
                         new Directory($target),
                         $this->getIntegerAttribute($log, 'lowUpperBound', 50),
-                        $this->getIntegerAttribute($log, 'highLowerBound', 90)
+                        $this->getIntegerAttribute($log, 'highLowerBound', 90),
                     );
 
                     break;
 
                 case 'coverage-php':
                     $php = new CodeCoveragePhp(
-                        new File($target)
+                        new File($target),
                     );
 
                     break;
@@ -662,14 +662,14 @@ final class Loader
                     $text = new CodeCoverageText(
                         new File($target),
                         $this->getBooleanAttribute($log, 'showUncoveredFiles', false),
-                        $this->getBooleanAttribute($log, 'showOnlySummary', false)
+                        $this->getBooleanAttribute($log, 'showOnlySummary', false),
                     );
 
                     break;
 
                 case 'coverage-xml':
                     $xml = new CodeCoverageXml(
-                        new Directory($target)
+                        new Directory($target),
                     );
 
                     break;
@@ -693,7 +693,7 @@ final class Loader
             $html,
             $php,
             $text,
-            $xml
+            $xml,
         );
     }
 
@@ -737,7 +737,7 @@ final class Loader
                 $this->toAbsolutePath($filename, $directoryPath),
                 $directoryNode->hasAttribute('prefix') ? (string) $directoryNode->getAttribute('prefix') : '',
                 $directoryNode->hasAttribute('suffix') ? (string) $directoryNode->getAttribute('suffix') : '.php',
-                $directoryNode->hasAttribute('group') ? (string) $directoryNode->getAttribute('group') : 'DEFAULT'
+                $directoryNode->hasAttribute('group') ? (string) $directoryNode->getAttribute('group') : 'DEFAULT',
             );
         }
 
@@ -784,7 +784,7 @@ final class Loader
 
         return new Groups(
             GroupCollection::fromArray($include),
-            GroupCollection::fromArray($exclude)
+            GroupCollection::fromArray($exclude),
         );
     }
 
@@ -809,7 +809,7 @@ final class Loader
 
         return (bool) $this->getBoolean(
             (string) $element->getAttribute($attribute),
-            false
+            false,
         );
     }
 
@@ -821,7 +821,7 @@ final class Loader
 
         return $this->getInteger(
             (string) $element->getAttribute($attribute),
-            $default
+            $default,
         );
     }
 
@@ -862,7 +862,7 @@ final class Loader
 
             $iniSettings[] = new IniSetting(
                 (string) $ini->getAttribute('name'),
-                (string) $ini->getAttribute('value')
+                (string) $ini->getAttribute('value'),
             );
         }
 
@@ -875,7 +875,7 @@ final class Loader
 
             $constants[] = new Constant(
                 (string) $const->getAttribute('name'),
-                $this->getBoolean($value, $value)
+                $this->getBoolean($value, $value),
             );
         }
 
@@ -1077,7 +1077,7 @@ final class Loader
             $this->getBooleanAttribute($document->documentElement, 'backupGlobals', false),
             $this->getBooleanAttribute($document->documentElement, 'backupStaticAttributes', false),
             $this->getBooleanAttribute($document->documentElement, 'registerMockObjectsFromTestArgumentsRecursively', false),
-            $conflictBetweenPrinterClassAndTestdox
+            $conflictBetweenPrinterClassAndTestdox,
         );
     }
 
@@ -1171,7 +1171,7 @@ final class Loader
                     $prefix,
                     $suffix,
                     $phpVersion,
-                    $phpVersionOperator
+                    $phpVersionOperator,
                 );
             }
 
@@ -1201,7 +1201,7 @@ final class Loader
                 $files[] = new TestFile(
                     $this->toAbsolutePath($filename, $file),
                     $phpVersion,
-                    $phpVersionOperator
+                    $phpVersionOperator,
                 );
             }
 
@@ -1209,7 +1209,7 @@ final class Loader
                 (string) $element->getAttribute('name'),
                 TestDirectoryCollection::fromArray($directories),
                 TestFileCollection::fromArray($files),
-                FileCollection::fromArray($exclude)
+                FileCollection::fromArray($exclude),
             );
         }
 

--- a/src/TextUI/XmlConfiguration/Migration/MigrationBuilder.php
+++ b/src/TextUI/XmlConfiguration/Migration/MigrationBuilder.php
@@ -51,8 +51,8 @@ final class MigrationBuilder
             throw new MigrationBuilderException(
                 sprintf(
                     'Migration from schema version %s is not supported',
-                    $fromVersion
-                )
+                    $fromVersion,
+                ),
             );
         }
 

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/IntroduceCoverageElement.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/IntroduceCoverageElement.php
@@ -22,7 +22,7 @@ final class IntroduceCoverageElement implements Migration
 
         $document->documentElement->insertBefore(
             $coverage,
-            $document->documentElement->firstChild
+            $document->documentElement->firstChild,
         );
     }
 }

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/LogToReportMigration.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/LogToReportMigration.php
@@ -67,7 +67,7 @@ abstract class LogToReportMigration implements Migration
     private function findLogNode(DOMDocument $document): ?DOMElement
     {
         $logNode = (new DOMXPath($document))->query(
-            sprintf('//logging/log[@type="%s"]', $this->forType())
+            sprintf('//logging/log[@type="%s"]', $this->forType()),
         )->item(0);
 
         if (!$logNode instanceof DOMElement) {

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistExcludesToCoverage.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/MoveWhitelistExcludesToCoverage.php
@@ -47,7 +47,7 @@ final class MoveWhitelistExcludesToCoverage implements Migration
 
         if ($targetExclude === null) {
             $targetExclude = $coverage->appendChild(
-                $document->createElement('exclude')
+                $document->createElement('exclude'),
             );
         }
 

--- a/src/TextUI/XmlConfiguration/Migration/Migrations/UpdateSchemaLocationTo93.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrations/UpdateSchemaLocationTo93.php
@@ -21,7 +21,7 @@ final class UpdateSchemaLocationTo93 implements Migration
         $document->documentElement->setAttributeNS(
             'http://www.w3.org/2001/XMLSchema-instance',
             'xsi:noNamespaceSchemaLocation',
-            'https://schema.phpunit.de/9.3/phpunit.xsd'
+            'https://schema.phpunit.de/9.3/phpunit.xsd',
         );
     }
 }

--- a/src/TextUI/XmlConfiguration/Migration/Migrator.php
+++ b/src/TextUI/XmlConfiguration/Migration/Migrator.php
@@ -34,7 +34,7 @@ final class Migrator
                 sprintf(
                     '"%s" is not a valid PHPUnit XML configuration file that can be migrated',
                     $filename,
-                )
+                ),
             );
         }
 
@@ -42,7 +42,7 @@ final class Migrator
             $filename,
             false,
             true,
-            true
+            true,
         );
 
         foreach ((new MigrationBuilder)->build($origin->version()) as $migration) {

--- a/src/TextUI/XmlConfiguration/PHP/PhpHandler.php
+++ b/src/TextUI/XmlConfiguration/PHP/PhpHandler.php
@@ -52,7 +52,7 @@ final class PhpHandler
                 'include_path',
                 implode(PATH_SEPARATOR, $includePathsAsStrings) .
                 PATH_SEPARATOR .
-                ini_get('include_path')
+                ini_get('include_path'),
             );
         }
     }

--- a/src/Util/Annotation/DocBlock.php
+++ b/src/Util/Annotation/DocBlock.php
@@ -128,7 +128,7 @@ final class DocBlock
             $class->getEndLine(),
             $class->getFileName(),
             $className,
-            $className
+            $className,
         );
     }
 
@@ -145,7 +145,7 @@ final class DocBlock
             $method->getEndLine(),
             $method->getFileName(),
             $method->getName(),
-            $classNameInHierarchy
+            $classNameInHierarchy,
         );
     }
 
@@ -263,7 +263,7 @@ final class DocBlock
             array_filter([
                 'setting'            => $recordedSettings,
                 'extension_versions' => $extensionVersions,
-            ])
+            ]),
         );
     }
 
@@ -290,8 +290,8 @@ final class DocBlock
                 throw new InvalidDataSetException(
                     sprintf(
                         'Data set %s is invalid.',
-                        is_int($key) ? '#' . $key : '"' . $key . '"'
-                    )
+                        is_int($key) ? '#' . $key : '"' . $key . '"',
+                    ),
                 );
             }
         }
@@ -399,14 +399,14 @@ final class DocBlock
                 $dataProviderClass = new ReflectionClass($dataProviderClassName);
 
                 $dataProviderMethod = $dataProviderClass->getMethod(
-                    $dataProviderMethodName
+                    $dataProviderMethodName,
                 );
                 // @codeCoverageIgnoreStart
             } catch (ReflectionException $e) {
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
                 // @codeCoverageIgnoreEnd
             }
@@ -435,8 +435,8 @@ final class DocBlock
                             sprintf(
                                 'The key "%s" has already been defined in the data provider "%s".',
                                 $key,
-                                $match
-                            )
+                                $match,
+                            ),
                         );
                     } else {
                         $data[$key] = $value;
@@ -478,7 +478,7 @@ final class DocBlock
 
             if (json_last_error() !== JSON_ERROR_NONE) {
                 throw new Exception(
-                    'The data set for the @testWith annotation cannot be parsed: ' . json_last_error_msg()
+                    'The data set for the @testWith annotation cannot be parsed: ' . json_last_error_msg(),
                 );
             }
 
@@ -533,14 +533,14 @@ final class DocBlock
                     {
                         return self::parseDocBlock((string) $trait->getDocComment());
                     },
-                    array_values($reflector->getTraits())
-                )
+                    array_values($reflector->getTraits()),
+                ),
             );
         }
 
         return array_merge(
             $annotations,
-            self::parseDocBlock((string) $reflector->getDocComment())
+            self::parseDocBlock((string) $reflector->getDocComment()),
         );
     }
 }

--- a/src/Util/Annotation/Registry.php
+++ b/src/Util/Annotation/Registry.php
@@ -59,7 +59,7 @@ final class Registry
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -85,7 +85,7 @@ final class Registry
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -120,7 +120,7 @@ final class Color
                 {
                     return self::dim($matches[0]);
                 },
-                $path[$last]
+                $path[$last],
             );
         }
 

--- a/src/Util/ErrorHandler.php
+++ b/src/Util/ErrorHandler.php
@@ -64,7 +64,7 @@ final class ErrorHandler
                 }
 
                 return false;
-            }
+            },
         );
 
         $result = $callable();

--- a/src/Util/ExcludeList.php
+++ b/src/Util/ExcludeList.php
@@ -161,8 +161,8 @@ final class ExcludeList
             throw new Exception(
                 sprintf(
                     '"%s" is not a directory',
-                    $directory
-                )
+                    $directory,
+                ),
             );
         }
 

--- a/src/Util/FileLoader.php
+++ b/src/Util/FileLoader.php
@@ -42,7 +42,7 @@ final class FileLoader
             $includePathFilename === $localFile ||
             !self::isReadable($includePathFilename)) {
             throw new Exception(
-                sprintf('Cannot open file "%s".' . "\n", $filename)
+                sprintf('Cannot open file "%s".' . "\n", $filename),
             );
         }
 

--- a/src/Util/Filesystem.php
+++ b/src/Util/Filesystem.php
@@ -30,7 +30,7 @@ final class Filesystem
         return str_replace(
             ['_', '\\'],
             DIRECTORY_SEPARATOR,
-            $className
+            $className,
         ) . '.php';
     }
 

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -53,7 +53,7 @@ final class Filter
         if (!self::frameExists($eTrace, $eFile, $eLine)) {
             array_unshift(
                 $eTrace,
-                ['file' => $eFile, 'line' => $eLine]
+                ['file' => $eFile, 'line' => $eLine],
             );
         }
 
@@ -65,7 +65,7 @@ final class Filter
                 $filteredStacktrace .= sprintf(
                     "%s:%s\n",
                     $frame['file'],
-                    $frame['line'] ?? '?'
+                    $frame['line'] ?? '?',
                 );
             }
         }

--- a/src/Util/GlobalState.php
+++ b/src/Util/GlobalState.php
@@ -188,7 +188,7 @@ final class GlobalState
             $result .= sprintf(
                 '@ini_set(%s, %s);' . "\n",
                 self::exportVariable($key),
-                self::exportVariable((string) $value)
+                self::exportVariable((string) $value),
             );
         }
 
@@ -206,7 +206,7 @@ final class GlobalState
                     'if (!defined(\'%s\')) define(\'%s\', %s);' . "\n",
                     $name,
                     $name,
-                    self::exportVariable($value)
+                    self::exportVariable($value),
                 );
             }
         }
@@ -229,7 +229,7 @@ final class GlobalState
                         '$GLOBALS[\'%s\'][\'%s\'] = %s;' . "\n",
                         $superGlobalArray,
                         $key,
-                        self::exportVariable($GLOBALS[$superGlobalArray][$key])
+                        self::exportVariable($GLOBALS[$superGlobalArray][$key]),
                     );
                 }
             }
@@ -243,7 +243,7 @@ final class GlobalState
                 $result .= sprintf(
                     '$GLOBALS[\'%s\'] = %s;' . "\n",
                     $key,
-                    self::exportVariable($GLOBALS[$key])
+                    self::exportVariable($GLOBALS[$key]),
                 );
             }
         }

--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -37,7 +37,7 @@ final class Json
 
         if (json_last_error()) {
             throw new Exception(
-                'Cannot prettify invalid json'
+                'Cannot prettify invalid json',
             );
         }
 

--- a/src/Util/Log/JUnit.php
+++ b/src/Util/Log/JUnit.php
@@ -226,37 +226,37 @@ final class JUnit extends Printer implements TestListener
     {
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'tests',
-            (string) $this->testSuiteTests[$this->testSuiteLevel]
+            (string) $this->testSuiteTests[$this->testSuiteLevel],
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'assertions',
-            (string) $this->testSuiteAssertions[$this->testSuiteLevel]
+            (string) $this->testSuiteAssertions[$this->testSuiteLevel],
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'errors',
-            (string) $this->testSuiteErrors[$this->testSuiteLevel]
+            (string) $this->testSuiteErrors[$this->testSuiteLevel],
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'warnings',
-            (string) $this->testSuiteWarnings[$this->testSuiteLevel]
+            (string) $this->testSuiteWarnings[$this->testSuiteLevel],
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'failures',
-            (string) $this->testSuiteFailures[$this->testSuiteLevel]
+            (string) $this->testSuiteFailures[$this->testSuiteLevel],
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'skipped',
-            (string) $this->testSuiteSkipped[$this->testSuiteLevel]
+            (string) $this->testSuiteSkipped[$this->testSuiteLevel],
         );
 
         $this->testSuites[$this->testSuiteLevel]->setAttribute(
             'time',
-            sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
+            sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel]),
         );
 
         if ($this->testSuiteLevel > 1) {
@@ -293,7 +293,7 @@ final class JUnit extends Printer implements TestListener
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -308,7 +308,7 @@ final class JUnit extends Printer implements TestListener
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd
@@ -337,16 +337,16 @@ final class JUnit extends Printer implements TestListener
 
         $this->currentTestCase->setAttribute(
             'assertions',
-            (string) $numAssertions
+            (string) $numAssertions,
         );
 
         $this->currentTestCase->setAttribute(
             'time',
-            sprintf('%F', $time)
+            sprintf('%F', $time),
         );
 
         $this->testSuites[$this->testSuiteLevel]->appendChild(
-            $this->currentTestCase
+            $this->currentTestCase,
         );
 
         $this->testSuiteTests[$this->testSuiteLevel]++;
@@ -361,7 +361,7 @@ final class JUnit extends Printer implements TestListener
         if (!empty($testOutput)) {
             $systemOut = $this->document->createElement(
                 'system-out',
-                Xml::prepareString($testOutput)
+                Xml::prepareString($testOutput),
             );
 
             $this->currentTestCase->appendChild($systemOut);
@@ -392,12 +392,12 @@ final class JUnit extends Printer implements TestListener
 
         $buffer .= trim(
             TestFailure::exceptionToString($t) . "\n" .
-            Filter::getFilteredStacktrace($t)
+            Filter::getFilteredStacktrace($t),
         );
 
         $fault = $this->document->createElement(
             $type,
-            Xml::prepareString($buffer)
+            Xml::prepareString($buffer),
         );
 
         if ($t instanceof ExceptionWrapper) {

--- a/src/Util/Log/TeamCity.php
+++ b/src/Util/Log/TeamCity.php
@@ -77,7 +77,7 @@ final class TeamCity extends DefaultResultPrinter
                 'message'  => self::getMessage($t),
                 'details'  => self::getDetails($t),
                 'duration' => self::toMilliseconds($time),
-            ]
+            ],
         );
     }
 
@@ -169,7 +169,7 @@ final class TeamCity extends DefaultResultPrinter
                 'message'  => self::getMessage($t),
                 'details'  => self::getDetails($t),
                 'duration' => self::toMilliseconds($time),
-            ]
+            ],
         );
     }
 
@@ -189,7 +189,7 @@ final class TeamCity extends DefaultResultPrinter
 
             $this->printEvent(
                 'testCount',
-                ['count' => count($suite)]
+                ['count' => count($suite)],
             );
         }
 
@@ -271,7 +271,7 @@ final class TeamCity extends DefaultResultPrinter
             [
                 'name'     => $test->getName(),
                 'duration' => self::toMilliseconds($time),
-            ]
+            ],
         );
     }
 
@@ -351,7 +351,7 @@ final class TeamCity extends DefaultResultPrinter
         return str_replace(
             ['|', "'", "\n", "\r", ']', '['],
             ['||', "|'", '|n', '|r', '|]', '|['],
-            $text
+            $text,
         );
     }
 
@@ -367,7 +367,7 @@ final class TeamCity extends DefaultResultPrinter
             throw new Exception(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -184,7 +184,7 @@ abstract class AbstractPhpProcess
             $test,
             $result,
             $_result['stdout'],
-            $_result['stderr']
+            $_result['stderr'],
         );
     }
 
@@ -199,15 +199,15 @@ abstract class AbstractPhpProcess
             $settings = array_merge(
                 $settings,
                 $this->runtime->getCurrentSettings(
-                    array_keys(ini_get_all('pcov'))
-                )
+                    array_keys(ini_get_all('pcov')),
+                ),
             );
         } elseif ($this->runtime->hasXdebug()) {
             $settings = array_merge(
                 $settings,
                 $this->runtime->getCurrentSettings(
-                    array_keys(ini_get_all('xdebug'))
-                )
+                    array_keys(ini_get_all('xdebug')),
+                ),
             );
         }
 
@@ -268,7 +268,7 @@ abstract class AbstractPhpProcess
             $result->addError(
                 $test,
                 new Exception(trim($stderr)),
-                $time
+                $time,
             );
         } else {
             set_error_handler(
@@ -278,7 +278,7 @@ abstract class AbstractPhpProcess
                 static function ($errno, $errstr, $errfile, $errline): void
                 {
                     throw new ErrorException($errstr, $errno, $errno, $errfile, $errline);
-                }
+                },
             );
 
             try {
@@ -293,7 +293,7 @@ abstract class AbstractPhpProcess
                     $result->addFailure(
                         $test,
                         new AssertionFailedError('Test was run in child process and ended unexpectedly'),
-                        $time
+                        $time,
                     );
                 }
             } catch (ErrorException $e) {
@@ -303,7 +303,7 @@ abstract class AbstractPhpProcess
                 $result->addError(
                     $test,
                     new Exception(trim($stdout), 0, $e),
-                    $time
+                    $time,
                 );
             }
 
@@ -322,7 +322,7 @@ abstract class AbstractPhpProcess
 
                 if ($result->getCollectCodeCoverageInformation()) {
                     $result->getCodeCoverage()->merge(
-                        $childResult->getCodeCoverage()
+                        $childResult->getCodeCoverage(),
                     );
                 }
 
@@ -338,37 +338,37 @@ abstract class AbstractPhpProcess
                     $result->addError(
                         $test,
                         $this->getException($notImplemented[0]),
-                        $time
+                        $time,
                     );
                 } elseif (!empty($risky)) {
                     $result->addError(
                         $test,
                         $this->getException($risky[0]),
-                        $time
+                        $time,
                     );
                 } elseif (!empty($skipped)) {
                     $result->addError(
                         $test,
                         $this->getException($skipped[0]),
-                        $time
+                        $time,
                     );
                 } elseif (!empty($errors)) {
                     $result->addError(
                         $test,
                         $this->getException($errors[0]),
-                        $time
+                        $time,
                     );
                 } elseif (!empty($warnings)) {
                     $result->addWarning(
                         $test,
                         $this->getException($warnings[0]),
-                        $time
+                        $time,
                     );
                 } elseif (!empty($failures)) {
                     $result->addFailure(
                         $test,
                         $this->getException($failures[0]),
-                        $time
+                        $time,
                     );
                 }
             }
@@ -402,12 +402,12 @@ abstract class AbstractPhpProcess
                 sprintf(
                     '%s: %s',
                     $exceptionArray['_PHP_Incomplete_Class_Name'],
-                    $exceptionArray['message']
+                    $exceptionArray['message'],
                 ),
                 $exceptionArray['code'],
                 $exceptionArray['file'],
                 $exceptionArray['line'],
-                $exceptionArray['trace']
+                $exceptionArray['trace'],
             );
         }
 

--- a/src/Util/PHP/DefaultPhpProcess.php
+++ b/src/Util/PHP/DefaultPhpProcess.php
@@ -49,7 +49,7 @@ class DefaultPhpProcess extends AbstractPhpProcess
             if (!($this->tempFile = tempnam(sys_get_temp_dir(), 'PHPUnit')) ||
                 file_put_contents($this->tempFile, $job) === false) {
                 throw new Exception(
-                    'Unable to write temporary file'
+                    'Unable to write temporary file',
                 );
             }
 
@@ -101,12 +101,12 @@ class DefaultPhpProcess extends AbstractPhpProcess
             $pipeSpec,
             $pipes,
             null,
-            $env
+            $env,
         );
 
         if (!is_resource($process)) {
             throw new Exception(
-                'Unable to spawn worker process'
+                'Unable to spawn worker process',
             );
         }
 
@@ -138,8 +138,8 @@ class DefaultPhpProcess extends AbstractPhpProcess
                     throw new Exception(
                         sprintf(
                             'Job execution aborted after %d seconds',
-                            $this->timeout
-                        )
+                            $this->timeout,
+                        ),
                     );
                 }
 

--- a/src/Util/PHP/WindowsPhpProcess.php
+++ b/src/Util/PHP/WindowsPhpProcess.php
@@ -36,7 +36,7 @@ final class WindowsPhpProcess extends DefaultPhpProcess
     {
         if (false === $stdout_handle = tmpfile()) {
             throw new Exception(
-                'A temporary file could not be created; verify that your TEMP environment variable is writable'
+                'A temporary file could not be created; verify that your TEMP environment variable is writable',
             );
         }
 

--- a/src/Util/Printer.php
+++ b/src/Util/Printer.php
@@ -67,8 +67,8 @@ class Printer
                 throw new Exception(
                     sprintf(
                         '"%s" does not match "socket://hostname:port" format',
-                        $out
-                    )
+                        $out,
+                    ),
                 );
             }
 
@@ -81,8 +81,8 @@ class Printer
             throw new Exception(
                 sprintf(
                     'Directory "%s" was not created',
-                    dirname($out)
-                )
+                    dirname($out),
+                ),
             );
         }
 

--- a/src/Util/RegularExpression.php
+++ b/src/Util/RegularExpression.php
@@ -25,7 +25,7 @@ final class RegularExpression
             static function () use ($pattern, $subject)
             {
                 return preg_match($pattern, $subject);
-            }
+            },
         );
     }
 }

--- a/src/Util/Test.php
+++ b/src/Util/Test.php
@@ -119,7 +119,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         if (!self::shouldCoversAnnotationBeUsed($annotations)) {
@@ -145,7 +145,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             get_class($test),
-            $test->getName(false)
+            $test->getName(false),
         );
 
         // If there is no @covers annotation but a @coversNothing annotation on
@@ -182,7 +182,7 @@ final class Test
     {
         return self::mergeArraysRecursively(
             Registry::getInstance()->forClassName($className)->requirements(),
-            Registry::getInstance()->forMethod($className, $methodName)->requirements()
+            Registry::getInstance()->forMethod($className, $methodName)->requirements(),
         );
     }
 
@@ -213,7 +213,7 @@ final class Test
             if (!$required['PHP_constraint']['constraint']->complies($version)) {
                 $missing[] = sprintf(
                     'PHP version does not match the required constraint %s.',
-                    $required['PHP_constraint']['constraint']->asString()
+                    $required['PHP_constraint']['constraint']->asString(),
                 );
 
                 $hint = 'PHP_constraint';
@@ -235,7 +235,7 @@ final class Test
             if (!$required['PHPUnit_constraint']['constraint']->complies($phpunitVersion)) {
                 $missing[] = sprintf(
                     'PHPUnit version does not match the required constraint %s.',
-                    $required['PHPUnit_constraint']['constraint']->asString()
+                    $required['PHPUnit_constraint']['constraint']->asString(),
                 );
 
                 $hint = $hint ?? 'PHPUnit_constraint';
@@ -367,12 +367,12 @@ final class Test
             'backupGlobals' => self::getBooleanAnnotationSetting(
                 $className,
                 $methodName,
-                'backupGlobals'
+                'backupGlobals',
             ),
             'backupStaticAttributes' => self::getBooleanAnnotationSetting(
                 $className,
                 $methodName,
-                'backupStaticAttributes'
+                'backupStaticAttributes',
             ),
         ];
     }
@@ -386,7 +386,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         $dependsAnnotations = $annotations['class']['depends'] ?? [];
@@ -394,7 +394,7 @@ final class Test
         if (isset($annotations['method']['depends'])) {
             $dependsAnnotations = array_merge(
                 $dependsAnnotations,
-                $annotations['method']['depends']
+                $annotations['method']['depends'],
             );
         }
 
@@ -413,7 +413,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         $groups = [];
@@ -492,7 +492,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         return isset($annotations['class']['runTestsInSeparateProcesses']) || isset($annotations['method']['runInSeparateProcess']);
@@ -503,7 +503,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         return isset($annotations['class']['runClassInSeparateProcess']);
@@ -515,7 +515,7 @@ final class Test
         return self::getBooleanAnnotationSetting(
             $className,
             $methodName,
-            'preserveGlobalState'
+            'preserveGlobalState',
         );
     }
 
@@ -537,7 +537,7 @@ final class Test
                         if ($docBlock->isHookToBeExecutedBeforeClass()) {
                             array_unshift(
                                 self::$hookMethods[$className]['beforeClass'],
-                                $method->getName()
+                                $method->getName(),
                             );
                         }
 
@@ -549,14 +549,14 @@ final class Test
                     if ($docBlock->isToBeExecutedBeforeTest()) {
                         array_unshift(
                             self::$hookMethods[$className]['before'],
-                            $method->getName()
+                            $method->getName(),
                         );
                     }
 
                     if ($docBlock->isToBeExecutedAsPreCondition()) {
                         array_unshift(
                             self::$hookMethods[$className]['preCondition'],
-                            $method->getName()
+                            $method->getName(),
                         );
                     }
 
@@ -589,9 +589,9 @@ final class Test
             'test',
             Registry::getInstance()->forMethod(
                 $method->getDeclaringClass()->getName(),
-                $method->getName()
+                $method->getName(),
             )
-                ->symbolAnnotations()
+                ->symbolAnnotations(),
         );
     }
 
@@ -604,7 +604,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         $classShortcut = null;
@@ -615,8 +615,8 @@ final class Test
                     sprintf(
                         'More than one @%sClass annotation in class or interface "%s".',
                         $mode,
-                        $className
-                    )
+                        $className,
+                    ),
                 );
             }
 
@@ -645,8 +645,8 @@ final class Test
                 throw new InvalidCoversTargetException(
                     sprintf(
                         'Trying to @cover interface "%s".',
-                        $element
-                    )
+                        $element,
+                    ),
                 );
             }
 
@@ -657,10 +657,10 @@ final class Test
                     sprintf(
                         '"@%s %s" is invalid',
                         $mode,
-                        $element
+                        $element,
                     ),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
         }
@@ -685,7 +685,7 @@ final class Test
     {
         $annotations = self::parseTestMethodAnnotations(
             $className,
-            $methodName
+            $methodName,
         );
 
         if (isset($annotations['method'][$settingName])) {
@@ -720,7 +720,7 @@ final class Test
         return preg_replace(
             '/^(\d+\.\d+(?:.\d+)?).*$/',
             '$1',
-            $version
+            $version,
         );
     }
 

--- a/src/Util/TestDox/CliTestDoxPrinter.php
+++ b/src/Util/TestDox/CliTestDoxPrinter.php
@@ -205,7 +205,7 @@ class CliTestDoxPrinter extends TestDoxPrinter
             ' %s %s%s' . PHP_EOL,
             $this->colorizeTextBox($style['color'], $style['symbol']),
             $testName,
-            $this->verbose ? ' ' . $this->formatRuntime($result['time'], $style['color']) : ''
+            $this->verbose ? ' ' . $this->formatRuntime($result['time'], $style['color']) : '',
         );
 
         $this->write($line);

--- a/src/Util/TestDox/HtmlResultPrinter.php
+++ b/src/Util/TestDox/HtmlResultPrinter.php
@@ -122,8 +122,8 @@ EOT;
         $this->write(
             sprintf(
                 self::CLASS_HEADER,
-                $this->currentTestClassPrettified
-            )
+                $this->currentTestClassPrettified,
+            ),
         );
     }
 
@@ -136,8 +136,8 @@ EOT;
             sprintf(
                 "            <li class=\"%s\">%s</li>\n",
                 $success ? 'success' : 'defect',
-                $name
-            )
+                $name,
+            ),
         );
     }
 

--- a/src/Util/TestDox/NamePrettifier.php
+++ b/src/Util/TestDox/NamePrettifier.php
@@ -124,7 +124,7 @@ final class NamePrettifier
     {
         $annotations = Test::parseTestMethodAnnotations(
             get_class($test),
-            $test->getName(false)
+            $test->getName(false),
         );
 
         $annotationWithPlaceholders = false;
@@ -243,7 +243,7 @@ final class NamePrettifier
             throw new UtilException(
                 $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
         // @codeCoverageIgnoreEnd
@@ -263,7 +263,7 @@ final class NamePrettifier
                     throw new UtilException(
                         $e->getMessage(),
                         $e->getCode(),
-                        $e
+                        $e,
                     );
                 }
                 // @codeCoverageIgnoreEnd

--- a/src/Util/TestDox/TestDoxPrinter.php
+++ b/src/Util/TestDox/TestDoxPrinter.php
@@ -381,8 +381,8 @@ class TestDoxPrinter extends DefaultResultPrinter
                 {
                     return '   ' . $prefix . ($text ? ' ' . $text : '');
                 },
-                preg_split('/\r\n|\r|\n/', $message)
-            )
+                preg_split('/\r\n|\r|\n/', $message),
+            ),
         );
     }
 }

--- a/src/Util/TestDox/XmlResultPrinter.php
+++ b/src/Util/TestDox/XmlResultPrinter.php
@@ -164,7 +164,7 @@ final class XmlResultPrinter extends Printer implements TestListener
             static function ($group)
             {
                 return !($group === 'small' || $group === 'medium' || $group === 'large' || strpos($group, '__phpunit_') === 0);
-            }
+            },
         );
 
         $testNode = $this->document->createElement('test');
@@ -188,7 +188,7 @@ final class XmlResultPrinter extends Printer implements TestListener
 
         $annotations = TestUtil::parseTestMethodAnnotations(
             get_class($test),
-            $test->getName(false)
+            $test->getName(false),
         );
 
         foreach (['class', 'method'] as $type) {
@@ -240,7 +240,7 @@ final class XmlResultPrinter extends Printer implements TestListener
                 throw new Exception(
                     $e->getMessage(),
                     $e->getCode(),
-                    $e
+                    $e,
                 );
             }
             // @codeCoverageIgnoreEnd

--- a/src/Util/TextTestListRenderer.php
+++ b/src/Util/TextTestListRenderer.php
@@ -35,7 +35,7 @@ final class TextTestListRenderer
                 $name = sprintf(
                     '%s::%s',
                     get_class($test),
-                    str_replace(' with data set ', '', $test->getName())
+                    str_replace(' with data set ', '', $test->getName()),
                 );
             } elseif ($test instanceof PhptTestCase) {
                 $name = $test->getName();
@@ -45,7 +45,7 @@ final class TextTestListRenderer
 
             $buffer .= sprintf(
                 ' - %s' . PHP_EOL,
-                $name
+                $name,
             );
         }
 

--- a/src/Util/VersionComparisonOperator.php
+++ b/src/Util/VersionComparisonOperator.php
@@ -50,8 +50,8 @@ final class VersionComparisonOperator
             throw new Exception(
                 sprintf(
                     '"%s" is not a valid version_compare() operator',
-                    $operator
-                )
+                    $operator,
+                ),
             );
         }
     }

--- a/src/Util/XdebugFilterScriptGenerator.php
+++ b/src/Util/XdebugFilterScriptGenerator.php
@@ -32,10 +32,10 @@ final class XdebugFilterScriptGenerator
             {
                 return sprintf(
                     "        '%s'",
-                    $item
+                    $item,
                 );
             },
-            $this->getItems($filter)
+            $this->getItems($filter),
         );
 
         $files = implode(",\n", $files);
@@ -67,7 +67,7 @@ EOF;
             if (is_string($path)) {
                 $files[] = sprintf(
                     addslashes('%s' . DIRECTORY_SEPARATOR),
-                    $path
+                    $path,
                 );
             }
         }

--- a/src/Util/Xml.php
+++ b/src/Util/Xml.php
@@ -68,8 +68,8 @@ final class Xml
             '',
             htmlspecialchars(
                 self::convertToUtf8($string),
-                ENT_QUOTES
-            )
+                ENT_QUOTES,
+            ),
         );
     }
 
@@ -127,7 +127,7 @@ final class Xml
                         throw new Exception(
                             $e->getMessage(),
                             $e->getCode(),
-                            $e
+                            $e,
                         );
                     }
                     // @codeCoverageIgnoreEnd

--- a/src/Util/Xml/Loader.php
+++ b/src/Util/Xml/Loader.php
@@ -38,8 +38,8 @@ final class Loader
             throw new Exception(
                 sprintf(
                     'Could not read "%s".',
-                    $filename
-                )
+                    $filename,
+                ),
             );
         }
 
@@ -100,8 +100,8 @@ final class Loader
                     sprintf(
                         'Could not load "%s".%s',
                         $filename,
-                        $message !== '' ? "\n" . $message : ''
-                    )
+                        $message !== '' ? "\n" . $message : '',
+                    ),
                 );
             }
 

--- a/src/Util/Xml/SchemaDetector.php
+++ b/src/Util/Xml/SchemaDetector.php
@@ -23,7 +23,7 @@ final class SchemaDetector
             $filename,
             false,
             true,
-            true
+            true,
         );
 
         foreach (['9.2', '8.5'] as $candidate) {

--- a/src/Util/Xml/SchemaFinder.php
+++ b/src/Util/Xml/SchemaFinder.php
@@ -34,8 +34,8 @@ final class SchemaFinder
             throw new Exception(
                 sprintf(
                     'Schema for PHPUnit %s is not available',
-                    $version
-                )
+                    $version,
+                ),
             );
         }
 

--- a/src/Util/XmlTestListRenderer.php
+++ b/src/Util/XmlTestListRenderer.php
@@ -60,8 +60,8 @@ final class XmlTestListRenderer
                         str_replace(
                             ' with data set ',
                             '',
-                            $test->getDataSetAsString(false)
-                        )
+                            $test->getDataSetAsString(false),
+                        ),
                     );
                 }
 

--- a/tests/_files/CountConstraint.php
+++ b/tests/_files/CountConstraint.php
@@ -37,7 +37,7 @@ final class CountConstraint extends Constraint
     {
         return sprintf(
             'is accepted by %s',
-            self::class
+            self::class,
         );
     }
 

--- a/tests/_files/MultipleDataProviderTest.php
+++ b/tests/_files/MultipleDataProviderTest.php
@@ -66,7 +66,7 @@ class MultipleDataProviderTest extends TestCase
                 [null, null, 'ok'],
                 [null, null, 'ok'],
                 [null, null, 'ok'],
-            ]
+            ],
         );
 
         return $object->getIterator();

--- a/tests/_files/ThrowExceptionTestCase.php
+++ b/tests/_files/ThrowExceptionTestCase.php
@@ -23,7 +23,7 @@ class ThrowExceptionTestCase extends TestCase
     {
         throw new RuntimeException(
             'Cannot compute at this time.',
-            9000
+            9000,
         );
     }
 }

--- a/tests/end-to-end/regression/4407/Issue4407Test.php
+++ b/tests/end-to-end/regression/4407/Issue4407Test.php
@@ -15,7 +15,7 @@ final class Issue4407Test extends TestCase
     {
         $this->assertXmlStringEqualsXmlFile(
             __DIR__ . '/test.xml',
-            new DOMDocument
+            new DOMDocument,
         );
     }
 }

--- a/tests/end-to-end/regression/503/Issue503Test.php
+++ b/tests/end-to-end/regression/503/Issue503Test.php
@@ -15,7 +15,7 @@ class Issue503Test extends TestCase
     {
         $this->assertSame(
             "foo\n",
-            "foo\r\n"
+            "foo\r\n",
         );
     }
 }

--- a/tests/end-to-end/regression/581/Issue581Test.php
+++ b/tests/end-to-end/regression/581/Issue581Test.php
@@ -15,7 +15,7 @@ class Issue581Test extends TestCase
     {
         $this->assertEquals(
             (object) [1, 2, "Test\r\n", 4, 5, 6, 7, 8],
-            (object) [1, 2, "Test\r\n", 4, 1, 6, 7, 8]
+            (object) [1, 2, "Test\r\n", 4, 1, 6, 7, 8],
         );
     }
 }

--- a/tests/end-to-end/regression/873/Issue873Test.php
+++ b/tests/end-to-end/regression/873/Issue873Test.php
@@ -12,5 +12,5 @@ if (\extension_loaded('xdebug') && \version_compare(\phpversion('xdebug'), '3', 
 }
 
 throw new Exception(
-    'PHPUnit suppresses exceptions thrown outside of test case function'
+    'PHPUnit suppresses exceptions thrown outside of test case function',
 );

--- a/tests/unit/Framework/Assert/FunctionsTest.php
+++ b/tests/unit/Framework/Assert/FunctionsTest.php
@@ -22,9 +22,9 @@ final class FunctionsTest extends TestCase
         preg_match_all(
             '/function (assert[^ \(]+)/',
             file_get_contents(
-                __DIR__ . '/../../../../src/Framework/Assert/Functions.php'
+                __DIR__ . '/../../../../src/Framework/Assert/Functions.php',
             ),
-            $matches
+            $matches,
         );
 
         self::$globalAssertionFunctions = $matches[1];
@@ -38,7 +38,7 @@ final class FunctionsTest extends TestCase
         Assert::assertContains(
             $methodName,
             self::$globalAssertionFunctions,
-            "Mapping for Assert::{$methodName} is missing in Functions.php"
+            "Mapping for Assert::{$methodName} is missing in Functions.php",
         );
     }
 
@@ -47,9 +47,9 @@ final class FunctionsTest extends TestCase
         preg_match_all(
             '/public static function (assert[^ \(]+)/',
             file_get_contents(
-                __DIR__ . '/../../../../src/Framework/Assert.php'
+                __DIR__ . '/../../../../src/Framework/Assert.php',
             ),
-            $matches
+            $matches,
         );
 
         return array_reduce(
@@ -60,7 +60,7 @@ final class FunctionsTest extends TestCase
 
                 return $functionNames;
             },
-            []
+            [],
         );
     }
 }

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -369,14 +369,14 @@ final class AssertTest extends TestCase
     {
         $this->assertXmlFileEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'foo.xml'
+            TEST_FILES_PATH . 'foo.xml',
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertXmlFileEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'bar.xml'
+            TEST_FILES_PATH . 'bar.xml',
         );
     }
 
@@ -384,14 +384,14 @@ final class AssertTest extends TestCase
     {
         $this->assertXmlFileNotEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'bar.xml'
+            TEST_FILES_PATH . 'bar.xml',
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertXmlFileNotEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'foo.xml'
+            TEST_FILES_PATH . 'foo.xml',
         );
     }
 
@@ -399,14 +399,14 @@ final class AssertTest extends TestCase
     {
         $this->assertXmlStringEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'foo.xml')
+            file_get_contents(TEST_FILES_PATH . 'foo.xml'),
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertXmlStringEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'bar.xml')
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
     }
 
@@ -414,14 +414,14 @@ final class AssertTest extends TestCase
     {
         $this->assertXmlStringNotEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'bar.xml')
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertXmlStringNotEqualsXmlFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'foo.xml')
+            file_get_contents(TEST_FILES_PATH . 'foo.xml'),
         );
     }
 
@@ -638,7 +638,7 @@ XML;
 
         $tempFile = tempnam(
             sys_get_temp_dir(),
-            'unreadable'
+            'unreadable',
         );
 
         chmod($tempFile, octdec('0'));
@@ -810,17 +810,17 @@ XML;
     {
         $this->assertNotSame(
             new stdClass,
-            null
+            null,
         );
 
         $this->assertNotSame(
             null,
-            new stdClass
+            new stdClass,
         );
 
         $this->assertNotSame(
             new stdClass,
-            new stdClass
+            new stdClass,
         );
 
         $o = new stdClass;
@@ -919,8 +919,8 @@ XML;
             'anything',
             $this->logicalAnd(
                 $this->anything(),
-                $this->anything()
-            )
+                $this->anything(),
+            ),
         );
     }
 
@@ -933,8 +933,8 @@ XML;
             'anything',
             $this->logicalOr(
                 $this->anything(),
-                $this->anything()
-            )
+                $this->anything(),
+            ),
         );
     }
 
@@ -947,8 +947,8 @@ XML;
             'anything',
             $this->logicalXor(
                 $this->anything(),
-                $this->logicalNot($this->anything())
-            )
+                $this->logicalNot($this->anything()),
+            ),
         );
     }
 
@@ -1042,7 +1042,7 @@ XML;
             $this->callback(static function ($other)
             {
                 return true;
-            })
+            }),
         );
     }
 
@@ -1055,14 +1055,14 @@ XML;
     {
         $this->assertFileEquals(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'foo.xml'
+            TEST_FILES_PATH . 'foo.xml',
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertFileEquals(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'bar.xml'
+            TEST_FILES_PATH . 'bar.xml',
         );
     }
 
@@ -1070,14 +1070,14 @@ XML;
     {
         $this->assertFileNotEquals(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'bar.xml'
+            TEST_FILES_PATH . 'bar.xml',
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertFileNotEquals(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'foo.xml'
+            TEST_FILES_PATH . 'foo.xml',
         );
     }
 
@@ -1085,14 +1085,14 @@ XML;
     {
         $this->assertStringEqualsFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'foo.xml')
+            file_get_contents(TEST_FILES_PATH . 'foo.xml'),
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertStringEqualsFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'bar.xml')
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
     }
 
@@ -1100,14 +1100,14 @@ XML;
     {
         $this->assertStringEqualsFileIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'fooUppercase.xml')
+            file_get_contents(TEST_FILES_PATH . 'fooUppercase.xml'),
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertStringEqualsFileIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'bar.xml')
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
     }
 
@@ -1115,14 +1115,14 @@ XML;
     {
         $this->assertStringNotEqualsFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'bar.xml')
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertStringNotEqualsFile(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'foo.xml')
+            file_get_contents(TEST_FILES_PATH . 'foo.xml'),
         );
     }
 
@@ -1130,14 +1130,14 @@ XML;
     {
         $this->assertStringNotEqualsFileIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'bar.xml')
+            file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertStringNotEqualsFileIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            file_get_contents(TEST_FILES_PATH . 'fooUppercase.xml')
+            file_get_contents(TEST_FILES_PATH . 'fooUppercase.xml'),
         );
     }
 
@@ -1145,14 +1145,14 @@ XML;
     {
         $this->assertFileEqualsIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'fooUppercase.xml'
+            TEST_FILES_PATH . 'fooUppercase.xml',
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertFileEqualsIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'bar.xml'
+            TEST_FILES_PATH . 'bar.xml',
         );
     }
 
@@ -1160,14 +1160,14 @@ XML;
     {
         $this->assertFileNotEqualsIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'bar.xml'
+            TEST_FILES_PATH . 'bar.xml',
         );
 
         $this->expectException(AssertionFailedError::class);
 
         $this->assertFileNotEqualsIgnoringCase(
             TEST_FILES_PATH . 'foo.xml',
-            TEST_FILES_PATH . 'fooUppercase.xml'
+            TEST_FILES_PATH . 'fooUppercase.xml',
         );
     }
 
@@ -1461,7 +1461,7 @@ XML;
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
                 'Failed asserting that \'{"Mascott":"Beastie"}\' matches JSON string "{"Mascott":"Tux"}".',
-                $e->getMessage()
+                $e->getMessage(),
             );
 
             return;
@@ -1930,8 +1930,8 @@ XML;
             true,
             $this->logicalAnd(
                 $this->isTrue(),
-                $this->isTrue()
-            )
+                $this->isTrue(),
+            ),
         );
 
         $this->expectException(AssertionFailedError::class);
@@ -1940,8 +1940,8 @@ XML;
             true,
             $this->logicalAnd(
                 $this->isTrue(),
-                $this->isFalse()
-            )
+                $this->isFalse(),
+            ),
         );
     }
 
@@ -1951,8 +1951,8 @@ XML;
             true,
             $this->logicalOr(
                 $this->isTrue(),
-                $this->isFalse()
-            )
+                $this->isFalse(),
+            ),
         );
 
         $this->expectException(AssertionFailedError::class);
@@ -1961,8 +1961,8 @@ XML;
             true,
             $this->logicalOr(
                 $this->isFalse(),
-                $this->isFalse()
-            )
+                $this->isFalse(),
+            ),
         );
     }
 
@@ -1972,8 +1972,8 @@ XML;
             true,
             $this->logicalXor(
                 $this->isTrue(),
-                $this->isFalse()
-            )
+                $this->isFalse(),
+            ),
         );
 
         $this->expectException(AssertionFailedError::class);
@@ -1982,8 +1982,8 @@ XML;
             true,
             $this->logicalXor(
                 $this->isTrue(),
-                $this->isTrue()
-            )
+                $this->isTrue(),
+            ),
         );
     }
 

--- a/tests/unit/Framework/Constraint/ArrayHasKeyTest.php
+++ b/tests/unit/Framework/Constraint/ArrayHasKeyTest.php
@@ -34,7 +34,7 @@ Failed asserting that an array has the key 0.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -56,7 +56,7 @@ custom message\nFailed asserting that an array has the key 0.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -78,7 +78,7 @@ Failed asserting that an array has the key 0.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }

--- a/tests/unit/Framework/Constraint/BinaryOperatorTestCase.php
+++ b/tests/unit/Framework/Constraint/BinaryOperatorTestCase.php
@@ -52,7 +52,7 @@ abstract class BinaryOperatorTestCase extends OperatorTestCase
         $this->assertTrue($reflection->isSubclassOf(Operator::class), sprintf(
             'Failed to assert that "%s" is subclass of "%s".',
             $className,
-            Operator::class
+            Operator::class,
         ));
     }
 
@@ -192,8 +192,8 @@ abstract class BinaryOperatorTestCase extends OperatorTestCase
                     {
                         return $operand->toString();
                     },
-                    $constraints
-                )
+                    $constraints,
+                ),
             );
             $message = "Failed asserting that 'the following expression is true' " . $expectedString;
             $this->expectException(ExpectationFailedException::class);

--- a/tests/unit/Framework/Constraint/ClassHasAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ClassHasAttributeTest.php
@@ -23,7 +23,7 @@ final class ClassHasAttributeTest extends ConstraintTestCase
     public function testConstraintClassHasAttribute(): void
     {
         $constraint = new ClassHasAttribute(
-            'privateAttribute'
+            'privateAttribute',
         );
 
         $this->assertTrue($constraint->evaluate(ClassWithNonPublicAttributes::class, '', true));
@@ -41,9 +41,9 @@ Failed asserting that class "%s" has attribute "privateAttribute".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -55,7 +55,7 @@ EOF
     public function testConstraintClassHasAttribute2(): void
     {
         $constraint = new ClassHasAttribute(
-            'privateAttribute'
+            'privateAttribute',
         );
 
         try {
@@ -69,9 +69,9 @@ Failed asserting that class "%s" has attribute "privateAttribute".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/ClassHasStaticAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ClassHasStaticAttributeTest.php
@@ -39,9 +39,9 @@ Failed asserting that class "%s" has static attribute "privateStaticAttribute".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -65,9 +65,9 @@ Failed asserting that class "%s" has static attribute "foo".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/ConstraintTestCase.php
+++ b/tests/unit/Framework/Constraint/ConstraintTestCase.php
@@ -30,7 +30,7 @@ abstract class ConstraintTestCase extends TestCase
         $this->assertTrue($reflection->implementsInterface(Countable::class), sprintf(
             'Failed to assert that "%s" implements "%s".',
             $className,
-            Countable::class
+            Countable::class,
         ));
     }
 
@@ -43,7 +43,7 @@ abstract class ConstraintTestCase extends TestCase
         $this->assertTrue($reflection->implementsInterface(SelfDescribing::class), sprintf(
             'Failed to assert that "%s" implements "%s".',
             $className,
-            SelfDescribing::class
+            SelfDescribing::class,
         ));
     }
 
@@ -55,7 +55,7 @@ abstract class ConstraintTestCase extends TestCase
         return preg_replace(
             '/Test$/',
             '',
-            static::class
+            static::class,
         );
     }
 }

--- a/tests/unit/Framework/Constraint/CountTest.php
+++ b/tests/unit/Framework/Constraint/CountTest.php
@@ -184,7 +184,7 @@ Failed asserting that actual size 0 matches expected size 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }

--- a/tests/unit/Framework/Constraint/DirectoryExistsTest.php
+++ b/tests/unit/Framework/Constraint/DirectoryExistsTest.php
@@ -58,7 +58,7 @@ Failed asserting that directory "{$directory}" exists.
 
 PHP
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/ExceptionCodeTest.php
+++ b/tests/unit/Framework/Constraint/ExceptionCodeTest.php
@@ -31,7 +31,7 @@ Failed asserting that 456 is equal to expected exception code 123.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/FileExistsTest.php
+++ b/tests/unit/Framework/Constraint/FileExistsTest.php
@@ -34,7 +34,7 @@ Failed asserting that file "foo" exists.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -57,7 +57,7 @@ Failed asserting that file "foo" exists.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/GreaterThanTest.php
+++ b/tests/unit/Framework/Constraint/GreaterThanTest.php
@@ -35,7 +35,7 @@ Failed asserting that 0 is greater than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -58,7 +58,7 @@ Failed asserting that 0 is greater than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/IsEmptyTest.php
+++ b/tests/unit/Framework/Constraint/IsEmptyTest.php
@@ -39,7 +39,7 @@ Failed asserting that an array is empty.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -61,7 +61,7 @@ custom message\nFailed asserting that an array is empty.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/IsEqualTest.php
+++ b/tests/unit/Framework/Constraint/IsEqualTest.php
@@ -42,7 +42,7 @@ Failed asserting that 0 matches expected 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -63,7 +63,7 @@ EOF
         } catch (ExpectationFailedException $e) {
             $this->assertEquals(
                 "custom message\n{$message}",
-                $this->trimnl(TestFailure::exceptionToString($e))
+                $this->trimnl(TestFailure::exceptionToString($e)),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/IsIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/IsIdenticalTest.php
@@ -31,9 +31,9 @@ final class IsIdenticalTest extends ConstraintTestCase
         $this->assertEquals(
             sprintf(
                 'is identical to an object of class "%s"',
-                stdClass::class
+                stdClass::class,
             ),
-            $constraint->toString()
+            $constraint->toString(),
         );
         $this->assertCount(1, $constraint);
 
@@ -46,7 +46,7 @@ Failed asserting that two variables reference the same object.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -72,7 +72,7 @@ Failed asserting that two variables reference the same object.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -100,7 +100,7 @@ Failed asserting that two strings are identical.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -138,7 +138,7 @@ Failed asserting that two arrays are identical.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -197,7 +197,7 @@ Failed asserting that two arrays are identical.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/IsInstanceOfTest.php
@@ -42,9 +42,9 @@ Failed asserting that '%s' is an instance of class "%s".
 EOT
                     ,
                     stdClass::class,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }
@@ -58,9 +58,9 @@ EOT
         $this->assertSame(
             sprintf(
                 'is instance of class "%s"',
-                NotExistingClass::class
+                NotExistingClass::class,
             ),
-            $constraint->toString()
+            $constraint->toString(),
         );
     }
 }

--- a/tests/unit/Framework/Constraint/IsJsonTest.php
+++ b/tests/unit/Framework/Constraint/IsJsonTest.php
@@ -60,7 +60,7 @@ Failed asserting that an empty string is valid JSON.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }

--- a/tests/unit/Framework/Constraint/IsNullTest.php
+++ b/tests/unit/Framework/Constraint/IsNullTest.php
@@ -35,7 +35,7 @@ Failed asserting that 0 is null.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -58,7 +58,7 @@ Failed asserting that 0 is null.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/IsReadableTest.php
+++ b/tests/unit/Framework/Constraint/IsReadableTest.php
@@ -34,7 +34,7 @@ Failed asserting that "foo" is readable.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/IsTypeTest.php
+++ b/tests/unit/Framework/Constraint/IsTypeTest.php
@@ -43,9 +43,9 @@ Failed asserting that %s Object &%%x () is of type "string".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                $this->trimnl(TestFailure::exceptionToString($e))
+                $this->trimnl(TestFailure::exceptionToString($e)),
             );
 
             return;
@@ -69,9 +69,9 @@ Failed asserting that %s Object &%%x () is of type "string".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                $this->trimnl(TestFailure::exceptionToString($e))
+                $this->trimnl(TestFailure::exceptionToString($e)),
             );
 
             return;
@@ -133,7 +133,7 @@ PHPUnit\Framework\Exception: Type specified for PHPUnit\Framework\Constraint\IsT
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }

--- a/tests/unit/Framework/Constraint/IsWritableTest.php
+++ b/tests/unit/Framework/Constraint/IsWritableTest.php
@@ -34,7 +34,7 @@ Failed asserting that "foo" is writable.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/JsonMatchesErrorMessageProviderTest.php
+++ b/tests/unit/Framework/Constraint/JsonMatchesErrorMessageProviderTest.php
@@ -73,7 +73,7 @@ final class JsonMatchesErrorMessageProviderTest extends TestCase
     {
         $this->assertEquals(
             $expected,
-            JsonMatchesErrorMessageProvider::translateTypeToPrefix($type)
+            JsonMatchesErrorMessageProvider::translateTypeToPrefix($type),
         );
     }
 
@@ -91,8 +91,8 @@ final class JsonMatchesErrorMessageProviderTest extends TestCase
             $expected,
             JsonMatchesErrorMessageProvider::determineJsonError(
                 (string) $error,
-                $prefix
-            )
+                $prefix,
+            ),
         );
     }
 }

--- a/tests/unit/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/unit/Framework/Constraint/JsonMatchesTest.php
@@ -116,7 +116,7 @@ Failed asserting that '{"Mascott"::}' matches JSON string "{"Mascott"::}".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }
@@ -135,7 +135,7 @@ Failed asserting that '{"Mascott":"Tux"}' matches JSON string "{"Mascott"::}".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }
@@ -161,7 +161,7 @@ Failed asserting that '{"obj": {}, "val": 2}' matches JSON string "{"obj": {}, "
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }
@@ -188,7 +188,7 @@ Failed asserting that '{"obj": {"y": 2, "x": 1}, "val": 2}' matches JSON string 
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
         }
     }

--- a/tests/unit/Framework/Constraint/LessThanTest.php
+++ b/tests/unit/Framework/Constraint/LessThanTest.php
@@ -35,7 +35,7 @@ Failed asserting that 1 is less than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -58,7 +58,7 @@ Failed asserting that 1 is less than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/LogicalExpressionsTest.php
+++ b/tests/unit/Framework/Constraint/LogicalExpressionsTest.php
@@ -22,7 +22,7 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = new LogicalNot(
             LogicalAnd::fromConstraints(
                 new IsNull,
-            )
+            ),
         );
 
         $this->assertTrue($constraint->evaluate('string', '', true));
@@ -44,8 +44,8 @@ final class LogicalExpressionsTest extends TestCase
             LogicalAnd::fromConstraints(
                 new IsType('int'),
                 new GreaterThan(5),
-                new LessThan(10)
-            )
+                new LessThan(10),
+            ),
         );
 
         $this->assertTrue($constraint->evaluate('string', '', true));
@@ -71,7 +71,7 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = new LogicalNot(
             LogicalOr::fromConstraints(
                 new IsNull,
-            )
+            ),
         );
 
         $this->assertTrue($constraint->evaluate('string', '', true));
@@ -93,8 +93,8 @@ final class LogicalExpressionsTest extends TestCase
             LogicalOr::fromConstraints(
                 new IsNull,
                 new IsType('int'),
-                new IsType('array')
-            )
+                new IsType('array'),
+            ),
         );
 
         $this->assertTrue($constraint->evaluate('string', '', true));
@@ -119,7 +119,7 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = new LogicalNot(
             LogicalXor::fromConstraints(
                 new IsNull,
-            )
+            ),
         );
 
         $this->assertTrue($constraint->evaluate('string', '', true));
@@ -141,7 +141,7 @@ final class LogicalExpressionsTest extends TestCase
             LogicalXor::fromConstraints(
                 new IsType('int'),
                 new IsEqual(false),
-            )
+            ),
         );
 
         $this->assertTrue($constraint->evaluate(0, '', true));
@@ -387,11 +387,11 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = LogicalAnd::fromConstraints(
             LogicalOr::fromConstraints(
                 new IsEqual(false),
-                new GreaterThan(5)
+                new GreaterThan(5),
             ),
             LogicalOr::fromConstraints(
                 new IsType('int'),
-                new IsType('bool')
+                new IsType('bool'),
             ),
         );
 
@@ -419,12 +419,12 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = LogicalOr::fromConstraints(
             LogicalAnd::fromConstraints(
                 new IsType('bool'),
-                new IsEqual(false)
+                new IsEqual(false),
             ),
             LogicalAnd::fromConstraints(
                 new IsType('int'),
-                new GreaterThan(5)
-            )
+                new GreaterThan(5),
+            ),
         );
 
         $this->assertTrue($constraint->evaluate(false, '', true));
@@ -450,14 +450,14 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = LogicalOr::fromConstraints(
             LogicalAnd::fromConstraints(
                 new IsType('bool'),
-                new IsEqual(false)
+                new IsEqual(false),
             ),
             new LogicalNot(
                 LogicalAnd::fromConstraints(
                     new IsType('int'),
-                    new GreaterThan(5)
-                )
-            )
+                    new GreaterThan(5),
+                ),
+            ),
         );
 
         $this->assertTrue($constraint->evaluate(false, '', true));
@@ -483,14 +483,14 @@ final class LogicalExpressionsTest extends TestCase
         $constraint = LogicalOr::fromConstraints(
             LogicalAnd::fromConstraints(
                 new IsType('bool'),
-                new IsEqual(false)
+                new IsEqual(false),
             ),
             new LogicalNot(new LogicalNot(
                 LogicalAnd::fromConstraints(
                     new IsType('int'),
-                    new GreaterThan(5)
-                )
-            ))
+                    new GreaterThan(5),
+                ),
+            )),
         );
 
         $this->assertTrue($constraint->evaluate(false, '', true));

--- a/tests/unit/Framework/Constraint/ObjectHasAttributeTest.php
+++ b/tests/unit/Framework/Constraint/ObjectHasAttributeTest.php
@@ -39,9 +39,9 @@ Failed asserting that object of class "%s" has attribute "privateAttribute".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -65,9 +65,9 @@ Failed asserting that object of class "%s" has attribute "privateAttribute".
 
 EOF
                     ,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/OperatorTestCase.php
+++ b/tests/unit/Framework/Constraint/OperatorTestCase.php
@@ -23,7 +23,7 @@ abstract class OperatorTestCase extends ConstraintTestCase
         $this->assertTrue($reflection->isSubclassOf(Constraint::class), sprintf(
             'Failed to assert that "%s" is subclass of "%s".',
             $className,
-            Constraint::class
+            Constraint::class,
         ));
     }
 

--- a/tests/unit/Framework/Constraint/RegularExpressionTest.php
+++ b/tests/unit/Framework/Constraint/RegularExpressionTest.php
@@ -35,7 +35,7 @@ Failed asserting that 'barbazbar' matches PCRE pattern "/foo/".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -58,7 +58,7 @@ Failed asserting that 'barbazbar' matches PCRE pattern "/foo/".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/SameSizeTest.php
+++ b/tests/unit/Framework/Constraint/SameSizeTest.php
@@ -56,7 +56,7 @@ Failed asserting that actual size 2 matches expected size 5.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/StringContainsTest.php
@@ -35,7 +35,7 @@ Failed asserting that 'barbazbar' contains "foo".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -88,7 +88,7 @@ Failed asserting that 'barbazbar' contains "foo".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/StringEndsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringEndsWithTest.php
@@ -72,7 +72,7 @@ Failed asserting that 'error' ends with "suffix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -95,7 +95,7 @@ Failed asserting that 'error' ends with "suffix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/StringStartsWithTest.php
+++ b/tests/unit/Framework/Constraint/StringStartsWithTest.php
@@ -79,7 +79,7 @@ Failed asserting that 'error' starts with "prefix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -102,7 +102,7 @@ Failed asserting that 'error' starts with "prefix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/Constraint/UnaryOperatorTestCase.php
+++ b/tests/unit/Framework/Constraint/UnaryOperatorTestCase.php
@@ -50,7 +50,7 @@ abstract class UnaryOperatorTestCase extends OperatorTestCase
         $this->assertTrue($reflection->isSubclassOf(Operator::class), sprintf(
             'Failed to assert that "%s" is subclass of "%s".',
             $className,
-            Operator::class
+            Operator::class,
         ));
     }
 

--- a/tests/unit/Framework/ConstraintTest.php
+++ b/tests/unit/Framework/ConstraintTest.php
@@ -28,7 +28,7 @@ final class ConstraintTest extends TestCase
     public function testConstraintArrayNotHasKey(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::arrayHasKey(0)
+            Assert::arrayHasKey(0),
         );
 
         $this->assertFalse($constraint->evaluate([0 => 1], '', true));
@@ -44,7 +44,7 @@ Failed asserting that an array does not have the key 0.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -56,7 +56,7 @@ EOF
     public function testConstraintArrayNotHasKey2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::arrayHasKey(0)
+            Assert::arrayHasKey(0),
         );
 
         try {
@@ -69,7 +69,7 @@ Failed asserting that an array does not have the key 0.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -83,7 +83,7 @@ EOF
         $file = TEST_FILES_PATH . 'ClassWithNonPublicAttributes.php';
 
         $constraint = Assert::logicalNot(
-            Assert::fileExists()
+            Assert::fileExists(),
         );
 
         $this->assertFalse($constraint->evaluate($file, '', true));
@@ -99,7 +99,7 @@ Failed asserting that file "{$file}" does not exist.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -113,7 +113,7 @@ EOF
         $file = TEST_FILES_PATH . 'ClassWithNonPublicAttributes.php';
 
         $constraint = Assert::logicalNot(
-            Assert::fileExists()
+            Assert::fileExists(),
         );
 
         try {
@@ -126,7 +126,7 @@ Failed asserting that file "{$file}" does not exist.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -138,7 +138,7 @@ EOF
     public function testConstraintNotGreaterThan(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::greaterThan(1)
+            Assert::greaterThan(1),
         );
 
         $this->assertTrue($constraint->evaluate(1, '', true));
@@ -154,7 +154,7 @@ Failed asserting that 2 is not greater than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -166,7 +166,7 @@ EOF
     public function testConstraintNotGreaterThan2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::greaterThan(1)
+            Assert::greaterThan(1),
         );
 
         try {
@@ -179,7 +179,7 @@ Failed asserting that 2 is not greater than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -206,7 +206,7 @@ Failed asserting that 0 is equal to 1 or is greater than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -229,7 +229,7 @@ Failed asserting that 0 is equal to 1 or is greater than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -241,7 +241,7 @@ EOF
     public function testConstraintNotGreaterThanOrEqual(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::greaterThanOrEqual(1)
+            Assert::greaterThanOrEqual(1),
         );
 
         $this->assertFalse($constraint->evaluate(1, '', true));
@@ -257,7 +257,7 @@ Failed asserting that not( 1 is equal to 1 or is greater than 1 ).
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -269,7 +269,7 @@ EOF
     public function testConstraintNotGreaterThanOrEqual2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::greaterThanOrEqual(1)
+            Assert::greaterThanOrEqual(1),
         );
 
         try {
@@ -282,7 +282,7 @@ Failed asserting that not( 1 is equal to 1 or is greater than 1 ).
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -304,7 +304,7 @@ EOF
     public function testConstraintNotIsAnything(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::anything()
+            Assert::anything(),
         );
 
         $this->assertFalse($constraint->evaluate(null, '', true));
@@ -320,7 +320,7 @@ Failed asserting that null is not anything.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -332,7 +332,7 @@ EOF
     public function testConstraintIsNotEqual(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::equalTo(1)
+            Assert::equalTo(1),
         );
 
         $this->assertTrue($constraint->evaluate(0, '', true));
@@ -349,7 +349,7 @@ Failed asserting that 1 is not equal to 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -361,7 +361,7 @@ EOF
     public function testConstraintIsNotEqual2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::equalTo(1)
+            Assert::equalTo(1),
         );
 
         try {
@@ -374,7 +374,7 @@ Failed asserting that 1 is not equal to 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -389,7 +389,7 @@ EOF
         $b = new stdClass;
 
         $constraint = Assert::logicalNot(
-            Assert::identicalTo($a)
+            Assert::identicalTo($a),
         );
 
         $this->assertTrue($constraint->evaluate($b, '', true));
@@ -397,9 +397,9 @@ EOF
         $this->assertEquals(
             sprintf(
                 'is not identical to an object of class "%s"',
-                stdClass::class
+                stdClass::class,
             ),
-            $constraint->toString()
+            $constraint->toString(),
         );
         $this->assertCount(1, $constraint);
 
@@ -412,7 +412,7 @@ Failed asserting that two variables don't reference the same object.
 
 EOF
                 ,
-                $this->trimnl(TestFailure::exceptionToString($e))
+                $this->trimnl(TestFailure::exceptionToString($e)),
             );
 
             return;
@@ -426,7 +426,7 @@ EOF
         $a = new stdClass;
 
         $constraint = Assert::logicalNot(
-            Assert::identicalTo($a)
+            Assert::identicalTo($a),
         );
 
         try {
@@ -439,7 +439,7 @@ Failed asserting that two variables don't reference the same object.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -451,7 +451,7 @@ EOF
     public function testConstraintIsNotIdentical3(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::identicalTo('a')
+            Assert::identicalTo('a'),
         );
 
         try {
@@ -464,7 +464,7 @@ Failed asserting that two strings are not identical.
 
 EOF
                 ,
-                $this->trimnl(TestFailure::exceptionToString($e))
+                $this->trimnl(TestFailure::exceptionToString($e)),
             );
 
             return;
@@ -482,9 +482,9 @@ EOF
         $this->assertEquals(
             sprintf(
                 'is instance of class "%s"',
-                \Exception::class
+                \Exception::class,
             ),
-            $constraint->toString()
+            $constraint->toString(),
         );
         $this->assertCount(1, $constraint);
 
@@ -494,9 +494,9 @@ EOF
         $this->assertEquals(
             sprintf(
                 'is instance of interface "%s"',
-                Countable::class
+                Countable::class,
             ),
-            $interfaceConstraint->toString()
+            $interfaceConstraint->toString(),
         );
 
         try {
@@ -510,9 +510,9 @@ Failed asserting that %s Object () is an instance of class "%s".
 EOF
                     ,
                     stdClass::class,
-                    \Exception::class
+                    \Exception::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -537,9 +537,9 @@ Failed asserting that %s Object () is an instance of class "%s".
 EOF
                     ,
                     stdClass::class,
-                    \Exception::class
+                    \Exception::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -551,7 +551,7 @@ EOF
     public function testConstraintIsNotInstanceOf(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::isInstanceOf(stdClass::class)
+            Assert::isInstanceOf(stdClass::class),
         );
 
         $this->assertFalse($constraint->evaluate(new stdClass, '', true));
@@ -559,9 +559,9 @@ EOF
         $this->assertEquals(
             sprintf(
                 'is not instance of class "%s"',
-                stdClass::class
+                stdClass::class,
             ),
-            $constraint->toString()
+            $constraint->toString(),
         );
         $this->assertCount(1, $constraint);
 
@@ -576,9 +576,9 @@ Failed asserting that %s Object () is not an instance of class "%s".
 EOF
                     ,
                     stdClass::class,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -590,7 +590,7 @@ EOF
     public function testConstraintIsNotInstanceOf2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::isInstanceOf(stdClass::class)
+            Assert::isInstanceOf(stdClass::class),
         );
 
         try {
@@ -605,9 +605,9 @@ Failed asserting that %s Object () is not an instance of class "%s".
 EOF
                     ,
                     stdClass::class,
-                    stdClass::class
+                    stdClass::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -619,7 +619,7 @@ EOF
     public function testConstraintIsNotType(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::isType('string')
+            Assert::isType('string'),
         );
 
         $this->assertTrue($constraint->evaluate(0, '', true));
@@ -636,7 +636,7 @@ Failed asserting that '' is not of type "string".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -648,7 +648,7 @@ EOF
     public function testConstraintIsNotType2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::isType('string')
+            Assert::isType('string'),
         );
 
         try {
@@ -661,7 +661,7 @@ Failed asserting that '' is not of type "string".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -673,7 +673,7 @@ EOF
     public function testConstraintIsNotNull(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::isNull()
+            Assert::isNull(),
         );
 
         $this->assertFalse($constraint->evaluate(null, '', true));
@@ -690,7 +690,7 @@ Failed asserting that null is not null.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -702,7 +702,7 @@ EOF
     public function testConstraintIsNotNull2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::isNull()
+            Assert::isNull(),
         );
 
         try {
@@ -715,7 +715,7 @@ Failed asserting that null is not null.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -727,7 +727,7 @@ EOF
     public function testConstraintNotLessThan(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::lessThan(1)
+            Assert::lessThan(1),
         );
 
         $this->assertTrue($constraint->evaluate(1, '', true));
@@ -744,7 +744,7 @@ Failed asserting that 0 is not less than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -756,7 +756,7 @@ EOF
     public function testConstraintNotLessThan2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::lessThan(1)
+            Assert::lessThan(1),
         );
 
         try {
@@ -769,7 +769,7 @@ Failed asserting that 0 is not less than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -796,7 +796,7 @@ Failed asserting that 2 is equal to 1 or is less than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -819,7 +819,7 @@ Failed asserting that 2 is equal to 1 or is less than 1.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -831,7 +831,7 @@ EOF
     public function testConstraintNotLessThanOrEqual(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::lessThanOrEqual(1)
+            Assert::lessThanOrEqual(1),
         );
 
         $this->assertTrue($constraint->evaluate(2, '', true));
@@ -848,7 +848,7 @@ Failed asserting that not( 1 is equal to 1 or is less than 1 ).
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -860,7 +860,7 @@ EOF
     public function testConstraintNotLessThanOrEqual2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::lessThanOrEqual(1)
+            Assert::lessThanOrEqual(1),
         );
 
         try {
@@ -873,7 +873,7 @@ Failed asserting that not( 1 is equal to 1 or is less than 1 ).
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -888,7 +888,7 @@ EOF
     public function testConstraintPCRENotMatch(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::matchesRegularExpression('/foo/')
+            Assert::matchesRegularExpression('/foo/'),
         );
 
         $this->assertTrue($constraint->evaluate('barbazbar', '', true));
@@ -905,7 +905,7 @@ Failed asserting that 'barfoobar' does not match PCRE pattern "/foo/".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -920,7 +920,7 @@ EOF
     public function testConstraintPCRENotMatch2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::matchesRegularExpression('/foo/')
+            Assert::matchesRegularExpression('/foo/'),
         );
 
         try {
@@ -933,7 +933,7 @@ Failed asserting that 'barfoobar' does not match PCRE pattern "/foo/".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -945,7 +945,7 @@ EOF
     public function testConstraintStringStartsNotWith(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringStartsWith('prefix')
+            Assert::stringStartsWith('prefix'),
         );
 
         $this->assertTrue($constraint->evaluate('foo', '', true));
@@ -962,7 +962,7 @@ Failed asserting that 'prefixfoo' starts not with "prefix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -974,7 +974,7 @@ EOF
     public function testConstraintStringStartsNotWith2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringStartsWith('prefix')
+            Assert::stringStartsWith('prefix'),
         );
 
         try {
@@ -987,7 +987,7 @@ Failed asserting that 'prefixfoo' starts not with "prefix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -999,7 +999,7 @@ EOF
     public function testConstraintStringNotContains(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringContains('foo')
+            Assert::stringContains('foo'),
         );
 
         $this->assertTrue($constraint->evaluate('barbazbar', '', true));
@@ -1016,7 +1016,7 @@ Failed asserting that 'barfoobar' does not contain "foo".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1028,7 +1028,7 @@ EOF
     public function testConstraintStringNotContainsWhenIgnoreCase(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringContains('oryginał')
+            Assert::stringContains('oryginał'),
         );
 
         $this->assertTrue($constraint->evaluate('original', '', true));
@@ -1045,7 +1045,7 @@ EOF
     public function testConstraintStringNotContainsForUtf8StringWhenNotIgnoreCase(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringContains('oryginał', false)
+            Assert::stringContains('oryginał', false),
         );
 
         $this->assertTrue($constraint->evaluate('original', '', true));
@@ -1062,7 +1062,7 @@ EOF
     public function testConstraintStringNotContains2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringContains('foo')
+            Assert::stringContains('foo'),
         );
 
         try {
@@ -1075,7 +1075,7 @@ Failed asserting that 'barfoobar' does not contain "foo".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1087,7 +1087,7 @@ EOF
     public function testConstraintStringEndsNotWith(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringEndsWith('suffix')
+            Assert::stringEndsWith('suffix'),
         );
 
         $this->assertTrue($constraint->evaluate('foo', '', true));
@@ -1104,7 +1104,7 @@ Failed asserting that 'foosuffix' ends not with "suffix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1116,7 +1116,7 @@ EOF
     public function testConstraintStringEndsNotWith2(): void
     {
         $constraint = Assert::logicalNot(
-            Assert::stringEndsWith('suffix')
+            Assert::stringEndsWith('suffix'),
         );
 
         try {
@@ -1129,7 +1129,7 @@ Failed asserting that 'foosuffix' ends not with "suffix".
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1175,7 +1175,7 @@ Failed asserting that actual size 2 matches expected size 5.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1187,7 +1187,7 @@ EOF
     public function testConstraintNotCountFailing(): void
     {
         $constraint = Assert::logicalNot(
-            new Count(2)
+            new Count(2),
         );
 
         try {
@@ -1199,7 +1199,7 @@ Failed asserting that actual size 2 does not match expected size 2.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1211,7 +1211,7 @@ EOF
     public function testConstraintNotSameSizeFailing(): void
     {
         $constraint = Assert::logicalNot(
-            new SameSize([1, 2])
+            new SameSize([1, 2]),
         );
 
         try {
@@ -1223,7 +1223,7 @@ Failed asserting that actual size 2 does not match expected size 2.
 
 EOF
                 ,
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;
@@ -1249,9 +1249,9 @@ Failed asserting that exception of type "%s" matches expected exception "FoobarE
 
 EOF
                     ,
-                    DummyException::class
+                    DummyException::class,
                 ),
-                TestFailure::exceptionToString($e)
+                TestFailure::exceptionToString($e),
             );
 
             return;

--- a/tests/unit/Framework/ExceptionWrapperTest.php
+++ b/tests/unit/Framework/ExceptionWrapperTest.php
@@ -56,7 +56,7 @@ final class ExceptionWrapperTest extends TestCase
         $this->assertStringNotContainsString(
             'BadFunctionCallException',
             $data,
-            'Assert there is s no other BadFunctionCallException mention in stacktrace'
+            'Assert there is s no other BadFunctionCallException mention in stacktrace',
         );
     }
 }

--- a/tests/unit/Framework/ExecutionOrderDependencyTest.php
+++ b/tests/unit/Framework/ExecutionOrderDependencyTest.php
@@ -74,13 +74,13 @@ class ExecutionOrderDependencyTest extends TestCase
         $this->assertSame(
             $expectedTarget,
             $dependency->getTarget(),
-            'Incorrect dependency class::method target'
+            'Incorrect dependency class::method target',
         );
 
         $this->assertSame(
             $expectedTargetIsClass,
             $dependency->targetIsClass(),
-            'Incorrect targetIsClass'
+            'Incorrect targetIsClass',
         );
     }
 
@@ -99,13 +99,13 @@ class ExecutionOrderDependencyTest extends TestCase
         $this->assertSame(
             $expectedShallowClone,
             $dependency->useShallowClone(),
-            'Incorrect shallowClone option'
+            'Incorrect shallowClone option',
         );
 
         $this->assertSame(
             $expectedDeepClone,
             $dependency->useDeepClone(),
-            'Incorrect clone option'
+            'Incorrect clone option',
         );
     }
 
@@ -133,18 +133,18 @@ class ExecutionOrderDependencyTest extends TestCase
             [$depOne, $depTwo],
             ExecutionOrderDependency::mergeUnique(
                 [],
-                [$depOne, $depTwo]
+                [$depOne, $depTwo],
             ),
-            'Left side of merge could be empty'
+            'Left side of merge could be empty',
         );
 
         $this->assertSame(
             [$depOne, $depTwo],
             ExecutionOrderDependency::mergeUnique(
                 [$depOne, $depTwo],
-                []
+                [],
             ),
-            'Right side of merge could be empty'
+            'Right side of merge could be empty',
         );
     }
 
@@ -158,8 +158,8 @@ class ExecutionOrderDependencyTest extends TestCase
             [$depOne, $depTwo, $depThree],
             ExecutionOrderDependency::mergeUnique(
                 [$depOne, $depTwo],
-                [$depTwo, $depThree]
-            )
+                [$depTwo, $depThree],
+            ),
         );
     }
 
@@ -175,32 +175,32 @@ class ExecutionOrderDependencyTest extends TestCase
             [],
             ExecutionOrderDependency::diff(
                 [$depOne, $depTwo],
-                [$depOne, $depTwo, $depThree, $depFour]
-            )
+                [$depOne, $depTwo, $depThree, $depFour],
+            ),
         );
 
         $this->assertSame(
             [$depOne, $depTwo],
             ExecutionOrderDependency::diff(
                 [$depOne, $depTwo],
-                [$depThree, $depFour]
-            )
+                [$depThree, $depFour],
+            ),
         );
 
         $this->assertSame(
             [$depOne, $depFour],
             ExecutionOrderDependency::diff(
                 [$depOne, $depTwo, $depThree, $depFour],
-                [$depTwo, $depThreeClone]
-            )
+                [$depTwo, $depThreeClone],
+            ),
         );
 
         $this->assertSame(
             [$depOne, $depTwo, $depThree, $depFour],
             ExecutionOrderDependency::diff(
                 [$depOne, $depTwo, $depThree, $depFour],
-                []
-            )
+                [],
+            ),
         );
 
         $this->assertSame([], ExecutionOrderDependency::diff([], []));

--- a/tests/unit/Framework/IncompleteTestCaseTest.php
+++ b/tests/unit/Framework/IncompleteTestCaseTest.php
@@ -19,7 +19,7 @@ final class IncompleteTestCaseTest extends TestCase
     {
         $testCase = new IncompleteTestCase(
             'Foo',
-            'testThatBars'
+            'testThatBars',
         );
 
         $this->assertSame('', $testCase->getMessage());
@@ -32,13 +32,13 @@ final class IncompleteTestCaseTest extends TestCase
 
         $testCase = new IncompleteTestCase(
             $className,
-            $methodName
+            $methodName,
         );
 
         $name = sprintf(
             '%s::%s',
             $className,
-            $methodName
+            $methodName,
         );
 
         $this->assertSame($name, $testCase->getName());
@@ -51,7 +51,7 @@ final class IncompleteTestCaseTest extends TestCase
         $testCase = new IncompleteTestCase(
             'Foo',
             'testThatBars',
-            $message
+            $message,
         );
 
         $this->assertSame($message, $testCase->getMessage());
@@ -66,7 +66,7 @@ final class IncompleteTestCaseTest extends TestCase
         $testCase = new IncompleteTestCase(
             $className,
             $methodName,
-            $message
+            $message,
         );
 
         $result = $testCase->run();
@@ -81,7 +81,7 @@ final class IncompleteTestCaseTest extends TestCase
         $name = sprintf(
             '%s::%s',
             $className,
-            $methodName
+            $methodName,
         );
 
         $this->assertSame($name, $failure->getTestName());

--- a/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
+++ b/tests/unit/Framework/MockObject/Builder/InvocationMockerTest.php
@@ -90,7 +90,7 @@ final class InvocationMockerTest extends TestCase
 
         $invocationMocker = new InvocationMocker(
             $matcherCollection,
-            new Matcher($this->any())
+            new Matcher($this->any()),
         );
 
         $this->expectException(MethodCannotBeConfiguredException::class);
@@ -145,7 +145,7 @@ final class InvocationMockerTest extends TestCase
         $this->expectExceptionMessage(sprintf(
             'Method methodWithClassReturnTypeDeclaration may not return value of type %s, its declared return type is "%s"',
             Foo::class,
-            stdClass::class
+            stdClass::class,
         ));
         $invocationMocker->willReturn(new Foo);
     }

--- a/tests/unit/Framework/MockObject/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/GeneratorTest.php
@@ -142,7 +142,7 @@ final class GeneratorTest extends TestCase
             true,
             true,
             true,
-            ['nonexistentMethod']
+            ['nonexistentMethod'],
         );
 
         $this->assertTrue(method_exists($mock, 'nonexistentMethod'));
@@ -176,7 +176,7 @@ final class GeneratorTest extends TestCase
             true,
             true,
             true,
-            ['nonexistentMethod']
+            ['nonexistentMethod'],
         );
 
         $this->assertTrue(method_exists($mock, 'nonexistentMethod'));
@@ -291,7 +291,7 @@ final class GeneratorTest extends TestCase
             false,
             true,
             false,
-            true
+            true,
         );
 
         $arguments = [1, 'foo', false];
@@ -343,7 +343,7 @@ final class GeneratorTest extends TestCase
             [
                 AnInterface::class,
                 AnotherInterface::class,
-            ]
+            ],
         );
 
         $this->assertInstanceOf(AnInterface::class, $stub);

--- a/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
+++ b/tests/unit/Framework/MockObject/Matcher/ConsecutiveParametersTest.php
@@ -29,7 +29,7 @@ final class ConsecutiveParametersTest extends TestCase
             ->method('foo')
             ->withConsecutive(
                 ['bar'],
-                [21, 42]
+                [21, 42],
             );
 
         $this->assertNull($mock->foo('bar'));
@@ -45,7 +45,7 @@ final class ConsecutiveParametersTest extends TestCase
         $mock->expects($this->any())
             ->method('foo')
             ->withConsecutive(
-                ['bar']
+                ['bar'],
             );
 
         $this->assertNull($mock->foo('bar'));
@@ -62,7 +62,7 @@ final class ConsecutiveParametersTest extends TestCase
             ->method('foo')
             ->withConsecutive(
                 ['bar'],
-                [21, 42]
+                [21, 42],
             );
 
         $mock->foo('bar');
@@ -85,7 +85,7 @@ final class ConsecutiveParametersTest extends TestCase
             ->method('foo')
             ->withConsecutive(
                 ['bar'],
-                $this->identicalTo([21, 42]) // this is not an array
+                $this->identicalTo([21, 42]), // this is not an array
             );
     }
 }

--- a/tests/unit/Framework/MockObject/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/MockBuilderTest.php
@@ -58,7 +58,7 @@ final class MockBuilderTest extends TestCase
         $this->expectException(CannotUseOnlyMethodsException::class);
         $this->expectExceptionMessage(sprintf(
             'Trying to configure method "mockableMethodWithCrazyName" with onlyMethods(), but it does not exist in class "%s". Use addMethods() for methods that do not exist in the class',
-            Mockable::class
+            Mockable::class,
         ));
 
         $this->getMockBuilder(Mockable::class)
@@ -90,7 +90,7 @@ final class MockBuilderTest extends TestCase
         $this->expectException(CannotUseAddMethodsException::class);
         $this->expectExceptionMessage(sprintf(
             'Trying to configure method "mockableMethod" with addMethods(), but it exists in class "%s". Use onlyMethods() for methods that exist in the class',
-            Mockable::class
+            Mockable::class,
         ));
 
         $this->getMockBuilder(Mockable::class)

--- a/tests/unit/Framework/MockObject/MockMethodTest.php
+++ b/tests/unit/Framework/MockObject/MockMethodTest.php
@@ -31,7 +31,7 @@ final class MockMethodTest extends TestCase
             false,
             false,
             null,
-            false
+            false,
         );
         $this->assertEquals('methodName', $method->getName());
     }

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -304,7 +304,7 @@ final class MockObjectTest extends TestCase
             ->method('doSomething')
             ->will($this->returnCallback(sprintf(
                 '%s::functionCallback',
-                FunctionCallbackWrapper::class
+                FunctionCallbackWrapper::class,
             )));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
@@ -317,7 +317,7 @@ final class MockObjectTest extends TestCase
             ->method('doSomething')
             ->willReturnCallback(sprintf(
                 '%s::functionCallback',
-                FunctionCallbackWrapper::class
+                FunctionCallbackWrapper::class,
             ));
 
         $this->assertEquals('pass', $mock->doSomething('foo', 'bar'));
@@ -622,8 +622,8 @@ final class MockObjectTest extends TestCase
                     static function () use (&$actualArguments): void
                     {
                         $actualArguments = func_get_args();
-                    }
-                )
+                    },
+                ),
             );
 
         $mock->doSomethingElse($expectedObject);
@@ -650,8 +650,8 @@ final class MockObjectTest extends TestCase
                     static function () use (&$actualArguments): void
                     {
                         $actualArguments = func_get_args();
-                    }
-                )
+                    },
+                ),
             );
 
         $mock->doSomethingElse($expectedObject);
@@ -693,7 +693,7 @@ final class MockObjectTest extends TestCase
             $this->assertSame(
                 "Expectation failed for method name is \"right\" when invoked 1 time(s).\n" .
                 'Method was expected to be called 1 times, actually called 0 times.' . "\n",
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -718,7 +718,7 @@ final class MockObjectTest extends TestCase
             $this->assertSame(
                 "Expectation failed for method name is \"right\" when invoked 1 time(s).\n" .
                 'Method was expected to be called 1 times, actually called 0 times.' . "\n",
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -746,9 +746,9 @@ Parameter 0 for invocation %s::right(Array (...)) does not match expected value.
 Failed asserting that two arrays are equal.
 EOF
                     ,
-                    SomeClass::class
+                    SomeClass::class,
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -775,9 +775,9 @@ Failed asserting that two arrays are equal.
 
 EOF
                     ,
-                    SomeClass::class
+                    SomeClass::class,
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -801,9 +801,9 @@ EOF
             $this->assertSame(
                 sprintf(
                     '%s::right() was not expected to be called.',
-                    SomeClass::class
+                    SomeClass::class,
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -827,9 +827,9 @@ EOF
             $this->assertSame(
                 sprintf(
                     '%s::right() was not expected to be called.',
-                    SomeClass::class
+                    SomeClass::class,
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -858,9 +858,9 @@ Parameter count for invocation %s::right() is too low.
 To allow 0 or more parameters with any value, omit ->with() or use ->withAnyParameters() instead.
 EOF
                     ,
-                    SomeClass::class
+                    SomeClass::class,
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -903,7 +903,7 @@ EOF
                 static function (&$a, &$b, $c): void
                 {
                     $b = 1;
-                }
+                },
             ));
 
         $a = $b = $c = 0;
@@ -964,7 +964,7 @@ EOF
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            get_class($mock)
+            get_class($mock),
         );
     }
 
@@ -977,7 +977,7 @@ EOF
 
         $this->assertStringStartsWith(
             'Mock_WsdlMock_',
-            get_class($mock)
+            get_class($mock),
         );
     }
 
@@ -1016,7 +1016,7 @@ EOF
     {
         $this->assertInstanceOf(
             InterfaceWithStaticMethod::class,
-            $this->getMockBuilder(InterfaceWithStaticMethod::class)->getMock()
+            $this->getMockBuilder(InterfaceWithStaticMethod::class)->getMock(),
         );
     }
 
@@ -1042,7 +1042,7 @@ EOF
             ClassThatImplementsSerializable::class,
             $this->getMockBuilder(ClassThatImplementsSerializable::class)
                 ->disableOriginalConstructor()
-                ->getMock()
+                ->getMock(),
         );
     }
 
@@ -1050,7 +1050,7 @@ EOF
     {
         $this->assertInstanceOf(
             ClassWithSelfTypeHint::class,
-            $this->getMockBuilder(ClassWithSelfTypeHint::class)->getMock()
+            $this->getMockBuilder(ClassWithSelfTypeHint::class)->getMock(),
         );
     }
 
@@ -1120,7 +1120,7 @@ EOF
         $this->expectException(ReturnValueNotConfiguredException::class);
         $this->expectExceptionMessage(sprintf(
             'Return value inference disabled and no expectation set up for %s::doSomethingElse()',
-            SomeClass::class
+            SomeClass::class,
         ));
 
         $mock->doSomethingElse(1);
@@ -1142,9 +1142,9 @@ EOF
             $this->assertSame(
                 sprintf(
                     'Return value inference disabled and no expectation set up for %s::__toString()',
-                    StringableClass::class
+                    StringableClass::class,
                 ),
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 

--- a/tests/unit/Framework/SkippedTestCaseTest.php
+++ b/tests/unit/Framework/SkippedTestCaseTest.php
@@ -19,7 +19,7 @@ final class SkippedTestCaseTest extends TestCase
     {
         $testCase = new SkippedTestCase(
             'Foo',
-            'testThatBars'
+            'testThatBars',
         );
 
         $this->assertSame('', $testCase->getMessage());
@@ -32,13 +32,13 @@ final class SkippedTestCaseTest extends TestCase
 
         $testCase = new SkippedTestCase(
             $className,
-            $methodName
+            $methodName,
         );
 
         $name = sprintf(
             '%s::%s',
             $className,
-            $methodName
+            $methodName,
         );
 
         $this->assertSame($name, $testCase->getName());
@@ -51,7 +51,7 @@ final class SkippedTestCaseTest extends TestCase
         $testCase = new SkippedTestCase(
             'Foo',
             'testThatBars',
-            $message
+            $message,
         );
 
         $this->assertSame($message, $testCase->getMessage());
@@ -66,7 +66,7 @@ final class SkippedTestCaseTest extends TestCase
         $testCase = new SkippedTestCase(
             $className,
             $methodName,
-            $message
+            $message,
         );
 
         $result = $testCase->run();
@@ -81,7 +81,7 @@ final class SkippedTestCaseTest extends TestCase
         $name = sprintf(
             '%s::%s',
             $className,
-            $methodName
+            $methodName,
         );
 
         $this->assertSame($name, $failure->getTestName());

--- a/tests/unit/Framework/TestCaseTest.php
+++ b/tests/unit/Framework/TestCaseTest.php
@@ -98,9 +98,9 @@ class TestCaseTest extends TestCase
         $this->assertEquals(
             sprintf(
                 '%s::testCaseToString',
-                self::class
+                self::class,
             ),
-            $this->toString()
+            $this->toString(),
         );
     }
 
@@ -113,12 +113,12 @@ class TestCaseTest extends TestCase
 
         $this->assertEquals(
             [new ExecutionOrderDependency(static::class, 'testCaseDefaultExecutionOrderDependencies')],
-            $this->provides()
+            $this->provides(),
         );
 
         $this->assertEquals(
             [],
-            $this->requires()
+            $this->requires(),
         );
     }
 
@@ -377,7 +377,7 @@ class TestCaseTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertEquals(
             "Failed asserting that exception message 'A runtime error occurred' contains 'A logic error occurred'.",
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -427,7 +427,7 @@ class TestCaseTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertEquals(
             "Failed asserting that exception message 'A runtime error occurred' matches '/logic .*? occurred/'.",
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -441,7 +441,7 @@ class TestCaseTest extends TestCase
 
         $this->assertEquals(
             "Invalid expected exception message regex given: '#runtime .*? occurred/'",
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -449,7 +449,7 @@ class TestCaseTest extends TestCase
     {
         $exception = new InvalidArgumentException(
             'Cannot compute at this time.',
-            9000
+            9000,
         );
 
         $test = new ThrowExceptionTestCase('testWithExpectExceptionObject');
@@ -466,7 +466,7 @@ class TestCaseTest extends TestCase
     {
         $exception = new RuntimeException(
             'This is fine!',
-            9000
+            9000,
         );
 
         $test = new ThrowExceptionTestCase('testWithExpectExceptionObject');
@@ -483,7 +483,7 @@ class TestCaseTest extends TestCase
     {
         $exception = new RuntimeException(
             'Cannot compute at this time.',
-            9001
+            9001,
         );
 
         $test = new ThrowExceptionTestCase('testWithExpectExceptionObject');
@@ -500,7 +500,7 @@ class TestCaseTest extends TestCase
     {
         $exception = new RuntimeException(
             'Cannot compute at this time',
-            9000
+            9000,
         );
 
         $test = new ThrowExceptionTestCase('testWithExpectExceptionObject');
@@ -517,7 +517,7 @@ class TestCaseTest extends TestCase
     {
         $exception = new RuntimeException(
             'Cannot compute at this time',
-            9000
+            9000,
         );
 
         $test = new ThrowExceptionTestCase('testWithExpectExceptionObject');
@@ -727,7 +727,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
             'PHPUnit >= 1111111 is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -739,7 +739,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
             'PHP >= 9999999 is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -751,7 +751,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
             'Operating system matching /DOESNOTEXIST/i is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -763,7 +763,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
             'Operating system DOESNOTEXIST is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -775,7 +775,7 @@ class TestCaseTest extends TestCase
         $this->assertEquals(1, $result->skippedCount());
         $this->assertEquals(
             'Function testFunc is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -786,7 +786,7 @@ class TestCaseTest extends TestCase
 
         $this->assertEquals(
             'Extension testExt is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -797,7 +797,7 @@ class TestCaseTest extends TestCase
 
         $this->assertEquals(
             'Extension testExt >= 1.8.0 is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -816,7 +816,7 @@ class TestCaseTest extends TestCase
             'Extension testExtOne is required.' . PHP_EOL .
             'Extension testExt2 is required.' . PHP_EOL .
             'Extension testExtThree >= 2.0 is required.',
-            $test->getStatusMessage()
+            $test->getStatusMessage(),
         );
     }
 
@@ -992,7 +992,7 @@ class TestCaseTest extends TestCase
             Mockable::class,
             [
                 'mockableMethod' => false,
-            ]
+            ],
         );
 
         $this->assertFalse($mock->mockableMethod());
@@ -1133,7 +1133,7 @@ class TestCaseTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage(sprintf(
             '%s::$name must be a non-blank string.',
-            TestCase::class
+            TestCase::class,
         ));
 
         $testCase->runBare();

--- a/tests/unit/Framework/TestSuiteTest.php
+++ b/tests/unit/Framework/TestSuiteTest.php
@@ -225,7 +225,7 @@ final class TestSuiteTest extends TestCase
                 'Test for %s::testDependency skipped by data provider',
                 DataProviderDependencyTest::class,
             ),
-            $message
+            $message,
         );
     }
 
@@ -252,7 +252,7 @@ final class TestSuiteTest extends TestCase
     public function testDoNotSkipInheritedClass(): void
     {
         $suite = new TestSuite(
-            'DontSkipInheritedClass'
+            'DontSkipInheritedClass',
         );
 
         $dir = TEST_FILES_PATH . DIRECTORY_SEPARATOR . 'Inheritance' . DIRECTORY_SEPARATOR;
@@ -281,7 +281,7 @@ final class TestSuiteTest extends TestCase
         $this->assertSame(
             'Exception in PHPUnit\TestFixture\ExceptionInTearDownAfterClassTest::tearDownAfterClass' . PHP_EOL .
             'throw Exception in tearDownAfterClass()',
-            $failure->thrownException()->getMessage()
+            $failure->thrownException()->getMessage(),
         );
     }
 

--- a/tests/unit/Runner/PhptTestCaseTest.php
+++ b/tests/unit/Runner/PhptTestCaseTest.php
@@ -336,7 +336,7 @@ EOF
                 "\r\n" => PHP_EOL,
                 "\r"   => PHP_EOL,
                 "\n"   => PHP_EOL,
-            ]
+            ],
         );
     }
 }

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -152,7 +152,7 @@ final class TestSuiteSorterTest extends TestCase
             $suite,
             TestSuiteSorter::ORDER_DURATION,
             $resolveDependencies,
-            TestSuiteSorter::ORDER_DEFAULT
+            TestSuiteSorter::ORDER_DEFAULT,
         );
 
         $this->assertSame($expected, $sorter->getExecutionOrder());
@@ -205,7 +205,7 @@ final class TestSuiteSorterTest extends TestCase
             $suite,
             TestSuiteSorter::ORDER_DURATION,
             $resolveDependencies,
-            TestSuiteSorter::ORDER_DEFAULT
+            TestSuiteSorter::ORDER_DEFAULT,
         );
 
         $this->assertSame($expected, $sorter->getExecutionOrder());
@@ -604,9 +604,9 @@ final class TestSuiteSorterTest extends TestCase
         $this->assertSame(
             sprintf(
                 'No tests found in class "%s".',
-                EmptyTestCaseTest::class
+                EmptyTestCaseTest::class,
             ),
-            $suite->tests()[0]->tests()[0]->getMessage()
+            $suite->tests()[0]->tests()[0]->getMessage(),
         );
     }
 

--- a/tests/unit/TextUI/MigrationTest.php
+++ b/tests/unit/TextUI/MigrationTest.php
@@ -23,9 +23,9 @@ final class MigrationTest extends TestCase
             (new XmlLoader)->loadFile(__DIR__ . '/../../_files/XmlConfigurationMigration/output-9.3.xml'),
             (new XmlLoader)->load(
                 (new Migrator)->migrate(
-                    __DIR__ . '/../../_files/XmlConfigurationMigration/input-9.2.xml'
-                )
-            )
+                    __DIR__ . '/../../_files/XmlConfigurationMigration/input-9.2.xml',
+                ),
+            ),
         );
     }
 }

--- a/tests/unit/TextUI/XmlConfigurationTest.php
+++ b/tests/unit/TextUI/XmlConfigurationTest.php
@@ -330,7 +330,7 @@ final class XmlConfigurationTest extends TestCase
                             7 => TEST_FILES_PATH . 'MyRelativePath',
                             8 => true,
                         ],
-                        $listener->arguments()
+                        $listener->arguments(),
                     );
 
                     break;
@@ -389,7 +389,7 @@ final class XmlConfigurationTest extends TestCase
                             6 => TEST_FILES_PATH . 'MyTestFile.php',
                             7 => TEST_FILES_PATH . 'MyRelativePath',
                         ],
-                        $extension->arguments()
+                        $extension->arguments(),
                     );
 
                     break;
@@ -675,7 +675,7 @@ final class XmlConfigurationTest extends TestCase
     {
         $this->assertSame(
             CliTestDoxPrinter::class,
-            $this->configuration('configuration_testdox.xml')->phpunit()->printerClass()
+            $this->configuration('configuration_testdox.xml')->phpunit()->printerClass(),
         );
     }
 

--- a/tests/unit/Util/Annotation/RegistryTest.php
+++ b/tests/unit/Util/Annotation/RegistryTest.php
@@ -33,13 +33,13 @@ final class RegistryTest extends TestCase
                 'covers' => ['\PHPUnit\Util\Annotation\Registry'],
                 'uses'   => ['\PHPUnit\Util\Annotation\DocBlock'],
             ],
-            $annotation->symbolAnnotations()
+            $annotation->symbolAnnotations(),
         );
 
         $this->assertSame(
             $annotation,
             Registry::getInstance()->forClassName(self::class),
-            'Registry memoizes retrieved DocBlock instances'
+            'Registry memoizes retrieved DocBlock instances',
         );
     }
 
@@ -47,7 +47,7 @@ final class RegistryTest extends TestCase
     {
         $annotation = Registry::getInstance()->forMethod(
             NumericGroupAnnotationTest::class,
-            'testTicketAnnotationSupportsNumericValue'
+            'testTicketAnnotationSupportsNumericValue',
         );
 
         $this->assertSame(
@@ -57,16 +57,16 @@ final class RegistryTest extends TestCase
                 'author'  => ['C. Lippy'],
                 'see'     => ['https://github.com/sebastianbergmann/phpunit/issues/3502'],
             ],
-            $annotation->symbolAnnotations()
+            $annotation->symbolAnnotations(),
         );
 
         $this->assertSame(
             $annotation,
             Registry::getInstance()->forMethod(
                 NumericGroupAnnotationTest::class,
-                'testTicketAnnotationSupportsNumericValue'
+                'testTicketAnnotationSupportsNumericValue',
             ),
-            'Registry memoizes retrieved DocBlock instances'
+            'Registry memoizes retrieved DocBlock instances',
         );
     }
 

--- a/tests/unit/Util/ConfigurationGeneratorTest.php
+++ b/tests/unit/Util/ConfigurationGeneratorTest.php
@@ -57,8 +57,8 @@ final class ConfigurationGeneratorTest extends TestCase
                 'vendor/autoload.php',
                 'tests',
                 'src',
-                '.phpunit.cache'
-            )
+                '.phpunit.cache',
+            ),
         );
     }
 }

--- a/tests/unit/Util/GlobalStateTest.php
+++ b/tests/unit/Util/GlobalStateTest.php
@@ -30,7 +30,7 @@ final class GlobalStateTest extends TestCase
         $this->assertEquals(
             "require_once '" . $dir . "/GlobalStateTest.php';\n" .
             "require_once 'file://" . $dir . "/XmlTest.php';\n",
-            GlobalState::processIncludedFilesAsString($files)
+            GlobalState::processIncludedFilesAsString($files),
         );
     }
 }

--- a/tests/unit/Util/TestClassTest.php
+++ b/tests/unit/Util/TestClassTest.php
@@ -90,7 +90,7 @@ final class TestClassTest extends TestCase
     {
         $this->assertEquals(
             $result,
-            Test::getRequirements(RequirementsTest::class, $test)
+            Test::getRequirements(RequirementsTest::class, $test),
         );
     }
 
@@ -541,19 +541,19 @@ final class TestClassTest extends TestCase
         foreach ($result as $type => $expected_requirement) {
             $this->assertArrayHasKey(
                 "{$type}_constraint",
-                $requirements
+                $requirements,
             );
             $this->assertArrayHasKey(
                 'constraint',
-                $requirements["{$type}_constraint"]
+                $requirements["{$type}_constraint"],
             );
             $this->assertInstanceOf(
                 VersionConstraint::class,
-                $requirements["{$type}_constraint"]['constraint']
+                $requirements["{$type}_constraint"]['constraint'],
             );
             $this->assertSame(
                 $expected_requirement['constraint'],
-                $requirements["{$type}_constraint"]['constraint']->asString()
+                $requirements["{$type}_constraint"]['constraint']->asString(),
             );
         }
     }
@@ -713,7 +713,7 @@ final class TestClassTest extends TestCase
 
         $this->assertEquals(
             $expectedAnnotations,
-            Test::getRequirements(RequirementsClassDocBlockTest::class, 'testMethod')
+            Test::getRequirements(RequirementsClassDocBlockTest::class, 'testMethod'),
         );
     }
 
@@ -730,7 +730,7 @@ final class TestClassTest extends TestCase
     {
         $this->assertEquals(
             $result,
-            Test::getMissingRequirements(RequirementsTest::class, $test)
+            Test::getMissingRequirements(RequirementsTest::class, $test),
         );
     }
 
@@ -1068,9 +1068,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'anotherAnnotation'
+                'anotherAnnotation',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertNull($result);
@@ -1081,9 +1081,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWith1'
+                'testWith1',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertEquals([[1]], $result);
@@ -1094,9 +1094,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWith1234'
+                'testWith1234',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertEquals([[1, 2], [3, 4]], $result);
@@ -1107,9 +1107,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWithABTrueNull'
+                'testWithABTrueNull',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertEquals([['ab'], [true], [null]], $result);
@@ -1120,9 +1120,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWith12AndAnotherAnnotation'
+                'testWith12AndAnotherAnnotation',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertEquals([[1], [2]], $result);
@@ -1133,9 +1133,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWith12AndBlahBlah'
+                'testWith12AndBlahBlah',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertEquals([[1], [2]], $result);
@@ -1146,9 +1146,9 @@ final class TestClassTest extends TestCase
         $result = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWithEscapedString'
+                'testWithEscapedString',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         )->getProvidedData();
 
         $this->assertEquals([['"', '"']], $result);
@@ -1159,9 +1159,9 @@ final class TestClassTest extends TestCase
         $docBlock = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWithMalformedValue'
+                'testWithMalformedValue',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         );
 
         $this->expectException(Exception::class);
@@ -1175,9 +1175,9 @@ final class TestClassTest extends TestCase
         $docBlock = DocBlock::ofMethod(
             new ReflectionMethod(
                 VariousDocblockDefinedDataProvider::class,
-                'testWithWellFormedAndMalformedValue'
+                'testWithWellFormedAndMalformedValue',
             ),
-            VariousDocblockDefinedDataProvider::class
+            VariousDocblockDefinedDataProvider::class,
         );
 
         $this->expectException(Exception::class);
@@ -1194,7 +1194,7 @@ final class TestClassTest extends TestCase
                 new ExecutionOrderDependency(self::class, 'ほげ'),
                 new ExecutionOrderDependency('AnotherClass::Foo'),
             ],
-            Test::getDependencies(self::class, 'methodForTestParseAnnotation')
+            Test::getDependencies(self::class, 'methodForTestParseAnnotation'),
         );
     }
 
@@ -1213,7 +1213,7 @@ final class TestClassTest extends TestCase
     {
         $this->assertEquals(
             [new ExecutionOrderDependency(self::class, 'Bar')],
-            Test::getDependencies(self::class, 'methodForTestParseAnnotationThatIsOnlyOneLine')
+            Test::getDependencies(self::class, 'methodForTestParseAnnotationThatIsOnlyOneLine'),
         );
     }
 
@@ -1236,8 +1236,8 @@ final class TestClassTest extends TestCase
             $expected,
             Test::getLinesToBeCovered(
                 $test,
-                'testSomething'
-            )
+                'testSomething',
+            ),
         );
     }
 
@@ -1247,7 +1247,7 @@ final class TestClassTest extends TestCase
 
         Test::getLinesToBeCovered(
             NotExistingCoveredElementTest::class,
-            'testOne'
+            'testOne',
         );
     }
 
@@ -1257,7 +1257,7 @@ final class TestClassTest extends TestCase
 
         Test::getLinesToBeCovered(
             NotExistingCoveredElementTest::class,
-            'testTwo'
+            'testTwo',
         );
     }
 
@@ -1267,7 +1267,7 @@ final class TestClassTest extends TestCase
 
         Test::getLinesToBeCovered(
             NotExistingCoveredElementTest::class,
-            'testThree'
+            'testThree',
         );
     }
 
@@ -1277,8 +1277,8 @@ final class TestClassTest extends TestCase
             [],
             Test::getLinesToBeCovered(
                 NotExistingCoveredElementTest::class,
-                'methodDoesNotExist'
-            )
+                'methodDoesNotExist',
+            ),
         );
     }
 
@@ -1288,7 +1288,7 @@ final class TestClassTest extends TestCase
 
         Test::getLinesToBeCovered(
             CoverageTwoDefaultClassAnnotations::class,
-            'testSomething'
+            'testSomething',
         );
     }
 
@@ -1298,8 +1298,8 @@ final class TestClassTest extends TestCase
             [TEST_FILES_PATH . 'CoveredFunction.php' => range(10, 12)],
             Test::getLinesToBeCovered(
                 CoverageFunctionParenthesesTest::class,
-                'testSomething'
-            )
+                'testSomething',
+            ),
         );
     }
 
@@ -1309,8 +1309,8 @@ final class TestClassTest extends TestCase
             [TEST_FILES_PATH . 'CoveredFunction.php' => range(10, 12)],
             Test::getLinesToBeCovered(
                 CoverageFunctionParenthesesWhitespaceTest::class,
-                'testSomething'
-            )
+                'testSomething',
+            ),
         );
     }
 
@@ -1320,8 +1320,8 @@ final class TestClassTest extends TestCase
             [TEST_FILES_PATH . 'CoveredClass.php' => range(31, 35)],
             Test::getLinesToBeCovered(
                 CoverageMethodParenthesesTest::class,
-                'testSomething'
-            )
+                'testSomething',
+            ),
         );
     }
 
@@ -1331,8 +1331,8 @@ final class TestClassTest extends TestCase
             [TEST_FILES_PATH . 'CoveredClass.php' => range(31, 35)],
             Test::getLinesToBeCovered(
                 CoverageMethodParenthesesWhitespaceTest::class,
-                'testSomething'
-            )
+                'testSomething',
+            ),
         );
     }
 
@@ -1344,8 +1344,8 @@ final class TestClassTest extends TestCase
             ],
             Test::getLinesToBeCovered(
                 CoverageNamespacedFunctionTest::class,
-                'testFunc'
-            )
+                'testFunc',
+            ),
         );
     }
 
@@ -1528,8 +1528,8 @@ final class TestClassTest extends TestCase
             ],
             Test::getLinesToBeCovered(
                 Test3194::class,
-                'testOne'
-            )
+                'testOne',
+            ),
         );
     }
 

--- a/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
+++ b/tests/unit/Util/XDebugFilterScriptGeneratorTest.php
@@ -62,33 +62,33 @@ EOF;
                         __DIR__,
                         '',
                         '.php',
-                        'DEFAULT'
+                        'DEFAULT',
                     ),
                     new Directory(
                         sprintf('%s/', __DIR__),
                         '',
                         '.php',
-                        'DEFAULT'
+                        'DEFAULT',
                     ),
                     new Directory(
                         sprintf('%s/./%s', dirname(__DIR__), basename(__DIR__)),
                         '',
                         '.php',
-                        'DEFAULT'
+                        'DEFAULT',
                     ),
                     new Directory(
                         $directoryPathThatDoesNotExist,
                         '',
                         '.php',
-                        'DEFAULT'
+                        'DEFAULT',
                     ),
-                ]
+                ],
             ),
             FileCollection::fromArray(
                 [
                     new File('src/foo.php'),
                     new File('src/bar.php'),
-                ]
+                ],
             ),
             DirectoryCollection::fromArray([]),
             FileCollection::fromArray([]),
@@ -103,7 +103,7 @@ EOF;
             null,
             null,
             null,
-            null
+            null,
         );
 
         $writer = new XdebugFilterScriptGenerator;

--- a/tests/unit/Util/Xml/ValidatorTest.php
+++ b/tests/unit/Util/Xml/ValidatorTest.php
@@ -28,9 +28,9 @@ final class ValidatorTest extends TestCase
                 __DIR__ . '/../../../../phpunit.xml',
                 false,
                 true,
-                true
+                true,
             ),
-            (new SchemaFinder)->find(Version::series())
+            (new SchemaFinder)->find(Version::series()),
         );
 
         $this->assertFalse($result->hasValidationErrors());
@@ -44,9 +44,9 @@ final class ValidatorTest extends TestCase
                 __DIR__ . '/../../../end-to-end/migration/_files/possibility-to-migrate-from-92-is-detected/phpunit.xml',
                 false,
                 true,
-                true
+                true,
             ),
-            (new SchemaFinder)->find(Version::series())
+            (new SchemaFinder)->find(Version::series()),
         );
 
         $this->assertTrue($result->hasValidationErrors());

--- a/tests/unit/Util/XmlTest.php
+++ b/tests/unit/Util/XmlTest.php
@@ -45,8 +45,8 @@ final class XmlTest extends TestCase
                 '%s::prepareString("\x%02x") should not crash %s',
                 Xml::class,
                 ord($char),
-                DOMDocument::class
-            )
+                DOMDocument::class,
+            ),
         );
     }
 


### PR DESCRIPTION
This pull request

- [x] adds `arguments` to the `elements` option of `trailing_comma_in_multiline` fixer
- [x] runs `tools/php-cs-fixer fix`
- [x] regenerates the baseline for `vimeo/psalm`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v2.19.0/doc/rules/control_structure/trailing_comma_in_multiline.rst.