### PR TITLE
PHPUnit 10.3: Generate code coverage report in PHP format as first in list to avoid serializing cache data

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -205,6 +205,21 @@ final class CodeCoverage
             return;
         }
 
+        if ($configuration->hasCoveragePhp()) {
+            $this->codeCoverageGenerationStart($printer, 'PHP');
+
+            try {
+                $writer = new PhpReport;
+                $writer->process($this->codeCoverage(), $configuration->coveragePhp());
+
+                $this->codeCoverageGenerationSucceeded($printer);
+
+                unset($writer);
+            } catch (CodeCoverageException $e) {
+                $this->codeCoverageGenerationFailed($printer, $e);
+            }
+        }
+
         if ($configuration->hasCoverageClover()) {
             $this->codeCoverageGenerationStart($printer, 'Clover XML');
 
@@ -280,21 +295,6 @@ final class CodeCoverage
                 );
 
                 $writer->process($this->codeCoverage(), $configuration->coverageHtml());
-
-                $this->codeCoverageGenerationSucceeded($printer);
-
-                unset($writer);
-            } catch (CodeCoverageException $e) {
-                $this->codeCoverageGenerationFailed($printer, $e);
-            }
-        }
-
-        if ($configuration->hasCoveragePhp()) {
-            $this->codeCoverageGenerationStart($printer, 'PHP');
-
-            try {
-                $writer = new PhpReport;
-                $writer->process($this->codeCoverage(), $configuration->coveragePhp());
 
                 $this->codeCoverageGenerationSucceeded($printer);
 


### PR DESCRIPTION
This is part of https://github.com/sebastianbergmann/php-code-coverage/issues/1009