### PR TITLE
Deprecate invalid named arguments in data providers

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -18,7 +18,9 @@ use const LC_TIME;
 use const PATHINFO_FILENAME;
 use const PHP_EOL;
 use const PHP_URL_PATH;
+use function array_is_list;
 use function array_keys;
+use function array_map;
 use function array_merge;
 use function array_values;
 use function assert;
@@ -56,6 +58,7 @@ use AssertionError;
 use DeepCopy\DeepCopy;
 use PHPUnit\Event;
 use PHPUnit\Event\NoPreviousThrowableException;
+use PHPUnit\Event\RuntimeException;
 use PHPUnit\Event\TestData\MoreThanOneDataSetFromDataProviderException;
 use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
 use PHPUnit\Framework\Constraint\ExceptionCode;
@@ -91,7 +94,9 @@ use PHPUnit\Util\Cloner;
 use PHPUnit\Util\Test as TestUtil;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionMethod;
 use ReflectionObject;
+use ReflectionParameter;
 use SebastianBergmann\CodeCoverage\StaticAnalysisCacheNotConfiguredException;
 use SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException;
 use SebastianBergmann\Comparator\Comparator;
@@ -1061,6 +1066,37 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     {
         $this->dataName = $dataName;
         $this->data     = $data;
+
+        if (array_is_list($data)) {
+            return;
+        }
+
+        try {
+            $reflector  = new ReflectionMethod($this, $this->name);
+            $parameters = array_map(static fn (ReflectionParameter $parameter) => $parameter->name, $reflector->getParameters());
+
+            foreach (array_keys($data) as $parameter) {
+                if (is_string($parameter) && !in_array($parameter, $parameters, true)) {
+                    Event\Facade::emitter()->testTriggeredPhpunitDeprecation(
+                        $this->valueObjectForEvents(),
+                        sprintf(
+                            'Providing invalid named argument $%s for method %s::%s() is deprecated and will not be supported in PHPUnit 11.0.',
+                            $parameter,
+                            $this::class,
+                            $this->name,
+                        ),
+                    );
+                }
+            }
+            // @codeCoverageIgnoreStart
+        } catch (ReflectionException $e) {
+            throw new RuntimeException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e,
+            );
+        }
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1060,6 +1060,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
+     * @throws RuntimeException
+     *
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
     final public function setData(int|string $dataName, array $data): void

--- a/tests/end-to-end/event/_files/InvalidParameterNameDataProviderTest.php
+++ b/tests/end-to-end/event/_files/InvalidParameterNameDataProviderTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class InvalidParameterNameDataProviderTest extends TestCase
+{
+    public static function values(): array
+    {
+        return [
+            ['value1' => true, 'value2' => true],
+            ['value3' => true, 'value4' => true],
+        ];
+    }
+
+    #[DataProvider('values')]
+    public function testSuccess(bool $value1, bool $value2): void
+    {
+        $this->assertTrue($value1);
+        $this->assertTrue($value2);
+    }
+}

--- a/tests/end-to-end/event/data-provider-invalid-argument-name.phpt
+++ b/tests/end-to-end/event/data-provider-invalid-argument-name.phpt
@@ -1,0 +1,54 @@
+--TEST--
+The right events are emitted in the right order for a test that uses a data provider that is not static
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = __DIR__ . '/_files/InvalidParameterNameDataProviderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Data Provider Method Called (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::values for test method PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess)
+Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess:
+- PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::values
+Test Triggered PHPUnit Deprecation (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
+Providing invalid named argument $value3 for method PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess() is deprecated and will not be supported in PHPUnit 11.0.
+Test Triggered PHPUnit Deprecation (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
+Providing invalid named argument $value4 for method PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess() is deprecated and will not be supported in PHPUnit 11.0.
+Test Suite Loaded (2 tests)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#0)
+Test Prepared (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#0)
+Assertion Succeeded (Constraint: is true, Value: true)
+Assertion Succeeded (Constraint: is true, Value: true)
+Test Passed (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#0)
+Test Finished (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#0)
+Test Preparation Started (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
+Test Prepared (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
+Assertion Succeeded (Constraint: is true, Value: true)
+Assertion Succeeded (Constraint: is true, Value: true)
+Test Passed (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
+Test Finished (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
+Test Suite Finished (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess, 2 tests)
+Test Suite Finished (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest, 2 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)


### PR DESCRIPTION
This PR adds a deprecation message when running a test with data provider with named arguments that don't match the method arguments.
It allows to detect data providers with string array keys which will break when upgraded to v11.0 (#5225).

Running this test under v11 throws:
```
Test Errored (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
Unknown named parameter $value3
Test Finished (PHPUnit\TestFixture\Event\InvalidParameterNameDataProviderTest::testSuccess#1)
```

I'm not sure if this is the right place to trigger the deprecation - perhaps it could also be moved to the test execution stage instead.