### PR TITLE
Sync PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,12 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.1",
+        "ext-ctype": "*",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-tokenizer": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
         "myclabs/deep-copy": "^1.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e06728e5442edec84af96f94a889b4a7",
+    "content-hash": "417d09bd26e28681a2d4effc3e023e19",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1529,10 +1529,12 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1",
+        "ext-ctype": "*",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-tokenizer": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*"
     },


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/5658

Synchronizing the extensions checked in the runtime: https://github.com/sebastianbergmann/phpunit/blob/10.5.6/phpunit#L41 with the ones in composer.json: https://github.com/sebastianbergmann/phpunit/blob/10.5.6/composer.json#L26-L31

Apparently, [paraunit](https://github.com/facile-it/paraunit) does not run the check from PHPUnit, in the 1st commit of https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7727 I've added the check and after adding `ctype` extension to CI the problem from the linked issue is resolved.