### PR TITLE
DX: PR friendly, branch-specific PHP CS Fixer cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 
 # PHP-CS-Fixer
 /.php-cs-fixer.php
-/.php-cs-fixer.cache
+/.php-cs-fixer.cache/
 
 # Psalm
 /.psalm/cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -342,6 +342,6 @@ $config->setFinder($finder)
         'whitespace_after_comma_in_array' => true,
     ]);
 
-$config->setCacheFile(__DIR__ . '/.php-cs-fixer.cache/' . sha1(@trim((string) @shell_exec('git rev-parse --abbrev-ref HEAD'))));
+$config->setCacheFile(__DIR__ . '/.php-cs-fixer.cache/' . json_decode((string) @file_get_contents('composer.json'), true)["extra"]["branch-alias"]["dev-master"] ?? 'unknown');
 
 return $config;


### PR DESCRIPTION
appendix to 
 https://github.com/sebastianbergmann/phpunit/commit/59f3dc25d0054cb437293dcf8003d04358b03b8b

sth to consider, as each branch is having configured composer branch alias.

Right now if I have a local branch 9.6 and I run Fixer for it, it creates a dedicated cache file. Then, I create a 9.6-fix-typo branch, which is very similar to 9.6 branch, yet have a separated cache file.

With proposed way, 9.6-fix-typo will reuse 9.6 cache file.