### PR TITLE
Destroy `TestCase` object after its test was run

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -81,6 +81,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
      */
     private ?array $providedTests    = null;
     private ?Factory $iteratorFilter = null;
+    private bool $wasRun             = false;
 
     /**
      * @psalm-param non-empty-string $name
@@ -346,6 +347,14 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
      */
     public function run(): void
     {
+        if ($this->wasRun) {
+            // @codeCoverageIgnoreStart
+            throw new Exception('The tests aggregated by this TestSuite were already run');
+            // @codeCoverageIgnoreEnd
+        }
+
+        $this->wasRun = true;
+
         if (count($this) === 0) {
             return;
         }

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -11,7 +11,6 @@ namespace PHPUnit\Framework;
 
 use const PHP_EOL;
 use function array_keys;
-use function array_map;
 use function array_merge;
 use function assert;
 use function call_user_func;
@@ -312,10 +311,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
      */
     public function groups(): array
     {
-        return array_map(
-            'strval',
-            array_keys($this->groups),
-        );
+        return array_keys($this->groups);
     }
 
     /**

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -300,7 +300,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
     /**
      * Returns the test groups of the suite.
      *
-     * @psalm-return list<string>
+     * @psalm-return list<non-empty-string>
      */
     public function groups(): array
     {

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -367,6 +367,30 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             }
 
             $test->run();
+
+            foreach (array_keys($this->tests) as $key) {
+                if ($test === $this->tests[$key]) {
+                    unset($this->tests[$key]);
+
+                    break;
+                }
+            }
+
+            if ($test instanceof TestCase || $test instanceof self) {
+                foreach ($test->groups() as $group) {
+                    if (!isset($this->groups[$group])) {
+                        continue;
+                    }
+
+                    foreach (array_keys($this->groups[$group]) as $key) {
+                        if ($test === $this->groups[$group][$key]) {
+                            unset($this->groups[$group][$key]);
+
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         $this->invokeMethodsAfterLastTest($emitter);

--- a/src/Runner/Filter/ExcludeGroupFilterIterator.php
+++ b/src/Runner/Filter/ExcludeGroupFilterIterator.php
@@ -17,9 +17,10 @@ use function in_array;
 final class ExcludeGroupFilterIterator extends GroupFilterIterator
 {
     /**
-     * @psalm-param list<int> $groupTests
+     * @psalm-param non-empty-string $id
+     * @psalm-param list<non-empty-string> $groupTests
      */
-    protected function doAccept(int $id, array $groupTests): bool
+    protected function doAccept(string $id, array $groupTests): bool
     {
         return !in_array($id, $groupTests, true);
     }

--- a/src/Runner/Filter/IncludeGroupFilterIterator.php
+++ b/src/Runner/Filter/IncludeGroupFilterIterator.php
@@ -17,9 +17,10 @@ use function in_array;
 final class IncludeGroupFilterIterator extends GroupFilterIterator
 {
     /**
-     * @psalm-param list<int> $groupTests
+     * @psalm-param non-empty-string $id
+     * @psalm-param list<non-empty-string> $groupTests
      */
-    protected function doAccept(int $id, array $groupTests): bool
+    protected function doAccept(string $id, array $groupTests): bool
     {
         return in_array($id, $groupTests, true);
     }


### PR DESCRIPTION
I may have found a short-term solution (before more architectural changes have been implemented for the test runner) to reduce PHPUnit's memory usage.

With PHPUnit's own test suite, I see a memory usage reduction from 48.00 MB (778070d58837db65849125eb075e5d2f430c8d11) to 44.00 MB (4df94e09c3563aabf5ec13ddda117bf45ea08b68).

I have tested this solution with a couple of test suites so far and 1) it does not break anything (good!) and 2) it reduces memory usage (also good!).

However, I am not comfortable shipping this without (a lot) more testing. So, if you want to help me out, then please test this change with your own test suite:

* Does this change break your test suite (you get a different result with and without the change)?
* Does this change reduce the memory usage of running your tests for you?

This change can be applied to PHPUnit 10.5 and PHPUnit 11.2.