### PR TITLE
Add testdox and teamcity printer tests

### DIFF
--- a/tests/end-to-end/logging/teamcity-print-deprecation.phpt
+++ b/tests/end-to-end/logging/teamcity-print-deprecation.phpt
@@ -1,0 +1,32 @@
+--TEST--
+TeamCity: print deprecation message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/DeprecationTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='%d' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/DeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/DeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest::testOne' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/DeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-error.phpt
+++ b/tests/end-to-end/logging/teamcity-print-error.phpt
@@ -1,0 +1,34 @@
+--TEST--
+TeamCity: print error message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-errors';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/ErrorTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\ErrorTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/ErrorTest.php::\PHPUnit\TestFixture\TestRunnerStopping\ErrorTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/ErrorTest.php::\PHPUnit\TestFixture\TestRunnerStopping\ErrorTest::testOne' flowId='%d']
+
+##teamcity[testFailed name='testOne' message='Exception: message' details='%s/tests/end-to-end/_files/stop-on-fail-on/ErrorTest.php:19|n' duration='%d' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/ErrorTest.php::\PHPUnit\TestFixture\TestRunnerStopping\ErrorTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\ErrorTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-failure.phpt
+++ b/tests/end-to-end/logging/teamcity-print-failure.phpt
@@ -1,0 +1,33 @@
+--TEST--
+TeamCity: print failure message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/FailureTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='%d' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\FailureTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/FailureTest.php::\PHPUnit\TestFixture\TestRunnerStopping\FailureTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/FailureTest.php::\PHPUnit\TestFixture\TestRunnerStopping\FailureTest::testOne' flowId='%d']
+
+##teamcity[testFailed name='testOne' message='Failed asserting that false is true.' details='%s/tests/end-to-end/_files/stop-on-fail-on/FailureTest.php:18|n' duration='%d' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/FailureTest.php::\PHPUnit\TestFixture\TestRunnerStopping\FailureTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\FailureTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-incomplete.phpt
+++ b/tests/end-to-end/logging/teamcity-print-incomplete.phpt
@@ -1,0 +1,34 @@
+--TEST--
+TeamCity: print incomplete message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-incomplete';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/IncompleteTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/IncompleteTest.php::\PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/IncompleteTest.php::\PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest::testOne' flowId='%d']
+
+##teamcity[testIgnored name='testOne' message='message' details='%s/tests/end-to-end/_files/stop-on-fail-on/IncompleteTest.php:18|n' duration='%d' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/IncompleteTest.php::\PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-notice.phpt
+++ b/tests/end-to-end/logging/teamcity-print-notice.phpt
@@ -1,0 +1,32 @@
+--TEST--
+TeamCity: print notice message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-notices';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/NoticeTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\NoticeTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/NoticeTest.php::\PHPUnit\TestFixture\TestRunnerStopping\NoticeTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/NoticeTest.php::\PHPUnit\TestFixture\TestRunnerStopping\NoticeTest::testOne' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/NoticeTest.php::\PHPUnit\TestFixture\TestRunnerStopping\NoticeTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\NoticeTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-risky.phpt
+++ b/tests/end-to-end/logging/teamcity-print-risky.phpt
@@ -1,0 +1,33 @@
+--TEST--
+TeamCity: print risky message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/RiskyTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\RiskyTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/RiskyTest.php::\PHPUnit\TestFixture\TestRunnerStopping\RiskyTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/RiskyTest.php::\PHPUnit\TestFixture\TestRunnerStopping\RiskyTest::testOne' flowId='%d']
+
+##teamcity[testFailed name='testOne' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/RiskyTest.php::\PHPUnit\TestFixture\TestRunnerStopping\RiskyTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\RiskyTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-skipped.phpt
+++ b/tests/end-to-end/logging/teamcity-print-skipped.phpt
@@ -1,0 +1,34 @@
+--TEST--
+TeamCity: print skipped message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/SkippedTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\SkippedTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/SkippedTest.php::\PHPUnit\TestFixture\TestRunnerStopping\SkippedTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/SkippedTest.php::\PHPUnit\TestFixture\TestRunnerStopping\SkippedTest::testOne' flowId='%d']
+
+##teamcity[testIgnored name='testOne' message='message' duration='%d' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/SkippedTest.php::\PHPUnit\TestFixture\TestRunnerStopping\SkippedTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\SkippedTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-warning.phpt
+++ b/tests/end-to-end/logging/teamcity-print-warning.phpt
@@ -1,0 +1,32 @@
+--TEST--
+TeamCity: print warning message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-warnings';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-teamcity';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/WarningTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+##teamcity[testCount count='2' flowId='%d']
+
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\WarningTest' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/WarningTest.php::\PHPUnit\TestFixture\TestRunnerStopping\WarningTest' flowId='%d']
+
+##teamcity[testStarted name='testOne' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/WarningTest.php::\PHPUnit\TestFixture\TestRunnerStopping\WarningTest::testOne' flowId='%d']
+
+##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
+
+##teamcity[testStarted name='testTwo' locationHint='%s/tests/end-to-end/_files/stop-on-fail-on/WarningTest.php::\PHPUnit\TestFixture\TestRunnerStopping\WarningTest::testTwo' flowId='%d']
+
+##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
+
+##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\WarningTest' flowId='%d']

--- a/tests/end-to-end/logging/testdox-print-deprecation.phpt
+++ b/tests/end-to-end/logging/testdox-print-deprecation.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testdox: print deprecation message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/DeprecationTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Deprecation (PHPUnit\TestFixture\TestRunnerStopping\Deprecation)
+ [x] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-error.phpt
+++ b/tests/end-to-end/logging/testdox-print-error.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testdox: print error message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-errors';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/ErrorTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Error (PHPUnit\TestFixture\TestRunnerStopping\Error)
+ [ ] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-failure.phpt
+++ b/tests/end-to-end/logging/testdox-print-failure.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Testdox: print failure message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/FailureTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Failure (PHPUnit\TestFixture\TestRunnerStopping\Failure)
+ [ ] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-incomplete.phpt
+++ b/tests/end-to-end/logging/testdox-print-incomplete.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testdox: print incomplete message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-incomplete';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/IncompleteTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Incomplete (PHPUnit\TestFixture\TestRunnerStopping\Incomplete)
+ [ ] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-notice.phpt
+++ b/tests/end-to-end/logging/testdox-print-notice.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testdox: print notice message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-notices';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/NoticeTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Notice (PHPUnit\TestFixture\TestRunnerStopping\Notice)
+ [x] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-risky.phpt
+++ b/tests/end-to-end/logging/testdox-print-risky.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Testdox: print risky message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/RiskyTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Risky (PHPUnit\TestFixture\TestRunnerStopping\Risky)
+ [ ] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-skipped.phpt
+++ b/tests/end-to-end/logging/testdox-print-skipped.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testdox: print skipped message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/SkippedTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Skipped (PHPUnit\TestFixture\TestRunnerStopping\Skipped)
+ [ ] One
+ [x] Two

--- a/tests/end-to-end/logging/testdox-print-warning.phpt
+++ b/tests/end-to-end/logging/testdox-print-warning.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Testdox: print warning message
+--FILE--
+<?php declare(strict_types=1);
+
+$parentDirectory = dirname(__DIR__);
+
+$_SERVER['argv'][] = '--display-warnings';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--testdox-text';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] =  realpath($parentDirectory. '/_files/stop-on-fail-on/WarningTest.php');
+
+require realpath($parentDirectory . '/../bootstrap.php');
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+Warning (PHPUnit\TestFixture\TestRunnerStopping\Warning)
+ [x] One
+ [x] Two


### PR DESCRIPTION
This pull request adds additional tests for the "testdox" and "teamcity" printers.

These tests showcase the current behavior of each printer in different scenarios, ensuring their accuracy and functionality going forward.

- Follows #5488

I'm not sure what branch to target, currently default `main` branch. 

If there's a specific branch you would like us to target, please let me know.

This pull request is open to edits by maintainers, so please feel free to provide any feedback, make changes as needed, or close it.

Thanks