### PR TITLE
Fix: Reuse reference to emitter

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -720,7 +720,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         }
 
         if ($this->status->isSuccess()) {
-            Event\Facade::emitter()->testPassed(
+            $emitter->testPassed(
                 $this->valueObjectForEvents(),
             );
 


### PR DESCRIPTION
This pull request

- [x] reuses a reference to the event emitter