### PR TITLE
Add `$schema` to infection.json5.dist, exclude files that breaks PHPUnit execution with Infection

### DIFF
--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -1,9 +1,17 @@
 {
-    "$schema": "vendor/infection/infection/resources/schema.json",
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.28.1/resources/schema.json",
     "testFrameworkOptions": "--testsuite=unit",
     "source": {
         "directories": [
             "src"
+        ],
+        "excludes": [
+            // causes errors during loading xml fies
+            "Util/Xml/Xml.php",
+            // causes syntax errors since invalid PHP code is generated
+            "{Framework/MockObject/Generator/.*}",
+            // causes issues with saving and reading result cache json files, failing phpunit
+            "{Runner/ResultCache/.*}",
         ]
     },
     "mutators": {


### PR DESCRIPTION
See https://github.com/sebastianbergmann/phpunit/pull/5788#issuecomment-2033186772 for the detailed explanation about what is going on and why it's needed.