### PR TITLE
variadic associative elements not being registered fix 

### DIFF
--- a/src/Framework/MockObject/Generator/mocked_method.tpl
+++ b/src/Framework/MockObject/Generator/mocked_method.tpl
@@ -1,6 +1,18 @@
 
     {modifier} function {reference}{method_name}({arguments_decl}){return_declaration}
     {{deprecation}
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [{arguments_call}];
         $__phpunit_count     = func_num_args();
 
@@ -11,6 +23,7 @@
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/src/Framework/MockObject/Generator/mocked_method_never_or_void.tpl
+++ b/src/Framework/MockObject/Generator/mocked_method_never_or_void.tpl
@@ -1,6 +1,18 @@
 
     {modifier} function {reference}{method_name}({arguments_decl}){return_declaration}
     {{deprecation}
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [{arguments_call}];
         $__phpunit_count     = func_num_args();
 
@@ -11,6 +23,7 @@
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/src/Framework/MockObject/Generator/proxied_method.tpl
+++ b/src/Framework/MockObject/Generator/proxied_method.tpl
@@ -1,6 +1,18 @@
 
     {modifier} function {reference}{method_name}({arguments_decl}){return_declaration}
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [{arguments_call}];
         $__phpunit_count     = func_num_args();
 
@@ -11,6 +23,7 @@
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/src/Framework/MockObject/Generator/proxied_method_never_or_void.tpl
+++ b/src/Framework/MockObject/Generator/proxied_method_never_or_void.tpl
@@ -1,6 +1,18 @@
 
     {modifier} function {reference}{method_name}({arguments_decl}){return_declaration}
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [{arguments_call}];
         $__phpunit_count     = func_num_args();
 
@@ -11,6 +23,7 @@
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/_files/mock-object/MethodWIthVariadicVariables.php
+++ b/tests/_files/mock-object/MethodWIthVariadicVariables.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\MockObject;
+
+class MethodWIthVariadicVariables
+{
+    public function testVariadic(string $foo, mixed ...$arguments): array
+    {
+
+        return [$foo, ...$arguments];
+    }
+}

--- a/tests/end-to-end/mock-objects/generator/232-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/232-php7.phpt
@@ -67,6 +67,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function speak()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -77,6 +89,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/232-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/232-php8.phpt
@@ -67,6 +67,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function speak()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -77,6 +89,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/3154_namespaced_constant_resolving-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/3154_namespaced_constant_resolving-php8.phpt
@@ -52,6 +52,18 @@ class Issue3154Mock extends Is\Namespaced\Issue3154 implements PHPUnit\Framework
 
     public function a(int $i = %d, int $j = 17, string $v = '%s', string $z = '#'): string
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$i, $j, $v, $z];
         $__phpunit_count     = func_num_args();
 
@@ -62,6 +74,7 @@ class Issue3154Mock extends Is\Namespaced\Issue3154 implements PHPUnit\Framework
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/3967-php7-php80.phpt
+++ b/tests/end-to-end/mock-objects/generator/3967-php7-php80.phpt
@@ -39,6 +39,18 @@ class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\Moc
 
     public function foo(): string
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -49,6 +61,7 @@ class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\Moc
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/3967.phpt
+++ b/tests/end-to-end/mock-objects/generator/3967.phpt
@@ -40,6 +40,18 @@ class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\Moc
 
     public function foo(): string
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -50,6 +62,7 @@ class MockBaz extends Exception implements Baz, PHPUnit\Framework\MockObject\Moc
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/397-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/397-php8.phpt
@@ -38,6 +38,18 @@ class MockC extends C implements PHPUnit\Framework\MockObject\MockObject
 
     public function m(?C $other): C
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$other];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockC extends C implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/4139-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/4139-php7.phpt
@@ -29,6 +29,18 @@ class %s implements PHPUnit\Framework\MockObject\MockObject, InterfaceWithConstr
 
     public function __construct()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -39,6 +51,7 @@ class %s implements PHPUnit\Framework\MockObject\MockObject, InterfaceWithConstr
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/4139-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/4139-php8.phpt
@@ -29,6 +29,18 @@ class %s implements PHPUnit\Framework\MockObject\MockObject, InterfaceWithConstr
 
     public function __construct()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -39,6 +51,7 @@ class %s implements PHPUnit\Framework\MockObject\MockObject, InterfaceWithConstr
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/abstract_class-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/abstract_class-php7.phpt
@@ -42,6 +42,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function one()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -52,6 +64,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -64,6 +77,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function two()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -74,6 +99,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -86,6 +112,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     protected function three()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -96,6 +134,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/abstract_class-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/abstract_class-php8.phpt
@@ -42,6 +42,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function one()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -52,6 +64,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -64,6 +77,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function two()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -74,6 +99,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -86,6 +112,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     protected function three()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -96,6 +134,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class-php8.phpt
@@ -42,6 +42,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -52,6 +64,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -64,6 +77,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function baz(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -74,6 +99,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_nonexistent_method-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_nonexistent_method-php7.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_nonexistent_method-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_nonexistent_method-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_partial-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_partial-php8.phpt
@@ -42,6 +42,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -52,6 +64,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_deprecated_method-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_deprecated_method-php7.phpt
@@ -44,6 +44,18 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
     {
         @trigger_error('The ClassWithDeprecatedMethod::deprecatedMethod method is deprecated (this method is deprecated).', E_USER_DEPRECATED);
 
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -54,6 +66,7 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_deprecated_method-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_deprecated_method-php8.phpt
@@ -44,6 +44,18 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
     {
         @trigger_error('The ClassWithDeprecatedMethod::deprecatedMethod method is deprecated (this method is deprecated).', E_USER_DEPRECATED);
 
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -54,6 +66,7 @@ class MockFoo extends ClassWithDeprecatedMethod implements PHPUnit\Framework\Moc
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_method_named_method-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_named_method-php7.phpt
@@ -37,6 +37,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function method()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -47,6 +59,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_method_named_method-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_named_method-php8.phpt
@@ -37,6 +37,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function method()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -47,6 +59,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_method_with_nullable_typehinted_variadic_arguments-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_with_nullable_typehinted_variadic_arguments-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends ClassWithMethodWithNullableTypehintedVariadicArguments imp
 
     public function methodWithNullableTypehintedVariadicArguments($a, ?string ...$parameters)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$a];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends ClassWithMethodWithNullableTypehintedVariadicArguments imp
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_method_with_typehinted_variadic_arguments-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_with_typehinted_variadic_arguments-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends ClassWithMethodWithTypehintedVariadicArguments implements 
 
     public function methodWithTypehintedVariadicArguments($a, string ...$parameters)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$a];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends ClassWithMethodWithTypehintedVariadicArguments implements 
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/class_with_method_with_variadic_arguments-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/class_with_method_with_variadic_arguments-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit\Fr
 
     public function methodWithVariadicArguments($a, ...$parameters)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$a];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends ClassWithMethodWithVariadicArguments implements PHPUnit\Fr
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/constant_as_parameter_default_value-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/constant_as_parameter_default_value-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(int $baz = %d)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/interface-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/interface-php8.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/invocation_object_clone_object-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/invocation_object_clone_object-php8.phpt
@@ -43,6 +43,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -53,6 +65,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -65,6 +78,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function baz(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -75,6 +100,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/namespaced_class-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class-php8.phpt
@@ -44,6 +44,18 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(NS\Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -54,6 +66,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -66,6 +79,18 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function baz(NS\Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -76,6 +101,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/namespaced_class_partial-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_class_partial-php8.phpt
@@ -44,6 +44,18 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(NS\Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -54,6 +66,7 @@ class MockFoo extends NS\Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/namespaced_interface-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/namespaced_interface-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, NS\Foo
 
     public function bar(NS\Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, NS\Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/nullable_types-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/nullable_types-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(?int $x)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$x];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/nullable_union_type_parameter.phpt
+++ b/tests/end-to-end/mock-objects/generator/nullable_union_type_parameter.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(bool|int $baz, Foo|null|stdClass $other)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz, $other];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/nullable_union_type_return.phpt
+++ b/tests/end-to-end/mock-objects/generator/nullable_union_type_return.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(): bool|int|null
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/parameter_dnf.phpt
+++ b/tests/end-to-end/mock-objects/generator/parameter_dnf.phpt
@@ -46,6 +46,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar((A&B)|int|null $baz)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -56,6 +68,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/parameter_false.phpt
+++ b/tests/end-to-end/mock-objects/generator/parameter_false.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(false $baz): void
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/parameter_intersection.phpt
+++ b/tests/end-to-end/mock-objects/generator/parameter_intersection.phpt
@@ -46,6 +46,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(AnInterface&AnotherInterface $baz)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -56,6 +68,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/parameter_null.phpt
+++ b/tests/end-to-end/mock-objects/generator/parameter_null.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(null $baz): void
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/parameter_true.phpt
+++ b/tests/end-to-end/mock-objects/generator/parameter_true.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(true $baz): void
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/parameter_union.phpt
+++ b/tests/end-to-end/mock-objects/generator/parameter_union.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(bool|int $baz, Foo|stdClass $other)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz, $other];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/proxy-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/proxy-php8.phpt
@@ -38,6 +38,18 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -60,6 +73,18 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function baz(Foo $foo)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -70,6 +95,7 @@ class ProxyFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_closure-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_closure-php7.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): Closure
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_closure-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_closure-php8.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): Closure
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_dnf.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_dnf.phpt
@@ -46,6 +46,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(): (A&B)|int|null
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -56,6 +68,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_false.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_false.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): false
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_final-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_final-php7.phpt
@@ -43,6 +43,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(): FinalClass
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -53,6 +65,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_final-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_final-php8.phpt
@@ -43,6 +43,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(): FinalClass
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -53,6 +65,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_generator-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_generator-php7.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): Generator
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_generator-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_generator-php8.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): Generator
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_intersection.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_intersection.phpt
@@ -46,6 +46,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(): AnInterface&AnotherInterface
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -56,6 +68,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_never.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_never.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(string $baz): never
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_null.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_null.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): null
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_nullable-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_nullable-php8.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(string $baz): ?string
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_object_method-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_object_method-php8.phpt
@@ -39,6 +39,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(string $baz): Bar
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -49,6 +61,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_parent-php7.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_parent-php7.phpt
@@ -43,6 +43,18 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
 
     public function baz(): Foo
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -53,6 +65,7 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_parent-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_parent-php8.phpt
@@ -43,6 +43,18 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
 
     public function baz(): Foo
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -53,6 +65,7 @@ class MockBar extends Bar implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_self-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_self-php8.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(string $baz): Foo
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_static.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_static.phpt
@@ -46,6 +46,18 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
 
     public function returnsStatic(): static
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -56,6 +68,7 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -68,6 +81,18 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
 
     public function returnsStaticOrNull(): ?static
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -78,6 +103,7 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(
@@ -90,6 +116,18 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
 
     public function returnsUnionWithStatic(): static|stdClass
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -100,6 +138,7 @@ class MockClassWithStaticReturnTypes extends ClassWithStaticReturnTypes implemen
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_true.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_true.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(): true
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_union.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_union.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(): bool|int
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/return_type_declarations_void-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/return_type_declarations_void-php8.phpt
@@ -36,6 +36,18 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
 
     public function bar(string $baz): void
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -46,6 +58,7 @@ class MockFoo implements PHPUnit\Framework\MockObject\MockObject, Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/generator/scalar_type_declarations-php8.phpt
+++ b/tests/end-to-end/mock-objects/generator/scalar_type_declarations-php8.phpt
@@ -38,6 +38,18 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
 
     public function bar(string $baz)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$baz];
         $__phpunit_count     = func_num_args();
 
@@ -48,6 +60,7 @@ class MockFoo extends Foo implements PHPUnit\Framework\MockObject\MockObject
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/call_original.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/call_original.phpt
@@ -23,6 +23,18 @@ print $code;
 
     public function bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ print $code;
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/call_original_with_argument.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/call_original_with_argument.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar($arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar($arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/call_original_with_argument_variadic.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/call_original_with_argument_variadic.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(...$args)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(...$args)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/call_original_with_return_type_void.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/call_original_with_return_type_void.phpt
@@ -23,6 +23,18 @@ print $code;
 
     public function bar(): void
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ print $code;
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/clone_method_arguments.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/clone_method_arguments.phpt
@@ -23,6 +23,18 @@ print $code;
 
     public function bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ print $code;
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/deprecated_with_description.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/deprecated_with_description.phpt
@@ -28,6 +28,18 @@ public function bar()
     {
         @trigger_error('The Foo::bar method is deprecated (some explanation).', E_USER_DEPRECATED);
 
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -38,6 +50,7 @@ public function bar()
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/deprecated_without_description.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/deprecated_without_description.phpt
@@ -28,6 +28,18 @@ public function bar()
     {
         @trigger_error('The Foo::bar method is deprecated ().', E_USER_DEPRECATED);
 
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -38,6 +50,7 @@ public function bar()
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/private_method.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/private_method.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar()
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/protected_method.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/protected_method.phpt
@@ -23,6 +23,18 @@ print $code;
 
 protected function bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ protected function bar()
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/return_by_reference.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_by_reference.phpt
@@ -23,6 +23,18 @@ print $code;
 
 public function &bar()
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ public function &bar()
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/return_by_reference_with_return_type.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_by_reference_with_return_type.phpt
@@ -23,6 +23,18 @@ print $code;
 
 public function &bar(): string
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ public function &bar(): string
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/return_type.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_type.phpt
@@ -23,6 +23,18 @@ print $code;
 
 public function bar(): string
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ public function bar(): string
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/return_type_parent.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_type_parent.phpt
@@ -27,6 +27,18 @@ print $code;
 
 public function bar(): Baz
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -37,6 +49,7 @@ public function bar(): Baz
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/return_type_self.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/return_type_self.phpt
@@ -23,6 +23,18 @@ print $code;
 
 public function bar(): Foo
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ public function bar(): Foo
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar($arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar($arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_default.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_default.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar($arg = false)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar($arg = false)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_default_constant.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_default_constant.phpt
@@ -28,6 +28,18 @@ print $code;
 
 private function bar($a = 1, $b = 2, $c = 3, $d = 4)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$a, $b, $c, $d];
         $__phpunit_count     = func_num_args();
 
@@ -38,6 +50,7 @@ private function bar($a = 1, $b = 2, $c = 3, $d = 4)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_default_new_expression.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_default_new_expression.phpt
@@ -35,6 +35,18 @@ print $code;
 
 public function method(Foo $foo = new \Foo(1, 2, 3))
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$foo];
         $__phpunit_count     = func_num_args();
 
@@ -45,6 +57,7 @@ public function method(Foo $foo = new \Foo(1, 2, 3))
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_default_null.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_default_null.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar($arg = NULL)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar($arg = NULL)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_nullable.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_nullable.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(?string $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(?string $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_reference.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_reference.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(&$arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [&$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(&$arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_array.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_array.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(array $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(array $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_callable.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_callable.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(callable $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(callable $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_class.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_class.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(Exception $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(Exception $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_scalar.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_scalar.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(string $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(string $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_self.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_self.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(Foo $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(Foo $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_unkown_class.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_unkown_class.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(UnknownClass $arg)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(UnknownClass $arg)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_typed_variadic.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_typed_variadic.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(string ...$args)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(string ...$args)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_argument_variadic.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_argument_variadic.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar(...$args)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar(...$args)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/end-to-end/mock-objects/mock-method/with_arguments.phpt
+++ b/tests/end-to-end/mock-objects/mock-method/with_arguments.phpt
@@ -23,6 +23,18 @@ print $code;
 
 private function bar($arg1, $arg2)
     {
+        $definedVariables = get_defined_vars();
+        $namedVariadicParameters = [];
+        foreach ($definedVariables as $name => $value) {
+            $reflectionParam = new ReflectionParameter([__CLASS__, __FUNCTION__], $name);
+            if ($reflectionParam->isVariadic()) {
+                foreach ($value as $key => $namedValue) {
+                    if (is_string($key)) {
+                        $namedVariadicParameters[$key] = $namedValue;
+                    }
+                }
+            }
+        }
         $__phpunit_arguments = [$arg1, $arg2];
         $__phpunit_count     = func_num_args();
 
@@ -33,6 +45,7 @@ private function bar($arg1, $arg2)
                 $__phpunit_arguments[] = $__phpunit_arguments_tmp[$__phpunit_i];
             }
         }
+        $__phpunit_arguments = array_merge($__phpunit_arguments, $namedVariadicParameters);
 
         $__phpunit_result = $this->__phpunit_getInvocationHandler()->invoke(
             new \PHPUnit\Framework\MockObject\Invocation(

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -38,6 +38,7 @@ use PHPUnit\TestFixture\MockObject\InterfaceWithMethodReturningFalse;
 use PHPUnit\TestFixture\MockObject\InterfaceWithMethodReturningIntersection;
 use PHPUnit\TestFixture\MockObject\InterfaceWithMethodReturningNull;
 use PHPUnit\TestFixture\MockObject\InterfaceWithMethodReturningTrue;
+use PHPUnit\TestFixture\MockObject\MethodWIthVariadicVariables;
 use PHPUnit\TestFixture\PartialMockTestClass;
 use PHPUnit\TestFixture\SomeClass;
 use PHPUnit\TestFixture\StringableClass;
@@ -1209,6 +1210,19 @@ EOF
         $stub = $this->createStub(ClassWithStaticReturnTypes::class);
 
         $this->assertInstanceOf(ClassWithStaticReturnTypes::class, $stub->returnsStatic());
+    }
+
+    public function testWillReturnCallbackWithVariadicVariables(): void
+    {
+        $mock = $this->createMock(MethodWIthVariadicVariables::class);
+        $mock->expects($this->once())->method('testVariadic')
+            ->withAnyParameters()
+            ->willReturnCallback(static fn ($string, ...$arguments) => [$string, ...$arguments]);
+
+        $testData = ['foo', 'bar', 'biz' => true];
+        $actual   = $mock->testVariadic(...$testData);
+
+        $this->assertSame($testData, $actual);
     }
 
     /**


### PR DESCRIPTION
**Issue:**
  - for variadic variables func_get_args() doesnt register associative elements

**Solution:**
  - use reflection to merge the  associative elements with the existing ones. isVariadic() check is only possible with reflection
  - https://github.com/sebastianbergmann/phpunit/issues/5455