### PR TITLE
Support for multiple arguments

### DIFF
--- a/tests/end-to-end/generic/multiple-arguments.phpt
+++ b/tests/end-to-end/generic/multiple-arguments.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit ../../_files/DummyFooTest.php ../../_files/DummyBarTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DummyFooTest.php';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DummyBarTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)


### PR DESCRIPTION
This work adds the support for providing multiple files or directories as arguments to PHPUnit:

```
./phpunit FooTest.php test/
```

It is very useful when you want to test multiple things together without having a Suite defined in the configuration, and most important (for me) is that it works for CircleCI's parallelisation command (apparently phpunit is one of the few test frameworks without this feature).

It could be easily extended for phpunit9.

**Point to discuss**
- naming the Test suite: a proposal is using a hash (md5) of all provided arguments (the list could be very long)