### PR TITLE
Micro-optimize `NamePrettifier::prettifyTestMethodName()` once again

### DIFF
--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -27,7 +27,7 @@ use function is_scalar;
 use function method_exists;
 use function preg_quote;
 use function preg_replace;
-use function range;
+use function rtrim;
 use function sprintf;
 use function str_contains;
 use function str_ends_with;
@@ -115,6 +115,7 @@ final class NamePrettifier
         }
 
         $string = rtrim($name, '0123456789');
+
         if (array_key_exists($string, self::$strings)) {
             $name = $string;
         } elseif ($string === $name) {
@@ -143,7 +144,9 @@ final class NamePrettifier
 
         $buffer = '';
 
-        foreach (range(0, strlen($name) - 1) as $i) {
+        $len = strlen($name);
+
+        for ($i = 0; $i < $len; $i++) {
             if ($i > 0 && $name[$i] >= 'A' && $name[$i] <= 'Z') {
                 $buffer .= ' ' . strtolower($name[$i]);
             } else {

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -114,11 +114,10 @@ final class NamePrettifier
             return '';
         }
 
-        $string = (string) preg_replace('#\d+$#', '', $name, -1, $count);
-
+        $string = rtrim($name, '0123456789');
         if (array_key_exists($string, self::$strings)) {
             $name = $string;
-        } elseif ($count === 0) {
+        } elseif ($string === $name) {
             self::$strings[$string] = 1;
         }
 


### PR DESCRIPTION
the `rtrim` variant is twice as fast on newer php versions, see https://github.com/php/php-src/issues/13710#issuecomment-1998175068