### PR TITLE
Add hints to CLI parameter deprecation messages

### DIFF
--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -434,7 +434,7 @@ final class Builder
                 case '--group':
                     if (str_contains($option[1], ',')) {
                         EventFacade::emitter()->testRunnerTriggeredWarning(
-                            'Using comma-separated values with --group is deprecated and will no longer work in PHPUnit 12',
+                            'Using comma-separated values with --group is deprecated and will no longer work in PHPUnit 12. You can use --group multiple times instead',
                         );
                     }
 
@@ -451,7 +451,7 @@ final class Builder
                 case '--exclude-group':
                     if (str_contains($option[1], ',')) {
                         EventFacade::emitter()->testRunnerTriggeredWarning(
-                            'Using comma-separated values with --exclude-group is deprecated and will no longer work in PHPUnit 12',
+                            'Using comma-separated values with --exclude-group is deprecated and will no longer work in PHPUnit 12. You can use --exclude-group multiple times instead',
                         );
                     }
 
@@ -468,7 +468,7 @@ final class Builder
                 case '--covers':
                     if (str_contains($option[1], ',')) {
                         EventFacade::emitter()->testRunnerTriggeredWarning(
-                            'Using comma-separated values with --covers is deprecated and will no longer work in PHPUnit 12',
+                            'Using comma-separated values with --covers is deprecated and will no longer work in PHPUnit 12. You can use --covers multiple times instead',
                         );
                     }
 
@@ -485,7 +485,7 @@ final class Builder
                 case '--uses':
                     if (str_contains($option[1], ',')) {
                         EventFacade::emitter()->testRunnerTriggeredWarning(
-                            'Using comma-separated values with --uses is deprecated and will no longer work in PHPUnit 12',
+                            'Using comma-separated values with --uses is deprecated and will no longer work in PHPUnit 12. You can use --uses multiple times instead',
                         );
                     }
 
@@ -502,7 +502,7 @@ final class Builder
                 case '--test-suffix':
                     if (str_contains($option[1], ',')) {
                         EventFacade::emitter()->testRunnerTriggeredWarning(
-                            'Using comma-separated values with --test-suffix is deprecated and will no longer work in PHPUnit 12',
+                            'Using comma-separated values with --test-suffix is deprecated and will no longer work in PHPUnit 12. You can use --test-suffix multiple times instead',
                         );
                     }
 

--- a/tests/end-to-end/cli/group/exclude-group-argument-csv.phpt
+++ b/tests/end-to-end/cli/group/exclude-group-argument-csv.phpt
@@ -22,7 +22,7 @@ print file_get_contents($traceFile);
 unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
-Test Runner Triggered Warning (Using comma-separated values with --exclude-group is deprecated and will no longer work in PHPUnit 12)
+Test Runner Triggered Warning (Using comma-separated values with --exclude-group is deprecated and will no longer work in PHPUnit 12. You can use --exclude-group multiple times instead)
 Test Runner Configured
 Test Suite Loaded (3 tests)
 Event Facade Sealed

--- a/tests/end-to-end/cli/group/exclude-group-configuration-csv.phpt
+++ b/tests/end-to-end/cli/group/exclude-group-configuration-csv.phpt
@@ -22,7 +22,7 @@ print file_get_contents($traceFile);
 unlink($traceFile);
 --EXPECTF--
 PHPUnit Started (PHPUnit %s using %s)
-Test Runner Triggered Warning (Using comma-separated values with --exclude-group is deprecated and will no longer work in PHPUnit 12)
+Test Runner Triggered Warning (Using comma-separated values with --exclude-group is deprecated and will no longer work in PHPUnit 12. You can use --exclude-group multiple times instead)
 Test Runner Configured
 Test Suite Loaded (3 tests)
 Event Facade Sealed

--- a/tests/end-to-end/cli/group/size-groups-csv.phpt
+++ b/tests/end-to-end/cli/group/size-groups-csv.phpt
@@ -18,7 +18,7 @@ Runtime: %s
 
 There were 7 PHPUnit test runner warnings:
 
-1) Using comma-separated values with --group is deprecated and will no longer work in PHPUnit 12
+1) Using comma-separated values with --group is deprecated and will no longer work in PHPUnit 12. You can use --group multiple times instead
 
 2) Group name "small" is not allowed for method PHPUnit\TestFixture\SizeGroups\SizeGroupsTest::testOne
 

--- a/tests/end-to-end/generic/test-suffix-multiple-csv.phpt
+++ b/tests/end-to-end/generic/test-suffix-multiple-csv.phpt
@@ -21,7 +21,7 @@ Time: %s, Memory: %s
 
 There was 1 PHPUnit test runner warning:
 
-1) Using comma-separated values with --test-suffix is deprecated and will no longer work in PHPUnit 12
+1) Using comma-separated values with --test-suffix is deprecated and will no longer work in PHPUnit 12. You can use --test-suffix multiple times instead
 
 WARNINGS!
 Tests: 5, Assertions: 5, Warnings: 1.


### PR DESCRIPTION
Add hints to the deprecation messages of all CLI parameters that previously allowed comma-separated values and now need multiple instances of the parameter.

Closes #5879