### PR TITLE
Add closure mocks

### DIFF
--- a/src/Framework/MockObject/Runtime/Stub/ClosureMock.php
+++ b/src/Framework/MockObject/Runtime/Stub/ClosureMock.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Stub;
+
+use PHPUnit\Framework\InvalidArgumentException;
+use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
+use PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException;
+use PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+
+/**
+ * @mixin \PHPUnit\Framework\MockObject\MockObject
+ *
+ * @method InvocationMocker method($constraint)
+ */
+class ClosureMock
+{
+    public function __invoke(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws MethodCannotBeConfiguredException
+     * @throws MethodNameAlreadyConfiguredException
+     */
+    public function expectsClosure(InvocationOrder $invocationRule): InvocationMocker
+    {
+        return $this->expects($invocationRule)
+            ->method('__invoke');
+    }
+
+    public function closure(): InvocationMocker
+    {
+        return $this->method('__invoke');
+    }
+}

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -72,6 +72,7 @@ use PHPUnit\Framework\MockObject\Rule\InvokedAtMostCount as InvokedAtMostCountMa
 use PHPUnit\Framework\MockObject\Rule\InvokedCount;
 use PHPUnit\Framework\MockObject\Rule\InvokedCount as InvokedCountMatcher;
 use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\MockObject\Stub\ClosureMock;
 use PHPUnit\Framework\MockObject\Stub\Exception as ExceptionStub;
 use PHPUnit\Framework\TestSize\TestSize;
 use PHPUnit\Framework\TestStatus\TestStatus;
@@ -1240,6 +1241,17 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         );
 
         return $partialMock;
+    }
+
+    /**
+     * Creates mock of a closure.
+     *
+     * @throws InvalidArgumentException
+     * @throws MockObjectException
+     */
+    final protected function createClosureMock(): ClosureMock|MockObject
+    {
+        return $this->createPartialMock(ClosureMock::class, ['__invoke']);
     }
 
     /**

--- a/tests/unit/Framework/MockObject/Creation/CreateClosureMockTest.php
+++ b/tests/unit/Framework/MockObject/Creation/CreateClosureMockTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use function call_user_func_array;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\Stub\ClosureMock;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+#[Group('test-doubles')]
+#[Group('test-doubles/creation')]
+#[Group('test-doubles/mock-object')]
+#[Medium]
+#[TestDox('createClosureMock()')]
+final class CreateClosureMockTest extends TestCase
+{
+    public function testCreateClosureMock(): void
+    {
+        $mock = $this->createClosureMock();
+
+        $this->assertInstanceOf(ClosureMock::class, $mock);
+        $this->assertInstanceOf(Stub::class, $mock);
+    }
+
+    public function testCreateClosureMockWithReturnValue(): void
+    {
+        $mock = $this->createClosureMock();
+
+        $mock->closure()->willReturn(123);
+
+        $this->assertSame(123, $mock());
+    }
+
+    public function testCreateClosureMockWithExpectation(): void
+    {
+        $mock = $this->createClosureMock();
+
+        $mock->expectsClosure($this->once())
+            ->willReturn(123);
+
+        $this->assertSame(123, $mock());
+    }
+
+    public function testClosureMockAppliesExpects(): void
+    {
+        $mock = $this->createClosureMock();
+
+        $mock->expectsClosure($this->once());
+
+        $this->assertThatMockObjectExpectationFails(
+            "Expectation failed for method name is \"__invoke\" when invoked 1 time.\nMethod was expected to be called 1 time, actually called 0 times.\n",
+            $mock,
+        );
+    }
+
+    private function assertThatMockObjectExpectationFails(string $expectationFailureMessage, MockObject $mock, string $methodName = '__phpunit_verify', array $arguments = []): void
+    {
+        try {
+            call_user_func_array([$mock, $methodName], $arguments);
+        } catch (ExpectationFailedException|MatchBuilderNotFoundException $e) {
+            $this->assertSame($expectationFailureMessage, $e->getMessage());
+
+            return;
+        } finally {
+            $this->resetMockObjects();
+        }
+
+        $this->fail();
+    }
+
+    private function resetMockObjects(): void
+    {
+        (new ReflectionProperty(TestCase::class, 'mockObjects'))->setValue($this, []);
+    }
+}


### PR DESCRIPTION
## The problem

Mocking closures is doable today by mocking `__invoke` on an invokable class. However, this is troublesome, as it requires writing an invokable class and mocking a class method (which is confusing, hard to figure out, and makes tests harder to understand afterward).

Here is another approach that is verbose and fragile:

```php
    public function test_validation(): void
    {
        $rule = new CustomLaravelValidationRule();
        
        $failed = false;
        $rule->validate('code', 'abcd', function () use (&$failed) {
            return $failed = true;
        });
        $this->assertTrue($failed);
    }
```

## The solution

This new helper makes things easier via a new `$this->createClosureMock()` method.

```php
$mock = $this->createClosureMock();

$mock->expectsClosure($this->once())
    ->willReturn(123);

$this->assertSame(123, $mock());
```

Here's the test above rewritten using the new helper:

```php
    public function test_validation(): void
    {
        $rule = new CustomLaravelValidationRule();
        
        $mock = $this->createClosureMock();
        $mock->expectsClosure($this->never());

        $rule->validate('code', 'abcd', $mock);
    }
```

This is essentially just a shortcut to the workaround that is doable today, so this PR should not introduce too much new code.

Related to #3536

Note that #3536 mentioned a workaround using `stdClass`. I was not able to make it work: PHPUnit refused to mock stdClass's `__invoke` method because it does not exist.

This is, to me, yet another reason to have such a helper.