### PR TITLE
Combine filter options with test/group lists

### DIFF
--- a/src/TextUI/Command/Commands/ListGroupsCommand.php
+++ b/src/TextUI/Command/Commands/ListGroupsCommand.php
@@ -13,7 +13,6 @@ use function sort;
 use function sprintf;
 use function str_starts_with;
 use PHPUnit\Framework\TestSuite;
-use PHPUnit\TextUI\Configuration\Registry;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -29,8 +28,7 @@ final readonly class ListGroupsCommand implements Command
 
     public function execute(): Result
     {
-        $buffer = $this->warnAboutConflictingOptions();
-        $buffer .= 'Available test group(s):' . PHP_EOL;
+        $buffer = 'Available test group(s):' . PHP_EOL;
 
         $groups = $this->suite->groups();
         sort($groups);
@@ -47,34 +45,5 @@ final readonly class ListGroupsCommand implements Command
         }
 
         return Result::from($buffer);
-    }
-
-    private function warnAboutConflictingOptions(): string
-    {
-        $buffer = '';
-
-        $configuration = Registry::get();
-
-        if ($configuration->hasFilter()) {
-            $buffer .= 'The --filter and --list-groups options cannot be combined, --filter is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasGroups()) {
-            $buffer .= 'The --group and --list-groups options cannot be combined, --group is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasExcludeGroups()) {
-            $buffer .= 'The --exclude-group and --list-groups options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->includeTestSuite() !== '') {
-            $buffer .= 'The --testsuite and --list-groups options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
-        if (!empty($buffer)) {
-            $buffer .= PHP_EOL;
-        }
-
-        return $buffer;
     }
 }

--- a/src/TextUI/Command/Commands/ListTestSuitesCommand.php
+++ b/src/TextUI/Command/Commands/ListTestSuitesCommand.php
@@ -10,7 +10,6 @@
 namespace PHPUnit\TextUI\Command;
 
 use function sprintf;
-use PHPUnit\TextUI\Configuration\Registry;
 use PHPUnit\TextUI\Configuration\TestSuiteCollection;
 
 /**
@@ -27,8 +26,7 @@ final readonly class ListTestSuitesCommand implements Command
 
     public function execute(): Result
     {
-        $buffer = $this->warnAboutConflictingOptions();
-        $buffer .= 'Available test suite(s):' . PHP_EOL;
+        $buffer = 'Available test suite(s):' . PHP_EOL;
 
         foreach ($this->suites as $suite) {
             $buffer .= sprintf(
@@ -38,34 +36,5 @@ final readonly class ListTestSuitesCommand implements Command
         }
 
         return Result::from($buffer);
-    }
-
-    private function warnAboutConflictingOptions(): string
-    {
-        $buffer = '';
-
-        $configuration = Registry::get();
-
-        if ($configuration->hasFilter()) {
-            $buffer .= 'The --filter and --list-suites options cannot be combined, --filter is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasGroups()) {
-            $buffer .= 'The --group and --list-suites options cannot be combined, --group is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasExcludeGroups()) {
-            $buffer .= 'The --exclude-group and --list-suites options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->includeTestSuite() !== '') {
-            $buffer .= 'The --testsuite and --list-suites options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
-        if (!empty($buffer)) {
-            $buffer .= PHP_EOL;
-        }
-
-        return $buffer;
     }
 }

--- a/src/TextUI/Command/Commands/ListTestsAsTextCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsTextCommand.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\TextUI\Configuration\Registry;
-use RecursiveIteratorIterator;
+use PHPUnit\Util\TestSuiteIteratorIterator;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -35,7 +35,7 @@ final readonly class ListTestsAsTextCommand implements Command
 
         $buffer .= 'Available test(s):' . PHP_EOL;
 
-        foreach (new RecursiveIteratorIterator($this->suite) as $test) {
+        foreach (new TestSuiteIteratorIterator($this->suite) as $test) {
             if ($test instanceof TestCase) {
                 $name = sprintf(
                     '%s::%s',

--- a/src/TextUI/Command/Commands/ListTestsAsTextCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsTextCommand.php
@@ -14,7 +14,6 @@ use function str_replace;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\PhptTestCase;
-use PHPUnit\TextUI\Configuration\Registry;
 use PHPUnit\Util\TestSuiteIteratorIterator;
 
 /**
@@ -31,9 +30,7 @@ final readonly class ListTestsAsTextCommand implements Command
 
     public function execute(): Result
     {
-        $buffer = $this->warnAboutConflictingOptions();
-
-        $buffer .= 'Available test(s):' . PHP_EOL;
+        $buffer = 'Available test(s):' . PHP_EOL;
 
         foreach (new TestSuiteIteratorIterator($this->suite) as $test) {
             if ($test instanceof TestCase) {
@@ -55,30 +52,5 @@ final readonly class ListTestsAsTextCommand implements Command
         }
 
         return Result::from($buffer);
-    }
-
-    private function warnAboutConflictingOptions(): string
-    {
-        $buffer = '';
-
-        $configuration = Registry::get();
-
-        if ($configuration->hasFilter()) {
-            $buffer .= 'The --filter and --list-tests options cannot be combined, --filter is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasGroups()) {
-            $buffer .= 'The --group and --list-tests options cannot be combined, --group is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasExcludeGroups()) {
-            $buffer .= 'The --exclude-group and --list-tests options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
-        if (!empty($buffer)) {
-            $buffer .= PHP_EOL;
-        }
-
-        return $buffer;
     }
 }

--- a/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\TextUI\Configuration\Registry;
-use RecursiveIteratorIterator;
+use PHPUnit\Util\TestSuiteIteratorIterator;
 use XMLWriter;
 
 /**
@@ -45,7 +45,7 @@ final readonly class ListTestsAsXmlCommand implements Command
 
         $currentTestCase = null;
 
-        foreach (new RecursiveIteratorIterator($this->suite) as $test) {
+        foreach (new TestSuiteIteratorIterator($this->suite) as $test) {
             if ($test instanceof TestCase) {
                 if ($test::class !== $currentTestCase) {
                     if ($currentTestCase !== null) {

--- a/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
@@ -15,7 +15,6 @@ use function sprintf;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\PhptTestCase;
-use PHPUnit\TextUI\Configuration\Registry;
 use PHPUnit\Util\TestSuiteIteratorIterator;
 use XMLWriter;
 
@@ -35,7 +34,6 @@ final readonly class ListTestsAsXmlCommand implements Command
 
     public function execute(): Result
     {
-        $buffer = $this->warnAboutConflictingOptions();
         $writer = new XMLWriter;
 
         $writer->openMemory();
@@ -88,36 +86,11 @@ final readonly class ListTestsAsXmlCommand implements Command
 
         file_put_contents($this->filename, $writer->outputMemory());
 
-        $buffer .= sprintf(
+        $buffer = sprintf(
             'Wrote list of tests that would have been run to %s' . PHP_EOL,
             $this->filename,
         );
 
         return Result::from($buffer);
-    }
-
-    private function warnAboutConflictingOptions(): string
-    {
-        $buffer = '';
-
-        $configuration = Registry::get();
-
-        if ($configuration->hasFilter()) {
-            $buffer .= 'The --filter and --list-tests-xml options cannot be combined, --filter is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasGroups()) {
-            $buffer .= 'The --group and --list-tests-xml options cannot be combined, --group is ignored' . PHP_EOL;
-        }
-
-        if ($configuration->hasExcludeGroups()) {
-            $buffer .= 'The --exclude-group and --list-tests-xml options cannot be combined, --exclude-group is ignored' . PHP_EOL;
-        }
-
-        if (!empty($buffer)) {
-            $buffer .= PHP_EOL;
-        }
-
-        return $buffer;
     }
 }

--- a/src/Util/TestSuiteIteratorIterator.php
+++ b/src/Util/TestSuiteIteratorIterator.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use IteratorAggregate;
+use PHPUnit\Framework\TestSuite;
+use RecursiveIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * @template-extends RecursiveIteratorIterator<TestSuite>
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+class TestSuiteIteratorIterator extends RecursiveIteratorIterator
+{
+    public function callGetChildren(): ?RecursiveIterator
+    {
+        $current = $this->current();
+
+        if (!$current instanceof IteratorAggregate) {
+            return null;
+        }
+
+        $iterator = $current->getIterator();
+
+        if (!$iterator instanceof RecursiveIterator) {
+            return null;
+        }
+
+        return $iterator;
+    }
+}

--- a/tests/end-to-end/cli/list-tests/list-tests-dataprovider-filter.phpt
+++ b/tests/end-to-end/cli/list-tests/list-tests-dataprovider-filter.phpt
@@ -14,10 +14,5 @@ require_once __DIR__ . '/../../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-The --filter and --list-tests options cannot be combined, --filter is ignored
-
 Available test(s):
  - PHPUnit\TestFixture\DataProviderTest::testAdd#0
- - PHPUnit\TestFixture\DataProviderTest::testAdd#1
- - PHPUnit\TestFixture\DataProviderTest::testAdd#2
- - PHPUnit\TestFixture\DataProviderTest::testAdd#3

--- a/tests/unit/Util/TestSuiteIteratorIteratorTest.php
+++ b/tests/unit/Util/TestSuiteIteratorIteratorTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace unit\Util;
+
+use ArrayIterator;
+use IteratorAggregate;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\Filter\Factory;
+use PHPUnit\TestFixture\Success;
+use PHPUnit\Util\TestSuiteIteratorIterator;
+use RuntimeException;
+use Traversable;
+
+#[CoversClass(TestSuiteIteratorIterator::class)]
+#[Small]
+final class TestSuiteIteratorIteratorTest extends TestCase
+{
+    public function testCurrentInitiallyReturnsFirstTestThatPassesFilter(): void
+    {
+        $suite   = $this->suiteWithFilter(false);
+        $subject = new TestSuiteIteratorIterator($suite);
+
+        $subject->rewind();
+        $test = $subject->current();
+
+        $this->assertInstanceOf(TestCase::class, $test);
+
+        /** @var TestCase $test */
+        $this->assertEquals('testTwo', $test->name());
+    }
+
+    public function testCurrentInitiallyReturnsFirstTestThatPassesFilterOnSub(): void
+    {
+        $suite   = $this->suiteWithFilter(true);
+        $subject = new TestSuiteIteratorIterator($suite);
+
+        $subject->rewind();
+        $test = $subject->current();
+
+        $this->assertInstanceOf(TestCase::class, $test);
+
+        /** @var TestCase $test */
+        $this->assertEquals('testTwo', $test->name());
+    }
+
+    public function testCallGetChildrenWhileNotOnSuiteGivesNoException(): void
+    {
+        $suite = TestSuite::empty('test suite name');
+        $suite->addTest(new Success('testOne'));
+        $subject = new TestSuiteIteratorIterator($suite);
+
+        $this->assertNull($subject->callGetChildren());
+    }
+
+    public function testNonRecursiveIteratorGivesNoException(): void
+    {
+        $suite = TestSuite::empty('test suite name');
+        $suite->addTest($this->getNonRecursiveIteratorAggregateTest());
+        $subject = new TestSuiteIteratorIterator($suite);
+
+        $this->assertNull($subject->callGetChildren());
+    }
+
+    private function suiteWithFilter(bool $filterOnSub): TestSuite
+    {
+        $suite = TestSuite::empty('test suite name');
+        $sub   = TestSuite::empty('child test suite name');
+
+        $sub->addTest(new Success('testOne'));
+        $sub->addTest(new Success('testTwo'));
+
+        $suite->addTest($sub);
+
+        $factory = new Factory;
+        $factory->addNameFilter('Two');
+
+        if ($filterOnSub) {
+            $sub->injectFilter($factory);
+        } else {
+            $suite->injectFilter($factory);
+        }
+
+        return $suite;
+    }
+
+    private function getNonRecursiveIteratorAggregateTest(): Test
+    {
+        return new class implements IteratorAggregate, Test
+        {
+            public function getIterator(): Traversable
+            {
+                return new ArrayIterator([]);
+            }
+
+            public function count(): int
+            {
+                return 0;
+            }
+
+            public function run(): void
+            {
+                throw new RuntimeException;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #5552

A few questions/comments I have for the reviewer:
- Do I need to add a commit adding a line to `ChangeLog-10.4.md` or is that done by the merger? I would add this pull request's title under the "Changed" header.
- Combining these options used to produce a warning, not an error. Does that mean this is technically a breaking change? (I've put a comment on the issue to discuss this)
- I could have solved this by fixing the filter iterators, but in that case the responsibility of recursing the filters would have moved from `TestSuite::injectFilter` to the iterators, which would mean the filters don't work when you recurse manually, such as in `TestRunner::run()`.
- `--list-test-suites` uses a completely different set of classes, so I would have to alter quite a bit to make it work.
- In a previous version, I injected the filter in `Application::run()`. This meant I didn't have to change `executeCommandsThatRequireCliConfigurationAndTestSuite`, but also caused `Ignore*ForCodeCoverage` annotations to be ignored if they were in filtered-out tests. I believed this to be undesirable. Was this the right call?

