### PR TITLE
Make exporter configurable

### DIFF
--- a/src/Event/Emitter/DispatchingEmitter.php
+++ b/src/Event/Emitter/DispatchingEmitter.php
@@ -27,7 +27,7 @@ use PHPUnit\Event\TestSuite\Sorted as TestSuiteSorted;
 use PHPUnit\Event\TestSuite\Started as TestSuiteStarted;
 use PHPUnit\Event\TestSuite\TestSuite;
 use PHPUnit\TextUI\Configuration\Configuration;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -582,7 +582,7 @@ final class DispatchingEmitter implements Emitter
             new Test\TestProxyCreated(
                 $this->telemetryInfo(),
                 $className,
-                (new Exporter)->export($constructorArguments),
+                ExporterFacade::instance()->export($constructorArguments),
             ),
         );
     }

--- a/src/Event/Value/Test/TestMethodBuilder.php
+++ b/src/Event/Value/Test/TestMethodBuilder.php
@@ -17,8 +17,8 @@ use PHPUnit\Event\TestData\DataFromTestDependency;
 use PHPUnit\Event\TestData\TestDataCollection;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
+use PHPUnit\Util\ExporterFacade;
 use PHPUnit\Util\Reflection;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -60,7 +60,6 @@ final readonly class TestMethodBuilder
 
     private static function dataFor(TestCase $testCase): TestDataCollection
     {
-        $exporter = new Exporter;
         $testData = [];
 
         if ($testCase->usesDataProvider()) {
@@ -72,14 +71,14 @@ final readonly class TestMethodBuilder
 
             $testData[] = DataFromDataProvider::from(
                 $dataSetName,
-                $exporter->export($testCase->providedData()),
+                ExporterFacade::instance()->export($testCase->providedData()),
                 $testCase->dataSetAsStringWithData(),
             );
         }
 
         if ($testCase->hasDependencyInput()) {
             $testData[] = DataFromTestDependency::from(
-                $exporter->export($testCase->dependencyInput()),
+                ExporterFacade::instance()->export($testCase->dependencyInput()),
             );
         }
 

--- a/src/Framework/Constraint/Cardinality/GreaterThan.php
+++ b/src/Framework/Constraint/Cardinality/GreaterThan.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -28,7 +28,7 @@ final class GreaterThan extends Constraint
      */
     public function toString(): string
     {
-        return 'is greater than ' . (new Exporter)->export($this->value);
+        return 'is greater than ' . ExporterFacade::instance()->export($this->value);
     }
 
     /**

--- a/src/Framework/Constraint/Cardinality/LessThan.php
+++ b/src/Framework/Constraint/Cardinality/LessThan.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -28,7 +28,7 @@ final class LessThan extends Constraint
      */
     public function toString(): string
     {
-        return 'is less than ' . (new Exporter)->export($this->value);
+        return 'is less than ' . ExporterFacade::instance()->export($this->value);
     }
 
     /**

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -15,8 +15,8 @@ use function strtolower;
 use Countable;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\SelfDescribing;
+use PHPUnit\Util\ExporterFacade;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -123,7 +123,7 @@ abstract class Constraint implements Countable, SelfDescribing
      */
     protected function failureDescription(mixed $other): string
     {
-        return (new Exporter)->export($other) . ' ' . $this->toString();
+        return ExporterFacade::instance()->export($other) . ' ' . $this->toString();
     }
 
     /**
@@ -163,7 +163,7 @@ abstract class Constraint implements Countable, SelfDescribing
             return '';
         }
 
-        return (new Exporter)->export($other) . ' ' . $string;
+        return ExporterFacade::instance()->export($other) . ' ' . $string;
     }
 
     /**

--- a/src/Framework/Constraint/Equality/IsEqual.php
+++ b/src/Framework/Constraint/Equality/IsEqual.php
@@ -14,9 +14,9 @@ use function sprintf;
 use function str_contains;
 use function trim;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\ExporterFacade;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory as ComparatorFactory;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -97,7 +97,7 @@ final class IsEqual extends Constraint
 
         return sprintf(
             'is equal to %s%s',
-            (new Exporter)->export($this->value),
+            ExporterFacade::instance()->export($this->value),
             $delta,
         );
     }

--- a/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
+++ b/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
@@ -14,9 +14,9 @@ use function sprintf;
 use function str_contains;
 use function trim;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\ExporterFacade;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory as ComparatorFactory;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -97,7 +97,7 @@ final class IsEqualCanonicalizing extends Constraint
 
         return sprintf(
             'is equal to %s',
-            (new Exporter)->export($this->value),
+            ExporterFacade::instance()->export($this->value),
         );
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
+++ b/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
@@ -14,9 +14,9 @@ use function sprintf;
 use function str_contains;
 use function trim;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\ExporterFacade;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory as ComparatorFactory;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -98,7 +98,7 @@ final class IsEqualIgnoringCase extends Constraint
 
         return sprintf(
             'is equal to %s',
-            (new Exporter)->export($this->value),
+            ExporterFacade::instance()->export($this->value),
         );
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualWithDelta.php
+++ b/src/Framework/Constraint/Equality/IsEqualWithDelta.php
@@ -12,9 +12,9 @@ namespace PHPUnit\Framework\Constraint;
 use function sprintf;
 use function trim;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\ExporterFacade;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory as ComparatorFactory;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -85,7 +85,7 @@ final class IsEqualWithDelta extends Constraint
     {
         return sprintf(
             'is equal to %s with delta <%F>',
-            (new Exporter)->export($this->value),
+            ExporterFacade::instance()->export($this->value),
             $this->delta,
         );
     }

--- a/src/Framework/Constraint/Exception/ExceptionCode.php
+++ b/src/Framework/Constraint/Exception/ExceptionCode.php
@@ -10,7 +10,7 @@
 namespace PHPUnit\Framework\Constraint;
 
 use function sprintf;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -46,12 +46,10 @@ final class ExceptionCode extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
-        $exporter = new Exporter;
-
         return sprintf(
             '%s is equal to expected exception code %s',
-            $exporter->export($other),
-            $exporter->export($this->expectedCode),
+            ExporterFacade::instance()->export($other),
+            ExporterFacade::instance()->export($this->expectedCode),
         );
     }
 }

--- a/src/Framework/Constraint/Exception/ExceptionMessageIsOrContains.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessageIsOrContains.php
@@ -11,7 +11,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use function sprintf;
 use function str_contains;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -31,7 +31,7 @@ final class ExceptionMessageIsOrContains extends Constraint
             return 'exception message is empty';
         }
 
-        return 'exception message contains ' . (new Exporter)->export($this->expectedMessage);
+        return 'exception message contains ' . ExporterFacade::instance()->export($this->expectedMessage);
     }
 
     protected function matches(mixed $other): bool

--- a/src/Framework/Constraint/Exception/ExceptionMessageMatchesRegularExpression.php
+++ b/src/Framework/Constraint/Exception/ExceptionMessageMatchesRegularExpression.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Framework\Constraint;
 use function preg_match;
 use function sprintf;
 use Exception;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -28,7 +28,7 @@ final class ExceptionMessageMatchesRegularExpression extends Constraint
 
     public function toString(): string
     {
-        return 'exception message matches ' . (new Exporter)->export($this->regularExpression);
+        return 'exception message matches ' . ExporterFacade::instance()->export($this->regularExpression);
     }
 
     /**

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -16,8 +16,8 @@ use function is_object;
 use function is_string;
 use function sprintf;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\ExporterFacade;
 use SebastianBergmann\Comparator\ComparisonFailure;
-use SebastianBergmann\Exporter\Exporter;
 use UnitEnum;
 
 /**
@@ -67,13 +67,11 @@ final class IsIdentical extends Constraint
 
             // if both values are array or enums, make sure a diff is generated
             if ((is_array($this->value) && is_array($other)) || ($this->value instanceof UnitEnum && $other instanceof UnitEnum)) {
-                $exporter = new Exporter;
-
                 $f = new ComparisonFailure(
                     $this->value,
                     $other,
-                    $exporter->export($this->value),
-                    $exporter->export($other),
+                    ExporterFacade::instance()->export($this->value),
+                    ExporterFacade::instance()->export($other),
                 );
             }
 
@@ -93,7 +91,7 @@ final class IsIdentical extends Constraint
                 $this->value::class . '"';
         }
 
-        return 'is identical to ' . (new Exporter)->export($this->value);
+        return 'is identical to ' . ExporterFacade::instance()->export($this->value);
     }
 
     /**

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -17,7 +17,7 @@ use function sprintf;
 use function str_contains;
 use function strlen;
 use function strtr;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -60,7 +60,7 @@ final class StringContains extends Constraint
 
     public function failureDescription(mixed $other): string
     {
-        $stringifiedHaystack = (new Exporter)->export($other);
+        $stringifiedHaystack = ExporterFacade::instance()->export($other);
         $haystackEncoding    = $this->getDetectedEncoding($other);
         $haystackLength      = $this->getHaystackLength($other);
 

--- a/src/Framework/Constraint/Traversable/ArrayHasKey.php
+++ b/src/Framework/Constraint/Traversable/ArrayHasKey.php
@@ -12,7 +12,7 @@ namespace PHPUnit\Framework\Constraint;
 use function array_key_exists;
 use function is_array;
 use ArrayAccess;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -31,7 +31,7 @@ final class ArrayHasKey extends Constraint
      */
     public function toString(): string
     {
-        return 'has the key ' . (new Exporter)->export($this->key);
+        return 'has the key ' . ExporterFacade::instance()->export($this->key);
     }
 
     /**

--- a/src/Framework/Constraint/Traversable/TraversableContains.php
+++ b/src/Framework/Constraint/Traversable/TraversableContains.php
@@ -11,7 +11,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use function is_array;
 use function sprintf;
-use SebastianBergmann\Exporter\Exporter;
+use PHPUnit\Util\ExporterFacade;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -30,7 +30,7 @@ abstract class TraversableContains extends Constraint
      */
     public function toString(): string
     {
-        return 'contains ' . (new Exporter)->export($this->value);
+        return 'contains ' . ExporterFacade::instance()->export($this->value);
     }
 
     /**

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -94,6 +94,7 @@ use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Runner\DeprecationCollector\Facade as DeprecationCollector;
 use PHPUnit\TestRunner\TestResult\PassedTests;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
+use PHPUnit\Util\ExporterFacade;
 use PHPUnit\Util\Test as TestUtil;
 use ReflectionClass;
 use ReflectionException;
@@ -2062,16 +2063,15 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     private function compareGlobalStateSnapshotPart(array $before, array $after, string $header): void
     {
         if ($before != $after) {
-            $differ   = new Differ(new UnifiedDiffOutputBuilder($header));
-            $exporter = new Exporter;
+            $differ = new Differ(new UnifiedDiffOutputBuilder($header));
 
             Event\Facade::emitter()->testConsideredRisky(
                 $this->valueObjectForEvents(),
                 'This test modified global state but was not expected to do so' . PHP_EOL .
                 trim(
                     $differ->diff(
-                        $exporter->export($before),
-                        $exporter->export($after),
+                        ExporterFacade::instance()->export($before),
+                        ExporterFacade::instance()->export($after),
                     ),
                 ),
             );

--- a/src/Framework/TestRunner.php
+++ b/src/Framework/TestRunner.php
@@ -22,6 +22,7 @@ use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
 use function var_export;
+use function xdebug_is_debugger_active;
 use AssertionError;
 use PHPUnit\Event;
 use PHPUnit\Event\NoPreviousThrowableException;

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -42,10 +42,10 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Metadata\TestDox;
 use PHPUnit\Util\Color;
+use PHPUnit\Util\ExporterFacade;
 use ReflectionEnum;
 use ReflectionMethod;
 use ReflectionObject;
-use SebastianBergmann\Exporter\Exporter;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -267,7 +267,7 @@ final class NamePrettifier
             }
 
             if (is_bool($value) || is_int($value) || is_float($value)) {
-                $value = (new Exporter)->export($value);
+                $value = ExporterFacade::instance()->export($value);
             }
 
             if ($value === '') {

--- a/src/Util/Exporter/DefaultExporter.php
+++ b/src/Util/Exporter/DefaultExporter.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use SebastianBergmann\Exporter\Exporter as ExporterImplementation;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class DefaultExporter implements Exporter
+{
+    private ExporterImplementation $exporter;
+
+    public function __construct()
+    {
+        $this->exporter = new ExporterImplementation;
+    }
+
+    public function export(mixed $value): string
+    {
+        return $this->exporter->export($value);
+    }
+}

--- a/src/Util/Exporter/DefaultExporter.php
+++ b/src/Util/Exporter/DefaultExporter.php
@@ -23,6 +23,11 @@ final readonly class DefaultExporter implements Exporter
         $this->exporter = new ExporterImplementation;
     }
 
+    public function handles(mixed $value): true
+    {
+        return true;
+    }
+
     public function export(mixed $value): string
     {
         return $this->exporter->export($value);

--- a/src/Util/Exporter/Exporter.php
+++ b/src/Util/Exporter/Exporter.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface Exporter
+{
+    public function export(mixed $value): string;
+}

--- a/src/Util/Exporter/Exporter.php
+++ b/src/Util/Exporter/Exporter.php
@@ -14,5 +14,7 @@ namespace PHPUnit\Util;
  */
 interface Exporter
 {
+    public function handles(mixed $value): bool;
+
     public function export(mixed $value): string;
 }

--- a/src/Util/Exporter/ExporterChain.php
+++ b/src/Util/Exporter/ExporterChain.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use function assert;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class ExporterChain implements Exporter
+{
+    /**
+     * @psalm-var non-empty-list<Exporter>
+     */
+    private array $exporter;
+
+    /**
+     * @psalm-param non-empty-list<Exporter> $exporter
+     */
+    public static function buildWith(array $exporter): self
+    {
+        $exporter[] = new DefaultExporter;
+
+        return new self($exporter);
+    }
+
+    /**
+     * @psalm-param non-empty-list<Exporter> $exporter
+     */
+    private function __construct(array $exporter)
+    {
+        $this->exporter = $exporter;
+    }
+
+    public function handles(mixed $value): true
+    {
+        return true;
+    }
+
+    public function export(mixed $value): string
+    {
+        foreach ($this->exporter as $exporter) {
+            if (!$exporter->handles($value)) {
+                /** @noinspection PhpUnnecessaryStopStatementInspection */
+                continue;
+            }
+        }
+
+        assert(isset($exporter));
+
+        return $exporter->export($value);
+    }
+}

--- a/src/Util/Exporter/ExporterFacade.php
+++ b/src/Util/Exporter/ExporterFacade.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ExporterFacade
+{
+    private static ?self $instance = null;
+    private Exporter $exporter;
+
+    public static function instance(): self
+    {
+        return self::$instance ?? self::$instance = new self;
+    }
+
+    private function __construct()
+    {
+        $this->exporter = new DefaultExporter;
+    }
+
+    public function export(mixed $value): string
+    {
+        return $this->exporter->export($value);
+    }
+
+    public function use(Exporter $exporter): void
+    {
+        $this->exporter = $exporter;
+    }
+}


### PR DESCRIPTION
PHPUnit uses `SebastianBergmann\Exporter\Exporter` from `sebastian/exporter` to export variables as strings, for instance when generating comparison failure messages or when creating immutable value objects representing tests and their data (from data providers) that are passed through the event system to internal as well as third-party subscribers.

In order to allow for the customization of the textual representation of comparison failures, to improve performance (using `SebastianBergmann\Exporter\Exporter` is expensive when large data structures are involved), and for other use cases it would be nice if `SebastianBergmann\Exporter\Exporter` could be swapped for a different implementation.

- [X] Introduce `PHPUnit\Util\Exporter` interface
- [X] Implement `PHPUnit\Util\DefaultExporter` as the default implementation of `PHPUnit\Util\Exporter` that simply wraps `SebastianBergmann\Exporter\Exporter`
- [X] Implement `PHPUnit\Util\ExporterFacade` that uses `PHPUnit\Util\DefaultExporter` by default, but can be configured to use an alternative implementation of `PHPUnit\Util\Exporter`
- [X] Implement `PHPUnit\Util\ExporterChain` for chaining `PHPUnit\Util\Exporter` implementations
- [X] Use `ExporterFacade::instance()->export()` instead of `SebastianBergmann\Exporter\Exporter::export()`
- [ ] Make alternative implementations of `PHPUnit\Util\Exporter` configurable via PHPUnit's XML configuration file
- [ ] Explore whether `SebastianBergmann\Exporter\Exporter::shortenedRecursiveExport()` and `SebastianBergmann\Exporter\Exporter::shortenedExport` should also be wrapped
- [ ] Explore whether the usage of `SebastianBergmann\Exporter\Exporter` in `sebastian/comparator` should also be configurable