### PR TITLE
Narrow class-types with generic

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -83,6 +83,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     }
 
     /**
+     * @psalm-param ReflectionClass<TestCase> $class
      * @psalm-param list<non-empty-string> $groups
      */
     public static function fromClassReflector(ReflectionClass $class, array $groups = []): static
@@ -475,7 +476,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     }
 
     /**
-     * @psalm-assert-if-true class-string $this->name
+     * @psalm-assert-if-true class-string<TestCase> $this->name
      */
     public function isForTestClass(): bool
     {
@@ -483,6 +484,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     }
 
     /**
+     * @psalm-param ReflectionClass<TestCase> $class
      * @psalm-param list<non-empty-string> $groups
      *
      * @throws Exception

--- a/src/Metadata/Api/HookMethods.php
+++ b/src/Metadata/Api/HookMethods.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Metadata\Api;
 
+use PHPUnit\Framework\TestCase;
 use function array_unshift;
 use function assert;
 use function class_exists;
@@ -27,7 +28,7 @@ final class HookMethods
     private static array $hookMethods = [];
 
     /**
-     * @psalm-param class-string $className
+     * @psalm-param class-string<TestCase> $className
      *
      * @psalm-return array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>}
      */

--- a/src/Metadata/Api/HookMethods.php
+++ b/src/Metadata/Api/HookMethods.php
@@ -9,10 +9,10 @@
  */
 namespace PHPUnit\Metadata\Api;
 
-use PHPUnit\Framework\TestCase;
 use function array_unshift;
 use function assert;
 use function class_exists;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\Parser\Registry;
 use PHPUnit\Util\Reflection;
 use ReflectionClass;

--- a/src/Runner/TestSuiteLoader.php
+++ b/src/Runner/TestSuiteLoader.php
@@ -39,6 +39,8 @@ final class TestSuiteLoader
 
     /**
      * @throws Exception
+     *
+     * @return ReflectionClass<TestCase>
      */
     public function load(string $suiteClassFile): ReflectionClass
     {

--- a/src/Util/Reflection.php
+++ b/src/Util/Reflection.php
@@ -48,6 +48,8 @@ final readonly class Reflection
     }
 
     /**
+     * @psalm-param ReflectionClass<TestCase> $class
+     *
      * @psalm-return list<ReflectionMethod>
      */
     public static function publicMethodsInTestClass(ReflectionClass $class): array
@@ -56,6 +58,8 @@ final readonly class Reflection
     }
 
     /**
+     * @psalm-param ReflectionClass<TestCase> $class
+     *
      * @psalm-return list<ReflectionMethod>
      */
     public static function methodsInTestClass(ReflectionClass $class): array
@@ -64,6 +68,8 @@ final readonly class Reflection
     }
 
     /**
+     * @psalm-param ReflectionClass<TestCase> $class
+     *
      * @psalm-return list<ReflectionMethod>
      */
     private static function filterAndSortMethods(ReflectionClass $class, ?int $filter, bool $sortHighestToLowest): array


### PR DESCRIPTION
sent this as a separate PR, as more precise parameter types can be considered a soft-bc-break (only for static analysis tooling; not runtime)