### PR TITLE
Use `shortenedRecursiveExport()` for data-providers

### DIFF
--- a/src/Event/Value/Test/TestMethodBuilder.php
+++ b/src/Event/Value/Test/TestMethodBuilder.php
@@ -70,9 +70,11 @@ final readonly class TestMethodBuilder
                 $dataSetName = (int) $dataSetName;
             }
 
+            $providedData = $testCase->providedData();
+
             $testData[] = DataFromDataProvider::from(
                 $dataSetName,
-                $exporter->export($testCase->providedData()),
+                $exporter->shortenedRecursiveExport($providedData),
                 $testCase->dataSetAsStringWithData(),
             );
         }


### PR DESCRIPTION
I just realized we already have a `shortenedRecursiveExport` version of the exporter, we just need to use

so instead of https://github.com/sebastianbergmann/exporter/pull/55 we could just do this single line change

tested this change on roave/BetterReflection:


phpunit 11.0.8
```
Time: 01:21.576, Memory: 3.79 GB

OK, but some tests were skipped!
Tests: 10383, Assertions: 65007, Skipped: 7.
```

this PR:
```
Time: 00:20.042, Memory: 1.04 GB

OK, but some tests were skipped!
Tests: 10383, Assertions: 65007, Skipped: 7.
```

---

maybe I did not yet understand that you actually try to make this type of exporter configurable via https://github.com/sebastianbergmann/phpunit/pull/5773 ?