### PR TITLE
Be more forgiving with error handlers that do not respect error suppression

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -638,7 +638,10 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         $coverage = RawCodeCoverageData::fromXdebugWithoutPathCoverage([]);
         $files    = $this->getCoverageFiles();
 
-        $buffer = @file_get_contents($files['coverage']);
+        $buffer = false;
+        if (is_file($files['coverage'])) {
+            $buffer = @file_get_contents($files['coverage']);
+        }
 
         if ($buffer !== false) {
             $coverage = @unserialize($buffer);

--- a/src/Runner/ResultCache/DefaultResultCache.php
+++ b/src/Runner/ResultCache/DefaultResultCache.php
@@ -85,7 +85,10 @@ final class DefaultResultCache implements ResultCache
 
     public function load(): void
     {
-        $contents = @file_get_contents($this->cacheFilename);
+        if (!is_file($this->cacheFilename)) {
+            return;
+        }
+        $contents = file_get_contents($this->cacheFilename);
 
         if ($contents === false) {
             return;

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -516,7 +516,9 @@ final class Application
     private function registerLogfileWriters(Configuration $configuration): void
     {
         if ($configuration->hasLogEventsText()) {
-            @unlink($configuration->logEventsText());
+            if (is_file($configuration->logEventsText())) {
+                unlink($configuration->logEventsText());
+            }
 
             EventFacade::instance()->registerTracer(
                 new EventLogger(
@@ -527,7 +529,9 @@ final class Application
         }
 
         if ($configuration->hasLogEventsVerboseText()) {
-            @unlink($configuration->logEventsVerboseText());
+            if (is_file($configuration->logEventsVerboseText())) {
+                unlink($configuration->logEventsVerboseText());
+            }
 
             EventFacade::instance()->registerTracer(
                 new EventLogger(

--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -138,13 +138,11 @@ abstract class AbstractPhpProcess
     {
         $_result = $this->runJob($job);
 
-        $processResult = @file_get_contents($processResultFile);
+        $processResult = '';
 
-        if ($processResult !== false) {
-
+        if (file_exists($processResultFile)) {
+            $processResult = file_get_contents($processResultFile);
             @unlink($processResultFile);
-        } else {
-            $processResult = '';
         }
 
         $this->processChildResult(

--- a/tests/end-to-end/regression/5764/5764.phpt
+++ b/tests/end-to-end/regression/5764/5764.phpt
@@ -1,0 +1,21 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/5764
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) No tests found in class "PHPUnit\TestFixture\Issue5764\Issue5764Test".
+
+No tests executed!

--- a/tests/end-to-end/regression/5764/error-handler.php
+++ b/tests/end-to-end/regression/5764/error-handler.php
@@ -1,0 +1,7 @@
+<?php
+
+// be forgiving with error handlers which do not suppress `@` prefixed lines
+set_error_handler(function(int $err_lvl, string $err_msg, string $err_file, int $err_line): bool {
+    throw new \ErrorException($err_msg, 0, $err_lvl, $err_file, $err_line);
+});
+

--- a/tests/end-to-end/regression/5764/phpunit.xml
+++ b/tests/end-to-end/regression/5764/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+         bootstrap="error-handler.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/regression/5764/tests/Issue5764Test.php
+++ b/tests/end-to-end/regression/5764/tests/Issue5764Test.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue5764;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+final class Issue5764Test extends TestCase
+{
+}


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/5764

reproduced the reported problem locally with:

```
$ php ./phpunit tests/end-to-end/regression/5764/5764.phpt  --configuration tests/end-to-end/regression/5764/phpunit.xml 
PHPUnit 10.5.14-3-gadd7c75c3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.12
Configuration: C:\dvl\Workspace\phpunit\tests\end-to-end\regression\5764\phpunit.xml



An error occurred inside PHPUnit.

Message:  file_get_contents(C:\dvl\Workspace\phpunit\tests\end-to-end\regression\5764\.phpunit.result.cache): Failed to open stream: No such file or directory
Location: C:\dvl\Workspace\phpunit\src\Runner\ResultCache\DefaultResultCache.php:88

#0 [internal function]: PHPUnit\TextUI\Application->{closure}()
#1 C:\dvl\Workspace\phpunit\src\Runner\ResultCache\DefaultResultCache.php(88): file_get_contents()
#2 C:\dvl\Workspace\phpunit\src\TextUI\TestRunner.php(40): PHPUnit\Runner\ResultCache\DefaultResultCache->load()
#3 C:\dvl\Workspace\phpunit\src\TextUI\Application.php(197): PHPUnit\TextUI\TestRunner->run()
#4 C:\dvl\Workspace\phpunit\phpunit(104): PHPUnit\TextUI\Application->run()
#5 {main}

```