### PR TITLE
[10.3] GH Actions: actually run the tests on Windows (includes necessary fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,10 @@ jobs:
           tools: none
 
       - name: Install dependencies with Composer
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: ./phpunit --testsuite unit
+        run: php ./phpunit --testsuite unit
 
   end-to-end-tests:
     name: End-to-End Tests
@@ -146,10 +146,10 @@ jobs:
           tools: none
 
       - name: Install dependencies with Composer
-        run: ./tools/composer update --no-ansi --no-interaction --no-progress
+        run: php ./tools/composer update --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: ./phpunit --testsuite end-to-end
+        run: php ./phpunit --testsuite end-to-end
 
   code-coverage:
     name: Code Coverage

--- a/tests/end-to-end/cli/filter-error-handler/filter-for-error-handler-events-disabled.phpt
+++ b/tests/end-to-end/cli/filter-error-handler/filter-for-error-handler-events-disabled.phpt
@@ -16,7 +16,7 @@ require_once __DIR__ . '/../../../bootstrap.php';
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
-Configuration: %s/filter-disabled.xml
+Configuration: %s%efilter-disabled.xml
 
 W                                                                   1 / 1 (100%)
 
@@ -24,61 +24,61 @@ Time: %s, Memory: %s
 
 1 test triggered 2 warnings:
 
-1) %s/src/SourceClass.php:23
+1) %s%esrc%eSourceClass.php:23
 warning
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
-2) %s/vendor/VendorClass.php:10
+2) %s%evendor%eVendorClass.php:10
 warning
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
 --
 
 1 test triggered 2 notices:
 
-1) %s/src/SourceClass.php:22
+1) %s%esrc%eSourceClass.php:22
 notice
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
-2) %s/vendor/VendorClass.php:9
+2) %s%evendor%eVendorClass.php:9
 notice
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
 --
 
 1 test triggered 2 deprecations:
 
-1) %s/src/SourceClass.php:21
+1) %s%esrc%eSourceClass.php:21
 deprecation
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
-2) %s/vendor/VendorClass.php:8
+2) %s%evendor%eVendorClass.php:8
 deprecation
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
 OK, but there were issues!
 Tests: 1, Assertions: 1, Warnings: 2, Deprecations: 2, Notices: 2.

--- a/tests/end-to-end/cli/filter-error-handler/filter-for-error-handler-events-enabled.phpt
+++ b/tests/end-to-end/cli/filter-error-handler/filter-for-error-handler-events-enabled.phpt
@@ -16,7 +16,7 @@ require_once __DIR__ . '/../../../bootstrap.php';
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
-Configuration: %s/filter-enabled.xml
+Configuration: %s%efilter-enabled.xml
 
 W                                                                   1 / 1 (100%)
 
@@ -24,37 +24,37 @@ Time: %s, Memory: %s
 
 1 test triggered 1 warning:
 
-1) %s/src/SourceClass.php:23
+1) %s%esrc%eSourceClass.php:23
 warning
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
 --
 
 1 test triggered 1 notice:
 
-1) %s/src/SourceClass.php:22
+1) %s%esrc%eSourceClass.php:22
 notice
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
 --
 
 1 test triggered 1 deprecation:
 
-1) %s/src/SourceClass.php:21
+1) %s%esrc%eSourceClass.php:21
 deprecation
 
 Triggered by:
 
 * PHPUnit\TestFixture\FilterErrorHandler\SourceClassTest::testSomething
-  %s/tests/SourceClassTest.php:16
+  %s%etests%eSourceClassTest.php:16
 
 OK, but there were issues!
 Tests: 1, Assertions: 1, Warnings: 1, Deprecations: 1, Notices: 1.

--- a/tests/end-to-end/generic/transform-exception-hook-method.phpt
+++ b/tests/end-to-end/generic/transform-exception-hook-method.phpt
@@ -25,7 +25,7 @@ There was 1 error:
 1) PHPUnit\TestFixture\TransformExceptionHookMethod\Test::testOne
 PHPUnit\TestFixture\TransformExceptionHookMethod\TransformedException: transformed message
 
-%s/Test.php:24
+%s%eTest.php:24
 
 ERRORS!
 Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/end-to-end/logging/teamcity-directory.phpt
+++ b/tests/end-to-end/logging/teamcity-directory.phpt
@@ -18,85 +18,85 @@ Runtime: %s
 
 ##teamcity[testCount count='19' flowId='%d']
 
-##teamcity[testSuiteStarted name='%stests/end-to-end/_files/basic/unit' flowId='%d']
+##teamcity[testSuiteStarted name='%stests%eend-to-end%e_files%ebasic%eunit' flowId='%d']
 
-##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\SetUpBeforeClassTest' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/SetUpBeforeClassTest.php::\PHPUnit\SelfTest\Basic\SetUpBeforeClassTest' flowId='%d']
+##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\SetUpBeforeClassTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eSetUpBeforeClassTest.php::\PHPUnit\SelfTest\Basic\SetUpBeforeClassTest' flowId='%d']
 
-##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\SetUpTest' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/SetUpTest.php::\PHPUnit\SelfTest\Basic\SetUpTest' flowId='%d']
+##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\SetUpTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eSetUpTest.php::\PHPUnit\SelfTest\Basic\SetUpTest' flowId='%d']
 
-##teamcity[testFailed name='testOneWithSetUpException' message='RuntimeException: throw exception in setUp' details='%stests/end-to-end/_files/basic/unit/SetUpTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testFailed name='testOneWithSetUpException' message='RuntimeException: throw exception in setUp' details='%stests%eend-to-end%e_files%ebasic%eunit%eSetUpTest.php:%d|n' duration='%d' flowId='%d']
 
-##teamcity[testFailed name='testTwoWithSetUpException' message='RuntimeException: throw exception in setUp' details='%stests/end-to-end/_files/basic/unit/SetUpTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testFailed name='testTwoWithSetUpException' message='RuntimeException: throw exception in setUp' details='%stests%eend-to-end%e_files%ebasic%eunit%eSetUpTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testSuiteFinished name='PHPUnit\SelfTest\Basic\SetUpTest' flowId='%d']
 
-##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\StatusTest' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest' flowId='%d']
+##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\StatusTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest' flowId='%d']
 
-##teamcity[testStarted name='testSuccess' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSuccess' flowId='%d']
+##teamcity[testStarted name='testSuccess' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSuccess' flowId='%d']
 
 ##teamcity[testFinished name='testSuccess' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testFailure' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testFailure' flowId='%d']
+##teamcity[testStarted name='testFailure' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testFailure' flowId='%d']
 
-##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%stests/end-to-end/_files/basic/unit/StatusTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testFailure' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testError' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testError' flowId='%d']
+##teamcity[testStarted name='testError' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testError' flowId='%d']
 
-##teamcity[testFailed name='testError' message='RuntimeException' details='%stests/end-to-end/_files/basic/unit/StatusTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testFailed name='testError' message='RuntimeException' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testError' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testIncomplete' flowId='%d']
+##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testIncomplete' flowId='%d']
 
-##teamcity[testIgnored name='testIncomplete' message='' details='%stests/end-to-end/_files/basic/unit/StatusTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testIgnored name='testIncomplete' message='' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testIncomplete' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testSkipped' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSkipped' flowId='%d']
+##teamcity[testStarted name='testSkipped' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSkipped' flowId='%d']
 
 ##teamcity[testIgnored name='testSkipped' message='' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testSkipped' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testRisky' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testRisky' flowId='%d']
+##teamcity[testStarted name='testRisky' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testRisky' flowId='%d']
 
 ##teamcity[testFailed name='testRisky' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testRisky' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testSuccessWithMessage' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSuccessWithMessage' flowId='%d']
+##teamcity[testStarted name='testSuccessWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSuccessWithMessage' flowId='%d']
 
 ##teamcity[testFinished name='testSuccessWithMessage' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testFailureWithMessage' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testFailureWithMessage' flowId='%d']
+##teamcity[testStarted name='testFailureWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testFailureWithMessage' flowId='%d']
 
-##teamcity[testFailed name='testFailureWithMessage' message='failure with custom message|nFailed asserting that false is true.' details='%stests/end-to-end/_files/basic/unit/StatusTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testFailed name='testFailureWithMessage' message='failure with custom message|nFailed asserting that false is true.' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testFailureWithMessage' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testErrorWithMessage' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testErrorWithMessage' flowId='%d']
+##teamcity[testStarted name='testErrorWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testErrorWithMessage' flowId='%d']
 
-##teamcity[testFailed name='testErrorWithMessage' message='RuntimeException: error with custom message' details='%stests/end-to-end/_files/basic/unit/StatusTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testFailed name='testErrorWithMessage' message='RuntimeException: error with custom message' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testErrorWithMessage' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testIncompleteWithMessage' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testIncompleteWithMessage' flowId='%d']
+##teamcity[testStarted name='testIncompleteWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testIncompleteWithMessage' flowId='%d']
 
-##teamcity[testIgnored name='testIncompleteWithMessage' message='incomplete with custom message' details='%stests/end-to-end/_files/basic/unit/StatusTest.php:%d|n' duration='%d' flowId='%d']
+##teamcity[testIgnored name='testIncompleteWithMessage' message='incomplete with custom message' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testIncompleteWithMessage' duration='%d' flowId='%d']
 
 ##teamcity[testIgnored name='testSkippedByMetadata' message='PHP > 9000 is required.' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testSkippedWithMessage' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSkippedWithMessage' flowId='%d']
+##teamcity[testStarted name='testSkippedWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testSkippedWithMessage' flowId='%d']
 
 ##teamcity[testIgnored name='testSkippedWithMessage' message='skipped with custom message' duration='%d' flowId='%d']
 
 ##teamcity[testFinished name='testSkippedWithMessage' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testRiskyWithMessage' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/StatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testRiskyWithMessage' flowId='%d']
+##teamcity[testStarted name='testRiskyWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\SelfTest\Basic\StatusTest::testRiskyWithMessage' flowId='%d']
 
 ##teamcity[testFailed name='testRiskyWithMessage' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
 
@@ -104,19 +104,19 @@ Runtime: %s
 
 ##teamcity[testSuiteFinished name='PHPUnit\SelfTest\Basic\StatusTest' flowId='%d']
 
-##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\TearDownAfterClassTest' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/TearDownAfterClassTest.php::\PHPUnit\SelfTest\Basic\TearDownAfterClassTest' flowId='%d']
+##teamcity[testSuiteStarted name='PHPUnit\SelfTest\Basic\TearDownAfterClassTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eTearDownAfterClassTest.php::\PHPUnit\SelfTest\Basic\TearDownAfterClassTest' flowId='%d']
 
-##teamcity[testStarted name='testOne' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/TearDownAfterClassTest.php::\PHPUnit\SelfTest\Basic\TearDownAfterClassTest::testOne' flowId='%d']
+##teamcity[testStarted name='testOne' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eTearDownAfterClassTest.php::\PHPUnit\SelfTest\Basic\TearDownAfterClassTest::testOne' flowId='%d']
 
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
 
-##teamcity[testStarted name='testTwo' locationHint='php_qn://%stests/end-to-end/_files/basic/unit/TearDownAfterClassTest.php::\PHPUnit\SelfTest\Basic\TearDownAfterClassTest::testTwo' flowId='%d']
+##teamcity[testStarted name='testTwo' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eTearDownAfterClassTest.php::\PHPUnit\SelfTest\Basic\TearDownAfterClassTest::testTwo' flowId='%d']
 
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
 
 ##teamcity[testSuiteFinished name='PHPUnit\SelfTest\Basic\TearDownAfterClassTest' flowId='%d']
 
-##teamcity[testSuiteFinished name='%stests/end-to-end/_files/basic/unit' flowId='%d']
+##teamcity[testSuiteFinished name='%stests%eend-to-end%e_files%ebasic%eunit' flowId='%d']
 Time: %s, Memory: %s
 
 There were 5 errors:
@@ -124,27 +124,27 @@ There were 5 errors:
 1) PHPUnit\SelfTest\Basic\SetUpBeforeClassTest
 Exception: forcing an Exception in setUpBeforeClass()
 
-%s/SetUpBeforeClassTest.php:%d
+%s%eSetUpBeforeClassTest.php:%d
 
 2) PHPUnit\SelfTest\Basic\SetUpTest::testOneWithSetUpException
 RuntimeException: throw exception in setUp
 
-%s/SetUpTest.php:%d
+%s%eSetUpTest.php:%d
 
 3) PHPUnit\SelfTest\Basic\SetUpTest::testTwoWithSetUpException
 RuntimeException: throw exception in setUp
 
-%s/SetUpTest.php:%d
+%s%eSetUpTest.php:%d
 
 4) PHPUnit\SelfTest\Basic\StatusTest::testError
 RuntimeException: 
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 5) PHPUnit\SelfTest\Basic\StatusTest::testErrorWithMessage
 RuntimeException: error with custom message
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -153,13 +153,13 @@ There were 2 failures:
 1) PHPUnit\SelfTest\Basic\StatusTest::testFailure
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 2) PHPUnit\SelfTest\Basic\StatusTest::testFailureWithMessage
 failure with custom message
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -168,12 +168,12 @@ There were 2 risky tests:
 1) PHPUnit\SelfTest\Basic\StatusTest::testRisky
 This test did not perform any assertions
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 2) PHPUnit\SelfTest\Basic\StatusTest::testRiskyWithMessage
 This test did not perform any assertions
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 ERRORS!
 Tests: 18, Assertions: 6, Errors: 5, Failures: 2, Skipped: 3, Incomplete: 2, Risky: 2.

--- a/tests/end-to-end/logging/teamcity-file.phpt
+++ b/tests/end-to-end/logging/teamcity-file.phpt
@@ -98,12 +98,12 @@ There were 2 errors:
 1) PHPUnit\SelfTest\Basic\StatusTest::testError
 RuntimeException: 
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 2) PHPUnit\SelfTest\Basic\StatusTest::testErrorWithMessage
 RuntimeException: error with custom message
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -112,13 +112,13 @@ There were 2 failures:
 1) PHPUnit\SelfTest\Basic\StatusTest::testFailure
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 2) PHPUnit\SelfTest\Basic\StatusTest::testFailureWithMessage
 failure with custom message
 Failed asserting that false is true.
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 --
 
@@ -127,12 +127,12 @@ There were 2 risky tests:
 1) PHPUnit\SelfTest\Basic\StatusTest::testRisky
 This test did not perform any assertions
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 2) PHPUnit\SelfTest\Basic\StatusTest::testRiskyWithMessage
 This test did not perform any assertions
 
-%s/StatusTest.php:%d
+%s%eStatusTest.php:%d
 
 ERRORS!
 Tests: 13, Assertions: 4, Errors: 2, Failures: 2, Skipped: 3, Incomplete: 2, Risky: 2.

--- a/tests/end-to-end/logging/teamcity-warning.phpt
+++ b/tests/end-to-end/logging/teamcity-warning.phpt
@@ -19,13 +19,13 @@ Configuration: %s
 
 ##teamcity[testCount count='1' flowId='%d']
 
-##teamcity[testSuiteStarted name='%s/tests/end-to-end/logging/_files/teamcity-warning/phpunit.xml' flowId='%d']
+##teamcity[testSuiteStarted name='%s%etests%eend-to-end%elogging%e_files%eteamcity-warning%ephpunit.xml' flowId='%d']
 
 ##teamcity[testSuiteStarted name='default' flowId='%d']
 
-##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Test' locationHint='php_qn://%s/teamcity-warning/tests/Test.php::\PHPUnit\TestFixture\Test' flowId='%d']
+##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Test' locationHint='php_qn://%s%eteamcity-warning%etests%eTest.php::\PHPUnit\TestFixture\Test' flowId='%d']
 
-##teamcity[testStarted name='testOne' locationHint='php_qn://%s/teamcity-warning/tests/Test.php::\PHPUnit\TestFixture\Test::testOne' flowId='%d']
+##teamcity[testStarted name='testOne' locationHint='php_qn://%s%eteamcity-warning%etests%eTest.php::\PHPUnit\TestFixture\Test::testOne' flowId='%d']
 
 ##teamcity[testFinished name='testOne' duration='%s' flowId='%d']
 
@@ -33,7 +33,7 @@ Configuration: %s
 
 ##teamcity[testSuiteFinished name='default' flowId='%d']
 
-##teamcity[testSuiteFinished name='%s/tests/end-to-end/logging/_files/teamcity-warning/phpunit.xml' flowId='%d']
+##teamcity[testSuiteFinished name='%s%etests%eend-to-end%elogging%e_files%eteamcity-warning%ephpunit.xml' flowId='%d']
 Time: %s, Memory: %s
 
 There was 1 PHPUnit test runner warning:

--- a/tests/end-to-end/regression/5340.phpt
+++ b/tests/end-to-end/regression/5340.phpt
@@ -36,13 +36,13 @@ There were 2 risky tests:
 1) Issue5340Test::testOne
 This test printed output: output printed from passing test
 
-%s/Issue5340Test.php:%d
+%s%eIssue5340Test.php:%d
 
 2) Issue5340Test::testTwo
 This test printed output: 
 output printed from failing test
 
-%s/Issue5340Test.php:%d
+%s%eIssue5340Test.php:%d
 
 FAILURES!
 Tests: 2, Assertions: 2, Failures: 1, Risky: 2.

--- a/tests/end-to-end/regression/5451.phpt
+++ b/tests/end-to-end/regression/5451.phpt
@@ -24,7 +24,7 @@ There was 1 PHPUnit error:
 The data provider specified for PHPUnit\TestFixture\Issue5451\Issue5451Test::testWithErrorInDataProvider is invalid
 Call to a member function bar() on array
 
-%s/Issue5451Test.php:26
+%s%eIssue5451Test.php:26
 
 ERRORS!
 Tests: 1, Assertions: 1, Errors: 1.

--- a/tests/end-to-end/regression/5498.phpt
+++ b/tests/end-to-end/regression/5498.phpt
@@ -26,7 +26,7 @@ Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/5498, 1 test)
+Test Suite Started (%s%e5498, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Issue5498\Test, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Issue5498\Test::testOne)
 Before Test Method Called (PHPUnit\TestFixture\Issue5498\Test::parentBefore)
@@ -44,7 +44,7 @@ After Test Method Finished:
 - PHPUnit\TestFixture\Issue5498\Test::parentAfter
 Test Finished (PHPUnit\TestFixture\Issue5498\Test::testOne)
 Test Suite Finished (PHPUnit\TestFixture\Issue5498\Test, 1 test)
-Test Suite Finished (%s/5498, 1 test)
+Test Suite Finished (%s%e5498, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/testdox/_files/DiffTest.php
+++ b/tests/end-to-end/testdox/_files/DiffTest.php
@@ -9,7 +9,6 @@
  */
 namespace PHPUnit\TestFixture\TestDox;
 
-use const PHP_EOL;
 use PHPUnit\Framework\TestCase;
 
 final class DiffTest extends TestCase
@@ -17,8 +16,8 @@ final class DiffTest extends TestCase
     public function testSomethingThatDoesNotWork(): void
     {
         $this->assertEquals(
-            'foo' . PHP_EOL . 'bar' . PHP_EOL . 'baz' . PHP_EOL,
-            'foo' . PHP_EOL . 'baz' . PHP_EOL . 'bar' . PHP_EOL,
+            "foo\nbar\nbaz\n",
+            "foo\nbaz\nbar\n",
         );
     }
 }

--- a/tests/end-to-end/testdox/data-provider-with-numeric-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/data-provider-with-numeric-data-set-name-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDataProviderWithNumericDataSetNameTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDataProviderWithNumericDataSetNameTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/data-provider-with-string-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/data-provider-with-string-data-set-name-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDataProviderWithStringDataSetNameTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDataProviderWithStringDataSetNameTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/diff-colorized-windows.phpt
+++ b/tests/end-to-end/testdox/diff-colorized-windows.phpt
@@ -1,9 +1,9 @@
 --TEST--
-TestDox: Diff; Colorized; *nix
+TestDox: Diff; Colorized; Windows
 --SKIPIF--
 <?php declare(strict_types=1);
-if (stripos(\PHP_OS, 'WIN') === 0) {
-    print 'skip: Colorized diff is different on Windows.';
+if (stripos(\PHP_OS, 'WIN') !== 0) {
+    print 'skip: Colorized diff is different on *nix systems.';
 }
 --FILE--
 <?php declare(strict_types=1);
@@ -28,14 +28,14 @@ Time: %s, Memory: %s
 [31m ✘ [0mSomething that does not work
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that two strings are equal.[0m
-   [31m┊[0m [31m---[2m·[22mExpected[0m
-   [31m┊[0m [32m+++[2m·[22mActual[0m
-   [31m┊[0m [36m@@ @@[0m
-   [31m┊[0m  'foo\n
-   [31m┊[0m [32m+baz\n[0m
-   [31m┊[0m  bar\n
-   [31m┊[0m [31m-baz\n[0m
-   [31m┊[0m  '
+   [31m├[0m [41;37m--- Expected                                [0m
+   [31m├[0m [41;37m+++ Actual                                  [0m
+   [31m├[0m [41;37m@@ @@                                       [0m
+   [31m├[0m [41;37m 'foo\n                                     [0m
+   [31m├[0m [41;37m+baz\n                                      [0m
+   [31m├[0m [41;37m bar\n                                      [0m
+   [31m├[0m [41;37m-baz\n                                      [0m
+   [31m├[0m [41;37m '                                          [0m
    [31m│[0m
    [31m│[0m %s[22m_files[2m%e[22mDiffTest.php[2m:[22m[34m%d[0m
    [31m┴[0m

--- a/tests/end-to-end/testdox/diff-colorized.phpt
+++ b/tests/end-to-end/testdox/diff-colorized.phpt
@@ -32,7 +32,7 @@ Time: %s, Memory: %s
    [31m┊[0m [31m-baz\n[0m
    [31m┊[0m  '
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDiffTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDiffTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mMetadataTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-data-provider-with-numeric-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-data-provider-with-numeric-data-set-name-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-data-provider-with-string-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-data-provider-with-string-data-set-name-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDataProviderWithStringDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDataProviderWithStringDataSetNameAndMetadataTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-numeric-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-numeric-data-set-name-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDataProviderWithNumericDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-string-data-set-name-colorized.phpt
+++ b/tests/end-to-end/testdox/metadata-with-placeholders-data-provider-with-string-data-set-name-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mDataProviderWithStringDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mDataProviderWithStringDataSetNameAndMetadataWithPlaceholdersTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/no-metadata-camel-case-colorized.phpt
+++ b/tests/end-to-end/testdox/no-metadata-camel-case-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mCamelCaseTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mCamelCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/end-to-end/testdox/no-metadata-snake-case-colorized.phpt
+++ b/tests/end-to-end/testdox/no-metadata-snake-case-colorized.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
    [31m┐[0m
    [31m├[0m [41;37mFailed asserting that false is true.[0m
    [31m│[0m
-   [31m│[0m %s[22m_files[2m/[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
+   [31m│[0m %s[22m_files[2m%e[22mSnakeCaseTest.php[2m:[22m[34m%d[0m
    [31m┴[0m
 
 [37;41mFAILURES![0m

--- a/tests/unit/Event/Events/Test/HookMethod/AfterLastTestMethodFinishedTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/AfterLastTestMethodFinishedTest.php
@@ -43,7 +43,7 @@ final class AfterLastTestMethodFinishedTest extends AbstractEventTestCase
             ...$this->calledMethods(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 After Last Test Method Finished:
 - HookClass::hookMethod

--- a/tests/unit/Event/Events/Test/HookMethod/AfterTestMethodFinishedTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/AfterTestMethodFinishedTest.php
@@ -43,7 +43,7 @@ final class AfterTestMethodFinishedTest extends AbstractEventTestCase
             ...$this->calledMethods(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 After Test Method Finished:
 - HookClass::hookMethod

--- a/tests/unit/Event/Events/Test/HookMethod/BeforeFirstTestMethodErroredTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/BeforeFirstTestMethodErroredTest.php
@@ -48,7 +48,7 @@ final class BeforeFirstTestMethodErroredTest extends AbstractEventTestCase
             Code\ThrowableBuilder::from(new Exception('message')),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Before First Test Method Errored (HookClass::hookMethod)
 message

--- a/tests/unit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFinishedTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFinishedTest.php
@@ -43,7 +43,7 @@ final class BeforeFirstTestMethodFinishedTest extends AbstractEventTestCase
             ...$this->calledMethods(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Before First Test Method Finished:
 - HookClass::hookMethod

--- a/tests/unit/Event/Events/Test/HookMethod/BeforeTestMethodFinishedTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/BeforeTestMethodFinishedTest.php
@@ -43,7 +43,7 @@ final class BeforeTestMethodFinishedTest extends AbstractEventTestCase
             ...$this->calledMethods(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Before Test Method Finished:
 - HookClass::hookMethod

--- a/tests/unit/Event/Events/Test/HookMethod/PostConditionFinishedTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/PostConditionFinishedTest.php
@@ -43,7 +43,7 @@ final class PostConditionFinishedTest extends AbstractEventTestCase
             ...$this->calledMethods(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Post Condition Method Finished:
 - HookClass::hookMethod

--- a/tests/unit/Event/Events/Test/HookMethod/PreConditionFinishedTest.php
+++ b/tests/unit/Event/Events/Test/HookMethod/PreConditionFinishedTest.php
@@ -43,7 +43,7 @@ final class PreConditionFinishedTest extends AbstractEventTestCase
             ...$this->calledMethods(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Pre Condition Method Finished:
 - HookClass::hookMethod

--- a/tests/unit/Event/Events/Test/Issue/ConsideredRiskyTest.php
+++ b/tests/unit/Event/Events/Test/Issue/ConsideredRiskyTest.php
@@ -43,7 +43,7 @@ final class ConsideredRiskyTest extends AbstractEventTestCase
             'message',
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Test Considered Risky (FooTest::testBar)
 message

--- a/tests/unit/Event/Events/Test/Lifecycle/DataProviderMethodFinishedTest.php
+++ b/tests/unit/Event/Events/Test/Lifecycle/DataProviderMethodFinishedTest.php
@@ -43,7 +43,7 @@ final class DataProviderMethodFinishedTest extends AbstractEventTestCase
             new ClassMethod('ClassTest', 'dataProvider'),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Data Provider Method Finished for ClassTest::testOne:
 - ClassTest::dataProvider

--- a/tests/unit/Event/Events/Test/Outcome/ErroredTest.php
+++ b/tests/unit/Event/Events/Test/Outcome/ErroredTest.php
@@ -44,7 +44,7 @@ final class ErroredTest extends AbstractEventTestCase
             $this->throwable(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Test Errored (FooTest::testBar)
 error

--- a/tests/unit/Event/Events/Test/Outcome/FailedTest.php
+++ b/tests/unit/Event/Events/Test/Outcome/FailedTest.php
@@ -70,7 +70,7 @@ final class FailedTest extends AbstractEventTestCase
             null,
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Test Failed (FooTest::testBar)
 failure

--- a/tests/unit/Event/Events/Test/Outcome/MarkedIncompleteTest.php
+++ b/tests/unit/Event/Events/Test/Outcome/MarkedIncompleteTest.php
@@ -44,7 +44,7 @@ final class MarkedIncompleteTest extends AbstractEventTestCase
             $this->throwable(),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Test Marked Incomplete (FooTest::testBar)
 incomplete

--- a/tests/unit/Event/Events/Test/Outcome/SkippedTest.php
+++ b/tests/unit/Event/Events/Test/Outcome/SkippedTest.php
@@ -42,7 +42,7 @@ final class SkippedTest extends AbstractEventTestCase
             'skipped',
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Test Skipped (FooTest::testBar)
 skipped

--- a/tests/unit/Event/Events/Test/PrintedUnexpectedOutputTest.php
+++ b/tests/unit/Event/Events/Test/PrintedUnexpectedOutputTest.php
@@ -38,7 +38,7 @@ final class PrintedUnexpectedOutputTest extends AbstractEventTestCase
             'output',
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'EOT'
 Test Printed Unexpected Output
 output

--- a/tests/unit/Framework/Constraint/Equality/IsEqualCanonicalizingTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualCanonicalizingTest.php
@@ -277,8 +277,8 @@ Failed asserting that two strings are equal.
 +another-string'
 
 EOT,
-                'string' . PHP_EOL . 'string',
-                'another-string' . PHP_EOL . 'another-string',
+                "string\nstring",
+                "another-string\nanother-string",
             ],
         ];
     }

--- a/tests/unit/Framework/Constraint/Equality/IsEqualIgnoringCaseTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualIgnoringCaseTest.php
@@ -254,8 +254,8 @@ Failed asserting that two strings are equal.
 +another-string'
 
 EOT,
-                'string' . PHP_EOL . 'string',
-                'another-string' . PHP_EOL . 'another-string',
+                "string\nstring",
+                "another-string\nanother-string",
             ],
         ];
     }

--- a/tests/unit/Framework/Constraint/Equality/IsEqualTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualTest.php
@@ -289,8 +289,8 @@ Failed asserting that two strings are equal.
 +another-string'
 
 EOT,
-                'string' . PHP_EOL . 'string',
-                'another-string' . PHP_EOL . 'another-string',
+                "string\nstring",
+                "another-string\nanother-string",
             ],
         ];
     }

--- a/tests/unit/TextUI/Output/Default/ResultPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/ResultPrinterTest.php
@@ -9,7 +9,9 @@
  */
 namespace PHPUnit\TextUI\Output\Default;
 
+use const PHP_OS;
 use function hrtime;
+use function stripos;
 use Exception;
 use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
@@ -136,7 +138,9 @@ final class ResultPrinterTest extends TestCase
             ],
 
             'risky test with multiple reasons with multi-line messages' => [
-                __DIR__ . '/expectations/risky_test_with_multiple_reasons_with_multi_line_messages.txt',
+                (stripos(PHP_OS, 'WIN') === 0) ?
+                    __DIR__ . '/expectations/risky_test_with_multiple_reasons_with_multi_line_messages_windows.txt' :
+                    __DIR__ . '/expectations/risky_test_with_multiple_reasons_with_multi_line_messages.txt',
                 self::createTestResult(
                     testConsideredRiskyEvents: [
                         'Foo::testBar' => [

--- a/tests/unit/TextUI/Output/Default/expectations/risky_test_with_multiple_reasons_with_multi_line_messages_windows.txt
+++ b/tests/unit/TextUI/Output/Default/expectations/risky_test_with_multiple_reasons_with_multi_line_messages_windows.txt
@@ -1,0 +1,15 @@
+There was 1 risky test:
+
+1) FooTest::testBar
+* message
+message
+message
+
+* message
+message
+message
+
+%s:%i
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Risky: 1.

--- a/tests/unit/TextUI/SourceFilterTest.php
+++ b/tests/unit/TextUI/SourceFilterTest.php
@@ -26,7 +26,7 @@ final class SourceFilterTest extends TestCase
         return [
             'file included using file' => [
                 true,
-                $fixtureDirectory . '/a/PrefixSuffix.php',
+                $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php',
                 new Source(
                     FilterDirectoryCollection::fromArray([]),
                     FileCollection::fromArray(
@@ -50,7 +50,7 @@ final class SourceFilterTest extends TestCase
             ],
             'file included using file, but excluded using directory' => [
                 false,
-                $fixtureDirectory . '/a/PrefixSuffix.php',
+                $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php',
                 new Source(
                     FilterDirectoryCollection::fromArray([]),
                     FileCollection::fromArray(
@@ -82,7 +82,7 @@ final class SourceFilterTest extends TestCase
             ],
             'file included using file, but excluded using file' => [
                 false,
-                $fixtureDirectory . '/a/PrefixSuffix.php',
+                $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php',
                 new Source(
                     FilterDirectoryCollection::fromArray([]),
                     FileCollection::fromArray(
@@ -110,7 +110,7 @@ final class SourceFilterTest extends TestCase
             ],
             'file included using directory' => [
                 true,
-                $fixtureDirectory . '/a/PrefixSuffix.php',
+                $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php',
                 new Source(
                     FilterDirectoryCollection::fromArray(
                         [
@@ -138,7 +138,7 @@ final class SourceFilterTest extends TestCase
             ],
             'file included using directory, but excluded using file' => [
                 false,
-                $fixtureDirectory . '/a/PrefixSuffix.php',
+                $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php',
                 new Source(
                     FilterDirectoryCollection::fromArray(
                         [
@@ -170,7 +170,7 @@ final class SourceFilterTest extends TestCase
             ],
             'file included using directory, but excluded using directory' => [
                 false,
-                $fixtureDirectory . '/a/PrefixSuffix.php',
+                $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php',
                 new Source(
                     FilterDirectoryCollection::fromArray(
                         [

--- a/tests/unit/TextUI/SourceMapperTest.php
+++ b/tests/unit/TextUI/SourceMapperTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use const DIRECTORY_SEPARATOR;
 use function realpath;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -26,7 +27,7 @@ final class SourceMapperTest extends TestCase
         return [
             'file included using file' => [
                 [
-                    $fixtureDirectory . '/a/PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
                 ],
                 new Source(
                     FilterDirectoryCollection::fromArray([]),
@@ -111,18 +112,18 @@ final class SourceMapperTest extends TestCase
             ],
             'file included using directory' => [
                 [
-                    $fixtureDirectory . '/a/PrefixSuffix.php'     => true,
-                    $fixtureDirectory . '/a/c/Prefix.php'         => true,
-                    $fixtureDirectory . '/a/c/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/a/c/Suffix.php'         => true,
-                    $fixtureDirectory . '/a/c/d/Prefix.php'       => true,
-                    $fixtureDirectory . '/a/c/d/PrefixSuffix.php' => true,
-                    $fixtureDirectory . '/a/c/d/Suffix.php'       => true,
-                    $fixtureDirectory . '/b/PrefixSuffix.php'     => true,
-                    $fixtureDirectory . '/b/e/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/b/e/g/PrefixSuffix.php' => true,
-                    $fixtureDirectory . '/b/f/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/b/f/h/PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                                                         => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'Prefix.php'                                   => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'Suffix.php'                                   => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'Prefix.php'       => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'Suffix.php'       => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                                                         => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'e' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'e' . DIRECTORY_SEPARATOR . 'g' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'f' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'f' . DIRECTORY_SEPARATOR . 'h' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
                 ],
                 new Source(
                     FilterDirectoryCollection::fromArray(
@@ -151,17 +152,17 @@ final class SourceMapperTest extends TestCase
             ],
             'file included using directory, but excluded using file' => [
                 [
-                    $fixtureDirectory . '/a/c/Prefix.php'         => true,
-                    $fixtureDirectory . '/a/c/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/a/c/Suffix.php'         => true,
-                    $fixtureDirectory . '/a/c/d/Prefix.php'       => true,
-                    $fixtureDirectory . '/a/c/d/PrefixSuffix.php' => true,
-                    $fixtureDirectory . '/a/c/d/Suffix.php'       => true,
-                    $fixtureDirectory . '/b/PrefixSuffix.php'     => true,
-                    $fixtureDirectory . '/b/e/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/b/e/g/PrefixSuffix.php' => true,
-                    $fixtureDirectory . '/b/f/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/b/f/h/PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'Prefix.php'                                   => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'Suffix.php'                                   => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'Prefix.php'       => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'Suffix.php'       => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                                                         => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'e' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'e' . DIRECTORY_SEPARATOR . 'g' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'f' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'f' . DIRECTORY_SEPARATOR . 'h' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
                 ],
                 new Source(
                     FilterDirectoryCollection::fromArray(
@@ -194,11 +195,11 @@ final class SourceMapperTest extends TestCase
             ],
             'file included using directory, but excluded using directory' => [
                 [
-                    $fixtureDirectory . '/b/PrefixSuffix.php'     => true,
-                    $fixtureDirectory . '/b/e/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/b/e/g/PrefixSuffix.php' => true,
-                    $fixtureDirectory . '/b/f/PrefixSuffix.php'   => true,
-                    $fixtureDirectory . '/b/f/h/PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                                                         => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'e' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'e' . DIRECTORY_SEPARATOR . 'g' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'f' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php'                             => true,
+                    $fixtureDirectory . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'f' . DIRECTORY_SEPARATOR . 'h' . DIRECTORY_SEPARATOR . 'PrefixSuffix.php' => true,
                 ],
                 new Source(
                     FilterDirectoryCollection::fromArray(


### PR DESCRIPTION
Sister-PR to #5490 and #5500 for the 10.x series.

Note: the build does not (yet) pass. This is related to a finding from the tests, which points to a potential bug - see commit https://github.com/sebastianbergmann/phpunit/commit/4c478fe9e7858ea631fc6f2f77571ff4f5c33240 for more info.

---

### E2E Tests: use OS agnostic directory separators

This fixes a number of tests which would otherwise fail when running on Windows.

### E2E/DiffTest: fix line endings

As far as I can see, this test is about the display of the diff, not about the line endings, in which case, let's make the line endings explicit and not OS-dependent to allow this test to pass on Windows as well.

### E2E/diff-colorized: add separate test for Windows

The colorized diff display on Windows is different from *nix systems.

This commit:
* Adds a test skip for the pre-existing test when the tests are run on Windows.
* Adds a separate test for the colorized diff display on Windows, which is skipped when running on *nix systems. (Note: this is an adjusted test compared to the 9.x version)

### Unit tests: compare multi-line expectations ignoring line endings

As the test files are saved using linux lined endings, while the actual output is generated using the `PHP_EOL` constant, the output will not match unless the line ending type is ignored.

### Unit Tests/SourceFilterTest: use OS based directory separators

Allow the `SourceFilter` class to actually find the file when included by using the correct OS based directory separator.

### Unit Tests/IsEqual*Tests: fix line endings

As far as I can see, these tests are about the "is equal" constraint, not about the line endings, in which case, let's make the line endings explicit and not OS-dependent to allow the failure message comparison test to pass on Windows as well.

### Unit Tests/ResultPrinterTest: allow for slight difference in resulting output on Windows

Not sure if this should be considered a bug, but the output does look different on Windows.

For now, I've added a separate expectation file for Windows to document the difference.

### Unit Tests/SourceMapperTest: use OS based directory separators

While this fixes the majority of the test failure diff, it does actually highlight something which could be considered a bug and for which I'd like a second opinion before investing time in this:
```
1) PHPUnit\TextUI\Configuration\SourceMapperTest::testDeterminesWhetherFileIsIncluded with data set "file included using directory"
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\PrefixSuffix.php' => true
+    'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\.hidden\PrefixSuffix.php' => true
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\Prefix.php' => true
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\PrefixSuffix.php' => true
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\Suffix.php' => true

2) PHPUnit\TextUI\Configuration\SourceMapperTest::testDeterminesWhetherFileIsIncluded with data set "file included using directory, but excluded using file"
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
+    'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\.hidden\PrefixSuffix.php' => true
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\Prefix.php' => true
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\PrefixSuffix.php' => true
     'E:\path\to\PHPUnit\phpunit\tests\_files\source-filter\a\c\Suffix.php' => true
```

### GH Actions: actually run the tests on Windows

PR #3982 added test run builds against Windows OS.

I'm not sure if this ever worked, but it sure isn't working now. The environment is created, but the actual steps to run things are not doing anything due to the command not being understood by Windows.

This commit fixes that and allows the tests to actually run on Windows.