### PR TITLE
[9.6] GH Actions: actually run the tests on Windows (includes necessary fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,10 @@ jobs:
           tools: none
 
       - name: Install dependencies with Composer
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: ./phpunit --testsuite unit
+        run: php ./phpunit --testsuite unit
 
   end-to-end-tests:
     name: End-to-End Tests
@@ -151,10 +151,10 @@ jobs:
           tools: none
 
       - name: Install dependencies with Composer
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: ./phpunit --testsuite end-to-end
+        run: php ./phpunit --testsuite end-to-end
 
   code-coverage:
     name: Code Coverage

--- a/tests/end-to-end/testdox/_files/DiffTest.php
+++ b/tests/end-to-end/testdox/_files/DiffTest.php
@@ -9,7 +9,6 @@
  */
 namespace PHPUnit\TestFixture\TestDox;
 
-use const PHP_EOL;
 use PHPUnit\Framework\TestCase;
 
 final class DiffTest extends TestCase
@@ -17,8 +16,8 @@ final class DiffTest extends TestCase
     public function testSomethingThatDoesNotWork(): void
     {
         $this->assertEquals(
-            'foo' . PHP_EOL . 'bar' . PHP_EOL . 'baz' . PHP_EOL,
-            'foo' . PHP_EOL . 'baz' . PHP_EOL . 'bar' . PHP_EOL,
+            "foo\nbar\nbaz\n",
+            "foo\nbaz\nbar\n",
         );
     }
 }

--- a/tests/end-to-end/testdox/data-provider-with-numeric-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/data-provider-with-numeric-data-set-name-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/data-provider-with-string-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/data-provider-with-string-data-set-name-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithStringDataSetNameTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithStringDataSetNameTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithStringDataSetNameTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithStringDataSetNameTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/diff-colorized-windows.phpt
+++ b/tests/end-to-end/testdox/diff-colorized-windows.phpt
@@ -1,9 +1,9 @@
 --TEST--
-TestDox: Diff; Colorized; *nix
+TestDox: Diff; Colorized; Windows
 --SKIPIF--
 <?php declare(strict_types=1);
-if (stripos(\PHP_OS, 'WIN') === 0) {
-    print 'skip: Colorized diff is different on Windows.';
+if (stripos(\PHP_OS, 'WIN') !== 0) {
+    print 'skip: Colorized diff is different on *nix systems.';
 }
 --FILE--
 <?php declare(strict_types=1);
@@ -23,14 +23,14 @@ PHPUnit %s by Sebastian Bergmann and contributors.
  [31m✘[0m Something that does not work
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that two strings are equal.[0m
-   [31m┊[0m [31m---[2m·[22mExpected[0m
-   [31m┊[0m [32m+++[2m·[22mActual[0m
-   [31m┊[0m [36m@@ @@[0m
-   [31m┊[0m  'foo\n
-   [31m┊[0m [32m+baz\n[0m
-   [31m┊[0m  bar\n
-   [31m┊[0m [31m-baz\n[0m
-   [31m┊[0m  '
+   [31m├[0m [41;37m--- Expected                                [0m
+   [31m├[0m [41;37m+++ Actual                                  [0m
+   [31m├[0m [41;37m@@ @@                                       [0m
+   [31m├[0m [41;37m 'foo\n                                     [0m
+   [31m├[0m [41;37m+baz\n                                      [0m
+   [31m├[0m [41;37m bar\n                                      [0m
+   [31m├[0m [41;37m-baz\n                                      [0m
+   [31m├[0m [41;37m '                                          [0m
    [31m│[0m
    [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDiffTest.php[2m:[22m[34m%d[0m
    [31m┴[0m

--- a/tests/end-to-end/testdox/diff-colorized.phpt
+++ b/tests/end-to-end/testdox/diff-colorized.phpt
@@ -27,7 +27,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┊[0m [31m-baz\n[0m
    [31m┊[0m  '
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDiffTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDiffTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s

--- a/tests/end-to-end/testdox/metadata-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-data-provider-with-numeric-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-data-provider-with-numeric-data-set-name-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-data-provider-with-string-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-data-provider-with-string-data-set-name-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithStringDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithStringDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithStringDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithStringDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-verbose-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-verbose-colorized.phpt
@@ -23,7 +23,7 @@ Runtime:       %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -35,7 +35,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mMetadataTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-numeric-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-numeric-data-set-name-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-string-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-string-data-set-name-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/no-metadata-camel-case-colorized.phpt
+++ b/tests/end-to-end/testdox/no-metadata-camel-case-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mCamelCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mCamelCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mCamelCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mCamelCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/no-metadata-camel-case-verbose-colorized.phpt
+++ b/tests/end-to-end/testdox/no-metadata-camel-case-verbose-colorized.phpt
@@ -23,7 +23,7 @@ Runtime:       %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mCamelCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mCamelCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -35,7 +35,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mCamelCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mCamelCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/no-metadata-snake-case-colorized.phpt
+++ b/tests/end-to-end/testdox/no-metadata-snake-case-colorized.phpt
@@ -20,7 +20,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -32,7 +32,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/no-metadata-snake-case-verbose-colorized.phpt
+++ b/tests/end-to-end/testdox/no-metadata-snake-case-verbose-colorized.phpt
@@ -23,7 +23,7 @@ Runtime:       %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 Time: %s, Memory: %s
@@ -35,7 +35,7 @@ Summary of non-successful tests:
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m╵[0m %stests[2m/[22mend-to-end[2m/[22mtestdox[2m/[22m_files[2m/[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
+   [31m╵[0m %stests[2m%e[22mend-to-end[2m%e[22mtestdox[2m%e[22m_files[2m%e[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m


### PR DESCRIPTION
Sister-PR to #5490 for the 9.x series.

----

### E2E Tests: use OS agnostic directory separators

This fixes a number of tests which would otherwise fail when running on Windows.

### E2E/DiffTest: fix line endings

As far as I can see, this test is about the display of the diff, not about the line endings, in which case, let's make the line endings explicit and not OS-dependent to allow this test to pass on Windows as well.

### E2E/diff-colorized: add separate test for Windows

The colorized diff display on Windows is different from *nix systems.

This commit:
* Adds a test skip for the pre-existing test when the tests are run on Windows.
* Adds a separate test for the colorized diff display on Windows, which is skipped when running on *nix systems.

### GH Actions: actually run the tests on Windows

PR #3982 added test run builds against Windows OS.

I'm not sure if this ever worked, but it sure isn't working now. The environment is created, but the actual steps to run things are not doing anything due to the command not being understood by Windows.

This commit fixes that and allows the tests to actually run on Windows.