### PR TITLE
Generate diff when comparing enums with assertSame

### DIFF
--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -16,6 +16,7 @@ use function sprintf;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Util\Exporter;
 use SebastianBergmann\Comparator\ComparisonFailure;
+use UnitEnum;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -62,8 +63,8 @@ final class IsIdentical extends Constraint
                 );
             }
 
-            // if both values are array, make sure a diff is generated
-            if (is_array($this->value) && is_array($other)) {
+            // if both values are array or enums, make sure a diff is generated
+            if ((is_array($this->value) && is_array($other)) || ($this->value instanceof UnitEnum && $other instanceof UnitEnum)) {
                 $f = new ComparisonFailure(
                     $this->value,
                     $other,


### PR DESCRIPTION
PHPUnit's Exporter supports enums, but when comparing enums with `assertSame`, the diff is currently not generated and the only message is "Failing to assert that two variables reference the same object".

This PR improves the underlying `IsIdentical` constraint to generate human readable diff by utilizing existing enum support in `Exporter`.