### PR TITLE
Save call to `Telemetry\System::snapshot()`

### DIFF
--- a/src/Event/Emitter/DispatchingEmitter.php
+++ b/src/Event/Emitter/DispatchingEmitter.php
@@ -42,7 +42,7 @@ final class DispatchingEmitter implements Emitter
         $this->system     = $system;
 
         $this->startSnapshot    = $system->snapshot();
-        $this->previousSnapshot = $system->snapshot();
+        $this->previousSnapshot = $this->startSnapshot;
     }
 
     /**


### PR DESCRIPTION
the function call is showing up in blackfire profiles  of `blackfire run  php ./phpunit --testsuite unit`

<img width="741" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/b40c8dbc-b7e6-47d8-b2db-96c01e47d723">


diff
<img width="475" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/03e01e22-9aff-4ade-a880-e31d546c4998">
