### PR TITLE
Update CI to `continue-on-error` for PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       PHP_EXTENSIONS: none, curl, dom, json, libxml, mbstring, openssl, phar, soap, tokenizer, xml, xmlwriter
       PHP_INI_VALUES: memory_limit=-1, assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
+    continue-on-error: ${{ matrix.os == 'windows-latest' && matrix.php-version == '8.4' }}
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fix CI tests failing on PHP 8.4 due to missing extension, enabling `continue-on-error` in order to allow `end-to-end-tests` to run.

Related: #5521

