### PR TITLE
Do not cache test double declarations

### DIFF
--- a/src/Framework/MockObject/Generator/Generator.php
+++ b/src/Framework/MockObject/Generator/Generator.php
@@ -93,11 +93,6 @@ final class Generator
     ];
 
     /**
-     * @psalm-var array<non-empty-string, MockClass>
-     */
-    private static array $cache = [];
-
-    /**
      * Returns a test double for the specified class.
      *
      * @throws ClassIsEnumerationException
@@ -415,21 +410,17 @@ final class Generator
             serialize($callOriginalMethods),
         );
 
-        if (!isset(self::$cache[$key])) {
-            self::$cache[$key] = $this->generateCodeForTestDoubleClass(
-                $type,
-                $mockObject,
-                $markAsMockObject,
-                $methods,
-                $mockClassName,
-                $callOriginalClone,
-                $callAutoload,
-                $cloneArguments,
-                $callOriginalMethods,
-            );
-        }
-
-        return self::$cache[$key];
+        return $this->generateCodeForTestDoubleClass(
+            $type,
+            $mockObject,
+            $markAsMockObject,
+            $methods,
+            $mockClassName,
+            $callOriginalClone,
+            $callAutoload,
+            $cloneArguments,
+            $callOriginalMethods,
+        );
     }
 
     /**


### PR DESCRIPTION
While profiling the test double code generator today, I noticed that (counter-intuitively) memory consumption increases when test double code declarations are not cached. For instance, for PHPUnit's own test suite from 48 MB to 52 MB.

This is PR is not intended to be merged, but I would like to have a place where the investigation of this issue can be discussed.