### PR TITLE
Enhancement: Add `parameters` to `elements` option of `trailing_comma_in_multiline` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -316,6 +316,7 @@ $config->setFinder($finder)
                 'arguments',
                 'arrays',
                 'match',
+                'parameters',
             ]
         ],
         'trim_array_spaces' => true,

--- a/tests/unit/Event/Value/Telemetry/HRTimeTest.php
+++ b/tests/unit/Event/Value/Telemetry/HRTimeTest.php
@@ -128,7 +128,7 @@ final class HRTimeTest extends TestCase
         int $startSeconds,
         int $startNanoseconds,
         int $endSeconds,
-        int $endNanoseconds
+        int $endNanoseconds,
     ): void {
         $start = HRTime::fromSecondsAndNanoseconds(
             $startSeconds,
@@ -152,7 +152,7 @@ final class HRTimeTest extends TestCase
         int $startNanoseconds,
         int $endSeconds,
         int $endNanoseconds,
-        Duration $duration
+        Duration $duration,
     ): void {
         $start = HRTime::fromSecondsAndNanoseconds(
             $startSeconds,

--- a/tests/unit/Framework/ExecutionOrderDependencyTest.php
+++ b/tests/unit/Framework/ExecutionOrderDependencyTest.php
@@ -54,7 +54,7 @@ class ExecutionOrderDependencyTest extends TestCase
         string $className,
         ?string $methodName,
         string $expectedTarget,
-        bool $expectedTargetIsClass
+        bool $expectedTargetIsClass,
     ): void {
         $dependency = new ExecutionOrderDependency($className, $methodName);
 


### PR DESCRIPTION
This pull request

- [x] adds `paramaters` to the `elements` option of `trailing_comma_in_multiline` fixer
- [x] runs `tools/php-cs-fixer fix`

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v2.19.0/doc/rules/control_structure/trailing_comma_in_multiline.rst.