### PR TITLE
Cache result of `Groups::groups()`

### DIFF
--- a/.psalm/baseline.xml
+++ b/.psalm/baseline.xml
@@ -640,13 +640,6 @@
     </RedundantCondition>
   </file>
   <file src="src/Metadata/Api/Groups.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[array_unique($groups)]]></code>
-      <code><![CDATA[array_unique($groups)]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[list<string>]]></code>
-    </MoreSpecificReturnType>
     <RedundantCondition>
       <code><![CDATA[$metadata instanceof CoversFunction]]></code>
       <code><![CDATA[$metadata instanceof UsesFunction]]></code>

--- a/src/Metadata/Api/Groups.php
+++ b/src/Metadata/Api/Groups.php
@@ -31,7 +31,7 @@ use PHPUnit\Metadata\UsesFunction;
 final class Groups
 {
     /**
-     * @var array<string, array<string>>
+     * @var array<string, array<int, string>>
      */
     private static array $groupCache = [];
 
@@ -39,7 +39,7 @@ final class Groups
      * @psalm-param class-string $className
      * @psalm-param non-empty-string $methodName
      *
-     * @psalm-return array<string>
+     * @psalm-return array<int, string>
      */
     public function groups(string $className, string $methodName, bool $includeVirtual = true): array
     {

--- a/src/Metadata/Api/Groups.php
+++ b/src/Metadata/Api/Groups.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Metadata\Api;
 
 use function array_flip;
+use function array_key_exists;
 use function array_unique;
 use function assert;
 use function strtolower;
@@ -30,6 +31,11 @@ use PHPUnit\Metadata\UsesFunction;
 final class Groups
 {
     /**
+     * @var array<string, list<string>>
+     */
+    private static array $groupCache = [];
+
+    /**
      * @psalm-param class-string $className
      * @psalm-param non-empty-string $methodName
      *
@@ -37,6 +43,12 @@ final class Groups
      */
     public function groups(string $className, string $methodName, bool $includeVirtual = true): array
     {
+        $key = $className . '::' . $methodName . '::' . $includeVirtual;
+
+        if (array_key_exists($key, self::$groupCache)) {
+            return self::$groupCache[$key];
+        }
+
         $groups = [];
 
         foreach (Registry::parser()->forClassAndMethod($className, $methodName)->isGroup() as $group) {
@@ -50,7 +62,7 @@ final class Groups
         }
 
         if (!$includeVirtual) {
-            return array_unique($groups);
+            return self::$groupCache[$key] = array_unique($groups);
         }
 
         foreach (Registry::parser()->forClassAndMethod($className, $methodName) as $metadata) {
@@ -85,7 +97,7 @@ final class Groups
             }
         }
 
-        return array_unique($groups);
+        return self::$groupCache[$key] = array_unique($groups);
     }
 
     /**

--- a/src/Metadata/Api/Groups.php
+++ b/src/Metadata/Api/Groups.php
@@ -31,7 +31,7 @@ use PHPUnit\Metadata\UsesFunction;
 final class Groups
 {
     /**
-     * @var array<string, list<string>>
+     * @var array<string, array<string>>
      */
     private static array $groupCache = [];
 
@@ -39,7 +39,7 @@ final class Groups
      * @psalm-param class-string $className
      * @psalm-param non-empty-string $methodName
      *
-     * @psalm-return list<string>
+     * @psalm-return array<string>
      */
     public function groups(string $className, string $methodName, bool $includeVirtual = true): array
     {


### PR DESCRIPTION
the function call is showing up in blackfire profiles  of `blackfire run  php ./phpunit --testsuite unit`

<img width="513" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/01d9344d-7f88-48c7-836e-26700ac4cf94">

----


after this PR the calls are gone

<img width="501" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/26d52b9b-6c1a-4ee1-9821-34dbe3c3651d">
