### PR TITLE
Fix: Avoid multiline parameter lists

### DIFF
--- a/tests/unit/Event/Value/Telemetry/HRTimeTest.php
+++ b/tests/unit/Event/Value/Telemetry/HRTimeTest.php
@@ -124,12 +124,8 @@ final class HRTimeTest extends TestCase
     }
 
     #[DataProvider('provideStartGreaterThanEnd')]
-    public function testDurationRejectsStartGreaterThanEnd(
-        int $startSeconds,
-        int $startNanoseconds,
-        int $endSeconds,
-        int $endNanoseconds
-    ): void {
+    public function testDurationRejectsStartGreaterThanEnd(int $startSeconds, int $startNanoseconds, int $endSeconds, int $endNanoseconds): void
+    {
         $start = HRTime::fromSecondsAndNanoseconds(
             $startSeconds,
             $startNanoseconds,
@@ -147,13 +143,8 @@ final class HRTimeTest extends TestCase
     }
 
     #[DataProvider('provideStartEndAndDuration')]
-    public function testDurationReturnsDifferenceBetweenEndAndStart(
-        int $startSeconds,
-        int $startNanoseconds,
-        int $endSeconds,
-        int $endNanoseconds,
-        Duration $duration
-    ): void {
+    public function testDurationReturnsDifferenceBetweenEndAndStart(int $startSeconds, int $startNanoseconds, int $endSeconds, int $endNanoseconds, Duration $duration): void
+    {
         $start = HRTime::fromSecondsAndNanoseconds(
             $startSeconds,
             $startNanoseconds,


### PR DESCRIPTION
This pull request

- [x] avoids multiline parameter lists

Follows https://github.com/sebastianbergmann/phpunit/pull/5395#issuecomment-1566153366. 