### PR TITLE
Add check to prevent running with xdebug.mode=develop

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -94,6 +94,16 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     die(1);
 }
 
+if (str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+    fwrite(
+        STDERR,
+        'PHPUnit requires the Xdebug \'develop\' mode to be disabled as it changes the output of var_dump().' . PHP_EOL . PHP_EOL .
+        'You can learn about this configuration setting at https://xdebug.org/docs/develop' . PHP_EOL
+    );
+
+    die(1);
+}
+
 require PHPUNIT_COMPOSER_INSTALL;
 
 exit((new PHPUnit\TextUI\Application)->run($_SERVER['argv']));


### PR DESCRIPTION
# User story
**As a** developer working on tooling
**I want** to not trip over minor differences between environments
**so that** I don't ~unnecessarily spend time on debugging and reconfiguring~ feel stupid

# Considerations and fix
Everywhere I work on PHP Xdebug is installed. Unfortunately I had completely forgotten that the `xdebug.mode=develop` setting changes the output a bit. For example `var_dump()` and stack traces are slightly different, causing 8 end-to-end tests to fail that rely on these for validation testing.

**Implemented solution:** check and abort the main `phpunit` script with an error:
```
PHPUnit requires the Xdebug 'develop' mode to be disabled as it changes the output of var_dump().

You can learn about this configuration setting at https://xdebug.org/docs/develop
```
Alternative solution: I can add checks and `--SKIPIF--` to the offending PHPT-based tests.

## Examples
Different `var_dump`:
```
+/home/ewout/proj/phpunit/tests/end-to-end/_files/UnexpectedOutputTest.php:20:
 array(1) {
-  ["foo"]=>
+  'foo' =>
   string(3) "bar"
 }
```

Different call stacks:
```
+Call Stack:
+    0.2004     393944   1. {main}() Standard input code:0
+    0.2074    2045208   2. PHPUnit\Event\Code\TestMethodBuilder::fromCallStack() Standard input code:4
```

I/O details:
```
+Standard input code:15:
 array(0) {
 }
+Standard input code:16:
 array(0) {
 }
+Standard input code:17:
 array(0) {
 }
```