### PR TITLE
Prevent creation of `socket:` folder when running infection

### DIFF
--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -8,6 +8,8 @@
         "excludes": [
             // causes errors during loading xml fies
             "Util/Xml/Xml.php",
+            // test causes creation of files in project root when mutated
+            "TextUI/Output/Printer/DefaultPrinter.php",
             // causes syntax errors since invalid PHP code is generated
             "{Framework/MockObject/Generator/.*}",
             // causes issues with saving and reading result cache json files, failing phpunit


### PR DESCRIPTION
Running the DefaultPrinter test with mutations lead to files/directories beeing created in unexpected locations. 

Since the test will have sideeffects when the DefaultPrinter is mutated, we should not run in with infection