### PR TITLE
Micro-optimize `NamePrettifier::prettifyTestMethodName()`

### DIFF
--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -145,7 +145,9 @@ final class NamePrettifier
         $wasNumeric = false;
 
         foreach (range(0, strlen($name) - 1) as $i) {
-            if ($i > 0 && ord($name[$i]) >= 65 && ord($name[$i]) <= 90) {
+            $ord = ord($name[$i]);
+
+            if ($i > 0 && $ord >= 65 && $ord <= 90) {
                 $buffer .= ' ' . strtolower($name[$i]);
             } else {
                 $isNumeric = is_numeric($name[$i]);


### PR DESCRIPTION
the function call is showing up in blackfire profiles  of `blackfire run  php ./phpunit --testsuite unit`

<img width="381" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/3245c8f8-d096-4444-b868-91f5fdda252b">

after the change it no longer appears