### PR TITLE
Catch catchable things from require when loading extensions from phar

### DIFF
--- a/src/Runner/Extension/PharLoader.php
+++ b/src/Runner/Extension/PharLoader.php
@@ -77,7 +77,7 @@ final class PharLoader
             }
 
             try {
-                /*
+                /**
                  * @psalm-suppress UnresolvableInclude
                  */
                 @require $file;

--- a/src/Runner/Extension/PharLoader.php
+++ b/src/Runner/Extension/PharLoader.php
@@ -18,6 +18,7 @@ use PharIo\Version\Version as PharIoVersion;
 use PHPUnit\Event;
 use PHPUnit\Runner\Version;
 use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
+use Throwable;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -75,10 +76,16 @@ final class PharLoader
                 continue;
             }
 
-            /**
-             * @psalm-suppress UnresolvableInclude
-             */
-            require $file;
+            try {
+                /*
+                 * @psalm-suppress UnresolvableInclude
+                 */
+                @require $file;
+            } catch (Throwable $t) {
+                $notLoadedExtensions[] = $file . ': ' . $t->getMessage();
+
+                continue;
+            }
 
             $loadedExtensions[] = $manifest->getName()->asString() . ' ' . $manifest->getVersion()->getVersionString();
 


### PR DESCRIPTION
This fixes the crash mentioned in https://github.com/ergebnis/phpunit-slow-test-detector/pull/273#issuecomment-1570216686