### PR TITLE
Fix error handler to not silence `error_get_last()` result

### DIFF
--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -13,6 +13,7 @@ use const PHP_EOL;
 use function assert;
 use function class_exists;
 use function defined;
+use function error_clear_last;
 use function extension_loaded;
 use function get_include_path;
 use function hrtime;
@@ -83,6 +84,8 @@ final class TestRunner
         $incomplete = false;
         $risky      = false;
         $skipped    = false;
+
+        error_clear_last();
 
         if ($this->shouldErrorHandlerBeUsed($test)) {
             ErrorHandler::instance()->enable();

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -17,8 +17,10 @@ use const E_DEPRECATED;
 use const E_ERROR;
 use const E_NOTICE;
 use const E_PARSE;
+use const E_RECOVERABLE_ERROR;
 use const E_STRICT;
 use const E_USER_DEPRECATED;
+use const E_USER_ERROR;
 use const E_USER_NOTICE;
 use const E_USER_WARNING;
 use const E_WARNING;
@@ -37,6 +39,7 @@ use PHPUnit\Util\ExcludeList;
 final class ErrorHandler
 {
     private const UNHANDLEABLE_LEVELS         = E_ERROR | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING;
+    private const UNSUPPRESSEABLE_LEVELS      = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
     private static ?self $instance            = null;
     private ?Baseline $baseline               = null;
     private bool $enabled                     = false;
@@ -52,7 +55,7 @@ final class ErrorHandler
      */
     public function __invoke(int $errorNumber, string $errorString, string $errorFile, int $errorLine): bool
     {
-        $suppressed = !($errorNumber & error_reporting());
+        $suppressed = (error_reporting() & ~self::UNSUPPRESSEABLE_LEVELS) === 0;
 
         if ($suppressed && (new ExcludeList)->isExcluded($errorFile)) {
             return false;

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -163,13 +163,7 @@ final class ErrorHandler
             return;
         }
 
-        $oldErrorHandler = set_error_handler($this);
-
-        if ($oldErrorHandler !== null) {
-            restore_error_handler();
-
-            return;
-        }
+        set_error_handler($this);
 
         $this->enabled = true;
 

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -27,6 +27,7 @@ use const E_WARNING;
 use function error_reporting;
 use function restore_error_handler;
 use function set_error_handler;
+use ErrorException;
 use PHPUnit\Event;
 use PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException;
 use PHPUnit\Runner\Baseline\Baseline;
@@ -151,7 +152,7 @@ final class ErrorHandler
                     $suppressed,
                 );
 
-                break;
+                throw new ErrorException('Any E_*_ERROR must abort execution');
 
             default:
                 return false;

--- a/tests/end-to-end/event/_files/DeprecatedFeatureTest.php
+++ b/tests/end-to-end/event/_files/DeprecatedFeatureTest.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\TestFixture\Event;
 
 use const E_USER_DEPRECATED;
+use function error_get_last;
 use function trigger_error;
 use PHPUnit\Framework\TestCase;
 
@@ -21,5 +22,12 @@ final class DeprecatedFeatureTest extends TestCase
         @trigger_error('message', E_USER_DEPRECATED);
 
         $this->assertTrue(true);
+    }
+
+    public function testDeprecatedSuppressedErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        @trigger_error('message', E_USER_DEPRECATED);
+        $this->assertIsArray(error_get_last());
     }
 }

--- a/tests/end-to-end/event/_files/IgnoreDeprecationsTest.php
+++ b/tests/end-to-end/event/_files/IgnoreDeprecationsTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TestFixture\Event;
 
+use function error_get_last;
 use function trigger_error;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
@@ -28,5 +29,20 @@ final class IgnoreDeprecationsTest extends TestCase
         trigger_error('message', E_USER_DEPRECATED);
 
         $this->assertTrue(true);
+    }
+
+    #[IgnoreDeprecations]
+    public function testOneErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        trigger_error('message', E_USER_DEPRECATED);
+        $this->assertIsArray(error_get_last());
+    }
+
+    public function testTwoErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        trigger_error('message', E_USER_DEPRECATED);
+        $this->assertIsArray(error_get_last());
     }
 }

--- a/tests/end-to-end/event/_files/SuppressedUserNoticeTest.php
+++ b/tests/end-to-end/event/_files/SuppressedUserNoticeTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TestFixture\Event;
 
+use function error_get_last;
 use function trigger_error;
 use PHPUnit\Framework\TestCase;
 
@@ -19,5 +20,12 @@ final class SuppressedUserNoticeTest extends TestCase
         $this->assertTrue(true);
 
         @trigger_error('message', E_USER_NOTICE);
+    }
+
+    public function testSuppressedUserNoticeErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        @trigger_error('message', E_USER_NOTICE);
+        $this->assertIsArray(error_get_last());
     }
 }

--- a/tests/end-to-end/event/_files/SuppressedUserWarningTest.php
+++ b/tests/end-to-end/event/_files/SuppressedUserWarningTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TestFixture\Event;
 
+use function error_get_last;
 use function trigger_error;
 use PHPUnit\Framework\TestCase;
 
@@ -19,5 +20,12 @@ final class SuppressedUserWarningTest extends TestCase
         $this->assertTrue(true);
 
         @trigger_error('message', E_USER_WARNING);
+    }
+
+    public function testSuppressedUserWarningErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        @trigger_error('message', E_USER_WARNING);
+        $this->assertIsArray(error_get_last());
     }
 }

--- a/tests/end-to-end/event/_files/UserErrorTest.php
+++ b/tests/end-to-end/event/_files/UserErrorTest.php
@@ -20,4 +20,10 @@ final class UserErrorTest extends TestCase
 
         trigger_error('message', E_USER_ERROR);
     }
+
+    public function testUserErrorMustAbortExecution(): void
+    {
+        trigger_error('message', E_USER_ERROR);
+        $this->assertTrue(false);
+    }
 }

--- a/tests/end-to-end/event/_files/UserNoticeTest.php
+++ b/tests/end-to-end/event/_files/UserNoticeTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TestFixture\Event;
 
+use function error_get_last;
 use function trigger_error;
 use PHPUnit\Framework\TestCase;
 
@@ -19,5 +20,12 @@ final class UserNoticeTest extends TestCase
         $this->assertTrue(true);
 
         trigger_error('message', E_USER_NOTICE);
+    }
+
+    public function testUserNoticeErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        trigger_error('message', E_USER_NOTICE);
+        $this->assertIsArray(error_get_last());
     }
 }

--- a/tests/end-to-end/event/_files/UserWarningTest.php
+++ b/tests/end-to-end/event/_files/UserWarningTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TestFixture\Event;
 
+use function error_get_last;
 use function trigger_error;
 use PHPUnit\Framework\TestCase;
 
@@ -19,5 +20,12 @@ final class UserWarningTest extends TestCase
         $this->assertTrue(true);
 
         trigger_error('message', E_USER_WARNING);
+    }
+
+    public function testUserWarningErrorGetLast(): void
+    {
+        $this->assertNull(error_get_last());
+        trigger_error('message', E_USER_WARNING);
+        $this->assertIsArray(error_get_last());
     }
 }

--- a/tests/end-to-end/event/_files/error-handler-can-be-disabled/tests/FooTest.php
+++ b/tests/end-to-end/event/_files/error-handler-can-be-disabled/tests/FooTest.php
@@ -9,6 +9,8 @@
  */
 namespace PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled;
 
+use function restore_error_handler;
+use function set_error_handler;
 use function sys_get_temp_dir;
 use function tempnam;
 use Exception;
@@ -32,5 +34,27 @@ final class FooTest extends TestCase
     public function testMethodB(): void
     {
         $this->assertSame('Triggering', (new Foo)->methodB()['message']);
+    }
+
+    public function testErrorHandlerSet(): void
+    {
+        $this->assertIsCallable($this->getErrorHandler());
+    }
+
+    #[WithoutErrorHandler]
+    public function testErrorHandlerIsNotSet(): void
+    {
+        $this->assertNull($this->getErrorHandler());
+    }
+
+    /**
+     * @return null|callable
+     */
+    private function getErrorHandler()
+    {
+        $res = set_error_handler(static fn () => false);
+        restore_error_handler();
+
+        return $res;
     }
 }

--- a/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute.phpt
+++ b/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (2 tests)
+Test Suite Loaded (4 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (2 tests)
-Test Suite Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest, 2 tests)
+Test Runner Execution Started (4 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest, 4 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOne)
 Test Prepared (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOne)
 Test Triggered Test-Ignored Deprecation (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOne)
@@ -41,7 +41,33 @@ message
 Assertion Succeeded (Constraint: is true, Value: true)
 Test Passed (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwo)
 Test Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwo)
-Test Suite Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Test-Ignored Deprecation (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 16384,
+    'message' => 'message',
+    'file' => '%s%e_files%eIgnoreDeprecationsTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
+Test Preparation Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Deprecation (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 16384,
+    'message' => 'message',
+    'file' => '%s%e_files%eIgnoreDeprecationsTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
+Test Suite Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest, 4 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute.phpt
+++ b/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute.phpt
@@ -43,7 +43,7 @@ Test Passed (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwo)
 Test Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwo)
 Test Preparation Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Test-Ignored Deprecation (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
@@ -56,7 +56,7 @@ Test Passed (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLa
 Test Finished (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testOneErrorGetLast)
 Test Preparation Started (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Deprecation (PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [

--- a/tests/end-to-end/event/error-handler-can-be-disabled.phpt
+++ b/tests/end-to-end/event/error-handler-can-be-disabled.phpt
@@ -23,14 +23,14 @@ unlink($traceFile);
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
 Bootstrap Finished (%s%esrc/Foo.php)
-Test Suite Loaded (2 tests)
+Test Suite Loaded (4 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (2 tests)
-Test Suite Started (%s%ephpunit.xml, 2 tests)
-Test Suite Started (default, 2 tests)
-Test Suite Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 2 tests)
+Test Runner Execution Started (4 tests)
+Test Suite Started (%s%ephpunit.xml, 4 tests)
+Test Suite Started (default, 4 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 4 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
 Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodA)
 Assertion Succeeded (Constraint: exception of type "Exception", Value: {enable export of objects to see this value})
@@ -42,9 +42,19 @@ Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::test
 Assertion Succeeded (Constraint: is identical to 'Triggering', Value: 'Triggering')
 Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
 Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testMethodB)
-Test Suite Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 2 tests)
-Test Suite Finished (default, 2 tests)
-Test Suite Finished (%s%ephpunit.xml, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerSet)
+Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerSet)
+Assertion Succeeded (Constraint: is of type callable, Value: {enable export of objects to see this value})
+Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerSet)
+Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerSet)
+Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
+Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
+Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
+Test Suite Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 4 tests)
+Test Suite Finished (default, 4 tests)
+Test Suite Finished (%s%ephpunit.xml, 4 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/error-handler-can-be-disabled.phpt
+++ b/tests/end-to-end/event/error-handler-can-be-disabled.phpt
@@ -49,7 +49,7 @@ Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testEr
 Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerSet)
 Test Preparation Started (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
 Test Prepared (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Passed (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
 Test Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest::testErrorHandlerIsNotSet)
 Test Suite Finished (PHPUnit\TestFixture\Event\ErrorHandlerCanBeDisabled\FooTest, 4 tests)

--- a/tests/end-to-end/event/suppressed-user-notice.phpt
+++ b/tests/end-to-end/event/suppressed-user-notice.phpt
@@ -36,7 +36,7 @@ Test Passed (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedU
 Test Finished (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNotice)
 Test Preparation Started (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Suppressed Notice (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [

--- a/tests/end-to-end/event/suppressed-user-notice.phpt
+++ b/tests/end-to-end/event/suppressed-user-notice.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest, 1 test)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNotice)
 Test Prepared (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNotice)
 Assertion Succeeded (Constraint: is true, Value: true)
@@ -34,7 +34,20 @@ Test Triggered Suppressed Notice (PHPUnit\TestFixture\Event\SuppressedUserNotice
 message
 Test Passed (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNotice)
 Test Finished (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNotice)
-Test Suite Finished (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Suppressed Notice (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 1024,
+    'message' => 'message',
+    'file' => '%s%e_files%eSuppressedUserNoticeTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest::testSuppressedUserNoticeErrorGetLast)
+Test Suite Finished (PHPUnit\TestFixture\Event\SuppressedUserNoticeTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/suppressed-user-warning.phpt
+++ b/tests/end-to-end/event/suppressed-user-warning.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (PHPUnit\TestFixture\Event\SuppressedUserWarningTest, 1 test)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\SuppressedUserWarningTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarning)
 Test Prepared (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarning)
 Assertion Succeeded (Constraint: is true, Value: true)
@@ -34,7 +34,20 @@ Test Triggered Suppressed Warning (PHPUnit\TestFixture\Event\SuppressedUserWarni
 message
 Test Passed (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarning)
 Test Finished (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarning)
-Test Suite Finished (PHPUnit\TestFixture\Event\SuppressedUserWarningTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Suppressed Warning (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 512,
+    'message' => 'message',
+    'file' => '%s%e_files%eSuppressedUserWarningTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
+Test Suite Finished (PHPUnit\TestFixture\Event\SuppressedUserWarningTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/suppressed-user-warning.phpt
+++ b/tests/end-to-end/event/suppressed-user-warning.phpt
@@ -36,7 +36,7 @@ Test Passed (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressed
 Test Finished (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarning)
 Test Preparation Started (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Suppressed Warning (PHPUnit\TestFixture\Event\SuppressedUserWarningTest::testSuppressedUserWarningErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [

--- a/tests/end-to-end/event/user-deprecated.phpt
+++ b/tests/end-to-end/event/user-deprecated.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (PHPUnit\TestFixture\Event\DeprecatedFeatureTest, 1 test)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\DeprecatedFeatureTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeature)
 Test Prepared (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeature)
 Test Triggered Deprecation (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeature)
@@ -36,7 +36,20 @@ message
 Assertion Succeeded (Constraint: is true, Value: true)
 Test Passed (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeature)
 Test Finished (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeature)
-Test Suite Finished (PHPUnit\TestFixture\Event\DeprecatedFeatureTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Suppressed Deprecation (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 16384,
+    'message' => 'message',
+    'file' => '%s%e_files%eDeprecatedFeatureTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
+Test Suite Finished (PHPUnit\TestFixture\Event\DeprecatedFeatureTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/user-deprecated.phpt
+++ b/tests/end-to-end/event/user-deprecated.phpt
@@ -38,7 +38,7 @@ Test Passed (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeat
 Test Finished (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedFeature)
 Test Preparation Started (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Suppressed Deprecation (PHPUnit\TestFixture\Event\DeprecatedFeatureTest::testDeprecatedSuppressedErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [

--- a/tests/end-to-end/event/user-error.phpt
+++ b/tests/end-to-end/event/user-error.phpt
@@ -32,7 +32,8 @@ Test Prepared (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
 Assertion Succeeded (Constraint: is true, Value: true)
 Test Triggered Error (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
 message
-Test Passed (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
+Test Errored (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
+Any E_*_ERROR must abort execution
 Test Finished (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
 Test Suite Finished (PHPUnit\TestFixture\Event\UserErrorTest, 1 test)
 Test Runner Execution Finished

--- a/tests/end-to-end/event/user-error.phpt
+++ b/tests/end-to-end/event/user-error.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (PHPUnit\TestFixture\Event\UserErrorTest, 1 test)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\UserErrorTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
 Test Prepared (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
 Assertion Succeeded (Constraint: is true, Value: true)
@@ -35,7 +35,14 @@ message
 Test Errored (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
 Any E_*_ERROR must abort execution
 Test Finished (PHPUnit\TestFixture\Event\UserErrorTest::testUserError)
-Test Suite Finished (PHPUnit\TestFixture\Event\UserErrorTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\UserErrorTest::testUserErrorMustAbortExecution)
+Test Prepared (PHPUnit\TestFixture\Event\UserErrorTest::testUserErrorMustAbortExecution)
+Test Triggered Error (PHPUnit\TestFixture\Event\UserErrorTest::testUserErrorMustAbortExecution)
+message
+Test Errored (PHPUnit\TestFixture\Event\UserErrorTest::testUserErrorMustAbortExecution)
+Any E_*_ERROR must abort execution
+Test Finished (PHPUnit\TestFixture\Event\UserErrorTest::testUserErrorMustAbortExecution)
+Test Suite Finished (PHPUnit\TestFixture\Event\UserErrorTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 2)

--- a/tests/end-to-end/event/user-notice.phpt
+++ b/tests/end-to-end/event/user-notice.phpt
@@ -36,7 +36,7 @@ Test Passed (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
 Test Finished (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
 Test Preparation Started (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Notice (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [

--- a/tests/end-to-end/event/user-notice.phpt
+++ b/tests/end-to-end/event/user-notice.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (PHPUnit\TestFixture\Event\UserNoticeTest, 1 test)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\UserNoticeTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
 Test Prepared (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
 Assertion Succeeded (Constraint: is true, Value: true)
@@ -34,7 +34,20 @@ Test Triggered Notice (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
 message
 Test Passed (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
 Test Finished (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNotice)
-Test Suite Finished (PHPUnit\TestFixture\Event\UserNoticeTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Notice (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 1024,
+    'message' => 'message',
+    'file' => '%s%e_files%eUserNoticeTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\UserNoticeTest::testUserNoticeErrorGetLast)
+Test Suite Finished (PHPUnit\TestFixture\Event\UserNoticeTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/user-warning.phpt
+++ b/tests/end-to-end/event/user-warning.phpt
@@ -21,12 +21,12 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (PHPUnit\TestFixture\Event\UserWarningTest, 1 test)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\UserWarningTest, 2 tests)
 Test Preparation Started (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarning)
 Test Prepared (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarning)
 Assertion Succeeded (Constraint: is true, Value: true)
@@ -34,7 +34,20 @@ Test Triggered Warning (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarni
 message
 Test Passed (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarning)
 Test Finished (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarning)
-Test Suite Finished (PHPUnit\TestFixture\Event\UserWarningTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
+Test Prepared (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
+Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Test Triggered Warning (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
+message
+Assertion Succeeded (Constraint: is of type array, Value: Array &0 [
+    'type' => 512,
+    'message' => 'message',
+    'file' => '%s%e_files%eUserWarningTest.php',
+    'line' => %d,
+])
+Test Passed (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
+Test Finished (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
+Test Suite Finished (PHPUnit\TestFixture\Event\UserWarningTest, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/user-warning.phpt
+++ b/tests/end-to-end/event/user-warning.phpt
@@ -36,7 +36,7 @@ Test Passed (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarning)
 Test Finished (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarning)
 Test Preparation Started (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
 Test Prepared (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
-Assertion Succeeded (Constraint: is null, Value: {enable export of objects to see this value})
+Assertion Succeeded (Constraint: is null, Value: null)
 Test Triggered Warning (PHPUnit\TestFixture\Event\UserWarningTest::testUserWarningErrorGetLast)
 message
 Assertion Succeeded (Constraint: is of type array, Value: Array &0 [

--- a/tests/end-to-end/generic/deprecations-can-be-ignored-using-attribute.phpt
+++ b/tests/end-to-end/generic/deprecations-can-be-ignored-using-attribute.phpt
@@ -15,11 +15,11 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-.D                                                                  2 / 2 (100%)
+.D.D                                                                4 / 4 (100%)
 
 Time: %s, Memory: %s
 
-1 test triggered 1 deprecation:
+2 tests triggered 2 deprecations:
 
 1) %sIgnoreDeprecationsTest.php:%d
 message
@@ -29,5 +29,13 @@ Triggered by:
 * PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwo
   %sIgnoreDeprecationsTest.php:%d
 
+2) %sIgnoreDeprecationsTest.php:%d
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\Event\IgnoreDeprecationsTest::testTwoErrorGetLast
+  %sIgnoreDeprecationsTest.php:%d
+
 OK, but there were issues!
-Tests: 2, Assertions: 2, Deprecations: 1.
+Tests: 4, Assertions: 6, Deprecations: 2.


### PR DESCRIPTION
fix #5587 (and older  #5428)

The updated PHPUnit error handler still supresses the output and still logs the errors as before.

This PR implies no BC break for existing PHPUnit 10.x tests /w and /wo `WithoutErrorHandler` attribute.

The `WithoutErrorHandler` attribute should be deprecated in the next minor version, as the new error handler impl. does not effectively imply any side effects so the behaviour /w and /wo PHPUnit error handler enabled is newly the same. In the next major version, the attribute should be completely removed and related https://github.com/sebastianbergmann/phpunit/commit/c2c8dbbd80b6e5c5ec98c844b37661f575908c7f and https://github.com/sebastianbergmann/phpunit/commit/e676667054ec44e55678a87dc7d8ee8b0a3637ba commits reverted.

In addition to fixing the linked issues:
- `error_clear_last()` is called before every test to clear `error_get_last()`
- `E_USER_ERROR` aborts script execution by default, so newly the updated PHPUnit error handled does the same