### PR TITLE
[v10.5] Implement xdebug.mode skip condition for end-to-end tests 

### DIFF
--- a/tests/end-to-end/event/test-method-builder-cannot-find-testcase-object.phpt
+++ b/tests/end-to-end/event/test-method-builder-cannot-find-testcase-object.phpt
@@ -1,5 +1,9 @@
 --TEST--
 The right exception is raised when TestMethodBuilder::fromCallStack() cannot find a TestCase object
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 require __DIR__ . '/../../bootstrap.php';

--- a/tests/end-to-end/generic/unexpected-output-with-progress-printing.phpt
+++ b/tests/end-to-end/generic/unexpected-output-with-progress-printing.phpt
@@ -1,5 +1,9 @@
 --TEST--
 phpunit ../../_files/UnexpectedOutputTest.php
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/generic/unexpected-output-without-progress-printing.phpt
+++ b/tests/end-to-end/generic/unexpected-output-without-progress-printing.phpt
@@ -1,5 +1,9 @@
 --TEST--
 phpunit ../../_files/UnexpectedOutputTest.php
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_generator_empty_by_default.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_generator_empty_by_default.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Iterable return types should return empty array by default
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 interface Foo

--- a/tests/end-to-end/phpt/expect-location-hint.phpt
+++ b/tests/end-to-end/phpt/expect-location-hint.phpt
@@ -1,5 +1,9 @@
 --TEST--
 PHPT EXPECT comparison returns correct code location hint
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/regression/5278.phpt
+++ b/tests/end-to-end/regression/5278.phpt
@@ -1,5 +1,9 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/5278
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/regression/5451.phpt
+++ b/tests/end-to-end/regression/5451.phpt
@@ -1,5 +1,9 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/5451
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/regression/765.phpt
+++ b/tests/end-to-end/regression/765.phpt
@@ -1,5 +1,9 @@
 --TEST--
 GH-765: Fatal error triggered in PHPUnit when exception is thrown in data provider of a test with a dependency
+--SKIPIF--
+<?php if(str_contains((string)ini_get('xdebug.mode'), 'develop')) {
+print 'skip: xdebug.mode=develop is enabled';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';


### PR DESCRIPTION
This is the alternative implementation pull request https://github.com/sebastianbergmann/phpunit/pull/5635 and implements the conditional skip for the xdebug.mode=develop check.