### PR TITLE
Test DefaultPrinter, ExecutionOrderDependency

### DIFF
--- a/tests/unit/Framework/ExecutionOrderDependencyTest.php
+++ b/tests/unit/Framework/ExecutionOrderDependencyTest.php
@@ -118,5 +118,8 @@ class ExecutionOrderDependencyTest extends TestCase
         $empty = new ExecutionOrderDependency('');
         $this->assertFalse($empty->shallowClone());
         $this->assertFalse($empty->deepClone());
+        $this->assertFalse($empty->targetIsClass());
+        $this->assertSame('', $empty->getTargetClassName());
+
     }
 }

--- a/tests/unit/Framework/ExecutionOrderDependencyTest.php
+++ b/tests/unit/Framework/ExecutionOrderDependencyTest.php
@@ -112,4 +112,11 @@ class ExecutionOrderDependencyTest extends TestCase
             'Right side of merge could be empty',
         );
     }
+
+    public function testEmptyClassOrCallable(): void
+    {
+        $empty = new ExecutionOrderDependency('');
+        $this->assertFalse($empty->shallowClone());
+        $this->assertFalse($empty->deepClone());
+    }
 }

--- a/tests/unit/TextUI/Output/Default/DefaultPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/DefaultPrinterTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\Output\Default;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\TextUI\InvalidSocketException;
+use PHPUnit\TextUI\Output\DefaultPrinter;
+
+#[CoversClass(DefaultPrinter::class)]
+#[Medium]
+final class DefaultPrinterTest extends TestCase
+{
+    public static function providePrinter(): array
+    {
+        return [
+            [DefaultPrinter::standardOutput()],
+            [DefaultPrinter::standardError()],
+            [DefaultPrinter::from('socket://hostname:port')],
+        ];
+    }
+
+    #[DataProvider('providePrinter')]
+    public function testFlush(DefaultPrinter $printer): void
+    {
+        $printer->flush();
+        $this->expectOutputString('');
+    }
+
+    public function testInvalidSocket(): void
+    {
+        $this->expectException(InvalidSocketException::class);
+        DefaultPrinter::from('socket://hostname:port:wrong');
+    }
+}


### PR DESCRIPTION
`DefaultPrinter` with a `socket://` url did not work before, because of the used readonly property 