### PR TITLE
Add additional tests for data provider values

### DIFF
--- a/tests/_files/DataProviderDependencyResultTest.php
+++ b/tests/_files/DataProviderDependencyResultTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+
+final class DataProviderDependencyResultTest extends TestCase
+{
+    public static function providerMethod(): array
+    {
+        return [
+            [0, 2],
+            [1, 1],
+        ];
+    }
+
+    #[DataProvider('providerMethod')]
+    #[Depends('testDependency')]
+    public function testAdd($a, $b, $c): void
+    {
+        $this->assertSame(2, $c);
+        $this->assertSame($c, $a + $b);
+    }
+
+    public function testDependency(): int
+    {
+        $a = 2;
+        $this->assertSame(2, $a);
+
+        return $a;
+    }
+}

--- a/tests/_files/DataProviderDependencyResultTest.php
+++ b/tests/_files/DataProviderDependencyResultTest.php
@@ -20,6 +20,7 @@ final class DataProviderDependencyResultTest extends TestCase
         return [
             [0, 2],
             [1, 1],
+            ['b' => 2, 'a' => 0],
         ];
     }
 

--- a/tests/end-to-end/generic/dataprovider-dependency-result.phpt
+++ b/tests/end-to-end/generic/dataprovider-dependency-result.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit ../../_files/DataProviderDependencyResultTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderDependencyResultTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+OK (3 tests, 5 assertions)

--- a/tests/end-to-end/generic/dataprovider-dependency-result.phpt
+++ b/tests/end-to-end/generic/dataprovider-dependency-result.phpt
@@ -13,8 +13,14 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-...                                                                 3 / 3 (100%)
+...E                                                                4 / 4 (100%)
 
 Time: %s, Memory: %s
 
-OK (3 tests, 5 assertions)
+There was 1 error:
+
+1) PHPUnit\TestFixture\DataProviderDependencyResultTest::testAdd with data set #2 (2, 0)
+Error: Cannot use positional argument after named argument during unpacking
+
+ERRORS!
+Tests: 4, Assertions: 5, Errors: 1.


### PR DESCRIPTION
Follow-up to #5225.

This MR adds tests that assert the following behavior:
- When a test receives input from both a data provider method and from one or more tests it depends on, the arguments from the data provider will come before the ones from depended-upon tests. This is taken from [the doc description](https://docs.phpunit.de/en/10.5/writing-tests-for-phpunit.html#data-providers).
- Combining named arguments (as introduced in #5225) with input from a dependency is not supported.