### PR TITLE
`--log-events-text` and `--log-events-verbose-text` CLI options do not handle absolute and relative paths

### DIFF
--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -808,7 +808,7 @@ final class Builder
                     $realPath = realpath($path);
 
                     if (!$realPath) {
-                        throw new Exception("The path {$path} specified for the --log-events-text option could not be resolved");
+                        throw new Exception("The path \"{$path}\" specified for the --log-events-text option could not be resolved");
                     }
                     $logEventsText = $realPath;
 
@@ -819,7 +819,7 @@ final class Builder
                     $realPath = realpath($path);
 
                     if (!$realPath) {
-                        throw new Exception("The path {$path} specified for the --log-events-verbose-text option could not be resolved");
+                        throw new Exception("The path \"{$path}\" specified for the --log-events-verbose-text option could not be resolved");
                     }
                     $logEventsVerboseText = $realPath;
 

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -808,7 +808,7 @@ final class Builder
                     $realPath = realpath($path);
 
                     if (!$realPath) {
-                        throw new Exception("Specified path: {$path} can't be resolved");
+                        throw new Exception("The path {$path} specified for the --log-events-text option could not be resolved");
                     }
                     $logEventsText = $realPath;
 
@@ -819,7 +819,7 @@ final class Builder
                     $realPath = realpath($path);
 
                     if (!$realPath) {
-                        throw new Exception("Specified path: {$path} can't be resolved");
+                        throw new Exception("The path {$path} specified for the --log-events-verbose-text option could not be resolved");
                     }
                     $logEventsVerboseText = $realPath;
 

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -15,6 +15,7 @@ use function explode;
 use function getcwd;
 use function is_file;
 use function is_numeric;
+use function realpath;
 use function sprintf;
 use PHPUnit\Runner\TestSuiteSorter;
 use SebastianBergmann\CliParser\Exception as CliParserException;
@@ -803,12 +804,24 @@ final class Builder
                     break;
 
                 case '--log-events-text':
-                    $logEventsText = $option[1];
+                    $path     = $option[1];
+                    $realPath = realpath($path);
+
+                    if (!$realPath) {
+                        throw new Exception("Specified path: {$path} can't be resolved");
+                    }
+                    $logEventsText = $realPath;
 
                     break;
 
                 case '--log-events-verbose-text':
-                    $logEventsVerboseText = $option[1];
+                    $path     = $option[1];
+                    $realPath = realpath($path);
+
+                    if (!$realPath) {
+                        throw new Exception("Specified path: {$path} can't be resolved");
+                    }
+                    $logEventsVerboseText = $realPath;
 
                     break;
             }

--- a/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
@@ -16,4 +16,4 @@ require __DIR__ . '/../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-The path "/tmp/invalid-directory/invalid.file" specified for the --log-events-text option could not be resolved
+The path "%s" specified for the --log-events-text option could not be resolved

--- a/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test fail with invalid path
+Test fails with invalid path
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = sys_get_temp_dir() . '/invalid-directory/invalid.file';
@@ -9,16 +9,11 @@ $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--no-output';
 $_SERVER['argv'][] = '--log-events-text';
 $_SERVER['argv'][] = $traceFile;
-$_SERVER['argv'][] = __DIR__ . '/../_files/log-events-text';
 
 require __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
-
-print file_get_contents($traceFile);
-
-unlink($traceFile);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-The path /tmp/invalid-directory/invalid.file specified for the --log-events-text option could not be resolved
+The path "/tmp/invalid-directory/invalid.file" specified for the --log-events-text option could not be resolved

--- a/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
@@ -1,8 +1,8 @@
 --TEST--
-phpunit --no-output --log-events-text logfile.txt
+Test fail with invalid path
 --FILE--
 <?php declare(strict_types=1);
-$traceFile = 'dasdasdasdasd/dasdasdsa.log';
+$traceFile = sys_get_temp_dir() . '/invalid-directory/invalid.file';
 
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
@@ -19,6 +19,6 @@ print file_get_contents($traceFile);
 
 unlink($traceFile);
 --EXPECTF--
-PHPUnit 10.5.3 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
-Specified path: dasdasdasdasd/dasdasdsa.log can't be resolved
+The path /tmp/invalid-directory/invalid.file specified for the --log-events-text option could not be resolved

--- a/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-text-invalid-argument.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --no-output --log-events-text logfile.txt
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = 'dasdasdasdasd/dasdasdsa.log';
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = __DIR__ . '/../_files/log-events-text';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit 10.5.3 by Sebastian Bergmann and contributors.
+
+Specified path: dasdasdasdasd/dasdasdsa.log can't be resolved

--- a/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test fail with invalid path
+Test fails with invalid path
 --FILE--
 <?php declare(strict_types=1);
 $traceFile = sys_get_temp_dir() . '/invalid-directory/invalid.file';
@@ -9,7 +9,6 @@ $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--no-output';
 $_SERVER['argv'][] = '--log-events-verbose-text';
 $_SERVER['argv'][] = $traceFile;
-$_SERVER['argv'][] = __DIR__ . '/../_files/log-events-text';
 
 require __DIR__ . '/../../bootstrap.php';
 
@@ -17,4 +16,4 @@ require __DIR__ . '/../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-The path /tmp/invalid-directory/invalid.file specified for the --log-events-verbose-text option could not be resolved
+The path "/tmp/invalid-directory/invalid.file" specified for the --log-events-verbose-text option could not be resolved

--- a/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
@@ -1,8 +1,8 @@
 --TEST--
-phpunit --no-output --log-events-verbose-text logfile.txt
+Test fail with invalid path
 --FILE--
 <?php declare(strict_types=1);
-$traceFile = 'dasdasdasdasd/dasdasdsa.log';
+$traceFile = sys_get_temp_dir() . '/invalid-directory/invalid.file';
 
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
@@ -14,11 +14,7 @@ $_SERVER['argv'][] = __DIR__ . '/../_files/log-events-text';
 require __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
-
-print file_get_contents($traceFile);
-
-unlink($traceFile);
 --EXPECTF--
-PHPUnit 10.5.3 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
-Specified path: dasdasdasdasd/dasdasdsa.log can't be resolved
+The path /tmp/invalid-directory/invalid.file specified for the --log-events-verbose-text option could not be resolved

--- a/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
@@ -16,4 +16,4 @@ require __DIR__ . '/../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-The path "/tmp/invalid-directory/invalid.file" specified for the --log-events-verbose-text option could not be resolved
+The path "%s" specified for the --log-events-verbose-text option could not be resolved

--- a/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text-invalid-argument.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --no-output --log-events-verbose-text logfile.txt
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = 'dasdasdasdasd/dasdasdsa.log';
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-verbose-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = __DIR__ . '/../_files/log-events-text';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit 10.5.3 by Sebastian Bergmann and contributors.
+
+Specified path: dasdasdasdasd/dasdasdsa.log can't be resolved


### PR DESCRIPTION
Resolve both relative and absolute paths, and handle invalid arguments.