### PR TITLE
gitignore .github folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Composer
 /vendor
 
+# GitHub.com
+/.github
+
 # Apache Ant
 /.ant_targets
 


### PR DESCRIPTION
having these files in the releases is unnecessary bloat.

(sneeeking in a commit with my coporate account, so you hopefully don't need to re-affirm my CI runs)