### PR TITLE
Do not collect unnecessary information using `debug_backtrace()`

### DIFF
--- a/src/Event/Value/Test/TestMethodBuilder.php
+++ b/src/Event/Value/Test/TestMethodBuilder.php
@@ -49,7 +49,7 @@ final readonly class TestMethodBuilder
      */
     public static function fromCallStack(): TestMethod
     {
-        foreach (debug_backtrace() as $frame) {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
             if (isset($frame['object']) && $frame['object'] instanceof TestCase) {
                 return $frame['object']->valueObjectForEvents();
             }

--- a/src/Framework/MockObject/MockBuilder.php
+++ b/src/Framework/MockObject/MockBuilder.php
@@ -552,7 +552,7 @@ final class MockBuilder
 
     private function calledFromTestCase(): bool
     {
-        $caller = debug_backtrace(limit: 3)[2];
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 3)[2];
 
         return isset($caller['class']) && $caller['class'] === TestCase::class;
     }


### PR DESCRIPTION
see https://www.php.net/debug_backtrace

<img width="1034" alt="grafik" src="https://github.com/sebastianbergmann/phpunit/assets/120441/37001ff5-7803-4bab-b8d9-2e4cc14a3664">
