### PR TITLE
Do not collect unnecessary information using `debug_backtrace()`

### DIFF
--- a/src/Event/Value/Test/TestMethodBuilder.php
+++ b/src/Event/Value/Test/TestMethodBuilder.php
@@ -54,7 +54,7 @@ final class TestMethodBuilder
      */
     public static function fromCallStack(): TestMethod
     {
-        foreach (debug_backtrace() as $frame) {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
             if (isset($frame['object']) && $frame['object'] instanceof TestCase) {
                 return $frame['object']->valueObjectForEvents();
             }


### PR DESCRIPTION
10.5.x variant of https://github.com/sebastianbergmann/phpunit/pull/5870

this PR here contains one less change, because 10.5.x has one less call to `debug_backtrace`