### PR TITLE
Fix: Keep fixers and options sorted by name

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,11 +29,11 @@ $config->setFinder($finder)
         'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'operators' => [
-                '=' => 'align_single_space_minimal',
+                '*=' => 'align_single_space_minimal',
                 '+=' => 'align_single_space_minimal',
                 '-=' => 'align_single_space_minimal',
-                '*=' => 'align_single_space_minimal',
                 '/=' => 'align_single_space_minimal',
+                '=' => 'align_single_space_minimal',
                 '=>' => 'align_single_space_minimal',
             ],
         ],


### PR DESCRIPTION
This pull request

- [x] keeps fixers and options for `friendsofphp/php-cs-fixer` sorted by name

Follows #5543.

💁‍♂️ I used https://github.com/ergebnis/rector-rules/tree/0.1.0#arrayssortassociativearraybykeyrector for that.