### PR TITLE
Fix: Do not configure deprecated `function_typehint_space` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -106,7 +106,6 @@ $config->setFinder($finder)
         'fully_qualified_strict_types' => true,
         'function_declaration' => true,
         'function_to_constant' => true,
-        'function_typehint_space' => true,
         'get_class_to_class_keyword' => true,
         'global_namespace_import' => [
             'import_classes' => true,


### PR DESCRIPTION
This pull request

- [x] stops configuring the deprecated `function_typehint_space` fixer

Follows 187a9c4c8.