### PR TITLE
fixed psalm violation for src/Util/VersionComparisonOperator

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -924,12 +924,4 @@
       <code>$filter</code>
     </ArgumentTypeCoercion>
   </file>
-  <file src="src/Util/VersionComparisonOperator.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[in_array($operator, ['<', 'lt', '<=', 'le', '>', 'gt', '>=', 'ge', '==', '=', 'eq', '!=', '<>', 'ne'], true)]]></code>
-    </DocblockTypeContradiction>
-    <NoValue>
-      <code>$operator</code>
-    </NoValue>
-  </file>
 </files>

--- a/src/Util/VersionComparisonOperator.php
+++ b/src/Util/VersionComparisonOperator.php
@@ -44,7 +44,7 @@ final class VersionComparisonOperator
     }
 
     /**
-     * @psalm-param '<'|'lt'|'<='|'le'|'>'|'gt'|'>='|'ge'|'=='|'='|'eq'|'!='|'<>'|'ne' $operator
+     * @psalm-param string $operator
      *
      * @throws InvalidVersionOperatorException
      */


### PR DESCRIPTION
see #4093

result of running Psalm on file src/Util/VersionComparisonOperator

```bash
➜  /workspace git:(draft/vibrant-tdd) ✗ ./tools/psalm --config=.psalm/config.xml --ignore-baseline --show-info src/Util/VersionComparisonOperator.php

Install the opcache extension to make use of JIT on PHP 8.0+ for a 20%+ performance boost!

Target PHP version: 8.1 (inferred from composer.json) Enabled extensions: dom.
Scanning files...
Analyzing files...

░
------------------------------
                              
       No errors found!       
                              
------------------------------

Checks took 0.84 seconds and used 247.546MB of memory
Psalm was able to infer types for 97.2186% of the codebase
```