### PR TITLE
`--exclude-filter` CLI option for excluding tests from execution

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -621,17 +621,23 @@
       <code><![CDATA[$this->groupTests]]></code>
     </PropertyTypeCoercion>
   </file>
-  <file src="src/Runner/Filter/NameFilterIterator.php">
+  <file src="src/Runner/Filter/IncludeNameFilterIterator.php">
     <ArgumentTypeCoercion>
       <code>$filter</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/Runner/Filter/ExcludeNameFilterIterator.php">
+    <ArgumentTypeCoercion>
+      <code>$filter</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/Runner/Filter/NameFilterIterator.php">
+    <ArgumentTypeCoercion>
       <code><![CDATA[$this->filter]]></code>
     </ArgumentTypeCoercion>
     <MissingTemplateParam>
       <code>NameFilterIterator</code>
     </MissingTemplateParam>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->filter]]></code>
-    </PossiblyNullArgument>
   </file>
   <file src="src/Runner/Filter/TestIdFilterIterator.php">
     <MissingTemplateParam>
@@ -671,6 +677,9 @@
     </UnresolvableInclude>
   </file>
   <file src="src/Runner/TestSuiteSorter.php">
+    <MissingThrowsDocblock>
+      <code>$suite</code>
+    </MissingThrowsDocblock>
     <ArgumentTypeCoercion>
       <code>$tests</code>
       <code><![CDATA[$this->randomize($suite->tests())]]></code>
@@ -951,6 +960,7 @@
   <file src="src/TextUI/TestSuiteFilterProcessor.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$configuration->excludeGroups()]]></code>
+      <code><![CDATA[$configuration->excludeFilter()]]></code>
       <code><![CDATA[$configuration->filter()]]></code>
       <code><![CDATA[$configuration->groups()]]></code>
     </ArgumentTypeCoercion>

--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -632,9 +632,12 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="src/Runner/Filter/NameFilterIterator.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$this->filter]]></code>
-    </ArgumentTypeCoercion>
+      <ArgumentTypeCoercion>
+          <code><![CDATA[$this->filter]]></code>
+      </ArgumentTypeCoercion>
+    <PropertyNotSetInConstructor>
+      <code>$filter</code>
+    </PropertyNotSetInConstructor>
     <MissingTemplateParam>
       <code>NameFilterIterator</code>
     </MissingTemplateParam>

--- a/src/Event/Value/TestSuite/TestSuiteBuilder.php
+++ b/src/Event/Value/TestSuite/TestSuiteBuilder.php
@@ -27,6 +27,7 @@ use ReflectionMethod;
 final readonly class TestSuiteBuilder
 {
     /**
+     * @throws ReflectionException
      * @throws RuntimeException
      */
     public static function from(FrameworkTestSuite $testSuite): TestSuite
@@ -104,6 +105,8 @@ final readonly class TestSuiteBuilder
 
     /**
      * @psalm-param list<Test> $tests
+     *
+     * @throws ReflectionException
      */
     private static function process(FrameworkTestSuite $testSuite, &$tests): void
     {

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -44,6 +44,7 @@ use PHPUnit\Util\Filter;
 use PHPUnit\Util\Reflection;
 use PHPUnit\Util\Test as TestUtil;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionMethod;
 use SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException;
 use Throwable;
@@ -261,6 +262,8 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
 
     /**
      * Counts the number of test cases that will be run by this test.
+     *
+     * @throws ReflectionException
      */
     public function count(): int
     {
@@ -310,6 +313,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
      * @throws Event\RuntimeException
      * @throws Exception
      * @throws NoPreviousThrowableException
+     * @throws ReflectionException
      * @throws UnintentionallyCoveredCodeException
      */
     public function run(): void
@@ -374,6 +378,8 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
 
     /**
      * Returns an iterator for this test suite.
+     *
+     * @throws ReflectionException
      */
     public function getIterator(): Iterator
     {
@@ -386,6 +392,9 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
         return $iterator;
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function injectFilter(Factory $filter): void
     {
         $this->iteratorFilter = $filter;
@@ -530,6 +539,9 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
         return true;
     }
 
+    /**
+     * @throws ReflectionException
+     */
     private function methodDoesNotExistOrIsDeclaredInTestCase(string $methodName): bool
     {
         $reflector = new ReflectionClass($this->name);
@@ -639,6 +651,9 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
         return true;
     }
 
+    /**
+     * @throws ReflectionException
+     */
     private function invokeMethodsAfterLastTest(Event\Emitter $emitter): void
     {
         if (!$this->isForTestClass()) {

--- a/src/Runner/Filter/ExcludeNameFilterIterator.php
+++ b/src/Runner/Filter/ExcludeNameFilterIterator.php
@@ -21,14 +21,16 @@ class ExcludeNameFilterIterator extends NameFilterIterator
      */
     protected function setFilter(string $filter): void
     {
-        $filter = sprintf(
-            '/^(?:(?!%s).)*/i',
-            str_replace(
-                '/',
-                '\\/',
-                $filter,
-            ),
-        );
+        if (@preg_match($filter, '') === false) {
+            $filter = sprintf(
+                '/^(?:(?!%s).)*/i',
+                str_replace(
+                    '/',
+                    '\\/',
+                    $filter,
+                ),
+            );
+        }
 
         $this->filter = $filter;
     }

--- a/src/Runner/Filter/ExcludeNameFilterIterator.php
+++ b/src/Runner/Filter/ExcludeNameFilterIterator.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use function preg_match;
+use function sprintf;
+use function str_replace;
+use Exception;
+
+class ExcludeNameFilterIterator extends NameFilterIterator
+{
+    /**
+     * @throws Exception
+     */
+    protected function setFilter(string $filter): void
+    {
+        if (@preg_match($filter, '') === false) {
+            // Handles:
+            //  * testAssertEqualsSucceeds#4
+            //  * testAssertEqualsSucceeds#4-8
+            if (preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
+                if (isset($matches[3]) && $matches[2] < $matches[3]) {
+                    $filter = sprintf(
+                        '^(?:(?!%s).)*with data set #(\d+)$',
+                        $matches[1],
+                    );
+
+                    $this->filterMin = (int) $matches[2];
+                    $this->filterMax = (int) $matches[3];
+                } else {
+                    // if the exclude-filter is name it will match anything that doesn't contain name
+                    $filter = sprintf(
+                        '^(?:(?!%s).)*with data set #%s$',
+                        $matches[1],
+                        $matches[2],
+                    );
+                }
+            } // Handles:
+            //  * testDetermineJsonError@JSON_ERROR_NONE
+            //  * testDetermineJsonError@JSON.*
+            elseif (preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
+                $filter = sprintf(
+                    '^(?:(?!%s).)*with data set "%s"$',
+                    $matches[1],
+                    $matches[2],
+                );
+            }
+
+            // Escape delimiters in regular expression. Do NOT use preg_quote,
+            // to keep magic characters.
+            $filter = sprintf(
+                '/^(?:(?!%s).)*/i',
+                str_replace(
+                    '/',
+                    '\\/',
+                    $filter,
+                ),
+            );
+        }
+
+        $this->filter = $filter;
+    }
+}

--- a/src/Runner/Filter/ExcludeNameFilterIterator.php
+++ b/src/Runner/Filter/ExcludeNameFilterIterator.php
@@ -21,49 +21,14 @@ class ExcludeNameFilterIterator extends NameFilterIterator
      */
     protected function setFilter(string $filter): void
     {
-        if (@preg_match($filter, '') === false) {
-            // Handles:
-            //  * testAssertEqualsSucceeds#4
-            //  * testAssertEqualsSucceeds#4-8
-            if (preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
-                if (isset($matches[3]) && $matches[2] < $matches[3]) {
-                    $filter = sprintf(
-                        '^(?:(?!%s).)*with data set #(\d+)$',
-                        $matches[1],
-                    );
-
-                    $this->filterMin = (int) $matches[2];
-                    $this->filterMax = (int) $matches[3];
-                } else {
-                    // if the exclude-filter is name it will match anything that doesn't contain name
-                    $filter = sprintf(
-                        '^(?:(?!%s).)*with data set #%s$',
-                        $matches[1],
-                        $matches[2],
-                    );
-                }
-            } // Handles:
-            //  * testDetermineJsonError@JSON_ERROR_NONE
-            //  * testDetermineJsonError@JSON.*
-            elseif (preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
-                $filter = sprintf(
-                    '^(?:(?!%s).)*with data set "%s"$',
-                    $matches[1],
-                    $matches[2],
-                );
-            }
-
-            // Escape delimiters in regular expression. Do NOT use preg_quote,
-            // to keep magic characters.
-            $filter = sprintf(
-                '/^(?:(?!%s).)*/i',
-                str_replace(
-                    '/',
-                    '\\/',
-                    $filter,
-                ),
-            );
-        }
+        $filter = sprintf(
+            '/^(?:(?!%s).)*/i',
+            str_replace(
+                '/',
+                '\\/',
+                $filter,
+            ),
+        );
 
         $this->filter = $filter;
     }

--- a/src/Runner/Filter/Factory.php
+++ b/src/Runner/Filter/Factory.php
@@ -14,6 +14,7 @@ use FilterIterator;
 use Iterator;
 use PHPUnit\Framework\TestSuite;
 use ReflectionClass;
+use ReflectionException;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -61,10 +62,23 @@ final class Factory
     public function addNameFilter(string $name): void
     {
         $this->filters[] = [
-            new ReflectionClass(NameFilterIterator::class), $name,
+            new ReflectionClass(IncludeNameFilterIterator::class), $name,
         ];
     }
 
+    /**
+     * @psalm-param non-empty-string $name
+     */
+    public function addExcludeNameFilter(string $name): void
+    {
+        $this->filters[] = [
+            new ReflectionClass(ExcludeNameFilterIterator::class), $name,
+        ];
+    }
+
+    /**
+     * @throws ReflectionException
+     */
     public function factory(Iterator $iterator, TestSuite $suite): FilterIterator
     {
         foreach ($this->filters as $filter) {

--- a/src/Runner/Filter/IncludeNameFilterIterator.php
+++ b/src/Runner/Filter/IncludeNameFilterIterator.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use function preg_match;
+use function sprintf;
+use function str_replace;
+
+final class IncludeNameFilterIterator extends NameFilterIterator
+{
+    protected function setFilter(string $filter): void
+    {
+        if (@preg_match($filter, '') === false) {
+            // Handles:
+            //  * testAssertEqualsSucceeds#4
+            //  * testAssertEqualsSucceeds#4-8
+            if (preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
+                if (isset($matches[3]) && $matches[2] < $matches[3]) {
+                    $filter = sprintf(
+                        '%s.*with data set #(\d+)$',
+                        $matches[1],
+                    );
+
+                    $this->filterMin = (int) $matches[2];
+                    $this->filterMax = (int) $matches[3];
+                } else {
+                    $filter = sprintf(
+                        '%s.*with data set #%s$',
+                        $matches[1],
+                        $matches[2],
+                    );
+                }
+            } // Handles:
+            //  * testDetermineJsonError@JSON_ERROR_NONE
+            //  * testDetermineJsonError@JSON.*
+            elseif (preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
+                $filter = sprintf(
+                    '%s.*with data set "%s"$',
+                    $matches[1],
+                    $matches[2],
+                );
+            }
+
+            // Escape delimiters in regular expression. Do NOT use preg_quote,
+            // to keep magic characters.
+            $filter = sprintf(
+                '/%s/i',
+                str_replace(
+                    '/',
+                    '\\/',
+                    $filter,
+                ),
+            );
+        }
+
+        $this->filter = $filter;
+    }
+}

--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -13,7 +13,6 @@ use function end;
 use function implode;
 use function preg_match;
 use Exception;
-use PHPUnit\Framework\SelfDescribing;
 use PHPUnit\Framework\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
@@ -25,7 +24,7 @@ use RecursiveIterator;
  */
 abstract class NameFilterIterator extends RecursiveFilterIterator
 {
-    protected ?string $filter = null;
+    protected string $filter;
     protected ?int $filterMin = null;
     protected ?int $filterMax = null;
 
@@ -41,6 +40,9 @@ abstract class NameFilterIterator extends RecursiveFilterIterator
         $this->setFilter($filter);
     }
 
+    /**
+     * @throws Exception
+     */
     public function accept(): bool
     {
         $test = $this->getInnerIterator()->current();
@@ -49,17 +51,8 @@ abstract class NameFilterIterator extends RecursiveFilterIterator
             return true;
         }
 
-        $tmp = $this->describe($test);
-
-        if ($tmp[0] !== '') {
-            $name = implode('::', $tmp);
-        } else {
-            $name = $tmp[1];
-        }
-
-        if (null === $this->filter) {
-            return false;
-        }
+        $tmp  = $this->describe($test);
+        $name = implode('::', $tmp);
 
         $accepted = @preg_match($this->filter, $name, $matches) === 1;
 
@@ -75,17 +68,15 @@ abstract class NameFilterIterator extends RecursiveFilterIterator
 
     /**
      * @psalm-return array{0: string, 1: string}
+     *
+     * @throws Exception
      */
     private function describe(Test $test): array
     {
-        if ($test instanceof TestCase) {
-            return [$test::class, $test->nameWithDataSet()];
+        if (!($test instanceof TestCase)) {
+            throw new Exception('You have to extend TestCase class.');
         }
 
-        if ($test instanceof SelfDescribing) {
-            return ['', $test->toString()];
-        }
-
-        return ['', $test::class];
+        return [$test::class, $test->nameWithDataSet()];
     }
 }

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -91,6 +91,7 @@ final class TestSuiteSorter
 
     /**
      * @throws Exception
+     * @throws ReflectionException
      */
     public function reorderTestsInSuite(Test $suite, int $order, bool $resolveDependencies, int $orderDefects, bool $isRootTestSuite = true): void
     {

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -72,6 +72,7 @@ use PHPUnit\TextUI\Output\Printer;
 use PHPUnit\TextUI\XmlConfiguration\Configuration as XmlConfiguration;
 use PHPUnit\TextUI\XmlConfiguration\DefaultConfiguration;
 use PHPUnit\TextUI\XmlConfiguration\Loader;
+use ReflectionException;
 use SebastianBergmann\Timer\Timer;
 use Throwable;
 
@@ -323,6 +324,9 @@ final readonly class Application
         }
     }
 
+    /**
+     * @throws ReflectionException
+     */
     private function buildTestSuite(Configuration $configuration): TestSuite
     {
         try {

--- a/src/TextUI/Command/Commands/ListGroupsCommand.php
+++ b/src/TextUI/Command/Commands/ListGroupsCommand.php
@@ -72,7 +72,7 @@ final readonly class ListGroupsCommand implements Command
         }
 
         if ($configuration->includeTestSuite() !== '') {
-            $buffer .= 'The --testsuite and --list-groups options cannot be combined, --exclude-group is ignored' . PHP_EOL;
+            $buffer .= 'The --testsuite and --list-groups options cannot be combined, --testsuite is ignored' . PHP_EOL;
         }
 
         if (!empty($buffer)) {

--- a/src/TextUI/Command/Commands/ListGroupsCommand.php
+++ b/src/TextUI/Command/Commands/ListGroupsCommand.php
@@ -59,6 +59,10 @@ final readonly class ListGroupsCommand implements Command
             $buffer .= 'The --filter and --list-groups options cannot be combined, --filter is ignored' . PHP_EOL;
         }
 
+        if ($configuration->hasExcludeFilter()) {
+            $buffer .= 'The --exclude-filter and --list-groups options cannot be combined, --exclude-filter is ignored' . PHP_EOL;
+        }
+
         if ($configuration->hasGroups()) {
             $buffer .= 'The --group and --list-groups options cannot be combined, --group is ignored' . PHP_EOL;
         }

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -57,6 +57,7 @@ final readonly class Builder
         'enforce-time-limit',
         'exclude-group=',
         'filter=',
+        'exclude-filter=',
         'generate-baseline=',
         'use-baseline=',
         'ignore-baseline',
@@ -196,6 +197,7 @@ final readonly class Builder
         $stopOnSkipped                     = null;
         $stopOnWarning                     = null;
         $filter                            = null;
+        $excludeFilter                     = null;
         $generateBaseline                  = null;
         $useBaseline                       = null;
         $ignoreBaseline                    = false;
@@ -352,6 +354,11 @@ final readonly class Builder
 
                 case '--filter':
                     $filter = $option[1];
+
+                    break;
+
+                case '--exclude-filter':
+                    $excludeFilter = $option[1];
 
                     break;
 
@@ -875,6 +882,7 @@ final readonly class Builder
             $stopOnSkipped,
             $stopOnWarning,
             $filter,
+            $excludeFilter,
             $generateBaseline,
             $useBaseline,
             $ignoreBaseline,

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -67,6 +67,7 @@ final readonly class Configuration
     private ?bool $stopOnSkipped;
     private ?bool $stopOnWarning;
     private ?string $filter;
+    private ?string $excludeFilter;
     private ?string $generateBaseline;
     private ?string $useBaseline;
     private bool $ignoreBaseline;
@@ -123,7 +124,7 @@ final readonly class Configuration
      * @psalm-param list<non-empty-string> $arguments
      * @psalm-param ?non-empty-list<non-empty-string> $testSuffixes
      */
-    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox)
+    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox)
     {
         $this->arguments                                    = $arguments;
         $this->atLeastVersion                               = $atLeastVersion;
@@ -173,6 +174,7 @@ final readonly class Configuration
         $this->stopOnSkipped                                = $stopOnSkipped;
         $this->stopOnWarning                                = $stopOnWarning;
         $this->filter                                       = $filter;
+        $this->excludeFilter                                = $excludeFilter;
         $this->generateBaseline                             = $generateBaseline;
         $this->useBaseline                                  = $useBaseline;
         $this->ignoreBaseline                               = $ignoreBaseline;
@@ -1118,6 +1120,26 @@ final readonly class Configuration
         }
 
         return $this->stopOnWarning;
+    }
+
+    /**
+     * @psalm-assert-if-true !null $this->excludeFilter
+     */
+    public function hasExcludeFilter(): bool
+    {
+        return $this->excludeFilter !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function excludeFilter(): string
+    {
+        if (!$this->hasExcludeFilter()) {
+            throw new Exception;
+        }
+
+        return $this->excludeFilter;
     }
 
     /**

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -120,6 +120,7 @@ final readonly class Configuration
     private bool $teamCityOutput;
     private bool $testDoxOutput;
     private ?string $filter;
+    private ?string $excludeFilter;
     private ?array $groups;
     private ?array $excludeGroups;
     private int $randomOrderSeed;
@@ -144,7 +145,7 @@ final readonly class Configuration
      * @psalm-param non-empty-list<non-empty-string> $testSuffixes
      * @psalm-param list<array{className: class-string, parameters: array<string, string>}> $extensionBootstrappers
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline)
+    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline)
     {
         $this->cliArguments                                 = $cliArguments;
         $this->configurationFile                            = $configurationFile;
@@ -234,6 +235,7 @@ final readonly class Configuration
         $this->testsCovering                                = $testsCovering;
         $this->testsUsing                                   = $testsUsing;
         $this->filter                                       = $filter;
+        $this->excludeFilter                                = $excludeFilter;
         $this->groups                                       = $groups;
         $this->excludeGroups                                = $excludeGroups;
         $this->randomOrderSeed                              = $randomOrderSeed;
@@ -1048,6 +1050,26 @@ final readonly class Configuration
         }
 
         return $this->filter;
+    }
+
+    /**
+     * @psalm-assert-if-true !null $this->excludeFilter
+     */
+    public function hasExcludeFilter(): bool
+    {
+        return $this->excludeFilter !== null;
+    }
+
+    /**
+     * @throws FilterNotConfiguredException
+     */
+    public function excludeFilter(): string
+    {
+        if (!$this->hasExcludeFilter()) {
+            throw new FilterNotConfiguredException;
+        }
+
+        return $this->excludeFilter;
     }
 
     /**

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -581,6 +581,12 @@ final readonly class Merger
             $filter = $cliConfiguration->filter();
         }
 
+        $excludeFilter = null;
+
+        if ($cliConfiguration->hasExcludeFilter()) {
+            $excludeFilter = $cliConfiguration->excludeFilter();
+        }
+
         if ($cliConfiguration->hasGroups()) {
             $groups = $cliConfiguration->groups();
         } else {
@@ -798,6 +804,7 @@ final readonly class Merger
             $testsCovering,
             $testsUsing,
             $filter,
+            $excludeFilter,
             $groups,
             $excludeGroups,
             $randomOrderSeed,

--- a/src/TextUI/Configuration/TestSuiteBuilder.php
+++ b/src/TextUI/Configuration/TestSuiteBuilder.php
@@ -23,6 +23,7 @@ use PHPUnit\TextUI\RuntimeException;
 use PHPUnit\TextUI\TestDirectoryNotFoundException;
 use PHPUnit\TextUI\TestFileNotFoundException;
 use PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper;
+use ReflectionException;
 use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 
 /**
@@ -32,6 +33,7 @@ final readonly class TestSuiteBuilder
 {
     /**
      * @throws \PHPUnit\Framework\Exception
+     * @throws ReflectionException
      * @throws RuntimeException
      * @throws TestDirectoryNotFoundException
      * @throws TestFileNotFoundException

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -59,6 +59,7 @@ final class Help
             ['arg' => '--list-tests', 'desc' => 'List available tests'],
             ['arg' => '--list-tests-xml <file>', 'desc' => 'List available tests in XML format'],
             ['arg' => '--filter <pattern>', 'desc' => 'Filter which tests to run'],
+            ['arg' => '--exclude-filter <pattern>', 'desc' => 'Exclude tests for the specified filter pattern'],
             ['arg' => '--test-suffix <suffixes>', 'desc' => 'Only search for test in files with specified suffix(es). Default: Test.php,.phpt'],
         ],
 

--- a/src/TextUI/TestSuiteFilterProcessor.php
+++ b/src/TextUI/TestSuiteFilterProcessor.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\Filter\Factory;
 use PHPUnit\TextUI\Configuration\Configuration;
 use PHPUnit\TextUI\Configuration\FilterNotConfiguredException;
+use ReflectionException;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -31,12 +32,14 @@ final readonly class TestSuiteFilterProcessor
     /**
      * @throws Event\RuntimeException
      * @throws FilterNotConfiguredException
+     * @throws ReflectionException
      */
     public function process(Configuration $configuration, TestSuite $suite): void
     {
         if (!$configuration->hasFilter() &&
             !$configuration->hasGroups() &&
             !$configuration->hasExcludeGroups() &&
+            !$configuration->hasExcludeFilter() &&
             !$configuration->hasTestsCovering() &&
             !$configuration->hasTestsUsing()) {
             return;
@@ -69,6 +72,12 @@ final readonly class TestSuiteFilterProcessor
                     static fn (string $name): string => '__phpunit_uses_' . $name,
                     $configuration->testsUsing(),
                 ),
+            );
+        }
+
+        if ($configuration->hasExcludeFilter()) {
+            $this->filterFactory->addExcludeNameFilter(
+                $configuration->excludeFilter(),
             );
         }
 

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -35,6 +35,8 @@
   [32m--list-tests                    [0m List available tests
   [32m--list-tests-xml [36m<file>[0m         [0m List available tests in XML format
   [32m--filter [36m<pattern>[0m              [0m Filter which tests to run
+  [32m--exclude-filter [36m<pattern>[0m      [0m Exclude tests for the specified filter
+                                   pattern
   [32m--test-suffix [36m<suffixes>[0m        [0m Only search for test in files with specified
                                    suffix(es). Default: Test.php,.phpt
 

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -31,6 +31,7 @@ Selection:
   --list-tests                     List available tests
   --list-tests-xml <file>          List available tests in XML format
   --filter <pattern>               Filter which tests to run
+  --exclude-filter <pattern>       Exclude tests for the specified filter pattern
   --test-suffix <suffixes>         Only search for test in files with specified suffix(es). Default: Test.php,.phpt
 
 Execution:

--- a/tests/end-to-end/cli/exclude-filter/match.phpt
+++ b/tests/end-to-end/cli/exclude-filter/match.phpt
@@ -1,0 +1,48 @@
+--TEST--
+phpunit --exclude-filter one tests/FooTest.php
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = '--exclude-filter';
+$_SERVER['argv'][] = 'testone';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/groups/tests/FooTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Test Suite Loaded (3 tests)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Suite Filtered (3 tests)
+Test Runner Execution Started (3 tests)
+Test Suite Started (PHPUnit\TestFixture\Groups\FooTest, 3 tests)
+Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testOne)
+Test Prepared (PHPUnit\TestFixture\Groups\FooTest::testOne)
+Test Passed (PHPUnit\TestFixture\Groups\FooTest::testOne)
+Test Finished (PHPUnit\TestFixture\Groups\FooTest::testOne)
+Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testTwo)
+Test Prepared (PHPUnit\TestFixture\Groups\FooTest::testTwo)
+Test Passed (PHPUnit\TestFixture\Groups\FooTest::testTwo)
+Test Finished (PHPUnit\TestFixture\Groups\FooTest::testTwo)
+Test Preparation Started (PHPUnit\TestFixture\Groups\FooTest::testThree)
+Test Prepared (PHPUnit\TestFixture\Groups\FooTest::testThree)
+Test Passed (PHPUnit\TestFixture\Groups\FooTest::testThree)
+Test Finished (PHPUnit\TestFixture\Groups\FooTest::testThree)
+Test Suite Finished (PHPUnit\TestFixture\Groups\FooTest, 3 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/group/failure/list-groups-and-exclude-filter.phpt
+++ b/tests/end-to-end/cli/group/failure/list-groups-and-exclude-filter.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --list-groups --exclude-filter name
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--list-groups';
+$_SERVER['argv'][] = '--exclude-filter';
+$_SERVER['argv'][] = 'name';
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+The --exclude-filter and --list-groups options cannot be combined, --exclude-filter is ignored
+
+Available test group(s):
+

--- a/tests/end-to-end/cli/group/failure/list-groups-and-exclude-group.phpt
+++ b/tests/end-to-end/cli/group/failure/list-groups-and-exclude-group.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --list-groups --exclude-group name
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--list-groups';
+$_SERVER['argv'][] = '--exclude-group';
+$_SERVER['argv'][] = 'name';
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+The --exclude-group and --list-groups options cannot be combined, --exclude-group is ignored
+
+Available test group(s):
+

--- a/tests/end-to-end/cli/group/failure/list-groups-and-filter.phpt
+++ b/tests/end-to-end/cli/group/failure/list-groups-and-filter.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --list-groups --filter name
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--list-groups';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'name';
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+The --filter and --list-groups options cannot be combined, --filter is ignored
+
+Available test group(s):
+

--- a/tests/end-to-end/cli/group/failure/list-groups-and-group.phpt
+++ b/tests/end-to-end/cli/group/failure/list-groups-and-group.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --list-groups --group name
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--list-groups';
+$_SERVER['argv'][] = '--group';
+$_SERVER['argv'][] = 'name';
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+The --group and --list-groups options cannot be combined, --group is ignored
+
+Available test group(s):
+

--- a/tests/end-to-end/cli/group/failure/list-groups-and-testsuite.phpt
+++ b/tests/end-to-end/cli/group/failure/list-groups-and-testsuite.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --list-groups --testsuite name
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--list-groups';
+$_SERVER['argv'][] = '--testsuite';
+$_SERVER['argv'][] = 'name';
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+The --testsuite and --list-groups options cannot be combined, --testsuite is ignored
+
+Available test group(s):
+

--- a/tests/unit/Runner/Filter/ExcludeNameFilterIteratorTest.php
+++ b/tests/unit/Runner/Filter/ExcludeNameFilterIteratorTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\TestFixture\BankAccountTest;
+
+#[CoversClass(ExcludeNameFilterIterator::class)]
+#[Small]
+class ExcludeNameFilterIteratorTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testCaseSensitiveMatch(): void
+    {
+        $this->assertTrue($this->createFilter('NotMatchingPattern')->accept());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testCaseInsensitiveMatch(): void
+    {
+        $this->assertTrue($this->createFilter('notmatchingbankaccount')->accept());
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function createFilter(string $filter): ExcludeNameFilterIterator
+    {
+        $suite = TestSuite::empty('test suite name');
+        $suite->addTest(new BankAccountTest('testBalanceIsInitiallyZero'));
+
+        $iterator = new ExcludeNameFilterIterator($suite->getIterator(), $filter);
+
+        $iterator->rewind();
+
+        return $iterator;
+    }
+}

--- a/tests/unit/Runner/Filter/IncludeNameFilterIteratorTest.php
+++ b/tests/unit/Runner/Filter/IncludeNameFilterIteratorTest.php
@@ -9,32 +9,42 @@
  */
 namespace PHPUnit\Runner\Filter;
 
+use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\TestFixture\BankAccountTest;
 
-#[CoversClass(NameFilterIterator::class)]
+#[CoversClass(IncludeNameFilterIterator::class)]
 #[Small]
-final class NameFilterIteratorTest extends TestCase
+final class IncludeNameFilterIteratorTest extends TestCase
 {
+    /**
+     * @throws Exception
+     */
     public function testCaseSensitiveMatch(): void
     {
         $this->assertTrue($this->createFilter('BankAccountTest')->accept());
     }
 
+    /**
+     * @throws Exception
+     */
     public function testCaseInsensitiveMatch(): void
     {
         $this->assertTrue($this->createFilter('bankaccounttest')->accept());
     }
 
-    private function createFilter(string $filter): NameFilterIterator
+    /**
+     * @throws Exception
+     */
+    private function createFilter(string $filter): IncludeNameFilterIterator
     {
         $suite = TestSuite::empty('test suite name');
         $suite->addTest(new BankAccountTest('testBalanceIsInitiallyZero'));
 
-        $iterator = new NameFilterIterator($suite->getIterator(), $filter);
+        $iterator = new IncludeNameFilterIterator($suite->getIterator(), $filter);
 
         $iterator->rewind();
 


### PR DESCRIPTION

Hi, I hope you will consider this, i added the --exclude-filter with everything that goes with it.
I even made the reverse logic for data provider selection, I think it doesnt make sense to have it but I leave it for you to decide.

Please give me any suggestions if you have them, and I'm willing to help with other stuff if you need me.
Thanks.

```
  --filter <pattern>               Filter which tests to run
  --exclude-filter <pattern>       Exclude tests for the specified filter pattern
  --test-suffix <suffixes>         Only search for test in files with specified suffix(es). Default: Test.php,.phpt
```