### PR TITLE
Allow different libxml error messages

### DIFF
--- a/tests/end-to-end/baseline/baseline-invalid-xml.phpt
+++ b/tests/end-to-end/baseline/baseline-invalid-xml.phpt
@@ -23,7 +23,7 @@ There was 1 PHPUnit test runner warning:
 
 1) Cannot read baseline: Could not load "%sbaseline.xml":
 
-Premature end of data in tag file line 3
+%snd%sag%s
 
 WARNINGS!
 Tests: 1, Assertions: 1, Warnings: 1, Deprecations: 1.


### PR DESCRIPTION
`Premature end of data in tag file line 3`
`EndTag: '</' not found`

See #5496

```
baseline-invalid-xml.phptFailed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 1) Cannot read baseline: Could not load "/.../tests/end-to-end/_files/baseline/invalid-baseline/baseline.xml":
 
-Premature end of data in tag file line 3
+EndTag: '</' not found
 
 WARNINGS!
 Tests: 1, Assertions: 1, Warnings: 1, Deprecations: 1.

/.../tests/end-to-end/baseline/baseline-invalid-xml.phpt:26
/.../src/Framework/TestSuite.php:340
/.../src/Framework/TestSuite.php:340
/.../src/TextUI/TestRunner.php:63
/.../src/TextUI/Application.php:183
```

From: https://revive.beccati.com/bamboo/browse/PHP-PHPUN-PHP83-3390/test/case/75464847
