### PR TITLE
Fix: Use `grep` directly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,7 +254,7 @@ jobs:
         run: ant phar-snapshot
 
       - name: Check whether PHAR is scoped
-        run: cat build/artifacts/phpunit-snapshot.phar | grep -q PHPUnit\\\\DeepCopy\\\\Exception\\\\CloneException || (echo "phpunit-snapshot.phar is not scoped." && false)
+        run: grep -q PHPUnit\\\\DeepCopy\\\\Exception\\\\CloneException build/artifacts/phpunit-snapshot.phar || (echo "phpunit-snapshot.phar is not scoped." && false)
 
       - name: Upload PHAR
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request

- [x] uses `grep` directly

Fixes #5598.

💁‍♂️ For reference, see https://stackoverflow.com/questions/49664991/why-am-i-getting-cat-write-error-broken-pipe-rarely-and-not-always.