### PR TITLE
Micro-optimize `TestRunner::runTestWithTimeout()`

### DIFF
--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -408,12 +408,13 @@ final class TestRunner
     private function runTestWithTimeout(TestCase $test): bool
     {
         $_timeout = $this->configuration->defaultTimeLimit();
+        $testSize = $test->size();
 
-        if ($test->size()->isSmall()) {
+        if ($testSize->isSmall()) {
             $_timeout = $this->configuration->timeoutForSmallTests();
-        } elseif ($test->size()->isMedium()) {
+        } elseif ($testSize->isMedium()) {
             $_timeout = $this->configuration->timeoutForMediumTests();
-        } elseif ($test->size()->isLarge()) {
+        } elseif ($testSize->isLarge()) {
             $_timeout = $this->configuration->timeoutForLargeTests();
         }
 


### PR DESCRIPTION
the function call is showing up in blackfire profiles  of `blackfire run  php ./phpunit --testsuite unit`

<img width="294" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/4e68d037-6c74-44be-8969-bdff05596707">
