### PR TITLE
Fix Testdox colorization handling of wide lines

### DIFF
--- a/src/TextUI/Output/Facade.php
+++ b/src/TextUI/Output/Facade.php
@@ -211,6 +211,7 @@ final class Facade
             self::$testDoxResultPrinter = new TestDoxResultPrinter(
                 self::$printer,
                 $configuration->colors(),
+                $configuration->columns(),
             );
         }
 

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -33,11 +33,13 @@ final readonly class ResultPrinter
 {
     private Printer $printer;
     private bool $colors;
+    private int $columns;
 
-    public function __construct(Printer $printer, bool $colors)
+    public function __construct(Printer $printer, bool $colors, int $columns)
     {
         $this->printer = $printer;
         $this->colors  = $colors;
+        $this->columns = $columns;
     }
 
     /**
@@ -226,7 +228,7 @@ final readonly class ResultPrinter
         $diff    = implode(PHP_EOL, $diff);
 
         if (!empty($message)) {
-            $message = Color::colorizeTextBox($style, $message);
+            $message = Color::colorizeTextBox($style, $message, $this->columns);
         }
 
         return [

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -228,7 +228,8 @@ final readonly class ResultPrinter
         $diff    = implode(PHP_EOL, $diff);
 
         if (!empty($message)) {
-            $message = Color::colorizeTextBox($style, $message, $this->columns);
+            // Testdox output has a left-margin of 5; keep right-margin to prevent terminal scrolling
+            $message = Color::colorizeTextBox($style, $message, $this->columns - 7);
         }
 
         return [

--- a/src/Util/Color.php
+++ b/src/Util/Color.php
@@ -99,7 +99,7 @@ final class Color
         return self::optimizeColor(sprintf("\x1b[%sm", implode(';', $styles)) . $buffer . "\x1b[0m");
     }
 
-    public static function colorizeTextBox(string $color, string $buffer): string
+    public static function colorizeTextBox(string $color, string $buffer, ?int $columns = 80): string
     {
         $lines   = preg_split('/\r\n|\r|\n/', $buffer);
         $padding = max(array_map('\strlen', $lines));

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -76,7 +76,7 @@ final class ColorTest extends TestCase
     {
         return [
             'fitting text' => [
-                40,
+                40,     // simulate 40 char wide terminal
                 'this is fine' . PHP_EOL .
                 PHP_EOL .
                 'all lines fit nicely' . PHP_EOL .
@@ -87,7 +87,7 @@ final class ColorTest extends TestCase
                 Color::colorize('red', 'bottom text         '),
             ],
             'oversize text' => [
-                20,
+                20,     // simulate 20 char wide terminal
                 'this is also fine' . PHP_EOL .
                 PHP_EOL .
                 'the very long lines do not stretch the whole textbox' . PHP_EOL .

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -79,14 +79,14 @@ final class ColorTest extends TestCase
                 40,
                 "this is fine\n" .
                 "\n" .
-                "all lines fit nicely even the extra long ones with inlined exceptions and var_dumps\n" .
+                "all lines fit nicely\n" .
                 'bottom text',
-                Color::colorize('red', 'this is fine                      ') . "\n" .
-                Color::colorize('red', '                                  ') . "\n" .
-                Color::colorize('red', 'all lines fit nicely even the long') . "\n" .
-                Color::colorize('red', 'ones                              '),
+                Color::colorize('red', 'this is fine        ') . "\n" .
+                Color::colorize('red', '                    ') . "\n" .
+                Color::colorize('red', 'all lines fit nicely') . "\n" .
+                Color::colorize('red', 'bottom text         '),
             ],
-            'oversized text' => [
+            'oversize text' => [
                 20,
                 "this is also fine\n" .
                 "\n" .

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -72,6 +72,30 @@ final class ColorTest extends TestCase
         ];
     }
 
+    public static function colorizeTextBoxProvider(): array
+    {
+        return [
+            'fitting text' => [
+                40,
+                "this is fine\n" .
+                "all lines fit nicely even the long\n" .
+                "ones",
+                Color::colorize('red', 'this is fine                      ') . "\n" .
+                Color::colorize('red', 'all lines fit nicely even the long') . "\n" .
+                Color::colorize('red', 'ones                              ')
+            ],
+            'oversized text' => [
+                20,
+                "this is also fine\n" .
+                "the very long lines do not stretch the whole textbox\n" .
+                "anymore",
+                Color::colorize('red', 'this is also fine   ') . "\n" .
+                Color::colorize('red', 'the very long lines do not stretch the whole textbox') . "\n" .
+                Color::colorize('red', 'anymore             ')
+            ]
+        ];
+    }
+
     public static function whitespacedStringProvider(): array
     {
         return [
@@ -117,6 +141,13 @@ final class ColorTest extends TestCase
     public function testColorizePath(?string $prevPath, string $path, bool $colorizeFilename, string $expected): void
     {
         $this->assertSame($expected, Color::colorizePath($path, $prevPath, $colorizeFilename));
+    }
+
+    #[TestDox('Colorize an autosizing text box')]
+    #[DataProvider('colorizeTextBoxProvider')]
+    public function testColorizeTextBox(int $columns, string $buffer, string $expected): void
+    {
+        $this->assertSame($expected, Color::colorizeTextBox('red', $buffer, $columns));
     }
 
     #[TestDox('dim($m) and colorize(\'dim\',$m) return different ANSI codes')]

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -79,20 +79,20 @@ final class ColorTest extends TestCase
                 40,
                 "this is fine\n" .
                 "all lines fit nicely even the long\n" .
-                "ones",
+                'ones',
                 Color::colorize('red', 'this is fine                      ') . "\n" .
                 Color::colorize('red', 'all lines fit nicely even the long') . "\n" .
-                Color::colorize('red', 'ones                              ')
+                Color::colorize('red', 'ones                              '),
             ],
             'oversized text' => [
                 20,
                 "this is also fine\n" .
                 "the very long lines do not stretch the whole textbox\n" .
-                "anymore",
+                'anymore',
                 Color::colorize('red', 'this is also fine   ') . "\n" .
                 Color::colorize('red', 'the very long lines do not stretch the whole textbox') . "\n" .
-                Color::colorize('red', 'anymore             ')
-            ]
+                Color::colorize('red', 'anymore             '),
+            ],
         ];
     }
 

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -78,18 +78,22 @@ final class ColorTest extends TestCase
             'fitting text' => [
                 40,
                 "this is fine\n" .
-                "all lines fit nicely even the long\n" .
-                'ones',
+                "\n" .
+                "all lines fit nicely even the extra long ones with inlined exceptions and var_dumps\n" .
+                'bottom text',
                 Color::colorize('red', 'this is fine                      ') . "\n" .
+                Color::colorize('red', '                                  ') . "\n" .
                 Color::colorize('red', 'all lines fit nicely even the long') . "\n" .
                 Color::colorize('red', 'ones                              '),
             ],
             'oversized text' => [
                 20,
                 "this is also fine\n" .
+                "\n" .
                 "the very long lines do not stretch the whole textbox\n" .
                 'anymore',
                 Color::colorize('red', 'this is also fine   ') . "\n" .
+                Color::colorize('red', '                    ') . "\n" .
                 Color::colorize('red', 'the very long lines do not stretch the whole textbox') . "\n" .
                 Color::colorize('red', 'anymore             '),
             ],

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Util;
 
 use const DIRECTORY_SEPARATOR;
+use function str_repeat;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
@@ -96,6 +97,13 @@ final class ColorTest extends TestCase
                 Color::colorize('red', '                    ') . PHP_EOL .
                 Color::colorize('red', 'the very long lines do not stretch the whole textbox') . PHP_EOL .
                 Color::colorize('red', 'anymore             '),
+            ],
+            'default terminal width cap' => [
+                80,     // simulate (default) 80 char wide terminal
+                str_repeat('.123456789', 8) . PHP_EOL .
+                'this is a shorter line',
+                Color::colorize('red', str_repeat('.123456789', 8)) . PHP_EOL .
+                Color::colorize('red', 'this is a shorter line                                                          '),
             ],
         ];
     }

--- a/tests/unit/Util/ColorTest.php
+++ b/tests/unit/Util/ColorTest.php
@@ -77,24 +77,24 @@ final class ColorTest extends TestCase
         return [
             'fitting text' => [
                 40,
-                "this is fine\n" .
-                "\n" .
-                "all lines fit nicely\n" .
+                'this is fine' . PHP_EOL .
+                PHP_EOL .
+                'all lines fit nicely' . PHP_EOL .
                 'bottom text',
-                Color::colorize('red', 'this is fine        ') . "\n" .
-                Color::colorize('red', '                    ') . "\n" .
-                Color::colorize('red', 'all lines fit nicely') . "\n" .
+                Color::colorize('red', 'this is fine        ') . PHP_EOL .
+                Color::colorize('red', '                    ') . PHP_EOL .
+                Color::colorize('red', 'all lines fit nicely') . PHP_EOL .
                 Color::colorize('red', 'bottom text         '),
             ],
             'oversize text' => [
                 20,
-                "this is also fine\n" .
-                "\n" .
-                "the very long lines do not stretch the whole textbox\n" .
+                'this is also fine' . PHP_EOL .
+                PHP_EOL .
+                'the very long lines do not stretch the whole textbox' . PHP_EOL .
                 'anymore',
-                Color::colorize('red', 'this is also fine   ') . "\n" .
-                Color::colorize('red', '                    ') . "\n" .
-                Color::colorize('red', 'the very long lines do not stretch the whole textbox') . "\n" .
+                Color::colorize('red', 'this is also fine   ') . PHP_EOL .
+                Color::colorize('red', '                    ') . PHP_EOL .
+                Color::colorize('red', 'the very long lines do not stretch the whole textbox') . PHP_EOL .
                 Color::colorize('red', 'anymore             '),
             ],
         ];


### PR DESCRIPTION
# Summary
<img width="690" alt="phpunit_screenshot_testdox_margin_fix_summary" src="https://github.com/sebastianbergmann/phpunit/assets/26651359/21fc65dc-9bb5-47fd-834d-0b9be3747f03">

# User story
**As a** developer who uses the testdox reporting as my default
**I want** the output to handle coloring failure messages more efficiently
**so that** I don't end up with a completely red terminal or memory allocation exceptions

# Considerations and fix
* Stop the terminal from scrolling unnecessarily.
  It makes relevant details very hard to find, see screenshots below. Crop the message box to always fit the width of the terminal, except for lines that already go past the right margin.
* Long output lines should not be broken up.
  This way soft-wrapped lines can be copied from the terminal without linebreaks. These long lines often contain URLs or tokens important to the test scenario.
* Improve resource efficiency
* Coverage for new functionality

### Screenshots of the issue during everyday usage of PHPUnit
A picture says more than a thousand `malloc()`s:

![phpunit_testdox_memery_failed_api_assert](https://github.com/sebastianbergmann/phpunit/assets/26651359/7f61d37b-e0c9-4dd3-acb0-9b21425c9a91)

When viewing the output in an editor without color support the memory hunger easy to spot: the highlighted area is _not_ empty but filled with spaces, terminated by a terminal command and newline. The current implementation will apply this style of padding to every line shorter than the longest, without any safeguards.

![phpunit_testdox_memery_failed_api_assert_raw](https://github.com/sebastianbergmann/phpunit/assets/26651359/93d5dd45-6ecd-4148-b956-0f799c4d7ca1)
