### PR TITLE
remove empty coverage tag when migrationg phpunit.xml https://github.com/sebastianbergmann/phpunit/issues/5612

### DIFF
--- a/src/TextUI/Configuration/Xml/Migration/MigrationBuilder.php
+++ b/src/TextUI/Configuration/Xml/Migration/MigrationBuilder.php
@@ -62,6 +62,7 @@ final class MigrationBuilder
 
         '10.0' => [
             MoveCoverageDirectoriesToSource::class,
+            RemoveEmptyCoverageTag::class,
         ],
     ];
 

--- a/src/TextUI/Configuration/Xml/Migration/Migrations/RemoveEmptyCoverageTag.php
+++ b/src/TextUI/Configuration/Xml/Migration/Migrations/RemoveEmptyCoverageTag.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\XmlConfiguration;
+
+use DOMDocument;
+use DOMElement;
+
+class RemoveEmptyCoverageTag implements Migration
+{
+    public function migrate(DOMDocument $document): void
+    {
+        $node = $document->getElementsByTagName('coverage')->item(0);
+
+        if (!$node instanceof DOMElement || $node->parentNode === null) {
+            return;
+        }
+
+        if ($node->childElementCount !== 0) {
+            return;
+        }
+
+        $node->parentNode->removeChild($node);
+    }
+}

--- a/tests/_files/XmlConfigurationMigration/output-9.5.xml
+++ b/tests/_files/XmlConfigurationMigration/output-9.5.xml
@@ -6,7 +6,6 @@
          cacheDirectory=".phpunit.cache"
          requireCoverageMetadata="true">
 
-    <coverage/>
 
     <logging/>
 


### PR DESCRIPTION
Remove empty coverage tag generated during migration of phpunit.xml
psalm check done,
php-cs-fixer done,
fixed tests after changes