### PR TITLE
Prevent duplicate call of `NamePrettifier::prettifyTestMethodName()`

### DIFF
--- a/src/Event/Value/Test/TestDoxBuilder.php
+++ b/src/Event/Value/Test/TestDoxBuilder.php
@@ -34,12 +34,13 @@ final readonly class TestDoxBuilder
      */
     public static function fromClassNameAndMethodName(string $className, string $methodName): TestDox
     {
-        $prettifier = new NamePrettifier;
+        $prettifier   = new NamePrettifier;
+        $prettyMethod = $prettifier->prettifyTestMethodName($methodName);
 
         return new TestDox(
             $prettifier->prettifyTestClassName($className),
-            $prettifier->prettifyTestMethodName($methodName),
-            $prettifier->prettifyTestMethodName($methodName),
+            $prettyMethod,
+            $prettyMethod,
         );
     }
 }


### PR DESCRIPTION
stumbled over it in a recent blackfire profile

<img width="518" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/f484a313-e72b-462f-960d-bbc252fe9faf">
