### PR TITLE
Exceptions in the destructor of a test double are ignored

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -733,7 +733,14 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
             }
         }
 
-        $this->mockObjects = [];
+        try {
+            $this->mockObjects = [];
+        } catch (Throwable $t) {
+            Event\Facade::emitter()->testErrored(
+                $this->valueObjectForEvents(),
+                Event\Code\ThrowableBuilder::from($t),
+            );
+        }
 
         // Tear down the fixture. An exception raised in tearDown() will be
         // caught and passed on when no exception was raised before.

--- a/tests/_files/ExceptionInMockDestructor.php
+++ b/tests/_files/ExceptionInMockDestructor.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use Exception;
+
+class ExceptionInMockDestructor
+{
+    public function __destruct()
+    {
+        throw new Exception('Some exception.');
+    }
+}

--- a/tests/_files/ExceptionInMockDestructorTest.php
+++ b/tests/_files/ExceptionInMockDestructorTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\TestCase;
+
+class ExceptionInMockDestructorTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $mock = $this->createMock(ExceptionInMockDestructor::class);
+
+        $this->assertInstanceOf(ExceptionInMockDestructor::class, $mock);
+    }
+}

--- a/tests/end-to-end/generic/exception-in-mock-destructor.phpt
+++ b/tests/end-to-end/generic/exception-in-mock-destructor.phpt
@@ -1,0 +1,28 @@
+--TEST--
+phpunit ../../_files/ExceptionInMockDestructorTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/ExceptionInMockDestructorTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) PHPUnit\TestFixture\ExceptionInMockDestructorTest::testOne
+Exception: Some exception.
+
+%sExceptionInMockDestructor.php:%d
+
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.


### PR DESCRIPTION
Currently, if an exception is thrown in a mock object's destructor, it's silently ignored because of the following:

https://github.com/sebastianbergmann/phpunit/blob/4918913ab151a632df59185b3ed269e29bea3a02/src/Framework/TestRunner.php#L131-L133