### PR TITLE
Do not use a shell in `proc_open()` if not really needed

### DIFF
--- a/src/Util/PHP/AbstractPhpProcess.php
+++ b/src/Util/PHP/AbstractPhpProcess.php
@@ -13,7 +13,7 @@ use const PHP_SAPI;
 use function array_keys;
 use function array_merge;
 use function assert;
-use function escapeshellarg;
+use function explode;
 use function file_exists;
 use function file_get_contents;
 use function ini_get_all;
@@ -156,12 +156,15 @@ abstract class AbstractPhpProcess
 
     /**
      * Returns the command based into the configurations.
+     *
+     * @return string[]
      */
-    public function getCommand(array $settings, ?string $file = null): string
+    public function getCommand(array $settings, ?string $file = null): array
     {
         $runtime = new Runtime;
 
-        $command = $runtime->getBinary();
+        $command   = [];
+        $command[] = $runtime->getRawBinary();
 
         if ($runtime->hasPCOV()) {
             $settings = array_merge(
@@ -179,29 +182,29 @@ abstract class AbstractPhpProcess
             );
         }
 
-        $command .= $this->settingsToParameters($settings);
+        $command = array_merge($command, $this->settingsToParameters($settings));
 
         if (PHP_SAPI === 'phpdbg') {
-            $command .= ' -qrr';
+            $command[] = '-qrr';
 
             if (!$file) {
-                $command .= 's=';
+                $command[] = 's=';
             }
         }
 
         if ($file) {
-            $command .= ' ' . escapeshellarg($file);
+            $command[] = '-f';
+            $command[] = $file;
         }
 
         if ($this->arguments) {
             if (!$file) {
-                $command .= ' --';
+                $command[] = '--';
             }
-            $command .= ' ' . $this->arguments;
-        }
 
-        if ($this->stderrRedirection) {
-            $command .= ' 2>&1';
+            foreach (explode(' ', $this->arguments) as $arg) {
+                $command[] = trim($arg);
+            }
         }
 
         return $command;
@@ -212,12 +215,16 @@ abstract class AbstractPhpProcess
      */
     abstract public function runJob(string $job, array $settings = []): array;
 
-    protected function settingsToParameters(array $settings): string
+    /**
+     * @return list<string>
+     */
+    protected function settingsToParameters(array $settings): array
     {
-        $buffer = '';
+        $buffer = [];
 
         foreach ($settings as $setting) {
-            $buffer .= ' -d ' . escapeshellarg($setting);
+            $buffer[] = '-d';
+            $buffer[] = $setting;
         }
 
         return $buffer;

--- a/src/Util/PHP/DefaultPhpProcess.php
+++ b/src/Util/PHP/DefaultPhpProcess.php
@@ -16,13 +16,10 @@ use function fwrite;
 use function is_array;
 use function is_resource;
 use function proc_close;
-use function proc_get_status;
 use function proc_open;
-use function rewind;
 use function stream_get_contents;
 use function sys_get_temp_dir;
 use function tempnam;
-use function time_nanosleep;
 use function unlink;
 use PHPUnit\Framework\Exception;
 
@@ -58,14 +55,6 @@ class DefaultPhpProcess extends AbstractPhpProcess
     }
 
     /**
-     * Returns an array of file handles to be used in place of pipes.
-     */
-    protected function getHandles(): array
-    {
-        return [];
-    }
-
-    /**
      * Handles creating the child process and returning the STDOUT and STDERR.
      *
      * @psalm-return array{stdout: string, stderr: string}
@@ -75,8 +64,6 @@ class DefaultPhpProcess extends AbstractPhpProcess
      */
     protected function runProcess(string $job, array $settings): array
     {
-        $handles = $this->getHandles();
-
         $env = null;
 
         if ($this->env) {
@@ -92,9 +79,9 @@ class DefaultPhpProcess extends AbstractPhpProcess
         }
 
         $pipeSpec = [
-            0 => $handles[0] ?? ['pipe', 'r'],
-            1 => $handles[1] ?? ['pipe', 'w'],
-            2 => $handles[2] ?? ['pipe', 'w'],
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
         ];
 
         if ($this->stderrRedirection) {
@@ -121,10 +108,6 @@ class DefaultPhpProcess extends AbstractPhpProcess
 
         fclose($pipes[0]);
 
-        while (proc_get_status($process)['running'] === true) {
-            time_nanosleep(0, 100000);
-        }
-
         $stderr = $stdout = '';
 
         if (isset($pipes[1])) {
@@ -137,22 +120,6 @@ class DefaultPhpProcess extends AbstractPhpProcess
             $stderr = stream_get_contents($pipes[2]);
 
             fclose($pipes[2]);
-        }
-
-        if (isset($handles[1])) {
-            rewind($handles[1]);
-
-            $stdout = stream_get_contents($handles[1]);
-
-            fclose($handles[1]);
-        }
-
-        if (isset($handles[2])) {
-            rewind($handles[2]);
-
-            $stderr = stream_get_contents($handles[2]);
-
-            fclose($handles[2]);
         }
 
         proc_close($process);

--- a/src/Util/PHP/WindowsPhpProcess.php
+++ b/src/Util/PHP/WindowsPhpProcess.php
@@ -38,6 +38,6 @@ final class WindowsPhpProcess extends DefaultPhpProcess
 
     protected function useTemporaryFile(): bool
     {
-        return true;
+        return false;
     }
 }

--- a/src/Util/PHP/WindowsPhpProcess.php
+++ b/src/Util/PHP/WindowsPhpProcess.php
@@ -9,9 +9,6 @@
  */
 namespace PHPUnit\Util\PHP;
 
-use function tmpfile;
-use PHPUnit\Framework\Exception;
-
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  *
@@ -19,23 +16,6 @@ use PHPUnit\Framework\Exception;
  */
 final class WindowsPhpProcess extends DefaultPhpProcess
 {
-    /**
-     * @throws Exception
-     * @throws PhpProcessException
-     */
-    protected function getHandles(): array
-    {
-        if (false === $stdout_handle = tmpfile()) {
-            throw new PhpProcessException(
-                'A temporary file could not be created; verify that your TEMP environment variable is writable',
-            );
-        }
-
-        return [
-            1 => $stdout_handle,
-        ];
-    }
-
     protected function useTemporaryFile(): bool
     {
         return false;


### PR DESCRIPTION
refs https://github.com/sebastianbergmann/phpunit/issues/5749#issuecomment-2016012543

in my testing I can confirm on PHP 8.3 the process starts 1-2ms faster.
a hello world process isolation test on my machine runs in 46-47ms, so 1-2ms faster is not too bad actually.

requires https://github.com/sebastianbergmann/environment/pull/72