### PR TITLE
Use `array_pop()` instead of `array_shift()` for processing `Test` objects in `TestSuite::run()` and optimize `TestSuite::isEmpty()`

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -12,7 +12,8 @@ namespace PHPUnit\Framework;
 use const PHP_EOL;
 use function array_keys;
 use function array_map;
-use function array_shift;
+use function array_pop;
+use function array_reverse;
 use function assert;
 use function call_user_func;
 use function class_exists;
@@ -356,10 +357,12 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             $tests[] = $test;
         }
 
+        $tests = array_reverse($tests);
+
         $this->tests  = [];
         $this->groups = [];
 
-        while ($test = array_shift($tests)) {
+        while (($test = array_pop($tests)) !== false) {
             if (TestResultFacade::shouldStop()) {
                 $emitter->testRunnerExecutionAborted();
 

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -137,7 +137,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
             $testSuite->addTestMethod($class, $method);
         }
 
-        if (count($testSuite) === 0) {
+        if ($testSuite->isEmpty()) {
             Event\Facade::emitter()->testRunnerTriggeredWarning(
                 sprintf(
                     'No tests found in class "%s".',
@@ -290,7 +290,13 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
 
     public function isEmpty(): bool
     {
-        return empty($this->tests);
+        foreach ($this as $test) {
+            if (count($test) !== 0) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -337,7 +343,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
 
         $this->wasRun = true;
 
-        if (count($this) === 0) {
+        if ($this->isEmpty()) {
             return;
         }
 
@@ -362,7 +368,7 @@ class TestSuite implements IteratorAggregate, Reorderable, SelfDescribing, Test
         $this->tests  = [];
         $this->groups = [];
 
-        while (($test = array_pop($tests)) !== false) {
+        while (($test = array_pop($tests)) !== null) {
             if (TestResultFacade::shouldStop()) {
                 $emitter->testRunnerExecutionAborted();
 


### PR DESCRIPTION
improve #5875 performance, `array_shift` is very slow with large arrays