### PR TITLE
Ignore suppression when generating baseline

### DIFF
--- a/src/Runner/Baseline/Generator.php
+++ b/src/Runner/Baseline/Generator.php
@@ -60,11 +60,11 @@ final class Generator
      */
     public function testTriggeredIssue(DeprecationTriggered|NoticeTriggered|PhpDeprecationTriggered|PhpNoticeTriggered|PhpWarningTriggered|WarningTriggered $event): void
     {
-        if (!$this->source->ignoreSuppressionOfPhpWarnings() && $event->wasSuppressed()) {
+        if ($event->wasSuppressed() && !$this->isSuppressionIgnored($event)) {
             return;
         }
 
-        if ($this->source->restrictWarnings() && !(new SourceFilter)->includes($this->source, $event->file())) {
+        if ($this->restrict($event) && !(new SourceFilter)->includes($this->source, $event->file())) {
             return;
         }
 
@@ -76,5 +76,43 @@ final class Generator
                 $event->message(),
             ),
         );
+    }
+
+    private function restrict(DeprecationTriggered|NoticeTriggered|PhpDeprecationTriggered|PhpNoticeTriggered|PhpWarningTriggered|WarningTriggered $event): bool
+    {
+        if ($event instanceof WarningTriggered || $event instanceof PhpWarningTriggered) {
+            return $this->source->restrictWarnings();
+        }
+
+        if ($event instanceof NoticeTriggered || $event instanceof PhpNoticeTriggered) {
+            return $this->source->restrictNotices();
+        }
+
+        return $this->source->restrictDeprecations();
+    }
+
+    private function isSuppressionIgnored(DeprecationTriggered|NoticeTriggered|PhpDeprecationTriggered|PhpNoticeTriggered|PhpWarningTriggered|WarningTriggered $event): bool
+    {
+        if ($event instanceof WarningTriggered) {
+            return $this->source->ignoreSuppressionOfWarnings();
+        }
+
+        if ($event instanceof PhpWarningTriggered) {
+            return $this->source->ignoreSuppressionOfPhpWarnings();
+        }
+
+        if ($event instanceof PhpNoticeTriggered) {
+            return $this->source->ignoreSuppressionOfPhpNotices();
+        }
+
+        if ($event instanceof NoticeTriggered) {
+            return $this->source->ignoreSuppressionOfNotices();
+        }
+
+        if ($event instanceof PhpDeprecationTriggered) {
+            return $this->source->ignoreSuppressionOfPhpDeprecations();
+        }
+
+        return $this->source->ignoreSuppressionOfDeprecations();
     }
 }

--- a/tests/end-to-end/_files/baseline/generate-baseline-suppressed/.gitignore
+++ b/tests/end-to-end/_files/baseline/generate-baseline-suppressed/.gitignore
@@ -1,0 +1,1 @@
+baseline.xml

--- a/tests/end-to-end/_files/baseline/generate-baseline-suppressed/phpunit.xml
+++ b/tests/end-to-end/_files/baseline/generate-baseline-suppressed/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source baseline="baseline.xml" ignoreSuppressionOfDeprecations="true">
+    </source>
+</phpunit>

--- a/tests/end-to-end/_files/baseline/generate-baseline-suppressed/tests/Test.php
+++ b/tests/end-to-end/_files/baseline/generate-baseline-suppressed/tests/Test.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Baseline;
+
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class Test extends TestCase
+{
+    public function testUserErrors(): void
+    {
+        @trigger_error('deprecation', E_USER_DEPRECATED);
+        trigger_error('warn', E_USER_WARNING);
+        trigger_error('notice', E_USER_NOTICE);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/baseline/generate-baseline-suppressed.phpt
+++ b/tests/end-to-end/baseline/generate-baseline-suppressed.phpt
@@ -1,0 +1,60 @@
+--TEST--
+phpunit --configuration ../_files/baseline/generate-baseline-suppressed/phpunit.xml --generate-baseline
+--FILE--
+<?php declare(strict_types=1);
+$baseline = __DIR__ . '/../_files/baseline/generate-baseline-suppressed/baseline.xml';
+@touch($baseline);
+$baseline = realpath($baseline);
+@unlink($baseline);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--generate-baseline';
+$_SERVER['argv'][] = $baseline;
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/baseline/generate-baseline-suppressed/phpunit.xml';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($baseline);
+
+@unlink($baseline);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+W                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 1 deprecation:
+
+1) %sTest.php:%d
+deprecation
+
+Triggered by:
+
+* PHPUnit\TestFixture\Baseline\Test::testUserErrors
+  %sTest.php:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Warnings: 1, Deprecations: 1, Notices: 1.
+
+Baseline written to %sbaseline.xml.
+<?xml version="1.0"?>
+<files version="1">
+ <file path="tests/Test.php">
+  <line number="19" hash="d830ec28e59b9f13d697e91ea3944db52a4aa5c8">
+   <issue><![CDATA[deprecation]]></issue>
+  </line>
+  <line number="20" hash="13b1892be6e70462a631716e4a730a64ba4d0c1b">
+   <issue><![CDATA[warn]]></issue>
+  </line>
+  <line number="21" hash="fff8be75c2fbcbc4d395247e58fbbe6541189cf0">
+   <issue><![CDATA[notice]]></issue>
+  </line>
+ </file>
+</files>


### PR DESCRIPTION
If an event is suppressed, while generating the baseline, we only checked for `ignoreSuppressionOfPhpWarnings` although we should check every option.  