### PR TITLE
Enhancement: Add `match` to `elements` option of `trailing_comma_in_multiline` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -314,7 +314,8 @@ $config->setFinder($finder)
         'trailing_comma_in_multiline' => [
             'elements' => [
                 'arguments',
-                'arrays'
+                'arrays',
+                'match',
             ]
         ],
         'trim_array_spaces' => true,

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -294,7 +294,7 @@ final class ResultPrinter
                 'message' => '├',
                 'diff'    => '┊',
                 'trace'   => '╵',
-                'last'    => '┴'
+                'last'    => '┴',
             },
         );
     }


### PR DESCRIPTION
This pull request

- [x] adds `match` to the `elements` option of `trailing_comma_in_multiline` fixer
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v2.19.0/doc/rules/control_structure/trailing_comma_in_multiline.rst.