### PR TITLE
Assertions for comparing arrays while ignoring a specified list of keys

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -9,9 +9,11 @@
  */
 namespace PHPUnit\Framework;
 
+use function array_keys;
 use function class_exists;
 use function count;
 use function file_get_contents;
+use function in_array;
 use function interface_exists;
 use function is_bool;
 use ArrayAccess;
@@ -73,17 +75,25 @@ abstract class Assert
     private static int $count = 0;
 
     /**
-     * Asserts that two arrays are equal while ignoring a list of keys.
+     * Asserts that two arrays are equal while only considering a list of keys.
      *
-     * @psalm-param list<array-key> $keysToBeIgnored
+     * @psalm-param list<array-key> $keysToBeConsidered
      *
      * @throws Exception
      * @throws ExpectationFailedException
      */
-    final public static function assertArrayIsEqualToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    final public static function assertArrayIsEqualToArrayOnlyConsideringListOfKeys(array $expected, array $actual, array $keysToBeConsidered, string $message = ''): void
     {
-        foreach ($keysToBeIgnored as $key) {
-            unset($expected[$key], $actual[$key]);
+        foreach (array_keys($expected) as $key) {
+            if (!in_array($key, $keysToBeConsidered, true)) {
+                unset($expected[$key]);
+            }
+        }
+
+        foreach (array_keys($actual) as $key) {
+            if (!in_array($key, $keysToBeConsidered, true)) {
+                unset($actual[$key]);
+            }
         }
 
         static::assertEquals($expected, $actual, $message);
@@ -97,7 +107,49 @@ abstract class Assert
      * @throws Exception
      * @throws ExpectationFailedException
      */
-    final public static function assertArrayIsIdenticalToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    final public static function assertArrayIsEqualToArrayIgnoringListOfKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    {
+        foreach ($keysToBeIgnored as $key) {
+            unset($expected[$key], $actual[$key]);
+        }
+
+        static::assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two arrays are identical while only considering a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeConsidered
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys(array $expected, array $actual, array $keysToBeConsidered, string $message = ''): void
+    {
+        foreach (array_keys($expected) as $key) {
+            if (!in_array($key, $keysToBeConsidered, true)) {
+                unset($expected[$key]);
+            }
+        }
+
+        foreach (array_keys($actual) as $key) {
+            if (!in_array($key, $keysToBeConsidered, true)) {
+                unset($actual[$key]);
+            }
+        }
+
+        static::assertSame($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two arrays are equal while ignoring a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeIgnored
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArrayIsIdenticalToArrayIgnoringListOfKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
     {
         foreach ($keysToBeIgnored as $key) {
             unset($expected[$key], $actual[$key]);

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -73,6 +73,40 @@ abstract class Assert
     private static int $count = 0;
 
     /**
+     * Asserts that two arrays are equal while ignoring a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeIgnored
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArrayIsEqualToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    {
+        foreach ($keysToBeIgnored as $key) {
+            unset($expected[$key], $actual[$key]);
+        }
+
+        static::assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two arrays are equal while ignoring a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeIgnored
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArrayIsIdenticalToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    {
+        foreach ($keysToBeIgnored as $key) {
+            unset($expected[$key], $actual[$key]);
+        }
+
+        static::assertSame($expected, $actual, $message);
+    }
+
+    /**
      * Asserts that an array has a specified key.
      *
      * @throws Exception

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -69,26 +69,26 @@ use PHPUnit\Framework\MockObject\Stub\ReturnValueMap as ReturnValueMapStub;
 use PHPUnit\Util\Xml\XmlException;
 use Throwable;
 
-if (!function_exists('PHPUnit\Framework\assertArrayIsEqualToArrayIgnoringKeys')) {
+if (!function_exists('PHPUnit\Framework\assertArrayIsEqualToArrayOnlyConsideringListOfKeys')) {
     /**
-     * Asserts that two arrays are equal while ignoring a list of keys.
+     * Asserts that two arrays are equal while only considering a list of keys.
      *
-     * @psalm-param list<array-key> $keysToBeIgnored
+     * @psalm-param list<array-key> $keysToBeConsidered
      *
      * @throws Exception
      * @throws ExpectationFailedException
      *
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
-     * @see Assert::assertArrayIsEqualToArrayIgnoringKeys
+     * @see Assert::assertArrayIsEqualToArrayOnlyConsideringListOfKeys
      */
-    function assertArrayIsEqualToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    function assertArrayIsEqualToArrayOnlyConsideringListOfKeys(array $expected, array $actual, array $keysToBeConsidered, string $message = ''): void
     {
-        Assert::assertArrayIsEqualToArrayIgnoringKeys(...func_get_args());
+        Assert::assertArrayIsEqualToArrayOnlyConsideringListOfKeys(...func_get_args());
     }
 }
 
-if (!function_exists('PHPUnit\Framework\assertArrayIsIdenticalToArrayIgnoringKeys')) {
+if (!function_exists('PHPUnit\Framework\assertArrayIsEqualToArrayIgnoringListOfKeys')) {
     /**
      * Asserts that two arrays are equal while ignoring a list of keys.
      *
@@ -99,11 +99,49 @@ if (!function_exists('PHPUnit\Framework\assertArrayIsIdenticalToArrayIgnoringKey
      *
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
-     * @see Assert::assertArrayIsIdenticalToArrayIgnoringKeys
+     * @see Assert::assertArrayIsEqualToArrayIgnoringListOfKeys
      */
-    function assertArrayIsIdenticalToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    function assertArrayIsEqualToArrayIgnoringListOfKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
     {
-        Assert::assertArrayIsIdenticalToArrayIgnoringKeys(...func_get_args());
+        Assert::assertArrayIsEqualToArrayIgnoringListOfKeys(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys')) {
+    /**
+     * Asserts that two arrays are identical while only considering a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeConsidered
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys
+     */
+    function assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys(array $expected, array $actual, array $keysToBeConsidered, string $message = ''): void
+    {
+        Assert::assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArrayIsIdenticalToArrayIgnoringListOfKeys')) {
+    /**
+     * Asserts that two arrays are equal while ignoring a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeIgnored
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArrayIsIdenticalToArrayIgnoringListOfKeys
+     */
+    function assertArrayIsIdenticalToArrayIgnoringListOfKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    {
+        Assert::assertArrayIsIdenticalToArrayIgnoringListOfKeys(...func_get_args());
     }
 }
 

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -69,6 +69,44 @@ use PHPUnit\Framework\MockObject\Stub\ReturnValueMap as ReturnValueMapStub;
 use PHPUnit\Util\Xml\XmlException;
 use Throwable;
 
+if (!function_exists('PHPUnit\Framework\assertArrayIsEqualToArrayIgnoringKeys')) {
+    /**
+     * Asserts that two arrays are equal while ignoring a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeIgnored
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArrayIsEqualToArrayIgnoringKeys
+     */
+    function assertArrayIsEqualToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    {
+        Assert::assertArrayIsEqualToArrayIgnoringKeys(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArrayIsIdenticalToArrayIgnoringKeys')) {
+    /**
+     * Asserts that two arrays are equal while ignoring a list of keys.
+     *
+     * @psalm-param list<array-key> $keysToBeIgnored
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArrayIsIdenticalToArrayIgnoringKeys
+     */
+    function assertArrayIsIdenticalToArrayIgnoringKeys(array $expected, array $actual, array $keysToBeIgnored, string $message = ''): void
+    {
+        Assert::assertArrayIsIdenticalToArrayIgnoringKeys(...func_get_args());
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertArrayHasKey')) {
     /**
      * Asserts that an array has a specified key.

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -143,28 +143,52 @@ final class AssertTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Book::class, $test2);
     }
 
-    public function testAssertArrayIsEqualToArrayIgnoringKeys(): void
+    public function testAssertArrayIsEqualToArrayOnlyConsideringListOfKeys(): void
     {
         $expected = ['a' => 'b', 'b' => 'c', 0 => 1, 1 => 2];
         $actual   = ['a' => 'b', 'b' => 'b', 0 => 1, 1 => 3];
 
-        $this->assertArrayIsEqualToArrayIgnoringKeys($expected, $actual, ['b', 1]);
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys($expected, $actual, ['a', 0]);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertArrayIsEqualToArrayIgnoringKeys($expected, $actual, ['b']);
+        $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys($expected, $actual, ['b']);
     }
 
-    public function testAssertArrayIsIdenticalToArrayIgnoringKeys(): void
+    public function testAssertArrayIsEqualToArrayIgnoringListOfKeys(): void
     {
         $expected = ['a' => 'b', 'b' => 'c', 0 => 1, 1 => 2];
         $actual   = ['a' => 'b', 'b' => 'b', 0 => 1, 1 => 3];
 
-        $this->assertArrayIsIdenticalToArrayIgnoringKeys($expected, $actual, ['b', 1]);
+        $this->assertArrayIsEqualToArrayIgnoringListOfKeys($expected, $actual, ['b', 1]);
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertArrayIsIdenticalToArrayIgnoringKeys($expected, $actual, ['b']);
+        $this->assertArrayIsEqualToArrayIgnoringListOfKeys($expected, $actual, ['b']);
+    }
+
+    public function testAssertArrayIsIdenticalToArrayOnlyConsideringListOfKeys(): void
+    {
+        $expected = ['a' => 'b', 'b' => 'c', 0 => 1, 1 => 2];
+        $actual   = ['a' => 'b', 'b' => 'b', 0 => 1, 1 => 3];
+
+        $this->assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys($expected, $actual, ['a', 0]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayIsIdenticalToArrayOnlyConsideringListOfKeys($expected, $actual, ['b']);
+    }
+
+    public function testAssertArrayIsIdenticalToArrayIgnoringListOfKeys(): void
+    {
+        $expected = ['a' => 'b', 'b' => 'c', 0 => 1, 1 => 2];
+        $actual   = ['a' => 'b', 'b' => 'b', 0 => 1, 1 => 3];
+
+        $this->assertArrayIsIdenticalToArrayIgnoringListOfKeys($expected, $actual, ['b', 1]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayIsIdenticalToArrayIgnoringListOfKeys($expected, $actual, ['b']);
     }
 
     public function testAssertArrayHasIntegerKey(): void

--- a/tests/unit/Framework/AssertTest.php
+++ b/tests/unit/Framework/AssertTest.php
@@ -143,6 +143,30 @@ final class AssertTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Book::class, $test2);
     }
 
+    public function testAssertArrayIsEqualToArrayIgnoringKeys(): void
+    {
+        $expected = ['a' => 'b', 'b' => 'c', 0 => 1, 1 => 2];
+        $actual   = ['a' => 'b', 'b' => 'b', 0 => 1, 1 => 3];
+
+        $this->assertArrayIsEqualToArrayIgnoringKeys($expected, $actual, ['b', 1]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayIsEqualToArrayIgnoringKeys($expected, $actual, ['b']);
+    }
+
+    public function testAssertArrayIsIdenticalToArrayIgnoringKeys(): void
+    {
+        $expected = ['a' => 'b', 'b' => 'c', 0 => 1, 1 => 2];
+        $actual   = ['a' => 'b', 'b' => 'b', 0 => 1, 1 => 3];
+
+        $this->assertArrayIsIdenticalToArrayIgnoringKeys($expected, $actual, ['b', 1]);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertArrayIsIdenticalToArrayIgnoringKeys($expected, $actual, ['b']);
+    }
+
     public function testAssertArrayHasIntegerKey(): void
     {
         $this->assertArrayHasKey(0, ['foo']);


### PR DESCRIPTION
This implements the `assertArrayIsEqualToArrayIgnoringListOfKeys()` and `assertArrayIsIdenticalToArrayIgnoringListOfKeys()` assertions that compare two arrays while ignoring a list of keys. This is useful when the arrays that are to be compared contain date/time-dependent or random information.

This also implements the `assertArrayIsEqualToArrayOnlyConsideringListOfKeys()` and `assertArrayIsEqualToArrayOnlyConsideringListOfKeys()` assertions that assert that two arrays are equal (or identical, respectively) while only considering a list of keys. This is useful when there are more keys to be ignored (see above) than to actually be considered for the comparison.

I am reluctant to add new assertions, but the use cases they address have been brought up a couple of times recently, so maybe they should be added.