### PR TITLE
Improve the failure description of `StringContains`-based assertions when the strings are encoded differently

### DIFF
--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -115,7 +115,7 @@ final class StringContains extends Constraint
 
     private function getDetectedEncoding(mixed $other): string
     {
-        if ($this->ignoreCase === true) {
+        if ($this->ignoreCase) {
             return 'Encoding ignored';
         }
 

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -48,8 +48,10 @@ final class StringContains extends Constraint
         }
 
         return sprintf(
-            'contains "%s"',
+            'contains "%s" [%s](length: %s)',
             $string,
+            mb_detect_encoding($string),
+            strlen($string)
         );
     }
 

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -10,10 +10,12 @@
 namespace PHPUnit\Framework\Constraint;
 
 use function is_string;
+use function mb_detect_encoding;
 use function mb_stripos;
 use function mb_strtolower;
 use function sprintf;
 use function str_contains;
+use function strlen;
 use function strtr;
 
 /**
@@ -21,17 +23,17 @@ use function strtr;
  */
 final class StringContains extends Constraint
 {
-    private readonly string $string;
+    private readonly string $needle;
     private readonly bool $ignoreCase;
     private readonly bool $ignoreLineEndings;
 
-    public function __construct(string $string, bool $ignoreCase = false, bool $ignoreLineEndings = false)
+    public function __construct(string $needle, bool $ignoreCase = false, bool $ignoreLineEndings = false)
     {
         if ($ignoreLineEndings) {
-            $string = $this->normalizeLineEndings($string);
+            $needle = $this->normalizeLineEndings($needle);
         }
 
-        $this->string            = $string;
+        $this->needle            = $needle;
         $this->ignoreCase        = $ignoreCase;
         $this->ignoreLineEndings = $ignoreLineEndings;
     }
@@ -41,18 +43,67 @@ final class StringContains extends Constraint
      */
     public function toString(): string
     {
-        $string = $this->string;
+        $needle = $this->needle;
 
         if ($this->ignoreCase) {
-            $string = mb_strtolower($this->string, 'UTF-8');
+            $needle = mb_strtolower($this->needle, 'UTF-8');
         }
 
         return sprintf(
             'contains "%s" [%s](length: %s)',
-            $string,
-            mb_detect_encoding($string),
-            strlen($string)
+            $needle,
+            $this->getDetectedEncoding($needle),
+            strlen($needle)
         );
+    }
+
+    public function failureDescription(mixed $other): string
+    {
+        $stringifiedHaystack = $this->exporter()->export($other);
+        $haystackEncoding    = $this->getDetectedEncoding($other);
+        $haystackLength      = $this->getHaystackLength($other);
+
+        $haystackInformation = sprintf(
+            '%s [%s](length: %s) ',
+            $stringifiedHaystack,
+            $haystackEncoding,
+            $haystackLength,
+        );
+        $needleInformation = $this->toString();
+
+        return $haystackInformation . $needleInformation;
+    }
+
+    public function getDetectedEncoding(mixed $other): string
+    {
+        if ($this->ignoreCase === true) {
+            return 'Encoding ignored';
+        }
+
+        if (!is_string($other)) {
+            return 'Encoding detection failed';
+        }
+
+        $detectedEncoding = mb_detect_encoding($other);
+
+        if (!$detectedEncoding) {
+            return 'Encoding detection failed';
+        }
+
+        return $detectedEncoding;
+    }
+
+    public function getHaystackLength(mixed $haystack): int
+    {
+        if (!is_string($haystack)) {
+            return 0;
+        }
+
+        if ($this->ignoreLineEndings) {
+            $haystack = $this->normalizeLineEndings($haystack);
+        }
+
+        return strlen($haystack);
     }
 
     /**
@@ -61,16 +112,18 @@ final class StringContains extends Constraint
      */
     protected function matches(mixed $other): bool
     {
-        if ('' === $this->string) {
+        $haystack = $other;
+
+        if ('' === $this->needle) {
             return true;
         }
 
-        if (!is_string($other)) {
+        if (!is_string($haystack)) {
             return false;
         }
 
         if ($this->ignoreLineEndings) {
-            $other = $this->normalizeLineEndings($other);
+            $haystack = $this->normalizeLineEndings($haystack);
         }
 
         if ($this->ignoreCase) {
@@ -78,7 +131,7 @@ final class StringContains extends Constraint
              * We must use the multi byte safe version so we can accurately compare non latin upper characters with
              * their lowercase equivalents.
              */
-            return mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
+            return mb_stripos($haystack, $this->needle, 0, 'UTF-8') !== false;
         }
 
         /*
@@ -89,7 +142,7 @@ final class StringContains extends Constraint
          * Additionally, we want this method to be binary safe so we can check if some binary data is in other binary
          * data.
          */
-        return str_contains($other, $this->string);
+        return str_contains($haystack, $this->needle);
     }
 
     private function normalizeLineEndings(string $string): string

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -11,7 +11,6 @@ namespace PHPUnit\Framework\Constraint;
 
 use function is_string;
 use function mb_detect_encoding;
-use function mb_detect_order;
 use function mb_stripos;
 use function mb_strtolower;
 use function sprintf;
@@ -85,7 +84,7 @@ final class StringContains extends Constraint
             return 'Encoding detection failed';
         }
 
-        $detectedEncoding = mb_detect_encoding($other, mb_detect_order(), true);
+        $detectedEncoding = mb_detect_encoding($other, null, true);
 
         if (!$detectedEncoding) {
             return 'Encoding detection failed';

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -74,38 +74,6 @@ final class StringContains extends Constraint
         return $haystackInformation . $needleInformation;
     }
 
-    public function getDetectedEncoding(mixed $other): string
-    {
-        if ($this->ignoreCase === true) {
-            return 'Encoding ignored';
-        }
-
-        if (!is_string($other)) {
-            return 'Encoding detection failed';
-        }
-
-        $detectedEncoding = mb_detect_encoding($other, null, true);
-
-        if (!$detectedEncoding) {
-            return 'Encoding detection failed';
-        }
-
-        return $detectedEncoding;
-    }
-
-    public function getHaystackLength(mixed $haystack): int
-    {
-        if (!is_string($haystack)) {
-            return 0;
-        }
-
-        if ($this->ignoreLineEndings) {
-            $haystack = $this->normalizeLineEndings($haystack);
-        }
-
-        return strlen($haystack);
-    }
-
     /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
@@ -143,6 +111,38 @@ final class StringContains extends Constraint
          * data.
          */
         return str_contains($haystack, $this->needle);
+    }
+
+    private function getDetectedEncoding(mixed $other): string
+    {
+        if ($this->ignoreCase === true) {
+            return 'Encoding ignored';
+        }
+
+        if (!is_string($other)) {
+            return 'Encoding detection failed';
+        }
+
+        $detectedEncoding = mb_detect_encoding($other, null, true);
+
+        if (!$detectedEncoding) {
+            return 'Encoding detection failed';
+        }
+
+        return $detectedEncoding;
+    }
+
+    private function getHaystackLength(mixed $haystack): int
+    {
+        if (!is_string($haystack)) {
+            return 0;
+        }
+
+        if ($this->ignoreLineEndings) {
+            $haystack = $this->normalizeLineEndings($haystack);
+        }
+
+        return strlen($haystack);
     }
 
     private function normalizeLineEndings(string $string): string

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use function is_string;
 use function mb_detect_encoding;
+use function mb_detect_order;
 use function mb_stripos;
 use function mb_strtolower;
 use function sprintf;
@@ -53,7 +54,7 @@ final class StringContains extends Constraint
             'contains "%s" [%s](length: %s)',
             $needle,
             $this->getDetectedEncoding($needle),
-            strlen($needle)
+            strlen($needle),
         );
     }
 
@@ -84,7 +85,7 @@ final class StringContains extends Constraint
             return 'Encoding detection failed';
         }
 
-        $detectedEncoding = mb_detect_encoding($other);
+        $detectedEncoding = mb_detect_encoding($other, mb_detect_order(), true);
 
         if (!$detectedEncoding) {
             return 'Encoding detection failed';

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -172,23 +172,6 @@ final class StringContainsTest extends TestCase
         ];
     }
 
-    #[DataProvider('providesEvaluationCases')]
-    public function testCanBeEvaluated(bool $result, string $failureDescription, bool $ignoreCase, bool $ignoreLineEndings, string $needle, mixed $haystack): void
-    {
-        $constraint = new StringContains($needle, $ignoreCase, $ignoreLineEndings);
-
-        $this->assertSame($result, $constraint->evaluate($haystack, returnResult: true));
-
-        if ($result) {
-            return;
-        }
-
-        $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage($failureDescription);
-
-        $constraint->evaluate($haystack);
-    }
-
     public static function providesToStringRepresentationCases(): array
     {
         return [
@@ -220,6 +203,23 @@ final class StringContainsTest extends TestCase
                 true,
             ],
         ];
+    }
+
+    #[DataProvider('providesEvaluationCases')]
+    public function testCanBeEvaluated(bool $result, string $failureDescription, bool $ignoreCase, bool $ignoreLineEndings, string $needle, mixed $haystack): void
+    {
+        $constraint = new StringContains($needle, $ignoreCase, $ignoreLineEndings);
+
+        $this->assertSame($result, $constraint->evaluate($haystack, returnResult: true));
+
+        if ($result) {
+            return;
+        }
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage($failureDescription);
+
+        $constraint->evaluate($haystack);
     }
 
     #[DataProvider('providesToStringRepresentationCases')]

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -159,7 +159,7 @@ final class StringContainsTest extends TestCase
 
             'Both the needle and haystack length in the failure message partly account for \r line endings given line endings are ignored' => [
                 false,
-                "Failed asserting that 'Some haystack with\\r\n line\\n\n endings \\n\\r\n' [ASCII](length: 35) contains \"Some needle with\n line\n endings \n\n\" [ASCII](length: 34).",
+                "Failed asserting that 'Some haystack with\\r\n line\\n\n endings \\n\\r\n' [ASCII](length: 36) contains \"Some needle with\n line\n endings \n\n\" [ASCII](length: 34).",
                 false,
                 true,
                 /**

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -112,7 +112,6 @@ final class StringContainsTest extends TestCase
                 'substring',
                 null,
             ],
-
             [
                 false,
                 'Failed asserting that \'prefix ... suffix\' contains "substring".',
@@ -120,6 +119,22 @@ final class StringContainsTest extends TestCase
                 false,
                 'substring',
                 'prefix ... suffix',
+            ],
+            [
+                false,
+                'Failed asserting that \'Example character encoding\' contains "Example character encoding".', // These looks identical in console output
+                false,
+                false,
+                /**
+                 * Below is an ASCII string using a 'blank space' character (code 32 in https://smartwebworker.com/ascii-codes)
+                 * between each word
+                 */
+                'Example character encoding',
+                /**
+                 * Below is a UTF-8 string using a 'thin-space' character (https://www.compart.com/en/unicode/U+2009)
+                 * between each word instead of usual 'space' character (https://www.compart.com/en/unicode/U+0020)
+                 */
+                'Example character encoding',
             ],
         ];
     }

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[Small]
 final class StringContainsTest extends TestCase
 {
-    public static function provider(): array
+    public static function providesEvaluationCases(): array
     {
         return [
             [
@@ -139,7 +139,7 @@ final class StringContainsTest extends TestCase
         ];
     }
 
-    #[DataProvider('provider')]
+    #[DataProvider('providesEvaluationCases')]
     public function testCanBeEvaluated(bool $result, string $failureDescription, bool $ignoreCase, bool $ignoreLineEndings, string $expected, mixed $actual): void
     {
         $constraint = new StringContains($expected, $ignoreCase, $ignoreLineEndings);
@@ -156,11 +156,34 @@ final class StringContainsTest extends TestCase
         $constraint->evaluate($actual);
     }
 
-    public function testCanBeRepresentedAsString(): void
+    public static function providesToStringRepresentationCases(): array
     {
-        $this->assertSame('contains "substring"', (new StringContains('substring'))->toString());
-        $this->assertSame('contains "substring"', (new StringContains('SUBSTRING', true))->toString());
-        $this->assertSame('contains "SUBSTRING' . "\n" . '"', (new StringContains("SUBSTRING\r\n", ignoreLineEndings: true))->toString());
+        return [
+            [
+                'contains "substring"',
+                'substring',
+                false,
+                false,
+            ],
+            [
+                'contains "substring"',
+                'SUBSTRING',
+                true,
+                false,
+            ],
+            [
+                'contains "SUBSTRING' . "\n" . '"',
+                "SUBSTRING\r\n",
+                false,
+                true,
+            ],
+        ];
+    }
+
+    #[DataProvider('providesToStringRepresentationCases')]
+    public function testCanBeRepresentedAsString(string $expected, string $givenString, bool $ignoreCase, bool $ignoreLineEndings): void
+    {
+        $this->assertSame($expected, (new StringContains($givenString, $ignoreCase, $ignoreLineEndings))->toString());
     }
 
     public function testIsCountable(): void

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -106,7 +106,7 @@ final class StringContainsTest extends TestCase
 
             [
                 false,
-                'Failed asserting that null contains "substring".',
+                'Failed asserting that null contains "substring" [ASCII](length: 9).',
                 false,
                 false,
                 'substring',
@@ -114,7 +114,7 @@ final class StringContainsTest extends TestCase
             ],
             [
                 false,
-                'Failed asserting that \'prefix ... suffix\' contains "substring".',
+                'Failed asserting that \'prefix ... suffix\' contains "substring" [ASCII](length: 9).',
                 false,
                 false,
                 'substring',
@@ -122,7 +122,7 @@ final class StringContainsTest extends TestCase
             ],
             [
                 false,
-                'Failed asserting that \'Example character encoding\' contains "Example character encoding".', // These looks identical in console output
+                'Failed asserting that \'Example character encoding\' contains "Example character encoding" [ASCII](length: 26).',
                 false,
                 false,
                 /**
@@ -160,19 +160,25 @@ final class StringContainsTest extends TestCase
     {
         return [
             [
-                'contains "substring"',
+                'contains "substring" [ASCII](length: 9)',
                 'substring',
                 false,
                 false,
             ],
             [
-                'contains "substring"',
+                'contains "substring" [ASCII](length: 9)',
                 'SUBSTRING',
                 true,
                 false,
             ],
             [
-                'contains "SUBSTRING' . "\n" . '"',
+                'contains "example UTF-8 substring £$" [UTF-8](length: 27)',
+                'example UTF-8 substring £$',
+                false,
+                false,
+            ],
+            [
+                'contains "SUBSTRING' . "\n" . '" [ASCII](length: 10)',
                 "SUBSTRING\r\n",
                 false,
                 true,

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -23,21 +23,21 @@ final class StringContainsTest extends TestCase
     public static function providesEvaluationCases(): array
     {
         return [
+            'It finds the needle with default options given' => [
+                true,
+                '',
+                false,
+                false,
+                'needle',
+                'prefix needle suffix',
+            ],
+
             'Empty needles are supported with default options given' => [
                 true,
                 '',
                 false,
                 false,
                 '',
-                'prefix needle suffix',
-            ],
-
-            'It finds the needle with default options given' => [ // TODO swap with test case above as this is the "main event" of this constraint
-                true,
-                '',
-                false,
-                false,
-                'needle',
                 'prefix needle suffix',
             ],
 
@@ -59,7 +59,7 @@ final class StringContainsTest extends TestCase
                 'prefix needle suffix',
             ],
 
-            'It finds the needle given letter case is ignored and needle is in a different case to haystack' => [
+            'It finds the needle given letter casing is ignored and needle is in a different case to haystack' => [
                 true,
                 '',
                 true,
@@ -68,7 +68,7 @@ final class StringContainsTest extends TestCase
                 'prefix NEEDLE suffix',
             ],
 
-            'It finds the needle given letter case is ignored and haystack is in a different case to needle' => [
+            'It finds the needle given letter casing is ignored and haystack is in a different case to needle' => [
                 true,
                 '',
                 true,
@@ -95,7 +95,7 @@ final class StringContainsTest extends TestCase
                 "prefix needle\n suffix",
             ],
 
-            'Both \r and \n line endings will be ignored in the needle given line endings are set up to be ignored' => [
+            '\r\n line endings will be ignored in the needle given line endings are set up to be ignored' => [
                 true,
                 '',
                 false,
@@ -104,7 +104,7 @@ final class StringContainsTest extends TestCase
                 "prefix needle\r suffix",
             ],
 
-            'Both \r and \n line endings will be ignored in the haystack given line endings are set up to be ignored' => [
+            '\r\n line endings will be ignored in the haystack given line endings are set up to be ignored' => [
                 true,
                 '',
                 true,
@@ -159,15 +159,15 @@ final class StringContainsTest extends TestCase
 
             'Both the needle and haystack length in the failure message partly account for \r line endings given line endings are ignored' => [
                 false,
-                "Failed asserting that 'Some haytack with\\r\n line\\n\n endings \\n\\r\n' [ASCII](length: 35) contains \"Some needle with\n line\n endings \n\n\" [ASCII](length: 34).",
+                "Failed asserting that 'Some haystack with\\r\n line\\n\n endings \\n\\r\n' [ASCII](length: 35) contains \"Some needle with\n line\n endings \n\n\" [ASCII](length: 34).",
                 false,
                 true,
                 /**
                  * See StringContains::normalizeLineEndings() to
                  * see how "\r" are mapped to "\n".
                  */
-                "Some needle with\r line\n endings \n\r", // 38 characters ling
-                "Some haytack with\r line\n endings \n\r", // 39 characters ling
+                "Some needle with\r line\n endings \n\r", // 38 characters long
+                "Some haystack with\r line\n endings \n\r", // 39 characters long
             ],
         ];
     }


### PR DESCRIPTION
This PR is a proposed improvement to the existing failure message being generated by the StringContains Constraint based on the discussions about it in the #5128 thread. 

For those not familiar with the issue, this improvement specifically adds additional information (the detected string encoding + string length) to the failure message returned for debugging purposes.
Reason for doing so: the console outputs tend to **hide** the visual difference between two strings when there are different but similar encoding characters (i.e. Unicode's 'thin spaces' verses ASCII's "regular" spaces <-- more on this in the new tests written below).

Example of test output after changes: 
```
Failed asserting that 'SANTAGATI SALVATORE' [ASCII](length: 19) contains "SANTAGATI SALVATORE" [UTF-8](length: 21).

[Stack trace here]
``` 

Example of test output before changes:
```
Failed asserting that 'SANTAGATI SALVATORE' contains "SANTAGATI SALVATORE".

[Stack trace here]
``` 

Here is the test that generated this output (note that the 'needle' string uses a thin space character for the space between the two words, whereas the haystack uses a regular space instead):
```
public function testCanReproduceThinSpaceExample(): void
{
    $this->assertStringContainsString('SANTAGATI SALVATORE', 'SANTAGATI SALVATORE');
}
```


&nbsp; 

## Notes to reviewer:
<ul>
⚛ - this PR was (primarily) written atomically, so reviewing each commit chronologically is recommended for the best review experience

📝 - this PR's commits contained details of the reasonings for technical decisions made - **so if you find yourself thinking: "why did they do that?", please read the commit messages 😊**
🐤 - this is my first PR for PHPUnit so I very much welcome advice / steering on conventions etc
</ul>