### PR TITLE
Allow empty `<extensions>` element in XML configuration

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -57,7 +57,7 @@
     </xs:complexType>
     <xs:complexType name="extensionsType">
         <xs:sequence>
-            <xs:element name="extension" type="objectType" maxOccurs="unbounded"/>
+            <xs:element name="extension" type="objectType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="listenersType">


### PR DESCRIPTION
In Symfony, we'd like to have new projects start with a `phpunit.xml.dist` file that contains an empty `<extensions>` tag, see https://github.com/symfony/recipes/pull/1215 for a bit of context. TL;DR, this empty tag would be a very useful hooks for automatically enabling extensions when they're installed with flex.

~Many tags already have this `minOccurs="0"` so I added it to the few tags that don't. Might be useful for similar reasons.~

I hope this change can make it as a bug fix :pray:  (let me know if I should/can target 8.5 instead)