### PR TITLE
disallowed trailing comma in the parameter list in PHP < 8.0

### DIFF
--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -2672,7 +2672,7 @@ if (!function_exists('PHPUnit\Framework\atLeast')) {
     function atLeast(int $requiredInvocations): InvokedAtLeastCountMatcher
     {
         return new InvokedAtLeastCountMatcher(
-            $requiredInvocations,
+            $requiredInvocations
         );
     }
 }


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected ')'

Prior to PHP 8.0, this would have caused a parse error due to the disallowed trailing comma in the parameter list