### PR TITLE
Prevent file IO when not strictly necessary

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -927,8 +927,6 @@
       <code><![CDATA[listTestsXml]]></code>
       <code><![CDATA[logEventsText]]></code>
       <code><![CDATA[logEventsText]]></code>
-      <code><![CDATA[logEventsText]]></code>
-      <code><![CDATA[logEventsVerboseText]]></code>
       <code><![CDATA[logEventsVerboseText]]></code>
       <code><![CDATA[logEventsVerboseText]]></code>
       <code><![CDATA[logfileJunit]]></code>

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -228,7 +228,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
      */
     public function addTestFile(string $filename): void
     {
-        if (is_file($filename) && str_ends_with($filename, '.phpt')) {
+        if (str_ends_with($filename, '.phpt') && is_file($filename)) {
             try {
                 $this->addTest(new PhptTestCase($filename));
             } catch (RunnerException $e) {

--- a/src/Runner/Baseline/Issue.php
+++ b/src/Runner/Baseline/Issue.php
@@ -123,12 +123,13 @@ final class Issue
      */
     private static function calculateHash(string $file, int $line): string
     {
-        if (!is_file($file)) {
+        $lines = @file($file, FILE_IGNORE_NEW_LINES);
+
+        if ($lines === false && !is_file($file)) {
             throw new FileDoesNotExistException($file);
         }
 
-        $lines = file($file, FILE_IGNORE_NEW_LINES);
-        $key   = $line - 1;
+        $key = $line - 1;
 
         if (!isset($lines[$key])) {
             throw new FileDoesNotHaveLineException($file, $line);

--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -638,15 +638,13 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         $coverage = RawCodeCoverageData::fromXdebugWithoutPathCoverage([]);
         $files    = $this->getCoverageFiles();
 
-        if (is_file($files['coverage'])) {
-            $buffer = @file_get_contents($files['coverage']);
+        $buffer = @file_get_contents($files['coverage']);
 
-            if ($buffer !== false) {
-                $coverage = @unserialize($buffer);
+        if ($buffer !== false) {
+            $coverage = @unserialize($buffer);
 
-                if ($coverage === false) {
-                    $coverage = RawCodeCoverageData::fromXdebugWithoutPathCoverage([]);
-                }
+            if ($coverage === false) {
+                $coverage = RawCodeCoverageData::fromXdebugWithoutPathCoverage([]);
             }
         }
 

--- a/src/Runner/ResultCache/DefaultResultCache.php
+++ b/src/Runner/ResultCache/DefaultResultCache.php
@@ -17,7 +17,6 @@ use function file_get_contents;
 use function file_put_contents;
 use function is_array;
 use function is_dir;
-use function is_file;
 use function json_decode;
 use function json_encode;
 use PHPUnit\Framework\TestStatus\TestStatus;
@@ -86,12 +85,14 @@ final class DefaultResultCache implements ResultCache
 
     public function load(): void
     {
-        if (!is_file($this->cacheFilename)) {
+        $contents = @file_get_contents($this->cacheFilename);
+
+        if ($contents === false) {
             return;
         }
 
         $data = json_decode(
-            file_get_contents($this->cacheFilename),
+            $contents,
             true,
         );
 

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -10,7 +10,6 @@
 namespace PHPUnit\TextUI;
 
 use const PHP_EOL;
-use function is_file;
 use function is_readable;
 use function printf;
 use function realpath;
@@ -517,9 +516,7 @@ final class Application
     private function registerLogfileWriters(Configuration $configuration): void
     {
         if ($configuration->hasLogEventsText()) {
-            if (is_file($configuration->logEventsText())) {
-                unlink($configuration->logEventsText());
-            }
+            @unlink($configuration->logEventsText());
 
             EventFacade::instance()->registerTracer(
                 new EventLogger(
@@ -530,9 +527,7 @@ final class Application
         }
 
         if ($configuration->hasLogEventsVerboseText()) {
-            if (is_file($configuration->logEventsVerboseText())) {
-                unlink($configuration->logEventsVerboseText());
-            }
+            @unlink($configuration->logEventsVerboseText());
 
             EventFacade::instance()->registerTracer(
                 new EventLogger(

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -399,7 +399,7 @@ final class Builder
                 case '--use-baseline':
                     $useBaseline = $option[1];
 
-                    if (!is_file($useBaseline) && basename($useBaseline) === $useBaseline) {
+                    if (basename($useBaseline) === $useBaseline && !is_file($useBaseline)) {
                         $useBaseline = getcwd() . DIRECTORY_SEPARATOR . $useBaseline;
                     }
 

--- a/src/TextUI/Configuration/TestSuiteBuilder.php
+++ b/src/TextUI/Configuration/TestSuiteBuilder.php
@@ -91,18 +91,18 @@ final class TestSuiteBuilder
      */
     private function testSuiteFromPath(string $path, array $suffixes, ?TestSuite $suite = null): TestSuite
     {
+        if (str_ends_with($path, '.phpt') && is_file($path)) {
+            $suite = $suite ?: TestSuite::empty($path);
+            $suite->addTestFile($path);
+
+            return $suite;
+        }
+
         if (is_dir($path)) {
             $files = (new FileIteratorFacade)->getFilesAsArray($path, $suffixes);
 
             $suite = $suite ?: TestSuite::empty('CLI Arguments');
             $suite->addTestFiles($files);
-
-            return $suite;
-        }
-
-        if (is_file($path) && str_ends_with($path, '.phpt')) {
-            $suite = $suite ?: TestSuite::empty($path);
-            $suite->addTestFile($path);
 
             return $suite;
         }

--- a/src/Util/Filter.php
+++ b/src/Util/Filter.php
@@ -89,10 +89,10 @@ final class Filter
             $script = '';
         }
 
-        return is_file($file) &&
+        return $fileIsNotPrefixed &&
+               $file !== $script &&
                self::fileIsExcluded($file, $excludeList) &&
-               $fileIsNotPrefixed &&
-               $file !== $script;
+               is_file($file);
     }
 
     private static function fileIsExcluded(string $file, ExcludeList $excludeList): bool

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -14,7 +14,6 @@ use function array_keys;
 use function array_merge;
 use function assert;
 use function escapeshellarg;
-use function file_exists;
 use function file_get_contents;
 use function ini_get_all;
 use function restore_error_handler;
@@ -139,12 +138,13 @@ abstract class AbstractPhpProcess
     {
         $_result = $this->runJob($job);
 
-        $processResult = '';
+        $processResult = @file_get_contents($processResultFile);
 
-        if (file_exists($processResultFile)) {
-            $processResult = file_get_contents($processResultFile);
+        if ($processResult !== false) {
 
             @unlink($processResultFile);
+        } else {
+            $processResult = '';
         }
 
         $this->processChildResult(


### PR DESCRIPTION
file IO largely depends on hardware and performance can vary a lot. it needs to be avoided at all cost.
especially on windows IO is slow (in comparison to linux based systems).

this PR re-orders conditions to do the IO only at the very last.