### PR TITLE
Request for Consistent Handler Restoration on `expectOutputString` and `expectOutputRegex` Failure

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -2212,8 +2212,6 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 Event\Code\ThrowableBuilder::from($e),
                 Event\Code\ComparisonFailureBuilder::from($e),
             );
-
-            throw $e;
         }
     }
 


### PR DESCRIPTION
Dear Sebastian Bergmann,

This pull request addresses an issue where error and exception handlers are not restored properly when `expectOutputString` or `expectOutputRegex` assertions fail. Below is a minimal code example to reproduce the behavior:

```php
<?php

namespace Test;

use PHPUnit\Framework\TestCase;

class Test extends TestCase
{
    public $existsOriginalErrorHandler;
    public $existsOriginalExceptionHandler;

    // Assume that the error handler is changed within the test code.
    public function setUp(): void
    {
        $this->existsOriginalErrorHandler = (bool)set_error_handler(fn () => null);
        $this->existsOriginalExceptionHandler = (bool)set_exception_handler(fn () => null);
    }

    // Assume that the error handler changes are reliably restored to their original state in `tearDown()`.
    public function tearDown(): void
    {
        restore_exception_handler();
        restore_error_handler();
    }

    // In PHPUnit, tests typically start with this handler setting.
    public function test1()
    {
        $this->assertTrue($this->existsOriginalErrorHandler);
        $this->assertFalse($this->existsOriginalExceptionHandler);
    }

    public function test2()
    {
        // The same assertions as before will obviously succeed.
        $this->assertTrue($this->existsOriginalErrorHandler);
        $this->assertFalse($this->existsOriginalExceptionHandler);

        // This assertion is intentionally set to fail. This failure leads to:
        $this->expectOutputString('This test will be failed'); // Failure (intentional)
    }

    // The next test starts without `tearDown()` being executed,
    public function test3()
    {
        // The exact same assertions will fail here.
        $this->assertTrue($this->existsOriginalErrorHandler);
        $this->assertFalse($this->existsOriginalExceptionHandler); // Failure (unintentional)
    }
}
```

Although this may not be a "bug" per se, the inconsistent behavior makes it challenging for some frameworks to avoid PHPUnit's warning messages like *"Test code or tested code ..."* . It would be greatly appreciated if this issue could be addressed in PHPUnit to ensure consistent handler restoration.

Thank you for considering this request.

Best regards,
Kentaro Takeda