### PR TITLE
Simplify `NamePrettifier::prettifyTestMethodName()`

### DIFF
--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -27,7 +27,6 @@ use function is_numeric;
 use function is_object;
 use function is_scalar;
 use function method_exists;
-use function ord;
 use function preg_quote;
 use function preg_replace;
 use function range;
@@ -145,9 +144,7 @@ final class NamePrettifier
         $wasNumeric = false;
 
         foreach (range(0, strlen($name) - 1) as $i) {
-            $ord = ord($name[$i]);
-
-            if ($i > 0 && $ord >= 65 && $ord <= 90) {
+            if ($i > 0 && $name[$i] >= 'A' && $name[$i] <= 'Z') {
                 $buffer .= ' ' . strtolower($name[$i]);
             } else {
                 $isNumeric = is_numeric($name[$i]);


### PR DESCRIPTION
remove a unnecessary function call in a hot path. additionally I think its more readable now.

<img width="583" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/b33c2335-65fc-4f7f-9d48-f2dee88f7759">
