### PR TITLE
Make test more resilient

### DIFF
--- a/tests/end-to-end/cli/log-events-verbose-text.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text.phpt
@@ -51,12 +51,12 @@ unlink($traceFile);
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
-                                                          Failed asserting that two variables reference the same object.
+                                                         %sFailed asserting that two variables reference the same object.
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
-                                                          Failed asserting that two variables reference the same resource.
+                                                         %sFailed asserting that two variables reference the same resource.
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Finished (PHPUnit\TestFixture\LogEventsText\Test, 7 tests)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Suite Finished (CLI Arguments, 7 tests)


### PR DESCRIPTION
I don't know why it fails on my macos machine, but before this PR the output has a single space more then the expected output..

the PR fixes  - refs https://github.com/sebastianbergmann/phpunit/issues/5785
```diff
1) /Users/staabm/workspace/phpunit/tests/end-to-end/cli/log-events-verbose-text.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 [00:00:00.045056083 / 00:00:00.000029208] [10485760 bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [00:00:00.045097375 / 00:00:00.000041292] [10485760 bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [00:00:00.047045375 / 00:00:00.001948000] [10485760 bytes] Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
-                                                          Failed asserting that two variables reference the same object.
+                                                           Failed asserting that two variables reference the same object.
 [00:00:00.047126875 / 00:00:00.000081500] [10485760 bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)
 [00:00:00.047213375 / 00:00:00.000086500] [10485760 bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
 [00:00:00.047260500 / 00:00:00.000047125] [10485760 bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
 [00:00:00.047412667 / 00:00:00.000152167] [10485760 bytes] Test Failed (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
-                                                          Failed asserting that two variables reference the same resource.
+                                                           Failed asserting that two variables reference the same resource.
 [00:00:00.047469417 / 00:00:00.000056750] [10485760 bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportResource)
 [00:00:00.047504583 / 00:00:00.000035166] [10485760 bytes] Test Suite Finished (PHPUnit\TestFixture\LogEventsText\Test, 7 tests)
 [00:00:00.047533042 / 00:00:00.000028459] [10485760 bytes] Test Suite Finished (CLI Arguments, 7 tests)

/Users/staabm/workspace/phpunit/tests/end-to-end/cli/log-events-verbose-text.phpt:54
/Users/staabm/workspace/phpunit/src/Framework/TestSuite.php:361
/Users/staabm/workspace/phpunit/src/Framework/TestSuite.php:361
/Users/staabm/workspace/phpunit/src/TextUI/TestRunner.php:62
/Users/staabm/workspace/phpunit/src/TextUI/Application.php:200
```