### PR TITLE
encode arguments ordering in equality assertion functions

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -277,6 +277,16 @@ abstract class Assert
     }
 
     /**
+     * Asserts that two variables are equal with explicit arguments ordering.
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertExpectedEqualsActual(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        self::assertEquals($expected, $actual, $message);
+    }
+
+    /**
      * Asserts that two variables are equal (canonicalizing).
      *
      * @throws ExpectationFailedException
@@ -289,6 +299,16 @@ abstract class Assert
     }
 
     /**
+     * Asserts that two variables are equal (canonicalizing) with explicit arguments ordering.
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertExpectedEqualsActualCanonicalizing(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        self::assertEqualsCanonicalizing($expected, $actual, $message);
+    }
+
+    /**
      * Asserts that two variables are equal (ignoring case).
      *
      * @throws ExpectationFailedException
@@ -298,6 +318,16 @@ abstract class Assert
         $constraint = new IsEqualIgnoringCase($expected);
 
         static::assertThat($actual, $constraint, $message);
+    }
+
+    /**
+     * Asserts that two variables are equal (ignoring case) with explicit arguments ordering.
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertExpectedEqualsActualIgnoringCase(mixed $expected, mixed $actual, string $message = ''): void
+    {
+        self::assertEqualsIgnoringCase($expected, $actual, $message);
     }
 
     /**


### PR DESCRIPTION
Hello, I would like to add some functions that are more of function aliases with arguments embedded in their names. For example, while working on a Laravel project I was calling the ``$this->assertEquals($actual, $expected)``, whereas the correct way was ``$this->assertEquals($expected, $actual)``. While reading the **Clean Code**  by **Robert C. Martin** the other day, I came across the same issue regarding the lack of natural ordering of the arguments. So I hope, these explicit function names will help someone in the future.