### PR TITLE
Command to print the list of test files

### DIFF
--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -52,6 +52,7 @@ use PHPUnit\TextUI\CliArguments\XmlConfigurationFileFinder;
 use PHPUnit\TextUI\Command\AtLeastVersionCommand;
 use PHPUnit\TextUI\Command\GenerateConfigurationCommand;
 use PHPUnit\TextUI\Command\ListGroupsCommand;
+use PHPUnit\TextUI\Command\ListTestFilesCommand;
 use PHPUnit\TextUI\Command\ListTestsAsTextCommand;
 use PHPUnit\TextUI\Command\ListTestsAsXmlCommand;
 use PHPUnit\TextUI\Command\ListTestSuitesCommand;
@@ -416,6 +417,10 @@ final readonly class Application
                     $testSuite,
                 ),
             );
+        }
+
+        if ($cliConfiguration->listTestFiles()) {
+            $this->execute(new ListTestFilesCommand($testSuite));
         }
     }
 

--- a/src/TextUI/Command/Commands/ListTestFilesCommand.php
+++ b/src/TextUI/Command/Commands/ListTestFilesCommand.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\Command;
+
+use function array_intersect;
+use function array_unique;
+use function sprintf;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\PhptTestCase;
+use PHPUnit\TextUI\Configuration\Registry;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class ListTestFilesCommand implements Command
+{
+    private readonly TestSuite $suite;
+
+    public function __construct(TestSuite $suite)
+    {
+        $this->suite = $suite;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function execute(): Result
+    {
+        $configuration = Registry::get();
+
+        $buffer = 'Available test files:' . PHP_EOL;
+
+        $results = [];
+
+        foreach (new RecursiveIteratorIterator($this->suite) as $test) {
+            if ($test instanceof TestCase) {
+                $name = (new ReflectionClass($test))->getFileName();
+
+                // @codeCoverageIgnoreStart
+                if ($name === false) {
+                    continue;
+                }
+                // @codeCoverageIgnoreEnd
+
+                if ($configuration->hasGroups() && empty(array_intersect($configuration->groups(), $test->groups()))) {
+                    continue;
+                }
+
+                if ($configuration->hasExcludeGroups() && !empty(array_intersect($configuration->excludeGroups(), $test->groups()))) {
+                    continue;
+                }
+            } elseif ($test instanceof PhptTestCase) {
+                $name = $test->getName();
+            } else {
+                continue;
+            }
+
+            $results[] = $name;
+        }
+
+        foreach (array_unique($results) as $result) {
+            $buffer .= sprintf(
+                ' - %s' . PHP_EOL,
+                $result,
+            );
+        }
+
+        return Result::from($buffer);
+    }
+}

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -72,6 +72,7 @@ final readonly class Builder
         'include-path=',
         'list-groups',
         'list-suites',
+        'list-test-files',
         'list-tests',
         'list-tests-xml=',
         'log-junit=',
@@ -213,6 +214,7 @@ final readonly class Builder
         $junitLogfile                      = null;
         $listGroups                        = false;
         $listSuites                        = false;
+        $listTestFiles                     = false;
         $listTests                         = false;
         $listTestsXml                      = null;
         $noCoverage                        = null;
@@ -444,6 +446,11 @@ final readonly class Builder
 
                 case '--list-suites':
                     $listSuites = true;
+
+                    break;
+
+                case '--list-test-files':
+                    $listTestFiles = true;
 
                     break;
 
@@ -904,6 +911,7 @@ final readonly class Builder
             $junitLogfile,
             $listGroups,
             $listSuites,
+            $listTestFiles,
             $listTests,
             $listTestsXml,
             $noCoverage,

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -82,6 +82,7 @@ final readonly class Configuration
     private ?string $junitLogfile;
     private bool $listGroups;
     private bool $listSuites;
+    private bool $listTestFiles;
     private bool $listTests;
     private ?string $listTestsXml;
     private ?bool $noCoverage;
@@ -125,7 +126,7 @@ final readonly class Configuration
      * @psalm-param list<non-empty-string> $arguments
      * @psalm-param ?non-empty-list<non-empty-string> $testSuffixes
      */
-    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox, bool $debug)
+    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox, bool $debug)
     {
         $this->arguments                                    = $arguments;
         $this->atLeastVersion                               = $atLeastVersion;
@@ -190,6 +191,7 @@ final readonly class Configuration
         $this->junitLogfile                                 = $junitLogfile;
         $this->listGroups                                   = $listGroups;
         $this->listSuites                                   = $listSuites;
+        $this->listTestFiles                                = $listTestFiles;
         $this->listTests                                    = $listTests;
         $this->listTestsXml                                 = $listTestsXml;
         $this->noCoverage                                   = $noCoverage;
@@ -1352,6 +1354,11 @@ final readonly class Configuration
     public function listSuites(): bool
     {
         return $this->listSuites;
+    }
+
+    public function listTestFiles(): bool
+    {
+        return $this->listTestFiles;
     }
 
     public function listTests(): bool

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -56,6 +56,7 @@ final class Help
             ['arg' => '--exclude-group <name>', 'desc' => 'Exclude tests from the specified group(s)'],
             ['arg' => '--covers <name>', 'desc' => 'Only run tests that intend to cover <name>'],
             ['arg' => '--uses <name>', 'desc' => 'Only run tests that intend to use <name>'],
+            ['arg' => '--list-test-files', 'desc' => 'List available test files'],
             ['arg' => '--list-tests', 'desc' => 'List available tests'],
             ['arg' => '--list-tests-xml <file>', 'desc' => 'List available tests in XML format'],
             ['arg' => '--filter <pattern>', 'desc' => 'Filter which tests to run'],

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -32,6 +32,7 @@
   [32m--exclude-group [36m<name>[0m          [0m Exclude tests from the specified group(s)
   [32m--covers [36m<name>[0m                 [0m Only run tests that intend to cover <name>
   [32m--uses [36m<name>[0m                   [0m Only run tests that intend to use <name>
+  [32m--list-test-files               [0m List available test files
   [32m--list-tests                    [0m List available tests
   [32m--list-tests-xml [36m<file>[0m         [0m List available tests in XML format
   [32m--filter [36m<pattern>[0m              [0m Filter which tests to run

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -28,6 +28,7 @@ Selection:
   --exclude-group <name>           Exclude tests from the specified group(s)
   --covers <name>                  Only run tests that intend to cover <name>
   --uses <name>                    Only run tests that intend to use <name>
+  --list-test-files                List available test files
   --list-tests                     List available tests
   --list-tests-xml <file>          List available tests in XML format
   --filter <pattern>               Filter which tests to run

--- a/tests/end-to-end/cli/list-file-tests/list-phpt-test-files.phpt
+++ b/tests/end-to-end/cli/list-file-tests/list-phpt-test-files.phpt
@@ -1,0 +1,15 @@
+--TEST--
+phpunit --list-test-files list-phpt-test-files.phpt
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--list-test-files';
+$_SERVER['argv'][] = __DIR__.'/list-phpt-test-files.phpt';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Available test files:
+ - %send-to-end%slist-phpt-test-files.phpt

--- a/tests/end-to-end/cli/list-file-tests/list-test-files-exclude-group.phpt
+++ b/tests/end-to-end/cli/list-file-tests/list-test-files-exclude-group.phpt
@@ -1,0 +1,16 @@
+--TEST--
+phpunit --list-test-files --exclude-group group ../../../_files/Metadata/Annotation/tests/GroupTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--list-test-files';
+$_SERVER['argv'][] = '--exclude-group';
+$_SERVER['argv'][] = 'group';
+$_SERVER['argv'][] = __DIR__.'/../../../_files/Metadata/Annotation/tests/GroupTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Available test files:

--- a/tests/end-to-end/cli/list-file-tests/list-test-files-group.phpt
+++ b/tests/end-to-end/cli/list-file-tests/list-test-files-group.phpt
@@ -1,0 +1,17 @@
+--TEST--
+phpunit --list-test-files --group group ../../../_files/Metadata/Annotation/tests/
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--list-test-files';
+$_SERVER['argv'][] = '--group';
+$_SERVER['argv'][] = 'group';
+$_SERVER['argv'][] = __DIR__.'/../../../_files/Metadata/Annotation/tests/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Available test files:
+ - %Annotation%sGroupTest.php

--- a/tests/end-to-end/cli/list-file-tests/list-test-files.phpt
+++ b/tests/end-to-end/cli/list-file-tests/list-test-files.phpt
@@ -1,0 +1,19 @@
+--TEST--
+phpunit --list-test-files --configuration ../../../_files/basic/configuration.basic.xml
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--list-test-files';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__.'/../../_files/basic/configuration.basic.xml';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Available test files:
+ - %send-to-end%sSetUpBeforeClassTest.php
+ - %send-to-end%sSetUpTest.php
+ - %send-to-end%sStatusTest.php
+ - %send-to-end%sTearDownAfterClassTest.php


### PR DESCRIPTION
Hello, this work introduces a new command for writing the list of test files, utilizing standard filters such as group, exclude-group, suite, etc. 

```
--list-test-files                List available test files
```

This could be beneficial when a test runner, like CircleCI, needs to split tests among different workers (see parallelism in https://circleci.com/docs/parallelism-faster-jobs/#other-ways-to-split-tests).

By utilizing this command in conjunction with my previous [PR#5462: Support for multiple arguments](https://github.com/sebastianbergmann/phpunit/pull/5462) on CircleCI it will be possible to efficiently split the tests in the following manner:

```
phpunit $(phpunit --list-test-files | sed -n 's/^ - //p' | circleci tests split)
```
Making the use of [phpunit-finder](https://github.com/previousnext/phpunit-finder) obsolete, which now seems to be deprecated.