### PR TITLE
Windows does not support exclusive locks on stdout

### DIFF
--- a/src/Logging/EventLogger.php
+++ b/src/Logging/EventLogger.php
@@ -40,10 +40,16 @@ final class EventLogger implements Tracer
         $indentation   = PHP_EOL . str_repeat(' ', strlen($telemetryInfo));
         $lines         = preg_split('/\r\n|\r|\n/', $event->asString());
 
+        $flags = FILE_APPEND;
+
+        if (PHP_OS_FAMILY !== 'Windows' || $this->path !== 'php://stdout') {
+            $flags |= LOCK_EX;
+        }
+
         file_put_contents(
             $this->path,
             $telemetryInfo . implode($indentation, $lines) . PHP_EOL,
-            FILE_APPEND | LOCK_EX,
+            $flags,
         );
     }
 


### PR DESCRIPTION
prevent errors like 

```
$ php ./phpunit tests/end-to-end/regression/5764/5764.phpt  --configuration tests/end-to-end/regression/5764/phpunit.xml --do-not-cache-result --debug

An error occurred inside PHPUnit.

Message:  file_put_contents(): Exclusive locks are not supported for this stream
Location: C:\dvl\Workspace\phpunit\src\Logging\EventLogger.php:44

#0 [internal function]: PHPUnit\TextUI\Application->{closure}()
#1 C:\dvl\Workspace\phpunit\src\Logging\EventLogger.php(44): file_put_contents()
#2 C:\dvl\Workspace\phpunit\src\Event\Dispatcher\DirectDispatcher.php(88): PHPUnit\Logging\EventLogger->trace()
#3 C:\dvl\Workspace\phpunit\src\Event\Dispatcher\DeferringDispatcher.php(53): PHPUnit\Event\DirectDispatcher->dispatch()
#4 C:\dvl\Workspace\phpunit\src\Event\Facade.php(121): PHPUnit\Event\DeferringDispatcher->flush()
#5 C:\dvl\Workspace\phpunit\src\TextUI\Application.php(190): PHPUnit\Event\Facade->seal()
#6 C:\dvl\Workspace\phpunit\phpunit(104): PHPUnit\TextUI\Application->run()
#7 {main}
```

see https://github.com/php/php-src/issues/13777

I was not able to reproduce this CLI command in a regression test