### PR TITLE
[DOCS] Shorten deprecation messages emitted in PHPUnit 11

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1705,7 +1705,7 @@ abstract class Assert
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             null,
-            'assertStringNotMatchesFormat() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'assertStringNotMatchesFormat() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         static::assertThat(
@@ -1746,7 +1746,7 @@ abstract class Assert
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             null,
-            'assertStringNotMatchesFormatFile() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'assertStringNotMatchesFormatFile() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         static::assertFileExists($formatFile, $message);

--- a/src/Framework/MockObject/Generator/Generator.php
+++ b/src/Framework/MockObject/Generator/Generator.php
@@ -768,7 +768,7 @@ final class Generator
         }
 
         if ($mockMethods->hasMethod('method') || (isset($class) && $class->hasMethod('method'))) {
-            $message = 'Doubling interfaces (or classes) that have a method named "method" is deprecated. Support for this will be removed in PHPUnit 12.';
+            $message = 'Doubling interfaces (or classes) that have a method named "method" is deprecated and will be removed in PHPUnit 12 without replacement.';
 
             try {
                 EventFacade::emitter()->testTriggeredPhpunitDeprecation(

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -133,7 +133,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::getMockForAbstractClass() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::getMockForAbstractClass() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $object = $this->generator->mockObjectForAbstractClass(
@@ -169,7 +169,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::getMockForTrait() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::getMockForTrait() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         assert(trait_exists($this->type));
@@ -250,7 +250,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::addMethods() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::addMethods() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         if (empty($methods)) {
@@ -367,7 +367,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::disableAutoload() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::disableAutoload() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $this->autoload = false;
@@ -386,7 +386,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::enableAutoload() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::enableAutoload() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $this->autoload = true;
@@ -406,7 +406,7 @@ final class MockBuilder
         if (!$this->calledFromTestCase()) {
             EventFacade::emitter()->testTriggeredPhpunitDeprecation(
                 $this->testCase->valueObjectForEvents(),
-                'MockBuilder::disableArgumentCloning() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+                'MockBuilder::disableArgumentCloning() is deprecated and will be removed in PHPUnit 12 without replacement.',
             );
         }
 
@@ -426,7 +426,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::enableArgumentCloning() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::enableArgumentCloning() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $this->cloneArguments = true;
@@ -446,7 +446,7 @@ final class MockBuilder
         if (!$this->calledFromTestCase()) {
             EventFacade::emitter()->testTriggeredPhpunitDeprecation(
                 $this->testCase->valueObjectForEvents(),
-                'MockBuilder::enableProxyingToOriginalMethods() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+                'MockBuilder::enableProxyingToOriginalMethods() is deprecated and will be removed in PHPUnit 12 without replacement.',
             );
         }
 
@@ -466,7 +466,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::disableProxyingToOriginalMethods() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::disableProxyingToOriginalMethods() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $this->callOriginalMethods = false;
@@ -486,7 +486,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::setProxyTarget() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::setProxyTarget() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $this->proxyTarget = $object;
@@ -503,7 +503,7 @@ final class MockBuilder
     {
         EventFacade::emitter()->testTriggeredPhpunitDeprecation(
             $this->testCase->valueObjectForEvents(),
-            'MockBuilder::allowMockingUnknownTypes() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'MockBuilder::allowMockingUnknownTypes() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $this->allowMockingUnknownTypes = true;
@@ -521,7 +521,7 @@ final class MockBuilder
         if (!$this->calledFromTestCase()) {
             EventFacade::emitter()->testTriggeredPhpunitDeprecation(
                 $this->testCase->valueObjectForEvents(),
-                'MockBuilder::disallowMockingUnknownTypes() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+                'MockBuilder::disallowMockingUnknownTypes() is deprecated and will be removed in PHPUnit 12 without replacement.',
             );
         }
 

--- a/src/Framework/MockObject/Runtime/Api/MockObjectApi.php
+++ b/src/Framework/MockObject/Runtime/Api/MockObjectApi.php
@@ -55,7 +55,7 @@ trait MockObjectApi
         assert($this instanceof StubInternal);
 
         if (!$this->__phpunit_wasGeneratedAsMockObject()) {
-            $message = 'Expectations configured on test doubles that are created as test stubs are no longer verified since PHPUnit 10. Test doubles that are created as test stubs will no longer have the expects() method in PHPUnit 12. Update your test code to use createMock() instead of createStub(), for example.';
+            $message = 'Expectations configured on test doubles that are created as test stubs are no longer verified since PHPUnit 10, their expects() method will be removed in PHPUnit 12. Use createMock() instead of createStub() for these expectations.';
 
             try {
                 $test = TestMethodBuilder::fromCallStack();

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1208,7 +1208,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'iniSet() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'iniSet() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $currentValue = ini_set($varName, $newValue);
@@ -1238,7 +1238,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'setLocale() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'setLocale() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         if (count($arguments) < 2) {
@@ -1405,7 +1405,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'createTestProxy() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'createTestProxy() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $testProxy = $this->getMockBuilder($originalClassName)
@@ -1441,7 +1441,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'getMockForAbstractClass() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'getMockForAbstractClass() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $mockObject = (new MockGenerator)->mockObjectForAbstractClass(
@@ -1476,7 +1476,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'getMockFromWsdl() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'getMockFromWsdl() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         if ($originalClassName === '') {
@@ -1539,7 +1539,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'getMockForTrait() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'getMockForTrait() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         $mockObject = (new MockGenerator)->mockObjectForTrait(
@@ -1573,7 +1573,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
             $this->valueObjectForEvents(),
-            'getObjectForTrait() is deprecated and will be removed in PHPUnit 12. No replacement is/will be provided.',
+            'getObjectForTrait() is deprecated and will be removed in PHPUnit 12 without replacement.',
         );
 
         return (new MockGenerator)->objectForTrait(


### PR DESCRIPTION
Since it was stated that alternate wording ideas for the deprecation messages emitted by PHPUnit 11 would be welcome, here's my approach to it to shorten the output to be "easier on the eye".