### PR TITLE
In callback there is no "file" in trace

### DIFF
--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -254,19 +254,18 @@ final class ErrorHandler
 
         $trace = $this->filteredStackTrace($filterTrigger);
 
-        assert(isset($trace[0]['file']));
-        assert(isset($trace[1]['file']));
-
         $triggeredInFirstPartyCode       = false;
         $triggerCalledFromFirstPartyCode = false;
 
-        if ($trace[0]['file'] === $test->file() ||
-            $this->sourceFilter->includes($this->source, $trace[0]['file'])) {
+        if (isset($trace[0]['file']) && (
+            $trace[0]['file'] === $test->file() ||
+            $this->sourceFilter->includes($this->source, $trace[0]['file']))) {
             $triggeredInFirstPartyCode = true;
         }
 
-        if ($trace[1]['file'] === $test->file() ||
-            $this->sourceFilter->includes($this->source, $trace[1]['file'])) {
+        if (isset($trace[0]['file']) && (
+            $trace[1]['file'] === $test->file() ||
+            $this->sourceFilter->includes($this->source, $trace[1]['file']))) {
             $triggerCalledFromFirstPartyCode = true;
         }
 

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -27,7 +27,6 @@ use const E_USER_WARNING;
 use const E_WARNING;
 use function array_keys;
 use function array_values;
-use function assert;
 use function debug_backtrace;
 use function error_reporting;
 use function restore_error_handler;
@@ -259,13 +258,15 @@ final class ErrorHandler
 
         if (isset($trace[0]['file']) && (
             $trace[0]['file'] === $test->file() ||
-            $this->sourceFilter->includes($this->source, $trace[0]['file']))) {
+            $this->sourceFilter->includes($this->source, $trace[0]['file'])
+        )) {
             $triggeredInFirstPartyCode = true;
         }
 
         if (isset($trace[1]['file']) && (
             $trace[1]['file'] === $test->file() ||
-            $this->sourceFilter->includes($this->source, $trace[1]['file']))) {
+            $this->sourceFilter->includes($this->source, $trace[1]['file'])
+        )) {
             $triggerCalledFromFirstPartyCode = true;
         }
 

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -263,7 +263,7 @@ final class ErrorHandler
             $triggeredInFirstPartyCode = true;
         }
 
-        if (isset($trace[0]['file']) && (
+        if (isset($trace[1]['file']) && (
             $trace[1]['file'] === $test->file() ||
             $this->sourceFilter->includes($this->source, $trace[1]['file']))) {
             $triggerCalledFromFirstPartyCode = true;

--- a/tests/end-to-end/regression/5822.phpt
+++ b/tests/end-to-end/regression/5822.phpt
@@ -1,0 +1,22 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/pull/5592
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/5822/phpunit.xml';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+D                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Deprecations: 1.

--- a/tests/end-to-end/regression/5822/phpunit.xml
+++ b/tests/end-to-end/regression/5822/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/regression/5822/src/.gitignore
+++ b/tests/end-to-end/regression/5822/src/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/end-to-end/regression/5822/tests/Issue5822Test.php
+++ b/tests/end-to-end/regression/5822/tests/Issue5822Test.php
@@ -9,11 +9,14 @@
  */
 namespace PHPUnit\TestFixture\Issue5822;
 
+use const E_USER_DEPRECATED;
+use function call_user_func;
+use function trigger_error;
 use PHPUnit\Framework\TestCase;
 
 class Issue5822Test extends TestCase
 {
-    public function testDebugBacktrace()
+    public function testDebugBacktrace(): void
     {
         $this->callUserFuncExample();
         $this->assertTrue(true);
@@ -26,6 +29,6 @@ class Issue5822Test extends TestCase
 
     private function exampleCallback(): void
     {
-        trigger_error('My Deprecation Error', \E_USER_DEPRECATED);
+        trigger_error('My Deprecation Error', E_USER_DEPRECATED);
     }
 }

--- a/tests/end-to-end/regression/5822/tests/Issue5822Test.php
+++ b/tests/end-to-end/regression/5822/tests/Issue5822Test.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue5822;
+
+use PHPUnit\Framework\TestCase;
+
+class Issue5822Test extends TestCase
+{
+    public function testDebugBacktrace()
+    {
+        $this->callUserFuncExample();
+        $this->assertTrue(true);
+    }
+
+    private function callUserFuncExample(): void
+    {
+        call_user_func([$this, 'exampleCallback']);
+    }
+
+    private function exampleCallback(): void
+    {
+        trigger_error('My Deprecation Error', \E_USER_DEPRECATED);
+    }
+}


### PR DESCRIPTION
In callback there is no "file" in trace.

For example, trace will look like
```
    [0] => Array
        (
            [file] => C:\wamp\www\atk4\validate\vendor\vlucas\valitron\src\Valitron\Validator.php
            [line] => 760
            [function] => strtotime
        )
    [1] => Array
        (
            [function] => validateDate
            [class] => Valitron\Validator
            [type] => ->
        )
    [2] => Array
        (
            [file] => C:\wamp\www\atk4\validate\vendor\vlucas\valitron\src\Valitron\Validator.php
            [line] => 1251
            [function] => call_user_func
        )
   ...
```
and `[1]` element has only function, class and type attributes, but no file and line.
