### PR TITLE
Prevent unnecessary `ExecutionOrderDependency::getTarget()` call

### DIFF
--- a/src/Framework/ExecutionOrderDependency.php
+++ b/src/Framework/ExecutionOrderDependency.php
@@ -88,11 +88,13 @@ final class ExecutionOrderDependency implements Stringable
         );
 
         foreach ($additional as $dependency) {
-            if (in_array($dependency->getTarget(), $existingTargets, true)) {
+            $additionalTarget = $dependency->getTarget();
+
+            if (in_array($additionalTarget, $existingTargets, true)) {
                 continue;
             }
 
-            $existingTargets[] = $dependency->getTarget();
+            $existingTargets[] = $additionalTarget;
             $existing[]        = $dependency;
         }
 


### PR DESCRIPTION
the function call is showing up in blackfire profiles  of `blackfire run  php ./phpunit --testsuite unit`

<img width="1205" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/e0d8cdff-42c5-4bc5-b726-8aaf5a04f453">
