### PR TITLE
Optionally repeat TestDox output for non-successful tests after the regular TestDox output

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -207,6 +207,7 @@
         <xs:attribute name="timeoutForLargeTests" type="xs:integer" default="60"/>
         <xs:attribute name="defaultTestSuite" type="xs:string" default=""/>
         <xs:attribute name="testdox" type="xs:boolean" default="false"/>
+        <xs:attribute name="testdoxSummary" type="xs:boolean" default="false"/>
         <xs:attribute name="stderr" type="xs:boolean" default="false"/>
         <xs:attribute name="reverseDefectList" type="xs:boolean" default="false"/>
         <xs:attribute name="extensionsDirectory" type="xs:anyURI"/>

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -120,6 +120,7 @@ final class Builder
         'strict-global-state',
         'teamcity',
         'testdox',
+        'testdox-summary',
         'testdox-html=',
         'testdox-text=',
         'test-suffix=',
@@ -252,6 +253,7 @@ final class Builder
         $logEventsVerboseText              = null;
         $printerTeamCity                   = null;
         $printerTestDox                    = null;
+        $printerTestDoxSummary             = null;
         $debug                             = false;
 
         foreach ($options[0] as $option) {
@@ -713,6 +715,11 @@ final class Builder
 
                     break;
 
+                case '--testdox-summary':
+                    $printerTestDoxSummary = true;
+
+                    break;
+
                 case '--testdox-html':
                     $testdoxHtmlFile = $option[1];
 
@@ -1032,6 +1039,7 @@ final class Builder
             $logEventsVerboseText,
             $printerTeamCity,
             $printerTestDox,
+            $printerTestDoxSummary,
             $debug,
         );
     }

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -103,6 +103,7 @@ final readonly class Configuration
     private ?string $testdoxHtmlFile;
     private ?string $testdoxTextFile;
     private ?bool $testdoxPrinter;
+    private ?bool $testdoxPrinterSummary;
 
     /**
      * @psalm-var ?non-empty-list<non-empty-string>
@@ -126,7 +127,7 @@ final readonly class Configuration
      * @psalm-param list<non-empty-string> $arguments
      * @psalm-param ?non-empty-list<non-empty-string> $testSuffixes
      */
-    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $printerTestDox, bool $debug)
+    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug)
     {
         $this->arguments                                    = $arguments;
         $this->atLeastVersion                               = $atLeastVersion;
@@ -224,7 +225,8 @@ final readonly class Configuration
         $this->logEventsText                                = $logEventsText;
         $this->logEventsVerboseText                         = $logEventsVerboseText;
         $this->teamCityPrinter                              = $printerTeamCity;
-        $this->testdoxPrinter                               = $printerTestDox;
+        $this->testdoxPrinter                               = $testdoxPrinter;
+        $this->testdoxPrinterSummary                        = $testdoxPrinterSummary;
         $this->debug                                        = $debug;
     }
 
@@ -1744,6 +1746,26 @@ final readonly class Configuration
         }
 
         return $this->testdoxPrinter;
+    }
+
+    /**
+     * @psalm-assert-if-true !null $this->testdoxPrinterSummary
+     */
+    public function hasTestDoxPrinterSummary(): bool
+    {
+        return $this->testdoxPrinterSummary !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testdoxPrinterSummary(): bool
+    {
+        if (!$this->hasTestdoxPrinterSummary()) {
+            throw new Exception;
+        }
+
+        return $this->testdoxPrinterSummary;
     }
 
     /**

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -119,6 +119,7 @@ final readonly class Configuration
     private ?array $testsUsing;
     private bool $teamCityOutput;
     private bool $testDoxOutput;
+    private bool $testDoxOutputSummary;
     private ?string $filter;
     private ?string $excludeFilter;
     private ?array $groups;
@@ -152,7 +153,7 @@ final readonly class Configuration
      * @psalm-param list<array{className: class-string, parameters: array<string, string>}> $extensionBootstrappers
      * @psalm-param non-negative-int $shortenArraysForExportThreshold
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
+    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, ?array $groups, ?array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
     {
         $this->cliArguments                                 = $cliArguments;
         $this->configurationFile                            = $configurationFile;
@@ -239,6 +240,7 @@ final readonly class Configuration
         $this->logEventsVerboseText                         = $logEventsVerboseText;
         $this->teamCityOutput                               = $teamCityOutput;
         $this->testDoxOutput                                = $testDoxOutput;
+        $this->testDoxOutputSummary                         = $testDoxOutputSummary;
         $this->testsCovering                                = $testsCovering;
         $this->testsUsing                                   = $testsUsing;
         $this->filter                                       = $filter;
@@ -995,6 +997,11 @@ final readonly class Configuration
     public function outputIsTestDox(): bool
     {
         return $this->testDoxOutput;
+    }
+
+    public function testDoxOutputWithSummary(): bool
+    {
+        return $this->testDoxOutputSummary;
     }
 
     /**

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -554,6 +554,12 @@ final readonly class Merger
             $testDoxOutput = $xmlConfiguration->phpunit()->testdoxPrinter();
         }
 
+        if ($cliConfiguration->hasTestDoxPrinterSummary() && $cliConfiguration->testdoxPrinterSummary()) {
+            $testDoxOutputSummary = true;
+        } else {
+            $testDoxOutputSummary = $xmlConfiguration->phpunit()->testdoxPrinterSummary();
+        }
+
         $noProgress = false;
 
         if ($cliConfiguration->hasNoProgress() && $cliConfiguration->noProgress()) {
@@ -814,6 +820,7 @@ final readonly class Merger
             $logEventsVerboseText,
             $teamCityOutput,
             $testDoxOutput,
+            $testDoxOutputSummary,
             $testsCovering,
             $testsUsing,
             $filter,

--- a/src/TextUI/Configuration/Xml/DefaultConfiguration.php
+++ b/src/TextUI/Configuration/Xml/DefaultConfiguration.php
@@ -146,6 +146,7 @@ final readonly class DefaultConfiguration extends Configuration
                 false,
                 false,
                 false,
+                false,
                 100,
                 0,
             ),

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -864,6 +864,7 @@ final readonly class Loader
             $this->getBooleanAttribute($document->documentElement, 'backupGlobals', false),
             $backupStaticProperties,
             $this->getBooleanAttribute($document->documentElement, 'testdox', false),
+            $this->getBooleanAttribute($document->documentElement, 'testdoxSummary', false),
             $this->getBooleanAttribute($document->documentElement, 'controlGarbageCollector', false),
             $this->getIntegerAttribute($document->documentElement, 'numberOfTestsBeforeGarbageCollection', 100),
             $shortenArraysForExportThreshold,

--- a/src/TextUI/Configuration/Xml/PHPUnit.php
+++ b/src/TextUI/Configuration/Xml/PHPUnit.php
@@ -68,6 +68,7 @@ final readonly class PHPUnit
     private bool $backupGlobals;
     private bool $backupStaticProperties;
     private bool $testdoxPrinter;
+    private bool $testdoxPrinterSummary;
     private bool $controlGarbageCollector;
     private int $numberOfTestsBeforeGarbageCollection;
 
@@ -80,7 +81,7 @@ final readonly class PHPUnit
      * @psalm-param ?non-empty-string $extensionsDirectory
      * @psalm-param non-negative-int $shortenArraysForExportThreshold
      */
-    public function __construct(?string $cacheDirectory, bool $cacheResult, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $testdoxPrinter, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, int $shortenArraysForExportThreshold)
+    public function __construct(?string $cacheDirectory, bool $cacheResult, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, bool $processIsolation, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $testdoxPrinter, bool $testdoxPrinterSummary, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, int $shortenArraysForExportThreshold)
     {
         $this->cacheDirectory                               = $cacheDirectory;
         $this->cacheResult                                  = $cacheResult;
@@ -130,6 +131,7 @@ final readonly class PHPUnit
         $this->backupGlobals                                = $backupGlobals;
         $this->backupStaticProperties                       = $backupStaticProperties;
         $this->testdoxPrinter                               = $testdoxPrinter;
+        $this->testdoxPrinterSummary                        = $testdoxPrinterSummary;
         $this->controlGarbageCollector                      = $controlGarbageCollector;
         $this->numberOfTestsBeforeGarbageCollection         = $numberOfTestsBeforeGarbageCollection;
         $this->shortenArraysForExportThreshold              = $shortenArraysForExportThreshold;
@@ -435,6 +437,11 @@ final readonly class PHPUnit
     public function testdoxPrinter(): bool
     {
         return $this->testdoxPrinter;
+    }
+
+    public function testdoxPrinterSummary(): bool
+    {
+        return $this->testdoxPrinterSummary;
     }
 
     public function controlGarbageCollector(): bool

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -248,6 +248,7 @@ final class Help
 
                 ['arg'    => '--teamcity', 'desc' => 'Replace default progress and result output with TeamCity format'],
                 ['arg'    => '--testdox', 'desc' => 'Replace default result output with TestDox format'],
+                ['arg'    => '--testdox-summary', 'desc' => 'Repeat TestDox output for tests with errors, failures, or issues'],
                 ['spacer' => ''],
 
                 ['arg' => '--debug', 'desc' => 'Replace default progress and result output with debugging information'],

--- a/src/TextUI/Output/Facade.php
+++ b/src/TextUI/Output/Facade.php
@@ -222,6 +222,7 @@ final class Facade
                 self::$printer,
                 $configuration->colors(),
                 $configuration->columns(),
+                $configuration->testDoxOutputWithSummary(),
             );
         }
 

--- a/tests/_files/configuration_testdox.xml
+++ b/tests/_files/configuration_testdox.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<phpunit testdox="true"></phpunit>
+<phpunit testdox="true" testdoxSummary="true"></phpunit>

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -125,6 +125,8 @@
                                      with TeamCity format
   [32m--testdox                         [0m Replace default result output with TestDox
                                      format
+  [32m--testdox-summary                 [0m Repeat TestDox output for tests with
+                                     errors, failures, or issues
 
   [32m--debug                           [0m Replace default progress and result output
                                      with debugging information

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -93,6 +93,7 @@ Reporting:
 
   --teamcity                         Replace default progress and result output with TeamCity format
   --testdox                          Replace default result output with TestDox format
+  --testdox-summary                  Repeat TestDox output for tests with errors, failures, or issues
 
   --debug                            Replace default progress and result output with debugging information
 

--- a/tests/end-to-end/testdox/_files/OutcomeAndIssuesTest.php
+++ b/tests/end-to-end/testdox/_files/OutcomeAndIssuesTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\TestDox;
+
+use const E_USER_DEPRECATED;
+use const E_USER_NOTICE;
+use const E_USER_WARNING;
+use function trigger_error;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+final class OutcomeAndIssuesTest extends TestCase
+{
+    public function testSuccess(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testSuccessButRisky(): void
+    {
+    }
+
+    public function testSuccessButDeprecation(): void
+    {
+        $this->assertTrue(true);
+
+        trigger_error('message', E_USER_DEPRECATED);
+    }
+
+    public function testSuccessButNotice(): void
+    {
+        $this->assertTrue(true);
+
+        trigger_error('message', E_USER_NOTICE);
+    }
+
+    public function testSuccessButWarning(): void
+    {
+        $this->assertTrue(true);
+
+        trigger_error('message', E_USER_WARNING);
+    }
+
+    public function testFailure(): void
+    {
+        $this->assertTrue(false);
+    }
+
+    public function testError(): void
+    {
+        throw new Exception('message');
+    }
+
+    public function testIncomplete(): void
+    {
+        $this->markTestIncomplete('message');
+    }
+
+    public function testSkipped(): void
+    {
+        $this->markTestSkipped('message');
+    }
+}

--- a/tests/end-to-end/testdox/outcome-and-issues-with-summary.phpt
+++ b/tests/end-to-end/testdox/outcome-and-issues-with-summary.phpt
@@ -1,0 +1,125 @@
+--TEST--
+Different outcomes and issues (with TestDox summary)
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--colors=never';
+$_SERVER['argv'][] = '--no-progress';
+$_SERVER['argv'][] = '--display-incomplete';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--display-notices';
+$_SERVER['argv'][] = '--display-warnings';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--testdox-summary';
+$_SERVER['argv'][] = __DIR__ . '/_files/OutcomeAndIssuesTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+Time: %s, Memory: %s
+
+Outcome And Issues (PHPUnit\TestFixture\TestDox\OutcomeAndIssues)
+ ✔ Success
+ ⚠ Success but risky
+ ⚠ Success but deprecation
+ ⚠ Success but notice
+ ⚠ Success but warning
+ ✘ Failure
+   │
+   │ Failed asserting that false is true.
+   │
+   │ %sOutcomeAndIssuesTest.php:53
+   │
+ ✘ Error
+   │
+   │ Exception: message
+   │
+   │ %sOutcomeAndIssuesTest.php:58
+   │
+ ∅ Incomplete
+   │
+   │ message
+   │
+   │ %sOutcomeAndIssuesTest.php:63
+   │
+ ↩ Skipped
+
+Summary of tests with errors, failures, or issues:
+
+Outcome And Issues (PHPUnit\TestFixture\TestDox\OutcomeAndIssues)
+ ⚠ Success but risky
+ ⚠ Success but deprecation
+ ⚠ Success but notice
+ ⚠ Success but warning
+ ✘ Failure
+   │
+   │ Failed asserting that false is true.
+   │
+   │ %sOutcomeAndIssuesTest.php:53
+   │
+ ✘ Error
+   │
+   │ Exception: message
+   │
+   │ %sOutcomeAndIssuesTest.php:58
+   │
+ ∅ Incomplete
+   │
+   │ message
+   │
+   │ %sOutcomeAndIssuesTest.php:63
+   │
+ ↩ Skipped
+
+There was 1 risky test:
+
+1) PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButRisky
+This test did not perform any assertions
+
+%sOutcomeAndIssuesTest.php:26
+
+--
+
+1 test triggered 1 warning:
+
+1) %sOutcomeAndIssuesTest.php:48
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButWarning
+  %sOutcomeAndIssuesTest.php:44
+
+--
+
+1 test triggered 1 notice:
+
+1) %sOutcomeAndIssuesTest.php:41
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButNotice
+  %sOutcomeAndIssuesTest.php:37
+
+--
+
+1 test triggered 1 deprecation:
+
+1) %sOutcomeAndIssuesTest.php:34
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButDeprecation
+  %sOutcomeAndIssuesTest.php:30
+
+ERRORS!
+Tests: 9, Assertions: 5, Errors: 1, Failures: 1, Warnings: 1, Deprecations: 1, Notices: 1, Skipped: 1, Incomplete: 1, Risky: 1.

--- a/tests/end-to-end/testdox/outcome-and-issues-without-summary.phpt
+++ b/tests/end-to-end/testdox/outcome-and-issues-without-summary.phpt
@@ -1,0 +1,97 @@
+--TEST--
+Different outcomes and issues (without TestDox summary)
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--colors=never';
+$_SERVER['argv'][] = '--no-progress';
+$_SERVER['argv'][] = '--display-incomplete';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--display-notices';
+$_SERVER['argv'][] = '--display-warnings';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = __DIR__ . '/_files/OutcomeAndIssuesTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+Time: %s, Memory: %s
+
+Outcome And Issues (PHPUnit\TestFixture\TestDox\OutcomeAndIssues)
+ ✔ Success
+ ⚠ Success but risky
+ ⚠ Success but deprecation
+ ⚠ Success but notice
+ ⚠ Success but warning
+ ✘ Failure
+   │
+   │ Failed asserting that false is true.
+   │
+   │ %sOutcomeAndIssuesTest.php:53
+   │
+ ✘ Error
+   │
+   │ Exception: message
+   │
+   │ %sOutcomeAndIssuesTest.php:58
+   │
+ ∅ Incomplete
+   │
+   │ message
+   │
+   │ %sOutcomeAndIssuesTest.php:63
+   │
+ ↩ Skipped
+
+There was 1 risky test:
+
+1) PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButRisky
+This test did not perform any assertions
+
+%sOutcomeAndIssuesTest.php:26
+
+--
+
+1 test triggered 1 warning:
+
+1) %sOutcomeAndIssuesTest.php:48
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButWarning
+  %sOutcomeAndIssuesTest.php:44
+
+--
+
+1 test triggered 1 notice:
+
+1) %sOutcomeAndIssuesTest.php:41
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButNotice
+  %sOutcomeAndIssuesTest.php:37
+
+--
+
+1 test triggered 1 deprecation:
+
+1) %sOutcomeAndIssuesTest.php:34
+message
+
+Triggered by:
+
+* PHPUnit\TestFixture\TestDox\OutcomeAndIssuesTest::testSuccessButDeprecation
+  %sOutcomeAndIssuesTest.php:30
+
+ERRORS!
+Tests: 9, Assertions: 5, Errors: 1, Failures: 1, Warnings: 1, Deprecations: 1, Notices: 1, Skipped: 1, Incomplete: 1, Risky: 1.

--- a/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
@@ -362,9 +362,10 @@ final class LoaderTest extends TestCase
 
     public function test_TestDox_configuration_is_parsed_correctly(): void
     {
-        $this->assertTrue(
-            $this->configuration('configuration_testdox.xml')->phpunit()->testdoxPrinter(),
-        );
+        $configuration = $this->configuration('configuration_testdox.xml')->phpunit();
+
+        $this->assertTrue($configuration->testdoxPrinter());
+        $this->assertTrue($configuration->testdoxPrinterSummary());
     }
 
     public function testConfigurationForSingleTestSuiteCanBeLoaded(): void


### PR DESCRIPTION
- [X] Implement `testdoxSummary` attribute on the `<phpunit>` element of the XML configuration file
- [X] Implement `--testdox-summary` CLI option
- [X] Merge the above into `PHPUnit\TextUI\Configuration\Configuration::testDoxOutputWithSummary()`
- [X] Pass the aforementioned flag to `PHPUnit\TextUI\Output\TestDox\ResultPrinter` and act on it
- [x] Implement automated end-to-end tests for this new functionality

#### Example: `--testdox --testdox-summary`
```
❯ ./phpunit --testdox --testdox-summary ~/ExampleTest.php
PHPUnit 11.3-g4cde41c5f8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.8
Configuration: /usr/local/src/phpunit/phpunit.xml

.FR                                                                 3 / 3 (100%)

Time: 00:00.018, Memory: 10.00 MB

Example
 ✔ Succeeds
 ✘ Fails
   ┐
   ├ Failed asserting that false is true.
   │
   │ /usr/local/src/phpunit/src/Framework/Constraint/Constraint.php:98
   │ /usr/local/src/phpunit/src/Framework/Constraint/Constraint.php:51
   │ /usr/local/src/phpunit/src/Framework/Assert.php:1973
   │ /usr/local/src/phpunit/src/Framework/Assert.php:940
   │ /home/sb/ExampleTest.php:13
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:1201
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:498
   │ /usr/local/src/phpunit/src/Framework/TestRunner/TestRunner.php:84
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:349
   │ /usr/local/src/phpunit/src/Framework/TestSuite.php:387
   │ /usr/local/src/phpunit/src/TextUI/TestRunner.php:62
   │ /usr/local/src/phpunit/src/TextUI/Application.php:201
   ┴
 ⚠ Risky

Summary of tests with errors, failures, or issues:

Example
 ✘ Fails
   ┐
   ├ Failed asserting that false is true.
   │
   │ /usr/local/src/phpunit/src/Framework/Constraint/Constraint.php:98
   │ /usr/local/src/phpunit/src/Framework/Constraint/Constraint.php:51
   │ /usr/local/src/phpunit/src/Framework/Assert.php:1973
   │ /usr/local/src/phpunit/src/Framework/Assert.php:940
   │ /home/sb/ExampleTest.php:13
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:1201
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:498
   │ /usr/local/src/phpunit/src/Framework/TestRunner/TestRunner.php:84
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:349
   │ /usr/local/src/phpunit/src/Framework/TestSuite.php:387
   │ /usr/local/src/phpunit/src/TextUI/TestRunner.php:62
   │ /usr/local/src/phpunit/src/TextUI/Application.php:201
   ┴
 ⚠ Risky

There was 1 risky test:

1) ExampleTest::testRisky
This test did not perform any assertions

/home/sb/ExampleTest.php:16

FAILURES!
Tests: 3, Assertions: 2, Failures: 1, Risky: 1.
```
#### Example: `--testdox`
```
❯ ./phpunit --testdox ~/ExampleTest.php
PHPUnit 11.3-g4cde41c5f8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.8
Configuration: /usr/local/src/phpunit/phpunit.xml

.FR                                                                 3 / 3 (100%)

Time: 00:00.010, Memory: 10.00 MB

Example
 ✔ Succeeds
 ✘ Fails
   ┐
   ├ Failed asserting that false is true.
   │
   │ /usr/local/src/phpunit/src/Framework/Constraint/Constraint.php:98
   │ /usr/local/src/phpunit/src/Framework/Constraint/Constraint.php:51
   │ /usr/local/src/phpunit/src/Framework/Assert.php:1973
   │ /usr/local/src/phpunit/src/Framework/Assert.php:940
   │ /home/sb/ExampleTest.php:13
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:1201
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:498
   │ /usr/local/src/phpunit/src/Framework/TestRunner/TestRunner.php:84
   │ /usr/local/src/phpunit/src/Framework/TestCase.php:349
   │ /usr/local/src/phpunit/src/Framework/TestSuite.php:387
   │ /usr/local/src/phpunit/src/TextUI/TestRunner.php:62
   │ /usr/local/src/phpunit/src/TextUI/Application.php:201
   ┴
 ⚠ Risky

There was 1 risky test:

1) ExampleTest::testRisky
This test did not perform any assertions

/home/sb/ExampleTest.php:16

FAILURES!
Tests: 3, Assertions: 2, Failures: 1, Risky: 1.
```
