### PR TITLE
Fix: Avoid multiline parameter lists

### DIFF
--- a/tests/unit/Framework/ExecutionOrderDependencyTest.php
+++ b/tests/unit/Framework/ExecutionOrderDependencyTest.php
@@ -63,12 +63,8 @@ class ExecutionOrderDependencyTest extends TestCase
      *
      * @dataProvider createFromParametersProvider
      */
-    public function testCreateDependencyFromParameters(
-        string $className,
-        ?string $methodName,
-        string $expectedTarget,
-        bool $expectedTargetIsClass
-    ): void {
+    public function testCreateDependencyFromParameters(string $className, ?string $methodName, string $expectedTarget, bool $expectedTargetIsClass): void
+    {
         $dependency = new ExecutionOrderDependency($className, $methodName);
 
         $this->assertSame(
@@ -89,11 +85,8 @@ class ExecutionOrderDependencyTest extends TestCase
      *
      * @dataProvider createWithCloneOptionProvider
      */
-    public function testCreateDependencyWithCloneOption(
-        ?string $option,
-        bool $expectedShallowClone,
-        bool $expectedDeepClone
-    ): void {
+    public function testCreateDependencyWithCloneOption(?string $option, bool $expectedShallowClone, bool $expectedDeepClone): void
+    {
         $dependency = new ExecutionOrderDependency('ClassName', 'methodName', $option);
 
         $this->assertSame(


### PR DESCRIPTION
This pull request

- [x] avoids multiline parameter lists

Follows https://github.com/sebastianbergmann/phpunit/pull/5395#issuecomment-1566153366. 