### PR TITLE
Lazy collorize method name

### DIFF
--- a/src/Event/Value/Test/TestDox.php
+++ b/src/Event/Value/Test/TestDox.php
@@ -14,17 +14,21 @@ namespace PHPUnit\Event\Code;
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-final readonly class TestDox
+final class TestDox
 {
-    private string $prettifiedClassName;
-    private string $prettifiedMethodName;
-    private string $prettifiedAndColorizedMethodName;
+    private readonly string $prettifiedClassName;
 
-    public function __construct(string $prettifiedClassName, string $prettifiedMethodName, string $prettifiedAndColorizedMethodName)
+    /** @var callable */
+    private $prettifiedMethodNameCallable;
+
+    /** @var callable */
+    private $prettifiedAndColorizedMethodNameCallable;
+
+    public function __construct(string $prettifiedClassName, callable $prettifiedMethodNameCallable, callable $prettifiedAndColorizedMethodNameCallable)
     {
-        $this->prettifiedClassName              = $prettifiedClassName;
-        $this->prettifiedMethodName             = $prettifiedMethodName;
-        $this->prettifiedAndColorizedMethodName = $prettifiedAndColorizedMethodName;
+        $this->prettifiedClassName                      = $prettifiedClassName;
+        $this->prettifiedMethodNameCallable             = $prettifiedMethodNameCallable;
+        $this->prettifiedAndColorizedMethodNameCallable = $prettifiedAndColorizedMethodNameCallable;
     }
 
     public function prettifiedClassName(): string
@@ -35,9 +39,9 @@ final readonly class TestDox
     public function prettifiedMethodName(bool $colorize = false): string
     {
         if ($colorize) {
-            return $this->prettifiedAndColorizedMethodName;
+            return ($this->prettifiedAndColorizedMethodNameCallable)();
         }
 
-        return $this->prettifiedMethodName;
+        return ($this->prettifiedMethodNameCallable)();
     }
 }

--- a/src/Event/Value/Test/TestDoxBuilder.php
+++ b/src/Event/Value/Test/TestDoxBuilder.php
@@ -23,8 +23,8 @@ final readonly class TestDoxBuilder
 
         return new TestDox(
             $prettifier->prettifyTestClassName($testCase::class),
-            $prettifier->prettifyTestCase($testCase, false),
-            $prettifier->prettifyTestCase($testCase, true),
+            static fn () => $prettifier->prettifyTestCase($testCase, false),
+            static fn () => $prettifier->prettifyTestCase($testCase, true),
         );
     }
 
@@ -40,8 +40,8 @@ final readonly class TestDoxBuilder
 
         return new TestDox(
             $prettifier->prettifyTestClassName($className),
-            $prettifiedMethodName,
-            $prettifiedMethodName,
+            static fn () => $prettifiedMethodName,
+            static fn () => $prettifiedMethodName,
         );
     }
 }


### PR DESCRIPTION
looking into blackfire profiles I can see the TestDoc colorization takes 10-15% of runtime.

testing of this PR confirmed the thesis

before
```
php ./phpunit --testsuite unit     
…
Time: 00:00.466, Memory: 44.00 MB
```

after
```
php ./phpunit --testsuite unit     
…
Time: 00:00.420, Memory: 52.00 MB
```

blackfire diff

<img width="1187" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/0b2631b6-467f-49c8-91fa-13d81912b7c8">

---

now the bad news :-). while this PR works with the unit test-suite, it does not with the end-to-end suite.

I can see that the changed TestDox class is no longer serializable, and therefore does not work with tests using process isolation or similar features.

since 10-15% percent is not that bad, I figured it would nevertheless make sense to bring this up for discussion.
maybe we can utilize the basic idea of doing coloring lazily for all tests which do not use process isolation..?

I would love anyones feedback