### PR TITLE
Narrow type of template parameter in Cloner

### DIFF
--- a/src/Util/Cloner.php
+++ b/src/Util/Cloner.php
@@ -17,7 +17,7 @@ use Throwable;
 final class Cloner
 {
     /**
-     * @psalm-template OriginalType
+     * @psalm-template OriginalType of object
      *
      * @psalm-param OriginalType $original
      *


### PR DESCRIPTION
fixes PHPStan errors, see https://phpstan.org/r/31bc15b5-0507-4739-a86d-9652e43bec9b