### PR TITLE
Fix Util\Exporter::export() to dump "null"

### DIFF
--- a/src/Util/Exporter.php
+++ b/src/Util/Exporter.php
@@ -20,16 +20,16 @@ final class Exporter
 {
     public static function export(mixed $value, bool $exportObjects = false): string
     {
-        if (self::isScalarOrArrayOfScalars($value) || $exportObjects) {
+        if (self::isScalarOrNullOrArrayOfScalars($value) || $exportObjects) {
             return (new \SebastianBergmann\Exporter\Exporter)->export($value);
         }
 
         return '{enable export of objects to see this value}';
     }
 
-    private static function isScalarOrArrayOfScalars(mixed &$value, Context $context = null): bool
+    private static function isScalarOrNullOrArrayOfScalars(mixed &$value, Context $context = null): bool
     {
-        if (is_scalar($value)) {
+        if (is_scalar($value) || $value === null) {
             return true;
         }
 
@@ -49,7 +49,7 @@ final class Exporter
         $context->add($value);
 
         foreach ($array as &$_value) {
-            if (!self::isScalarOrArrayOfScalars($_value, $context)) {
+            if (!self::isScalarOrNullOrArrayOfScalars($_value, $context)) {
                 return false;
             }
         }

--- a/tests/end-to-end/_files/log-events-text/Test.php
+++ b/tests/end-to-end/_files/log-events-text/Test.php
@@ -14,8 +14,13 @@ use stdClass;
 
 final class Test extends TestCase
 {
-    public function testOne(): void
+    public function testExportObject(): void
     {
         $this->assertSame(new stdClass, new stdClass);
+    }
+
+    public function testExportNull(): void
+    {
+        $this->assertNull(null);
     }
 }

--- a/tests/end-to-end/cli/log-events-text.phpt
+++ b/tests/end-to-end/cli/log-events-text.phpt
@@ -21,21 +21,26 @@ unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
 Test Runner Configured
-Test Suite Loaded (1 test)
+Test Suite Loaded (2 tests)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
-Test Runner Execution Started (1 test)
-Test Suite Started (CLI Arguments, 1 test)
-Test Suite Started (PHPUnit\TestFixture\LogEventsText\Test, 1 test)
-Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testOne)
-Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testOne)
+Test Runner Execution Started (2 tests)
+Test Suite Started (CLI Arguments, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\LogEventsText\Test, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
+Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 Assertion Failed (Constraint: is identical to an object of class "stdClass", Value: {enable export of objects to see this value})
-Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testOne)
+Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 Failed asserting that two variables reference the same object.
-Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testOne)
-Test Suite Finished (PHPUnit\TestFixture\LogEventsText\Test, 1 test)
-Test Suite Finished (CLI Arguments, 1 test)
+Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
+Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+Assertion Succeeded (Constraint: is null, Value: null)
+Test Passed (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+Test Suite Finished (PHPUnit\TestFixture\LogEventsText\Test, 2 tests)
+Test Suite Finished (CLI Arguments, 2 tests)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 1)

--- a/tests/end-to-end/cli/log-events-verbose-text.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text.phpt
@@ -21,21 +21,26 @@ unlink($traceFile);
 --EXPECTF--
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] PHPUnit Started (%s)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Runner Configured
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Loaded (1 test)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Loaded (2 tests)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Event Facade Sealed
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Runner Started
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Sorted
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Runner Execution Started (1 test)
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Started (CLI Arguments, 1 test)
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Started (PHPUnit\TestFixture\LogEventsText\Test, 1 test)
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testOne)
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testOne)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Runner Execution Started (2 tests)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Started (CLI Arguments, 2 tests)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Started (PHPUnit\TestFixture\LogEventsText\Test, 2 tests)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Assertion Failed (Constraint: is identical to an object of class "stdClass", Value: stdClass Object #%d ())
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testOne)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
                                                           Failed asserting that two variables reference the same object.
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testOne)
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Finished (PHPUnit\TestFixture\LogEventsText\Test, 1 test)
-[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Finished (CLI Arguments, 1 test)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Assertion Succeeded (Constraint: is null, Value: null)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Passed (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportNull)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Finished (PHPUnit\TestFixture\LogEventsText\Test, 2 tests)
+[%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Finished (CLI Arguments, 2 tests)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Runner Execution Finished
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Runner Finished
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] PHPUnit Finished (Shell Exit Code: 1)


### PR DESCRIPTION
previously `null` was dumped as `{enable export of objects to see this value}`