### PR TITLE
Fix "fsockopen(): Unable to connect to hostname:0" warning

### DIFF
--- a/tests/unit/TextUI/Output/Default/DefaultPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/DefaultPrinterTest.php
@@ -25,7 +25,7 @@ final class DefaultPrinterTest extends TestCase
         return [
             [DefaultPrinter::standardOutput()],
             [DefaultPrinter::standardError()],
-            [DefaultPrinter::from('socket://hostname:port')],
+            [DefaultPrinter::from('socket://www.example.com:80')],
         ];
     }
 


### PR DESCRIPTION
another try at fixing https://github.com/sebastianbergmann/phpunit/pull/5779#issuecomment-2027951918

after looking a bit into it, it seems that phpunit will only fail a test when a warning is triggered from the test itself, but not the dataprovider.. intentional?