### PR TITLE
Add a test to validate cloning of InvocationHandler on test doubles

### DIFF
--- a/tests/unit/Framework/MockObject/TestDoubleTestCase.php
+++ b/tests/unit/Framework/MockObject/TestDoubleTestCase.php
@@ -254,6 +254,23 @@ abstract class TestDoubleTestCase extends TestCase
         clone $double;
     }
 
+    final public function testInvocationExpectationsCloningWhenTestDoubleObjectIsCloned(): void
+    {
+        $double = $this->createTestDouble(InterfaceWithReturnTypeDeclaration::class);
+
+        $double->expects($this->exactly(2))->method('doSomething');
+
+        $clone = clone $double;
+
+        $double->expects($this->once())->method('doSomethingElse')->willReturn(1);
+        $clone->expects($this->once())->method('doSomethingElse')->willReturn(2);
+
+        $this->assertFalse($double->doSomething());
+        $this->assertFalse($clone->doSomething());
+        $this->assertSame(1, $double->doSomethingElse(0));
+        $this->assertSame(2, $clone->doSomethingElse(0));
+    }
+
     /**
      * @psalm-template RealInstanceType of object
      *


### PR DESCRIPTION
For each test double, there is a set of invocation expectations.
When cloning test double, there is a clone on the set, copying existing invocations.

The behavior is that the expectations done before cloning are shared between the original test doubles and the clone, while the new expectations added to each after cloning are not shared.