### PR TITLE
Actually run the tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,10 @@ jobs:
           tools: none
 
       - name: Install dependencies with Composer
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: ./phpunit --testsuite unit
+        run: php ./phpunit --testsuite unit
 
   end-to-end-tests:
     name: End-to-End Tests
@@ -151,10 +151,10 @@ jobs:
           tools: none
 
       - name: Install dependencies with Composer
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: ./phpunit --testsuite end-to-end
+        run: php ./phpunit --testsuite end-to-end
 
   code-coverage:
     name: Code Coverage


### PR DESCRIPTION
PR #3982 added test run builds against Windows OS.

I'm not sure if this ever worked, but it sure isn't working now. The environment is created, but the actual steps to run things are not doing anything due to the command not being understood by Windows.

![image](https://github.com/sebastianbergmann/phpunit/assets/663378/d32f295e-8d1b-4717-b754-728c35f91290)
Src: https://github.com/sebastianbergmann/phpunit/actions/runs/5989020062/job/16244808391

This commit fixes that and allows the tests to actually run on Windows.

Note: I've double-checked and confirmed that the tests really aren't running on Windows by introducing a test failure - this shows that the [Ubuntu tests fail (as expected), but that the Windows tests do not fail (as they aren't running)](https://github.com/jrfnl/phpunit/actions/runs/6001033906).
A test build with the same test failure + this commit shows that the [Windows tests will now fail correctly (as they will now run)](https://github.com/jrfnl/phpunit/actions/runs/6001062381).
