### PR TITLE
Improve performance of `NamePrettifier::prettifyTestMethodName()`

### DIFF
--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -23,7 +23,6 @@ use function in_array;
 use function is_bool;
 use function is_float;
 use function is_int;
-use function is_numeric;
 use function is_object;
 use function is_scalar;
 use function method_exists;
@@ -147,7 +146,7 @@ final class NamePrettifier
             if ($i > 0 && $name[$i] >= 'A' && $name[$i] <= 'Z') {
                 $buffer .= ' ' . strtolower($name[$i]);
             } else {
-                $isNumeric = is_numeric($name[$i]);
+                $isNumeric = $name[$i] >= '0' && $name[$i] <= '9';
 
                 if (!$wasNumeric && $isNumeric) {
                     $buffer .= ' ';

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -19,7 +19,6 @@ use function class_exists;
 use function explode;
 use function gettype;
 use function implode;
-use function in_array;
 use function is_bool;
 use function is_float;
 use function is_int;
@@ -54,7 +53,7 @@ use SebastianBergmann\Exporter\Exporter;
 final class NamePrettifier
 {
     /**
-     * @psalm-var list<string>
+     * @psalm-var array<string, int>
      */
     private static array $strings = [];
 
@@ -117,10 +116,10 @@ final class NamePrettifier
 
         $string = (string) preg_replace('#\d+$#', '', $name, -1, $count);
 
-        if (in_array($string, self::$strings, true)) {
+        if (array_key_exists($string, self::$strings)) {
             $name = $string;
         } elseif ($count === 0) {
-            self::$strings[] = $string;
+            self::$strings[$string] = 1;
         }
 
         if (str_starts_with($name, 'test_')) {
@@ -136,6 +135,7 @@ final class NamePrettifier
         $name[0] = strtoupper($name[0]);
 
         $noUnderscore = str_replace('_', ' ', $name);
+
         if ($noUnderscore !== $name) {
             return trim($noUnderscore);
         }
@@ -143,6 +143,7 @@ final class NamePrettifier
         $wasNumeric = false;
 
         $buffer = '';
+
         foreach (range(0, strlen($name) - 1) as $i) {
             if ($i > 0 && $name[$i] >= 'A' && $name[$i] <= 'Z') {
                 $buffer .= ' ' . strtolower($name[$i]);

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -111,10 +111,8 @@ final class NamePrettifier
     // NOTE: this method is on a hot path and very performance sensitive. change with care.
     public function prettifyTestMethodName(string $name): string
     {
-        $buffer = '';
-
         if ($name === '') {
-            return $buffer;
+            return '';
         }
 
         $string = (string) preg_replace('#\d+$#', '', $name, -1, $count);
@@ -132,7 +130,7 @@ final class NamePrettifier
         }
 
         if ($name === '') {
-            return $buffer;
+            return '';
         }
 
         $name[0] = strtoupper($name[0]);
@@ -144,6 +142,7 @@ final class NamePrettifier
 
         $wasNumeric = false;
 
+        $buffer = '';
         foreach (range(0, strlen($name) - 1) as $i) {
             if ($i > 0 && $name[$i] >= 'A' && $name[$i] <= 'Z') {
                 $buffer .= ' ' . strtolower($name[$i]);

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -108,6 +108,7 @@ final class NamePrettifier
         return $result;
     }
 
+    // NOTE: this method is on a hot path and very performance sensitive. change with care.
     public function prettifyTestMethodName(string $name): string
     {
         $buffer = '';
@@ -136,8 +137,9 @@ final class NamePrettifier
 
         $name[0] = strtoupper($name[0]);
 
-        if (str_contains($name, '_')) {
-            return trim(str_replace('_', ' ', $name));
+        $noUnderscore = str_replace('_', ' ', $name);
+        if ($noUnderscore !== $name) {
+            return trim($noUnderscore);
         }
 
         $wasNumeric = false;

--- a/tests/unit/Logging/TestDox/NamePrettifierTest.php
+++ b/tests/unit/Logging/TestDox/NamePrettifierTest.php
@@ -33,6 +33,7 @@ final class NamePrettifierTest extends TestCase
 
     public function testTestNameIsConvertedToASentence(): void
     {
+        $this->assertEquals('', (new NamePrettifier)->prettifyTestMethodName(''));
         $this->assertEquals('This is a test', (new NamePrettifier)->prettifyTestMethodName('testThisIsATest'));
         $this->assertEquals('This is a test', (new NamePrettifier)->prettifyTestMethodName('testThisIsATest2'));
         $this->assertEquals('This is a test', (new NamePrettifier)->prettifyTestMethodName('this_is_a_test'));


### PR DESCRIPTION
the function call is showing up in blackfire profiles  of `blackfire run  php ./phpunit --testsuite unit`

<img width="451" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/36a0deeb-1cf5-46f5-87c7-47051b3c83c3">


----

diff

<img width="522" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/cb5c4e84-28af-445b-becb-c391d82b36e5">
