### PR TITLE
Skip less E2E tests on Windows

### DIFF
--- a/tests/end-to-end/cli/fail-on/fail-on-deprecation.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-deprecation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Test Runner exits with shell exit code indicating failure when all tests are successful but at least one test triggered a deprecation
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/fail-on/fail-on-incomplete.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-incomplete.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Test Runner exits with shell exit code indicating failure when all tests are successful but at least one test was marked incomplete
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/fail-on/fail-on-notice.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-notice.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Test Runner exits with shell exit code indicating failure when all tests are successful but at least one test triggered a notice
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/fail-on/fail-on-risky.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-risky.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Test Runner exits with shell exit code indicating failure when all tests are successful but at least one test was considered risky
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/fail-on/fail-on-skipped.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-skipped.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Test Runner exits with shell exit code indicating failure when all tests are successful but at least one test was skipped
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/fail-on/fail-on-warning.phpt
+++ b/tests/end-to-end/cli/fail-on/fail-on-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Test Runner exits with shell exit code indicating failure when all tests are successful but at least one warning was triggered
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-class-match-argument.phpt
+++ b/tests/end-to-end/cli/filter/filter-class-match-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter FooTest tests/FooTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-class-match-configuration.phpt
+++ b/tests/end-to-end/cli/filter/filter-class-match-configuration.phpt
@@ -29,7 +29,7 @@ Test Runner Started
 Test Suite Sorted
 Test Suite Filtered (3 tests)
 Test Runner Execution Started (3 tests)
-Test Suite Started (%s/tests/end-to-end/_files/groups/phpunit.xml, 3 tests)
+Test Suite Started (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 3 tests)
 Test Suite Started (default, 3 tests)
 Test Suite Started (PHPUnit\TestFixture\Groups\FooTest, 3 tests)
 Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testOne)
@@ -49,7 +49,7 @@ Test Passed (PHPUnit\TestFixture\Groups\FooTest::testThree)
 Test Finished (PHPUnit\TestFixture\Groups\FooTest::testThree)
 Test Suite Finished (PHPUnit\TestFixture\Groups\FooTest, 3 tests)
 Test Suite Finished (default, 3 tests)
-Test Suite Finished (%s/tests/end-to-end/_files/groups/phpunit.xml, 3 tests)
+Test Suite Finished (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 3 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/filter/filter-class-match-configuration.phpt
+++ b/tests/end-to-end/cli/filter/filter-class-match-configuration.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter FooTest
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-class-nomatch-argument.phpt
+++ b/tests/end-to-end/cli/filter/filter-class-nomatch-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter BarTest tests/FooTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-class-nomatch-configuration.phpt
+++ b/tests/end-to-end/cli/filter/filter-class-nomatch-configuration.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter BarTest
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-method-match-argument.phpt
+++ b/tests/end-to-end/cli/filter/filter-method-match-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter testOne tests/FooTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-method-match-configuration.phpt
+++ b/tests/end-to-end/cli/filter/filter-method-match-configuration.phpt
@@ -29,7 +29,7 @@ Test Runner Started
 Test Suite Sorted
 Test Suite Filtered (1 test)
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/tests/end-to-end/_files/groups/phpunit.xml, 1 test)
+Test Suite Started (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 1 test)
 Test Suite Started (default, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Groups\FooTest, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testOne)
@@ -39,7 +39,7 @@ Test Passed (PHPUnit\TestFixture\Groups\FooTest::testOne)
 Test Finished (PHPUnit\TestFixture\Groups\FooTest::testOne)
 Test Suite Finished (PHPUnit\TestFixture\Groups\FooTest, 1 test)
 Test Suite Finished (default, 1 test)
-Test Suite Finished (%s/tests/end-to-end/_files/groups/phpunit.xml, 1 test)
+Test Suite Finished (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/filter/filter-method-match-configuration.phpt
+++ b/tests/end-to-end/cli/filter/filter-method-match-configuration.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter testOne
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-method-nomatch-argument.phpt
+++ b/tests/end-to-end/cli/filter/filter-method-nomatch-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter testFoo tests/FooTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/filter/filter-method-nomatch-configuration.phpt
+++ b/tests/end-to-end/cli/filter/filter-method-nomatch-configuration.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --filter testFoo
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/group/exclude-group-argument.phpt
+++ b/tests/end-to-end/cli/group/exclude-group-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --exclude-group one,two tests/FooTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/group/exclude-group-configuration.phpt
+++ b/tests/end-to-end/cli/group/exclude-group-configuration.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --exclude-group one,two
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/group/exclude-group-configuration.phpt
+++ b/tests/end-to-end/cli/group/exclude-group-configuration.phpt
@@ -29,7 +29,7 @@ Test Runner Started
 Test Suite Sorted
 Test Suite Filtered (1 test)
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/tests/end-to-end/_files/groups/phpunit.xml, 1 test)
+Test Suite Started (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 1 test)
 Test Suite Started (default, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Groups\FooTest, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testThree)
@@ -39,7 +39,7 @@ Test Passed (PHPUnit\TestFixture\Groups\FooTest::testThree)
 Test Finished (PHPUnit\TestFixture\Groups\FooTest::testThree)
 Test Suite Finished (PHPUnit\TestFixture\Groups\FooTest, 1 test)
 Test Suite Finished (default, 1 test)
-Test Suite Finished (%s/tests/end-to-end/_files/groups/phpunit.xml, 1 test)
+Test Suite Finished (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/group/group-argument.phpt
+++ b/tests/end-to-end/cli/group/group-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --group one tests/FooTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/group/group-configuration.phpt
+++ b/tests/end-to-end/cli/group/group-configuration.phpt
@@ -29,7 +29,7 @@ Test Runner Started
 Test Suite Sorted
 Test Suite Filtered (1 test)
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/tests/end-to-end/_files/groups/phpunit.xml, 1 test)
+Test Suite Started (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 1 test)
 Test Suite Started (default, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Groups\FooTest, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testOne)
@@ -39,7 +39,7 @@ Test Passed (PHPUnit\TestFixture\Groups\FooTest::testOne)
 Test Finished (PHPUnit\TestFixture\Groups\FooTest::testOne)
 Test Suite Finished (PHPUnit\TestFixture\Groups\FooTest, 1 test)
 Test Suite Finished (default, 1 test)
-Test Suite Finished (%s/tests/end-to-end/_files/groups/phpunit.xml, 1 test)
+Test Suite Finished (%s%etests%eend-to-end%e_files%egroups%ephpunit.xml, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/group/group-configuration.phpt
+++ b/tests/end-to-end/cli/group/group-configuration.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --group one
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/log-events-text.phpt
+++ b/tests/end-to-end/cli/log-events-text.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --no-output --log-events-text logfile.txt
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/log-events-verbose-text.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --no-output --log-events-verbose-text logfile.txt
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/no-log-no-cc.phpt
+++ b/tests/end-to-end/cli/no-log-no-cc.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit -c _files/phpunit.xml --no-logging --log-junit php://stdout _files/NoLogNoCcTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $logfile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-defect-for-error.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-defect-for-error.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first error works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-defect-for-failure.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-defect-for-failure.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first failure works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-defect-for-risky.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-defect-for-risky.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first risky test works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-defect-for-warning.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-defect-for-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first warning works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-deprecation.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-deprecation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first deprecation works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-error.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-error.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first error works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-failure.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-failure.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first failure works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-incomplete.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-incomplete.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first incomplete test works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-notice.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-notice.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first notice works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-risky.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-risky.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first risky test works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-skipped.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-skipped.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first skipped test works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/cli/stop-on/stop-on-warning.phpt
+++ b/tests/end-to-end/cli/stop-on/stop-on-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 Stopping test execution after first warning works
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/assert-failure.phpt
+++ b/tests/end-to-end/event/assert-failure.phpt
@@ -9,10 +9,6 @@ if (ini_get('zend.assertions') != 1) {
 if (ini_get('assert.exception') != 1) {
     print 'skip: assert.exception=1 is required' . PHP_EOL;
 }
-
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/assertion-failure-in-after-test-method.phpt
+++ b/tests/end-to-end/event/assertion-failure-in-after-test-method.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that fails because of an assertion failure in a "after test" method
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/assertion-failure-in-before-test-method.phpt
+++ b/tests/end-to-end/event/assertion-failure-in-before-test-method.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that fails because of an assertion failure in a "before test" method
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/assertion-failure-in-postcondition-method.phpt
+++ b/tests/end-to-end/event/assertion-failure-in-postcondition-method.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that fails because of an assertion failure in a postcondition method
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/assertion-failure-in-precondition-method.phpt
+++ b/tests/end-to-end/event/assertion-failure-in-precondition-method.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that fails because of an assertion failure in a precondition method
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/assertion-failure-in-test-method.phpt
+++ b/tests/end-to-end/event/assertion-failure-in-test-method.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that fails because of an assertion failure in the test method
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/custom-comparator.phpt
+++ b/tests/end-to-end/event/custom-comparator.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test that uses assertEquals() with a custom comparator
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-duplicate-key.phpt
+++ b/tests/end-to-end/event/data-provider-duplicate-key.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that provides duplicate keys
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-empty.phpt
+++ b/tests/end-to-end/event/data-provider-empty.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that returns an empty array
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-exception.phpt
+++ b/tests/end-to-end/event/data-provider-exception.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that raises an exception
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-expects-argument.phpt
+++ b/tests/end-to-end/event/data-provider-expects-argument.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that is not public
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-external.phpt
+++ b/tests/end-to-end/event/data-provider-external.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test that uses an external data provider
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-not-public.phpt
+++ b/tests/end-to-end/event/data-provider-not-public.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that is not public
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider-not-static.phpt
+++ b/tests/end-to-end/event/data-provider-not-static.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that is not static
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/data-provider.phpt
+++ b/tests/end-to-end/event/data-provider.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test that uses a data provider
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute.phpt
+++ b/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute.phpt
@@ -1,10 +1,5 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/5532
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/error-handler-can-be-disabled.phpt
+++ b/tests/end-to-end/event/error-handler-can-be-disabled.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order when PHPUnit's error handler is disabled
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/error-handler-can-be-disabled.phpt
+++ b/tests/end-to-end/event/error-handler-can-be-disabled.phpt
@@ -22,13 +22,13 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Bootstrap Finished (%s/src/Foo.php)
+Bootstrap Finished (%s%esrc/Foo.php)
 Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (2 tests)
-Test Suite Started (%s/phpunit.xml, 2 tests)
+Test Suite Started (%s%ephpunit.xml, 2 tests)
 Test Suite Started (default, 2 tests)
 Test Suite Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
@@ -44,7 +44,7 @@ Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMe
 Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
 Test Suite Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 2 tests)
 Test Suite Finished (default, 2 tests)
-Test Suite Finished (%s/phpunit.xml, 2 tests)
+Test Suite Finished (%s%ephpunit.xml, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/error.phpt
+++ b/tests/end-to-end/event/error.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for an errored test
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/exception-in-setup-before-class.phpt
+++ b/tests/end-to-end/event/exception-in-setup-before-class.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for when an exception is raised in setUpBeforeClass()
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/exception-in-setup.phpt
+++ b/tests/end-to-end/event/exception-in-setup.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for when an exception is raised in setUp()
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/expectation-on-output.phpt
+++ b/tests/end-to-end/event/expectation-on-output.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test with an output expectation
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/failed-mock-expectation.phpt
+++ b/tests/end-to-end/event/failed-mock-expectation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test with a failed expectation on a mock object
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/incomplete-test.phpt
+++ b/tests/end-to-end/event/incomplete-test.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for an incomplete test
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/invalid-coverage-metadata.phpt
+++ b/tests/end-to-end/event/invalid-coverage-metadata.phpt
@@ -2,9 +2,6 @@
 The right events are emitted in the right order for a test that has invalid code coverage metadata
 --SKIPIF--
 <?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 if (!extension_loaded('pcov')) {
     print "skip: this test requires pcov\n";
 }

--- a/tests/end-to-end/event/invalid-coverage-metadata.phpt
+++ b/tests/end-to-end/event/invalid-coverage-metadata.phpt
@@ -32,7 +32,7 @@ Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/tests/end-to-end/event/_files/invalid-coverage-metadata/phpunit.xml, 1 test)
+Test Suite Started (%s%etests%eend-to-end%eevent%e_files%einvalid-coverage-metadata%ephpunit.xml, 1 test)
 Test Suite Started (default, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Event\InvalidCoverageMetadata\InvalidCoverageMetadataTest, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Event\InvalidCoverageMetadata\InvalidCoverageMetadataTest::testOne)
@@ -44,7 +44,7 @@ Class "PHPUnit\TestFixture\Event\InvalidCoverageMetadata\This\Does\Not\Exist" is
 Test Finished (PHPUnit\TestFixture\Event\InvalidCoverageMetadata\InvalidCoverageMetadataTest::testOne)
 Test Suite Finished (PHPUnit\TestFixture\Event\InvalidCoverageMetadata\InvalidCoverageMetadataTest, 1 test)
 Test Suite Finished (default, 1 test)
-Test Suite Finished (%s/tests/end-to-end/event/_files/invalid-coverage-metadata/phpunit.xml, 1 test)
+Test Suite Finished (%s%etests%eend-to-end%eevent%e_files%einvalid-coverage-metadata%ephpunit.xml, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 1)

--- a/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
+++ b/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that returns an invalid array
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/invalid-data-provider.phpt
+++ b/tests/end-to-end/event/invalid-data-provider.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a data provider that returns an invalid array
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/invalid-test-dependency.phpt
+++ b/tests/end-to-end/event/invalid-test-dependency.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that has an invalid dependency
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/missing-test-dependency.phpt
+++ b/tests/end-to-end/event/missing-test-dependency.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that has a missing dependency
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/mock-object.phpt
+++ b/tests/end-to-end/event/mock-object.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a mock object
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/php-deprecated.phpt
+++ b/tests/end-to-end/event/php-deprecated.phpt
@@ -1,14 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers E_DEPRECATED
---SKIPIF--
-<?php declare(strict_types=1);
-if (!(PHP_MAJOR_VERSION === 8 && PHP_MINOR_VERSION === 1)) {
-    print "skip: this test requires PHP 8.1\n";
-}
-
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --INI--
 error_reporting=-1
 --FILE--

--- a/tests/end-to-end/event/php-notice.phpt
+++ b/tests/end-to-end/event/php-notice.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers E_NOTICE
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/php-warning.phpt
+++ b/tests/end-to-end/event/php-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers E_WARNING
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/phpt-skipif.phpt
+++ b/tests/end-to-end/event/phpt-skipif.phpt
@@ -26,13 +26,13 @@ Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/phpt-skipif-location-hint-example.phpt, 1 test)
-Test Preparation Started (%s/phpt-skipif-location-hint-example.phpt)
-Test Prepared (%s/phpt-skipif-location-hint-example.phpt)
-Test Skipped (%s/phpt-skipif-location-hint-example.phpt)
+Test Suite Started (%s%ephpt-skipif-location-hint-example.phpt, 1 test)
+Test Preparation Started (%s%ephpt-skipif-location-hint-example.phpt)
+Test Prepared (%s%ephpt-skipif-location-hint-example.phpt)
+Test Skipped (%s%ephpt-skipif-location-hint-example.phpt)
 something terrible happened
-Test Finished (%s/phpt-skipif-location-hint-example.phpt)
-Test Suite Finished (%s/phpt-skipif-location-hint-example.phpt, 1 test)
+Test Finished (%s%ephpt-skipif-location-hint-example.phpt)
+Test Suite Finished (%s%ephpt-skipif-location-hint-example.phpt, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/phpt-skipif.phpt
+++ b/tests/end-to-end/event/phpt-skipif.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a skipped PHPT test
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/phpunit-deprecated.phpt
+++ b/tests/end-to-end/event/phpunit-deprecated.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a deprecated PHPUnit feature
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/phpunit-warning.phpt
+++ b/tests/end-to-end/event/phpunit-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers a PHPUnit warning
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/process-isolation-fatal.phpt
+++ b/tests/end-to-end/event/process-isolation-fatal.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is run in process isolation and triggers a fatal error
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/registered-failure-interface.phpt
+++ b/tests/end-to-end/event/registered-failure-interface.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that registers a failure interface
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-depends-on-larger-test.phpt
+++ b/tests/end-to-end/event/risky-depends-on-larger-test.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky because it depends on a larger test
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-global-state-modification.phpt
+++ b/tests/end-to-end/event/risky-global-state-modification.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky because it modified global state
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-no-assertions-isolation.phpt
+++ b/tests/end-to-end/event/risky-no-assertions-isolation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is run in an isolated process and is considered risky because it did not perform assertions
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-no-assertions.phpt
+++ b/tests/end-to-end/event/risky-no-assertions.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky because it did not perform assertions
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-output.phpt
+++ b/tests/end-to-end/event/risky-output.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky because it prints output
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-time-limit-exceeded.phpt
+++ b/tests/end-to-end/event/risky-time-limit-exceeded.phpt
@@ -1,5 +1,8 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky because it timed out
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('pcntl')) echo 'skip: Extension pcntl is required';
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-time-limit-exceeded.phpt
+++ b/tests/end-to-end/event/risky-time-limit-exceeded.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky because it timed out
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/risky-with-multiple-reasons.phpt
+++ b/tests/end-to-end/event/risky-with-multiple-reasons.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that is considered risky for multiple reasons
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/success-process-isolation.phpt
+++ b/tests/end-to-end/event/success-process-isolation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test that is run in an isolated process
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/success-verbose.phpt
+++ b/tests/end-to-end/event/success-verbose.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test with extended information
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/success.phpt
+++ b/tests/end-to-end/event/success.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/successful-mock-expectation.phpt
+++ b/tests/end-to-end/event/successful-mock-expectation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test with a successful expectation on a mock object
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/suppressed-user-notice.phpt
+++ b/tests/end-to-end/event/suppressed-user-notice.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers a suppressed E_USER_NOTICE
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/suppressed-user-warning.phpt
+++ b/tests/end-to-end/event/suppressed-user-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers a suppressed E_USER_WARNING
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/template-methods.phpt
+++ b/tests/end-to-end/event/template-methods.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for the template methods of a test class
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/test-skipped-in-setup-before-class.phpt
+++ b/tests/end-to-end/event/test-skipped-in-setup-before-class.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test skipped in setUpBeforeClass()
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/test-skipped-in-setup.phpt
+++ b/tests/end-to-end/event/test-skipped-in-setup.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test skipped in setUp()
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/test-skipped.phpt
+++ b/tests/end-to-end/event/test-skipped.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a skipped test
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/test-stub.phpt
+++ b/tests/end-to-end/event/test-stub.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that uses a test stub
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/testwith-annotation.phpt
+++ b/tests/end-to-end/event/testwith-annotation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test that uses the TestWith and TestWithJson attributes
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/testwith-attribute.phpt
+++ b/tests/end-to-end/event/testwith-attribute.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a successful test that uses the TestWith and TestWithJson attributes
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/too-few-columns.phpt
+++ b/tests/end-to-end/event/too-few-columns.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order when too few columns are requested
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/unexpected-end-of-test-in-separate-process.phpt
+++ b/tests/end-to-end/event/unexpected-end-of-test-in-separate-process.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test run in a separate process that ends unexpectedly
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/unsatisfied-requirement.phpt
+++ b/tests/end-to-end/event/unsatisfied-requirement.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that has an unsatisfied requirement
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/user-deprecated.phpt
+++ b/tests/end-to-end/event/user-deprecated.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers E_USER_DEPRECATED
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/user-error.phpt
+++ b/tests/end-to-end/event/user-error.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers E_USER_ERROR
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/user-notice.phpt
+++ b/tests/end-to-end/event/user-notice.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers an E_USER_NOTICE
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/event/user-warning.phpt
+++ b/tests/end-to-end/event/user-warning.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order for a test that runs code which triggers E_USER_WARNING
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/extension/phar-extension.phpt
+++ b/tests/end-to-end/extension/phar-extension.phpt
@@ -28,7 +28,7 @@ Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%s/tests/end-to-end/_files/phar-extension/phpunit.xml, 1 test)
+Test Suite Started (%s%etests%eend-to-end%e_files%ephar-extension%ephpunit.xml, 1 test)
 Test Suite Started (default, 1 test)
 Test Suite Started (PHPUnit\TestFixture\Event\MyExtension\Test, 1 test)
 Test Preparation Started (PHPUnit\TestFixture\Event\MyExtension\Test::testOne)
@@ -38,7 +38,7 @@ Test Passed (PHPUnit\TestFixture\Event\MyExtension\Test::testOne)
 Test Finished (PHPUnit\TestFixture\Event\MyExtension\Test::testOne)
 Test Suite Finished (PHPUnit\TestFixture\Event\MyExtension\Test, 1 test)
 Test Suite Finished (default, 1 test)
-Test Suite Finished (%s/tests/end-to-end/_files/phar-extension/phpunit.xml, 1 test)
+Test Suite Finished (%s%etests%eend-to-end%e_files%ephar-extension%ephpunit.xml, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/extension/phar-extension.phpt
+++ b/tests/end-to-end/extension/phar-extension.phpt
@@ -1,10 +1,5 @@
 --TEST--
 The right events are emitted in the right order when a PHPUnit extension from a PHAR is loaded
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/generic/controlled-garbage-collection.phpt
+++ b/tests/end-to-end/generic/controlled-garbage-collection.phpt
@@ -28,7 +28,7 @@ Test Suite Sorted
 Test Runner Execution Started (2 tests)
 Test Runner Disabled Garbage Collection
 Test Runner Triggered Garbage Collection
-Test Suite Started (%s/phpunit.xml, 2 tests)
+Test Suite Started (%s%ephpunit.xml, 2 tests)
 Test Suite Started (default, 2 tests)
 Test Suite Started (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::testOne)
@@ -45,7 +45,7 @@ Test Finished (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest::test
 Test Runner Triggered Garbage Collection
 Test Suite Finished (PHPUnit\TestFixture\GarbageCollection\GarbageCollectionTest, 2 tests)
 Test Suite Finished (default, 2 tests)
-Test Suite Finished (%s/phpunit.xml, 2 tests)
+Test Suite Finished (%s%ephpunit.xml, 2 tests)
 Test Runner Execution Finished
 Test Runner Triggered Garbage Collection
 Test Runner Enabled Garbage Collection

--- a/tests/end-to-end/generic/controlled-garbage-collection.phpt
+++ b/tests/end-to-end/generic/controlled-garbage-collection.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --configuration=__DIR__.'/../_files/controlled-garbage-collection'
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/generic/dataprovider-log-xml-isolation.phpt
+++ b/tests/end-to-end/generic/dataprovider-log-xml-isolation.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --process-isolation --log-junit php://stdout ../../_files/DataProviderTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $logfile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/generic/dataprovider-log-xml.phpt
+++ b/tests/end-to-end/generic/dataprovider-log-xml.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --log-junit php://stdout ../../_files/DataProviderTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $logfile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/logging/log-junit-to-file.phpt
+++ b/tests/end-to-end/logging/log-junit-to-file.phpt
@@ -1,10 +1,5 @@
 --TEST--
 phpunit --log-junit junit.xml _files/StatusTest.php
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $logfile = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/regression/5287.phpt
+++ b/tests/end-to-end/regression/5287.phpt
@@ -1,10 +1,5 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/5287
---SKIPIF--
-<?php declare(strict_types=1);
-if (DIRECTORY_SEPARATOR === '\\') {
-    print "skip: this test does not work on Windows / GitHub Actions\n";
-}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = tempnam(sys_get_temp_dir(), __FILE__);


### PR DESCRIPTION
103 E2E tests were skipped on Windows, 93 were passing without any change needed.

The remaining 10 are adjusted to pass with `\` Windows directory separator.