### PR TITLE
Preserve whitespace during configuration migration

### DIFF
--- a/src/Util/Xml/Document.php
+++ b/src/Util/Xml/Document.php
@@ -40,20 +40,21 @@ final class Document extends DOMDocument
         preg_match_all('#<phpunit[^>]*>#', $xml, $phpunitTags);
 
         $phpunitTag = $phpunitTags[0][0] ?? null;
-        if (!$phpunitTag) {
+
+        if ($phpunitTag === null) {
             return $xml;
         }
 
         // Find all attributes within the <phpunit> tag
         preg_match('#(?<=<phpunit)(?:\s+([^\s=]+)="([^"]*)")*#', $phpunitTag, $attributes);
 
-        if (!$attributes) {
+        if ($attributes === null || $attributes === []) {
             return $xml;
         }
 
         $phpunitNewTag = $phpunitTag;
 
-        foreach (explode(' ', $attributes[0]) ?: [] as $attribute) {
+        foreach (explode(' ', $attributes[0]) as $attribute) {
             if (trim($attribute) === '' || str_contains($attribute, ':xsi=')) {
                 // skip `xmlns:xsi` attribute
                 continue;

--- a/src/Util/Xml/Document.php
+++ b/src/Util/Xml/Document.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util\Xml;
+
+use function explode;
+use function preg_match;
+use function preg_match_all;
+use function str_contains;
+use function str_replace;
+use function trim;
+use DOMDocument;
+use DOMNode;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class Document extends DOMDocument
+{
+    public function loadXML(string $source, int $options = 0): bool
+    {
+        $this->preserveWhiteSpace = false;
+
+        return parent::loadXML($source, $options);
+    }
+
+    public function saveXML(?DOMNode $node = null, int $options = 0): string
+    {
+        $this->formatOutput = true;
+
+        $xml = parent::saveXML($node, $options);
+
+        // find the first <phpunit> tag
+        preg_match_all('#<phpunit[^>]*>#', $xml, $phpunitTags);
+
+        $phpunitTag = $phpunitTags[0][0] ?? null;
+        if (!$phpunitTag) {
+            return $xml;
+        }
+
+        // Find all attributes within the <phpunit> tag
+        preg_match('#(?<=<phpunit)(?:\s+([^\s=]+)="([^"]*)")*#', $phpunitTag, $attributes);
+
+        if (!$attributes) {
+            return $xml;
+        }
+
+        $phpunitNewTag = $phpunitTag;
+
+        foreach (explode(' ', $attributes[0]) ?: [] as $attribute) {
+            if (trim($attribute) === '' || str_contains($attribute, ':xsi=')) {
+                // skip `xmlns:xsi` attribute
+                continue;
+            }
+
+            $phpunitNewTag = str_replace(' ' . $attribute, PHP_EOL . '    ' . $attribute, $phpunitNewTag);
+        }
+
+        return str_replace($phpunitTag, $phpunitNewTag . PHP_EOL, $xml);
+    }
+}

--- a/src/Util/Xml/Document.php
+++ b/src/Util/Xml/Document.php
@@ -48,7 +48,7 @@ final class Document extends DOMDocument
         // Find all attributes within the <phpunit> tag
         preg_match('#(?<=<phpunit)(?:\s+([^\s=]+)="([^"]*)")*#', $phpunitTag, $attributes);
 
-        if ($attributes === null || $attributes === []) {
+        if ($attributes === []) {
             return $xml;
         }
 

--- a/src/Util/Xml/Loader.php
+++ b/src/Util/Xml/Loader.php
@@ -61,7 +61,7 @@ final readonly class Loader
             );
         }
 
-        $document                     = new DOMDocument;
+        $document                     = new Document;
         $document->preserveWhiteSpace = false;
 
         $internal  = libxml_use_internal_errors(true);

--- a/tests/end-to-end/migration/migration-from-100.phpt
+++ b/tests/end-to-end/migration/migration-from-100.phpt
@@ -5,12 +5,19 @@ Configuration migration from PHPUnit 10.0 format works
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/migration-from-100/phpunit-10.0.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/phpunit.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/migration-from-100/phpunit-10.0.xml', 'phpunit.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+assert(
+    file_get_contents($originalPHPUnitXMLFile) === file_get_contents($phpunitXMLFile)
+);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/end-to-end/migration/migration-from-110.phpt
+++ b/tests/end-to-end/migration/migration-from-110.phpt
@@ -5,12 +5,19 @@ Configuration migration from PHPUnit 11.0 format works
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/migration-from-110/phpunit-11.0.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/phpunit.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/migration-from-110/phpunit-11.0.xml', 'phpunit.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+if (file_get_contents($originalPHPUnitXMLFile) === file_get_contents($phpunitXMLFile)) {
+    throw new Exception('Migration failed');
+}
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/end-to-end/migration/migration-from-85-with-custom-filename.phpt
+++ b/tests/end-to-end/migration/migration-from-85-with-custom-filename.phpt
@@ -7,12 +7,19 @@ $_SERVER['argv'][] = '--configuration';
 $_SERVER['argv'][] = 'custom.xml';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/migration-from-85/phpunit-8.5.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/custom.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/migration-from-85/phpunit-8.5.xml', 'custom.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+assert(
+    file_get_contents($originalPHPUnitXMLFile) === file_get_contents($phpunitXMLFile)
+);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/end-to-end/migration/migration-from-85.phpt
+++ b/tests/end-to-end/migration/migration-from-85.phpt
@@ -5,12 +5,19 @@ Configuration migration from PHPUnit 8.5 format works
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/migration-from-85/phpunit-8.5.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/phpunit.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/migration-from-85/phpunit-8.5.xml', 'phpunit.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+assert(
+    file_get_contents($originalPHPUnitXMLFile) === file_get_contents($phpunitXMLFile)
+);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/end-to-end/migration/migration-from-92.phpt
+++ b/tests/end-to-end/migration/migration-from-92.phpt
@@ -5,12 +5,19 @@ Configuration migration from PHPUnit 9.2 format works
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/migration-from-92/phpunit-9.2.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/phpunit.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/migration-from-92/phpunit-9.2.xml', 'phpunit.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+assert(
+    file_get_contents($originalPHPUnitXMLFile) === file_get_contents($phpunitXMLFile)
+);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/end-to-end/migration/migration-from-95.phpt
+++ b/tests/end-to-end/migration/migration-from-95.phpt
@@ -5,12 +5,19 @@ Configuration migration from PHPUnit 9.5 format works
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/migration-from-95/phpunit-9.5.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/phpunit.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/migration-from-95/phpunit-9.5.xml', 'phpunit.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+assert(
+    file_get_contents($originalPHPUnitXMLFile) === file_get_contents($phpunitXMLFile)
+);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 

--- a/tests/end-to-end/migration/unsupported-schema.phpt
+++ b/tests/end-to-end/migration/unsupported-schema.phpt
@@ -5,12 +5,17 @@ Configuration migration is not possible when the configuration file does not val
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--migrate-configuration';
 
+$originalPHPUnitXMLFile = __DIR__ . '/_files/unsupported-schema/phpunit.xml';
+$phpunitXMLFile = sys_get_temp_dir() . '/phpunit.xml';
+
 chdir(sys_get_temp_dir());
-copy(__DIR__ . '/_files/unsupported-schema/phpunit.xml', 'phpunit.xml');
+copy($originalPHPUnitXMLFile, $phpunitXMLFile);
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($phpunitXMLFile);
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 


### PR DESCRIPTION
This patch preserves formatting, new lines between attributes in the `phpunit` tag, during configuration migration, via the following changes:

 - Add `src/Util/Xml/Document.php` extends `DOMDocument` and overrides both `loadXML()` and `saveXML()` 
 - Update `src/Util/Xml/Loader.php`
