### PR TITLE
https://github.com/sebastianbergmann/phpunit/issues/5641

### DIFF
--- a/src/Event/Value/TestSuite/TestSuiteBuilder.php
+++ b/src/Event/Value/TestSuite/TestSuiteBuilder.php
@@ -107,7 +107,7 @@ final class TestSuiteBuilder
      */
     private static function process(FrameworkTestSuite $testSuite, &$tests): void
     {
-        foreach ($testSuite->tests() as $test) {
+        foreach ($testSuite->getIterator() as $test) {
             if ($test instanceof FrameworkTestSuite) {
                 self::process($test, $tests);
 

--- a/tests/unit/Event/Value/TestSuite/TestSuiteBuilderTest.php
+++ b/tests/unit/Event/Value/TestSuite/TestSuiteBuilderTest.php
@@ -34,10 +34,10 @@ final class TestSuiteBuilderTest extends TestCase
         $this->assertCount(3, $testSuite->tests());
     }
 
-    public function testBuildCountWithFilter()
+    public function testBuildCountWithFilter(): void
     {
-        $testSuite = $this->testSuiteFromXmlConfiguration();
-        $filterFactory = new Factory();
+        $testSuite     = $this->testSuiteFromXmlConfiguration();
+        $filterFactory = new Factory;
         $filterFactory->addNameFilter('one');
         $testSuite->injectFilter($filterFactory);
         $testSuite = TestSuiteBuilder::from($testSuite);

--- a/tests/unit/Event/Value/TestSuite/TestSuiteBuilderTest.php
+++ b/tests/unit/Event/Value/TestSuite/TestSuiteBuilderTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite as FrameworkTestSuite;
+use PHPUnit\Runner\Filter\Factory;
 use PHPUnit\TextUI\CliArguments\Builder as CliArgumentsBuilder;
 use PHPUnit\TextUI\Configuration\Merger as ConfigurationMerger;
 use PHPUnit\TextUI\XmlConfiguration\Loader as XmlConfigurationLoader;
@@ -29,7 +30,21 @@ final class TestSuiteBuilderTest extends TestCase
         $this->assertTrue($testSuite->isWithName());
         $this->assertStringEndsWith('phpunit.xml', $testSuite->name());
         $this->assertSame(3, $testSuite->count());
+        $this->assertSame(3, $testSuite->tests()->count());
         $this->assertCount(3, $testSuite->tests());
+    }
+
+    public function testBuildCountWithFilter()
+    {
+        $testSuite = $this->testSuiteFromXmlConfiguration();
+        $filterFactory = new Factory();
+        $filterFactory->addNameFilter('one');
+        $testSuite->injectFilter($filterFactory);
+        $testSuite = TestSuiteBuilder::from($testSuite);
+
+        $this->assertSame(1, $testSuite->count());
+        $this->assertSame(1, $testSuite->tests()->count());
+        $this->assertCount(1, $testSuite->tests());
     }
 
     public function test_Builds_TestSuite_value_object_for_test_case_class(): void


### PR DESCRIPTION
**Issue**: 
  - The TestSuite was never filtered because getIterator method was never called which is responsible to run the filtering.

**Solution:**:
  - Code fixed to apply the expected filtering which solves the issue. Test added to cover this issue.