### PR TITLE
Do not crash when test run in child process ends unexpectedly and `--log-junit` is used

### DIFF
--- a/src/Logging/JUnit/JunitXmlLogger.php
+++ b/src/Logging/JUnit/JunitXmlLogger.php
@@ -202,7 +202,7 @@ final class JunitXmlLogger
      */
     public function testFinished(Finished $event): void
     {
-        if ($this->preparationFailed) {
+        if (!$this->prepared || $this->preparationFailed) {
             return;
         }
 

--- a/tests/end-to-end/regression/5771.phpt
+++ b/tests/end-to-end/regression/5771.phpt
@@ -1,0 +1,26 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/5771
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/5771/Issue5771Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 error:
+
+1) PHPUnit\TestFixture\Issue5771\Issue5771Test::test
+Test was run in child process and ended unexpectedly
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/end-to-end/regression/5771.phpt
+++ b/tests/end-to-end/regression/5771.phpt
@@ -4,6 +4,8 @@ https://github.com/sebastianbergmann/phpunit/issues/5771
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = __DIR__ . '/5771/Issue5771Test.php';
+$_SERVER['argv'][] = '--log-junit';
+$_SERVER['argv'][] = tempnam(sys_get_temp_dir(), __FILE__);
 
 require_once __DIR__ . '/../../bootstrap.php';
 

--- a/tests/end-to-end/regression/5771/Issue5771Test.php
+++ b/tests/end-to-end/regression/5771/Issue5771Test.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue5771;
+
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+final class Issue5771Test extends TestCase
+{
+    #[RunInSeparateProcess]
+    public function test(): void
+    {
+        exit;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/5771

See commit messages.