### PR TITLE
fix: Setting error handler inside an isolated test may cause test failure on PHP 8.3

### DIFF
--- a/src/Util/PHP/Template/TestCaseClass.tpl
+++ b/src/Util/PHP/Template/TestCaseClass.tpl
@@ -66,6 +66,8 @@ function __phpunit_run_isolated_test()
 
     ini_set('xdebug.scream', '0');
 
+    set_error_handler('__phpunit_error_handler');
+
     // Not every STDOUT target stream is rewindable
     @rewind(STDOUT);
 
@@ -78,6 +80,8 @@ function __phpunit_run_isolated_test()
             @rewind(STDOUT);
         }
     }
+
+    restore_error_handler();
 
     file_put_contents(
         '{processResultFile}',

--- a/src/Util/PHP/Template/TestCaseClass.tpl
+++ b/src/Util/PHP/Template/TestCaseClass.tpl
@@ -66,7 +66,7 @@ function __phpunit_run_isolated_test()
 
     ini_set('xdebug.scream', '0');
 
-    set_error_handler('__phpunit_error_handler');
+    set_error_handler(static fn() => false);
 
     // Not every STDOUT target stream is rewindable
     @rewind(STDOUT);

--- a/src/Util/PHP/Template/TestCaseMethod.tpl
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl
@@ -31,11 +31,6 @@ if ($composerAutoload) {
     require $phar;
 }
 
-function __phpunit_error_handler($errno, $errstr, $errfile, $errline)
-{
-   return true;
-}
-
 function __phpunit_run_isolated_test()
 {
     $dispatcher = Facade::instance()->initForIsolation(
@@ -71,7 +66,7 @@ function __phpunit_run_isolated_test()
 
     ini_set('xdebug.scream', '0');
 
-    set_error_handler('__phpunit_error_handler');
+    set_error_handler(static fn() => false);
 
     // Not every STDOUT target stream is rewindable
     @rewind(STDOUT);
@@ -101,6 +96,11 @@ function __phpunit_run_isolated_test()
             ]
         )
     );
+}
+
+function __phpunit_error_handler($errno, $errstr, $errfile, $errline)
+{
+    return true;
 }
 
 set_error_handler('__phpunit_error_handler');

--- a/src/Util/PHP/Template/TestCaseMethod.tpl
+++ b/src/Util/PHP/Template/TestCaseMethod.tpl
@@ -31,6 +31,11 @@ if ($composerAutoload) {
     require $phar;
 }
 
+function __phpunit_error_handler($errno, $errstr, $errfile, $errline)
+{
+   return true;
+}
+
 function __phpunit_run_isolated_test()
 {
     $dispatcher = Facade::instance()->initForIsolation(
@@ -66,6 +71,8 @@ function __phpunit_run_isolated_test()
 
     ini_set('xdebug.scream', '0');
 
+    set_error_handler('__phpunit_error_handler');
+
     // Not every STDOUT target stream is rewindable
     @rewind(STDOUT);
 
@@ -78,6 +85,8 @@ function __phpunit_run_isolated_test()
             @rewind(STDOUT);
         }
     }
+
+    restore_error_handler();
 
     file_put_contents(
         '{processResultFile}',
@@ -92,11 +101,6 @@ function __phpunit_run_isolated_test()
             ]
         )
     );
-}
-
-function __phpunit_error_handler($errno, $errstr, $errfile, $errline)
-{
-   return true;
 }
 
 set_error_handler('__phpunit_error_handler');

--- a/tests/end-to-end/regression/5595.phpt
+++ b/tests/end-to-end/regression/5595.phpt
@@ -1,10 +1,5 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/5595
---SKIPIF--
-<?php declare(strict_types=1);
-if (version_compare('8.3.0-dev', PHP_VERSION, '>')) {
-    print 'skip: PHP 8.3 is required.';
-}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
@@ -19,32 +14,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-E                                                                   1 / 1 (100%)
+.                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %s
 
-There was 1 error:
-
-1) PHPUnit\TestFixture\Issue5595Test::test
-PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php:%d
-Stack trace:
-#0 %s%esrc%eRunner%eErrorHandler.php(%d): PHPUnit\Event\Code\TestMethodBuilder::fromCallStack()
-#1 [internal function]: PHPUnit\Runner\ErrorHandler->__invoke(2, 'rewind(): Strea...', 'Standard input ...', %d)
-#2 Standard input code(%d): rewind(Resource id #2)
-#3 Standard input code(%d): __phpunit_run_isolated_test()
-#4 {main}
-  thrown in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php on line %d
-
-Fatal error: Uncaught PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php on line %d
-
-PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php on line %d
-
-Call Stack:
-    %s
-    %s
-    %s
-    %s
-    %s
-
-ERRORS!
-Tests: 1, Assertions: 0, Errors: 1.
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/5595.phpt
+++ b/tests/end-to-end/regression/5595.phpt
@@ -1,0 +1,50 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/5595
+--SKIPIF--
+<?php declare(strict_types=1);
+if (version_compare('8.3.0-dev', PHP_VERSION, '>')) {
+    print 'skip: PHP 8.3 is required.';
+}
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][]  = '--process-isolation';
+$_SERVER['argv'][]  = __DIR__ . '/5595/Issue5595Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) PHPUnit\TestFixture\Issue5595Test::test
+PHPUnit\Framework\Exception: PHP Fatal error:  Uncaught PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php:%d
+Stack trace:
+#0 %s%esrc%eRunner%eErrorHandler.php(%d): PHPUnit\Event\Code\TestMethodBuilder::fromCallStack()
+#1 [internal function]: PHPUnit\Runner\ErrorHandler->__invoke(2, 'rewind(): Strea...', 'Standard input ...', %d)
+#2 Standard input code(%d): rewind(Resource id #2)
+#3 Standard input code(%d): __phpunit_run_isolated_test()
+#4 {main}
+  thrown in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php on line %d
+
+Fatal error: Uncaught PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php on line %d
+
+PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack in %s%esrc%eEvent%eValue%eTest%eTestMethodBuilder.php on line %d
+
+Call Stack:
+    %s
+    %s
+    %s
+    %s
+    %s
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/end-to-end/regression/5595/Issue5595Test.php
+++ b/tests/end-to-end/regression/5595/Issue5595Test.php
@@ -9,14 +9,16 @@
  */
 namespace PHPUnit\TestFixture;
 
+use function set_error_handler;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 class Issue5595Test extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
-        set_error_handler(function (): bool {
+        set_error_handler(static function (): bool
+        {
             return true;
         });
     }

--- a/tests/end-to-end/regression/5595/Issue5595Test.php
+++ b/tests/end-to-end/regression/5595/Issue5595Test.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+class Issue5595Test extends TestCase
+{
+    public function setUp(): void
+    {
+        set_error_handler(function (): bool {
+            return true;
+        });
+    }
+
+    #[RunInSeparateProcess]
+    public function test(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Related Issues

- https://github.com/sebastianbergmann/phpunit/issues/5595
- https://github.com/laravel/framework/issues/49237
- https://github.com/laravel/framework/issues/49593

## Summary

On PHP 8.3, calling `set_error_handler` in an isolated test (via `#[RunInSeparateProcess]`) may cause test failure, regardless of what the error handler does.

Some frameworks, including Laravel, enables their error handler on booting. After the test run, PHPUnit's temporary code tries to call `rewind(STDOUT)`. This may cause an error when STDOUT is not rewindable, as the comment says; this is expected. The error handler set by the framework is called even though `@` is prepended to the call.

After that `PHPUnit\Runner\ErrorHandler` is called somehow only on PHP 8.3; I don't know why this is called (a PHP bug?). ErrorHandler tries to find the call stack, but it's not possible. Then the test fails by ErrorHandler throwing `NoTestCaseObjectOnCallStackException`. In my application tests, this is shown as 'Test was run in child process and ended unexpectedly'.

This pull request sets a no-op error handler temporarily during doing fallible calls with `@`. This helps the tests calling `set_error_handler` but not calling `restore_error_handler` after the test.

## Workaround

Call `restore_error_handler` on `tearDown` or `tearDownAfterClass` depending on the situation.