### PR TITLE
Allow two different error messages

### DIFF
--- a/tests/unit/Util/Xml/LoaderTest.php
+++ b/tests/unit/Util/Xml/LoaderTest.php
@@ -43,7 +43,7 @@ final class LoaderTest extends TestCase
     public function testCannotParseFileWithInvalidXml(): void
     {
         $this->expectException(XmlException::class);
-        $this->expectExceptionMessage('Premature end of data in tag test line 1');
+        $this->expectExceptionMessageMatches("#Premature end of data in tag test line 1|EndTag: '</' not found#");
 
         (new Loader)->loadFile(__DIR__ . '/../../../_files/invalid.xml');
     }
@@ -66,7 +66,7 @@ final class LoaderTest extends TestCase
     public function testCannotParseStringWithInvalidXml(): void
     {
         $this->expectException(XmlException::class);
-        $this->expectExceptionMessage('Premature end of data in tag test line 1');
+        $this->expectExceptionMessageMatches("#Premature end of data in tag test line 1|EndTag: '</' not found#");
 
         (new Loader)->load('<test>');
     }


### PR DESCRIPTION
This was failing on my CI since forever, but I wasn't able to check until now:

```
PHPUnit\Util\Xml\LoaderTest::testCannotParseFileWithInvalidXml
Failed asserting that exception message 'Could not load "/home/atlassian/bamboo/local-working-dir/PHP-PHPUN-PHP83/tests/unit/Util/Xml/../../../_files/invalid.xml":

EndTag: '</' not found
' contains 'Premature end of data in tag test line 1'.
```

It looks like the error message depends on the version of libxml.

See:
* https://github.com/php/php-src/blob/master/ext/dom/tests/DOMDocument_load_error1.phpt#L24
* https://github.com/php/php-src/commit/e29922f054639a934f3077190729007896ae244c
* https://revive.beccati.com/bamboo/build/result/viewBuildResultsFailedTests.action?buildKey=PHP-PHPUN-PM&buildNumber=3377