### PR TITLE
Skip tests with no code coverage

### DIFF
--- a/tests/end-to-end/metadata/targeting-traits-with-coversclass-attribute-is-deprecated.phpt
+++ b/tests/end-to-end/metadata/targeting-traits-with-coversclass-attribute-is-deprecated.phpt
@@ -1,5 +1,10 @@
 --TEST--
 The right events are emitted in the right order for a successful test that targets a trait with #[CoversClass]
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('pcov') && !extension_loaded('xdebug')) {
+    print "skip: this test requires pcov or xdebug\n";
+}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile    = tempnam(sys_get_temp_dir(), __FILE__);

--- a/tests/end-to-end/metadata/targeting-traits-with-usesclass-attribute-is-deprecated.phpt
+++ b/tests/end-to-end/metadata/targeting-traits-with-usesclass-attribute-is-deprecated.phpt
@@ -1,5 +1,10 @@
 --TEST--
 The right events are emitted in the right order for a successful test that targets a trait with #[CoversClass]
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('pcov') && !extension_loaded('xdebug')) {
+    print "skip: this test requires pcov or xdebug\n";
+}
 --FILE--
 <?php declare(strict_types=1);
 $traceFile    = tempnam(sys_get_temp_dir(), __FILE__);


### PR DESCRIPTION
Should fix: https://github.com/mbeccati/php-latest-builds/actions/runs/8595701599

```
1) /home/matteo/OSS/phpunit/tests/end-to-end/metadata/targeting-traits-with-coversclass-attribute-is-deprecated-no-cov.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 Test Preparation Started (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithCoversClassTest::testSomething)
 Test Prepared (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithCoversClassTest::testSomething)
 Test Passed (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithCoversClassTest::testSomething)
-Test Runner Triggered Deprecation (Targeting a trait such as PHPUnit\TestFixture\CoveredTrait with #[CoversClass] is deprecated, please refactor your test to use #[CoversTrait] instead.)
 Test Finished (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithCoversClassTest::testSomething)
 Test Suite Finished (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithCoversClassTest, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 1)

/home/matteo/OSS/phpunit/tests/end-to-end/metadata/targeting-traits-with-coversclass-attribute-is-deprecated-no-cov.phpt:43
/home/matteo/OSS/phpunit/src/Framework/TestSuite.php:369
/home/matteo/OSS/phpunit/src/TextUI/TestRunner.php:62
/home/matteo/OSS/phpunit/src/TextUI/Application.php:200

2) /home/matteo/OSS/phpunit/tests/end-to-end/metadata/targeting-traits-with-usesclass-attribute-is-deprecated-no-cov.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 PHPUnit Started (PHPUnit 11.2-g0c2333363 using PHP 8.2.17 (cli) on Linux)
 Test Runner Configured
 Test Suite Loaded (1 test)
+Test Runner Triggered Warning (No code coverage driver available)
 Event Facade Sealed
 Test Runner Started
 Test Suite Sorted
@@ @@
 Test Preparation Started (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithUsesClassTest::testSomething)
 Test Prepared (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithUsesClassTest::testSomething)
 Test Passed (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithUsesClassTest::testSomething)
-Test Runner Triggered Deprecation (Targeting a trait such as PHPUnit\TestFixture\CoveredTrait with #[UsesClass] is deprecated, please refactor your test to use #[UsesTrait] instead.)
 Test Finished (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithUsesClassTest::testSomething)
 Test Suite Finished (PHPUnit\DeprecatedAnnotationsTestFixture\TraitTargetedWithUsesClassTest, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
-PHPUnit Finished (Shell Exit Code: 0)
+PHPUnit Finished (Shell Exit Code: 1)

/home/matteo/OSS/phpunit/tests/end-to-end/metadata/targeting-traits-with-usesclass-attribute-is-deprecated-no-cov.phpt:33
/home/matteo/OSS/phpunit/src/Framework/TestSuite.php:369
/home/matteo/OSS/phpunit/src/TextUI/TestRunner.php:62
/home/matteo/OSS/phpunit/src/TextUI/Application.php:200
```