### PR TITLE
Enhancement: Replace dashes with underscores when translating class name from file name

### DIFF
--- a/src/Runner/TestSuiteLoader.php
+++ b/src/Runner/TestSuiteLoader.php
@@ -86,7 +86,7 @@ final class TestSuiteLoader
 
     private function classNameFromFileName(string $suiteClassFile): string
     {
-        $className = basename($suiteClassFile, '.php');
+        $className = str_replace('-', '_', basename($suiteClassFile, '.php'));
         $dotPos    = strpos($className, '.');
 
         if ($dotPos !== false) {


### PR DESCRIPTION
Some folks in WordPress has a standard of using `test-class-name.php` or a similar form of dash-based file names for test suites. For example, see:

- https://github.com/alleyinteractive/mantle-framework/tree/main/tests/database/model
- https://github.com/humanmade/S3-Uploads/tree/master/tests
- https://github.com/Yoast/wordpress-seo/tree/trunk/tests/unit/admin

Previously in PHPUnit 9, these were loaded properly. With the upgrade to PHPUnit 10, we're seeing class not found for these same files because of their naming structure.

I know the 10.x upgrade is a breaking change but I know of many repositories where the upgrade will be made difficult because we'd have to rename the test suites to match the requirements of PHPUnit 10. Since class names can't include dashes this seems like a safe bet.

I appreciate your consideration! 