### PR TITLE
Implement `#[WithoutErrorHandler]` attribute to disable PHPUnit's error handler for a test method

### DIFF
--- a/ChangeLog-10.3.md
+++ b/ChangeLog-10.3.md
@@ -4,6 +4,10 @@ All notable changes of the PHPUnit 10.3 release series are documented in this fi
 
 ## [10.3.0] - 2023-08-04
 
+### Added
+
+* [#5428](https://github.com/sebastianbergmann/phpunit/issues/5428): Attribute `#[WithoutErrorHandler]` to disable PHPUnit's error handler for a test method
+
 ### Changed
 
 * When a test case class inherits test methods from a parent class then, by default (when no test reordering is requested), the test methods from the class that is highest in the inheritance tree (instead of the class that is lowest in the inheritance tree) are now run first

--- a/src/Framework/Attributes/WithoutErrorHandler.php
+++ b/src/Framework/Attributes/WithoutErrorHandler.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Attributes;
+
+use Attribute;
+
+/**
+ * @psalm-immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class WithoutErrorHandler
+{
+}

--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -84,7 +84,9 @@ final class TestRunner
         $risky      = false;
         $skipped    = false;
 
-        ErrorHandler::instance()->enable();
+        if ($this->shouldErrorHandlerBeUsed($test)) {
+            ErrorHandler::instance()->enable();
+        }
 
         $collectCodeCoverage = CodeCoverage::instance()->isActive() &&
                                $shouldCodeCoverageBeCollected;
@@ -451,5 +453,14 @@ final class TestRunner
         }
 
         return $path;
+    }
+
+    private function shouldErrorHandlerBeUsed(TestCase $test): bool
+    {
+        if (MetadataRegistry::parser()->forMethod($test::class, $test->name())->isWithoutErrorHandler()->isNotEmpty()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -364,6 +364,11 @@ abstract class Metadata
         return new UsesDefaultClass(self::CLASS_LEVEL, $className);
     }
 
+    public static function withoutErrorHandler(): WithoutErrorHandler
+    {
+        return new WithoutErrorHandler(self::METHOD_LEVEL);
+    }
+
     protected function __construct(int $level)
     {
         $this->level = $level;
@@ -705,6 +710,14 @@ abstract class Metadata
      * @psalm-assert-if-true UsesFunction $this
      */
     public function isUsesFunction(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @psalm-assert-if-true WithoutErrorHandler $this
+     */
+    public function isWithoutErrorHandler(): bool
     {
         return false;
     }

--- a/src/Metadata/MetadataCollection.php
+++ b/src/Metadata/MetadataCollection.php
@@ -529,4 +529,14 @@ final class MetadataCollection implements Countable, IteratorAggregate
             ),
         );
     }
+
+    public function isWithoutErrorHandler(): self
+    {
+        return new self(
+            ...array_filter(
+                $this->metadata,
+                static fn (Metadata $metadata): bool => $metadata->isWithoutErrorHandler(),
+            ),
+        );
+    }
 }

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -64,6 +64,7 @@ use PHPUnit\Framework\Attributes\TestWithJson;
 use PHPUnit\Framework\Attributes\Ticket;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\Attributes\UsesFunction;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Metadata\Metadata;
 use PHPUnit\Metadata\MetadataCollection;
 use PHPUnit\Metadata\Version\ConstraintRequirement;
@@ -613,6 +614,13 @@ final class AttributeParser implements Parser
                     assert($attributeInstance instanceof Ticket);
 
                     $result[] = Metadata::groupOnMethod($attributeInstance->text());
+
+                    break;
+
+                case WithoutErrorHandler::class:
+                    assert($attributeInstance instanceof WithoutErrorHandler);
+
+                    $result[] = Metadata::withoutErrorHandler();
 
                     break;
             }

--- a/src/Metadata/WithoutErrorHandler.php
+++ b/src/Metadata/WithoutErrorHandler.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata;
+
+/**
+ * @psalm-immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class WithoutErrorHandler extends Metadata
+{
+    public function isWithoutErrorHandler(): bool
+    {
+        return true;
+    }
+}

--- a/tests/_files/Metadata/Attribute/tests/WithoutErrorHandlerTest.php
+++ b/tests/_files/Metadata/Attribute/tests/WithoutErrorHandlerTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Metadata\Attribute;
+
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\TestCase;
+
+final class WithoutErrorHandlerTest extends TestCase
+{
+    #[WithoutErrorHandler]
+    public function testOne(): void
+    {
+    }
+}

--- a/tests/end-to-end/event/_files/error-handler-can-be-disabled/phpunit.xml
+++ b/tests/end-to-end/event/_files/error-handler-can-be-disabled/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         bootstrap="src/Foo.php"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/event/_files/error-handler-can-be-disabled/src/Foo.php
+++ b/tests/end-to-end/event/_files/error-handler-can-be-disabled/src/Foo.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled;
+
+use function error_get_last;
+use function fopen;
+use function trigger_error;
+use Exception;
+
+final class Foo
+{
+    public function methodA($fileName)
+    {
+        $stream_handle = @fopen($fileName, 'wb');
+
+        if ($stream_handle === false) {
+            $error = error_get_last();
+
+            throw new Exception($error['message']);
+        }
+
+        return $stream_handle;
+    }
+
+    public function methodB(): ?array
+    {
+        @trigger_error('Triggering', E_USER_WARNING);
+
+        return error_get_last();
+    }
+}

--- a/tests/end-to-end/event/_files/error-handler-can-be-disabled/tests/FooTest.php
+++ b/tests/end-to-end/event/_files/error-handler-can-be-disabled/tests/FooTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled;
+
+use function sys_get_temp_dir;
+use function tempnam;
+use Exception;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\TestCase;
+
+final class FooTest extends TestCase
+{
+    #[WithoutErrorHandler]
+    public function testMethodA(): void
+    {
+        $fileName = tempnam(sys_get_temp_dir(), 'RLT') . '/missing/directory';
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failed to open stream');
+
+        (new Foo)->methodA($fileName);
+    }
+
+    #[WithoutErrorHandler]
+    public function testMethodB(): void
+    {
+        $this->assertSame('Triggering', (new Foo)->methodB()['message']);
+    }
+}

--- a/tests/end-to-end/event/error-handler-can-be-disabled.phpt
+++ b/tests/end-to-end/event/error-handler-can-be-disabled.phpt
@@ -1,0 +1,62 @@
+--TEST--
+The right events are emitted in the right order when PHPUnit's error handler is disabled
+--SKIPIF--
+<?php declare(strict_types=1);
+if (DIRECTORY_SEPARATOR === '\\') {
+    print "skip: this test does not work on Windows / GitHub Actions\n";
+}
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = '--fail-on-notice';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/error-handler-can-be-disabled';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Bootstrap Finished (%s/src/Foo.php)
+Test Suite Loaded (2 tests)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (2 tests)
+Test Suite Started (%s/phpunit.xml, 2 tests)
+Test Suite Started (default, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
+Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
+Assertion Succeeded (Constraint: exception of type "Exception", Value: Exception Object #92 (
+    'message' => 'fopen(%s/missing/directory): Failed to open stream: No such file or directory'
+    'string' => ''
+    'code' => 0
+    'file' => '%s/src/Foo.php'
+    'line' => 26
+    'previous' => null
+))
+Assertion Succeeded (Constraint: exception message contains 'Failed to open stream', Value: 'fopen(%s/missing/directory): Failed to open stream: No such file or directory')
+Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
+Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
+Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
+Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
+Assertion Succeeded (Constraint: is identical to 'Triggering', Value: 'Triggering')
+Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
+Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
+Test Suite Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 2 tests)
+Test Suite Finished (default, 2 tests)
+Test Suite Finished (%s/phpunit.xml, 2 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Metadata/MetadataCollectionTest.php
+++ b/tests/unit/Metadata/MetadataCollectionTest.php
@@ -475,6 +475,14 @@ final class MetadataCollectionTest extends TestCase
         $this->assertTrue($collection->asArray()[0]->isUsesFunction());
     }
 
+    public function test_Can_be_filtered_for_WithoutErrorHandler(): void
+    {
+        $collection = $this->collectionWithOneOfEach()->isWithoutErrorHandler();
+
+        $this->assertCount(1, $collection);
+        $this->assertTrue($collection->asArray()[0]->isWithoutErrorHandler());
+    }
+
     private function collectionWithOneOfEach(): MetadataCollection
     {
         return MetadataCollection::fromArray(
@@ -531,6 +539,7 @@ final class MetadataCollectionTest extends TestCase
                 Metadata::usesClass(''),
                 Metadata::usesDefaultClass(''),
                 Metadata::usesFunction(''),
+                Metadata::withoutErrorHandler(),
             ],
         );
     }

--- a/tests/unit/Metadata/MetadataTest.php
+++ b/tests/unit/Metadata/MetadataTest.php
@@ -58,6 +58,7 @@ use PHPUnit\Util\VersionComparisonOperator;
 #[CoversClass(UsesClass::class)]
 #[CoversClass(UsesDefaultClass::class)]
 #[CoversClass(UsesFunction::class)]
+#[CoversClass(WithoutErrorHandler::class)]
 #[Small]
 final class MetadataTest extends TestCase
 {
@@ -107,6 +108,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeAfterClass(): void
@@ -155,6 +157,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeBackupGlobalsOnClass(): void
@@ -203,6 +206,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertFalse($metadata->enabled());
         $this->assertTrue($metadata->isClassLevel());
@@ -255,6 +259,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertFalse($metadata->enabled());
         $this->assertTrue($metadata->isMethodLevel());
@@ -307,6 +312,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertFalse($metadata->enabled());
         $this->assertTrue($metadata->isClassLevel());
@@ -359,6 +365,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertFalse($metadata->enabled());
         $this->assertTrue($metadata->isMethodLevel());
@@ -411,6 +418,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeBefore(): void
@@ -459,6 +467,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeCoversOnClass(): void
@@ -507,6 +516,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->target());
         $this->assertTrue($metadata->isClassLevel());
@@ -559,6 +569,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->target());
         $this->assertTrue($metadata->isMethodLevel());
@@ -611,6 +622,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertSame(self::class, $metadata->asStringForCodeUnitMapper());
@@ -662,6 +674,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
     }
@@ -712,6 +725,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('f', $metadata->functionName());
         $this->assertSame('::f', $metadata->asStringForCodeUnitMapper());
@@ -763,6 +777,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertTrue($metadata->isMethodLevel());
         $this->assertFalse($metadata->isClassLevel());
@@ -814,6 +829,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertTrue($metadata->isClassLevel());
         $this->assertFalse($metadata->isMethodLevel());
@@ -865,6 +881,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertSame('method', $metadata->methodName());
@@ -916,6 +933,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertFalse($metadata->deepClone());
@@ -968,6 +986,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertSame('method', $metadata->methodName());
@@ -1021,6 +1040,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertTrue($metadata->isClassLevel());
         $this->assertFalse($metadata->isMethodLevel());
@@ -1072,6 +1092,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertTrue($metadata->isMethodLevel());
         $this->assertFalse($metadata->isClassLevel());
@@ -1123,6 +1144,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('variable', $metadata->globalVariableName());
         $this->assertTrue($metadata->isClassLevel());
@@ -1175,6 +1197,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('variable', $metadata->globalVariableName());
         $this->assertTrue($metadata->isMethodLevel());
@@ -1227,6 +1250,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('class', $metadata->className());
         $this->assertSame('property', $metadata->propertyName());
@@ -1280,6 +1304,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('class', $metadata->className());
         $this->assertSame('property', $metadata->propertyName());
@@ -1333,6 +1358,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('name', $metadata->groupName());
         $this->assertTrue($metadata->isClassLevel());
@@ -1385,6 +1411,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('class', $metadata->className());
         $this->assertTrue($metadata->isClassLevel());
@@ -1437,6 +1464,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('class', $metadata->className());
         $this->assertSame('method', $metadata->methodName());
@@ -1490,6 +1518,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('function', $metadata->functionName());
         $this->assertTrue($metadata->isClassLevel());
@@ -1542,6 +1571,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('name', $metadata->groupName());
         $this->assertTrue($metadata->isMethodLevel());
@@ -1594,6 +1624,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeRunClassInSeparateProcess(): void
@@ -1642,6 +1673,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeRunInSeparateProcess(): void
@@ -1690,6 +1722,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBeTest(): void
@@ -1738,6 +1771,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBePreCondition(): void
@@ -1786,6 +1820,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBePostCondition(): void
@@ -1834,6 +1869,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
     }
 
     public function testCanBePreserveGlobalStateOnClass(): void
@@ -1881,6 +1917,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertFalse($metadata->enabled());
         $this->assertTrue($metadata->isClassLevel());
@@ -1932,6 +1969,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertFalse($metadata->enabled());
         $this->assertTrue($metadata->isMethodLevel());
@@ -1984,6 +2022,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertSame(__METHOD__, $metadata->methodName());
@@ -2037,6 +2076,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertSame(__METHOD__, $metadata->methodName());
@@ -2090,6 +2130,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('f', $metadata->functionName());
         $this->assertTrue($metadata->isClassLevel());
@@ -2142,6 +2183,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('f', $metadata->functionName());
         $this->assertTrue($metadata->isMethodLevel());
@@ -2194,6 +2236,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('Linux', $metadata->operatingSystem());
         $this->assertTrue($metadata->isClassLevel());
@@ -2246,6 +2289,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('Linux', $metadata->operatingSystem());
         $this->assertTrue($metadata->isMethodLevel());
@@ -2298,6 +2342,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('Linux', $metadata->operatingSystemFamily());
         $this->assertTrue($metadata->isClassLevel());
@@ -2350,6 +2395,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('Linux', $metadata->operatingSystemFamily());
         $this->assertTrue($metadata->isMethodLevel());
@@ -2407,6 +2453,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('>= 8.0.0', $metadata->versionRequirement()->asString());
 
@@ -2465,6 +2512,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('>= 8.0.0', $metadata->versionRequirement()->asString());
 
@@ -2518,6 +2566,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('test', $metadata->extension());
         $this->assertFalse($metadata->hasVersionRequirement());
@@ -2581,6 +2630,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('test', $metadata->extension());
         $this->assertTrue($metadata->hasVersionRequirement());
@@ -2636,6 +2686,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('test', $metadata->extension());
         $this->assertFalse($metadata->hasVersionRequirement());
@@ -2699,6 +2750,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('test', $metadata->extension());
         $this->assertTrue($metadata->hasVersionRequirement());
@@ -2759,6 +2811,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('>= 10.0.0', $metadata->versionRequirement()->asString());
 
@@ -2817,6 +2870,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('>= 10.0.0', $metadata->versionRequirement()->asString());
 
@@ -2870,6 +2924,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('foo', $metadata->setting());
         $this->assertSame('bar', $metadata->value());
@@ -2924,6 +2979,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('foo', $metadata->setting());
         $this->assertSame('bar', $metadata->value());
@@ -2978,6 +3034,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('text', $metadata->text());
 
@@ -3031,6 +3088,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('text', $metadata->text());
 
@@ -3084,6 +3142,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(['a', 'b'], $metadata->data());
     }
@@ -3134,6 +3193,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->target());
 
@@ -3187,6 +3247,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->target());
 
@@ -3240,6 +3301,7 @@ final class MetadataTest extends TestCase
         $this->assertTrue($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
         $this->assertSame(self::class, $metadata->asStringForCodeUnitMapper());
@@ -3291,6 +3353,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertTrue($metadata->isUsesDefaultClass());
         $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame(self::class, $metadata->className());
     }
@@ -3341,8 +3404,58 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isUsesClass());
         $this->assertFalse($metadata->isUsesDefaultClass());
         $this->assertTrue($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('f', $metadata->functionName());
         $this->assertSame('::f', $metadata->asStringForCodeUnitMapper());
+    }
+
+    public function testCanBeWithoutErrorHandler(): void
+    {
+        $metadata = Metadata::withoutErrorHandler();
+
+        $this->assertFalse($metadata->isAfter());
+        $this->assertFalse($metadata->isAfterClass());
+        $this->assertFalse($metadata->isBackupGlobals());
+        $this->assertFalse($metadata->isBackupStaticProperties());
+        $this->assertFalse($metadata->isBeforeClass());
+        $this->assertFalse($metadata->isBefore());
+        $this->assertFalse($metadata->isCovers());
+        $this->assertFalse($metadata->isCoversClass());
+        $this->assertFalse($metadata->isCoversDefaultClass());
+        $this->assertFalse($metadata->isCoversFunction());
+        $this->assertFalse($metadata->isCoversNothing());
+        $this->assertFalse($metadata->isDataProvider());
+        $this->assertFalse($metadata->isDependsOnClass());
+        $this->assertFalse($metadata->isDependsOnMethod());
+        $this->assertFalse($metadata->isDoesNotPerformAssertions());
+        $this->assertFalse($metadata->isExcludeGlobalVariableFromBackup());
+        $this->assertFalse($metadata->isExcludeStaticPropertyFromBackup());
+        $this->assertFalse($metadata->isGroup());
+        $this->assertFalse($metadata->isIgnoreClassForCodeCoverage());
+        $this->assertFalse($metadata->isIgnoreMethodForCodeCoverage());
+        $this->assertFalse($metadata->isIgnoreFunctionForCodeCoverage());
+        $this->assertFalse($metadata->isRunClassInSeparateProcess());
+        $this->assertFalse($metadata->isRunInSeparateProcess());
+        $this->assertFalse($metadata->isRunTestsInSeparateProcesses());
+        $this->assertFalse($metadata->isTest());
+        $this->assertFalse($metadata->isPreCondition());
+        $this->assertFalse($metadata->isPostCondition());
+        $this->assertFalse($metadata->isPreserveGlobalState());
+        $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresFunction());
+        $this->assertFalse($metadata->isRequiresOperatingSystem());
+        $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
+        $this->assertFalse($metadata->isRequiresPhp());
+        $this->assertFalse($metadata->isRequiresPhpExtension());
+        $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresSetting());
+        $this->assertFalse($metadata->isTestDox());
+        $this->assertFalse($metadata->isTestWith());
+        $this->assertFalse($metadata->isUses());
+        $this->assertFalse($metadata->isUsesClass());
+        $this->assertFalse($metadata->isUsesDefaultClass());
+        $this->assertFalse($metadata->isUsesFunction());
+        $this->assertTrue($metadata->isWithoutErrorHandler());
     }
 }

--- a/tests/unit/Metadata/Parser/AttributeParserTest.php
+++ b/tests/unit/Metadata/Parser/AttributeParserTest.php
@@ -83,6 +83,7 @@ use PHPUnit\TestFixture\Metadata\Attribute\SmallTest;
 use PHPUnit\TestFixture\Metadata\Attribute\TestDoxTest;
 use PHPUnit\TestFixture\Metadata\Attribute\TestWithTest;
 use PHPUnit\TestFixture\Metadata\Attribute\UsesTest;
+use PHPUnit\TestFixture\Metadata\Attribute\WithoutErrorHandlerTest;
 
 #[CoversClass(After::class)]
 #[CoversClass(AfterClass::class)]
@@ -131,6 +132,7 @@ use PHPUnit\TestFixture\Metadata\Attribute\UsesTest;
 #[CoversClass(Ticket::class)]
 #[CoversClass(UsesClass::class)]
 #[CoversClass(UsesFunction::class)]
+#[CoversClass(WithoutErrorHandler::class)]
 #[CoversClass(AttributeParser::class)]
 #[Small]
 final class AttributeParserTest extends TestCase
@@ -964,6 +966,15 @@ final class AttributeParserTest extends TestCase
         $this->assertCount(2, $metadata);
         $this->assertTrue($metadata->asArray()[1]->isGroup());
         $this->assertSame('another-ticket', $metadata->asArray()[1]->groupName());
+    }
+
+    #[TestDox('Parses #[WithoutErrorHandler] attribute on method')]
+    public function test_parses_WithoutErrorHandler_attribute_on_method(): void
+    {
+        $metadata = (new AttributeParser)->forMethod(WithoutErrorHandlerTest::class, 'testOne')->isWithoutErrorHandler();
+
+        $this->assertCount(1, $metadata);
+        $this->assertTrue($metadata->asArray()[0]->isWithoutErrorHandler());
     }
 
     public function test_parses_attributes_for_class_and_method(): void


### PR DESCRIPTION
- [X] Implement `#[WithoutErrorHandler]` attribute
- [x] Use `#[WithoutErrorHandler]` attribute
- https://github.com/sebastianbergmann/phpunit-documentation-english/issues/317