### PR TITLE
Configure global exception/error handlers checks

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -138,6 +138,9 @@ final readonly class TestBuilder
         }
 
         $test->setBackupStaticPropertiesExcludeList($backupSettings['backupStaticPropertiesExcludeList']);
+
+        $test->setShouldBackupGlobalErrorHandlers(ConfigurationRegistry::get()->backupGlobalErrorHandlers());
+        $test->setShouldBackupGlobalExceptionHandlers(ConfigurationRegistry::get()->backupGlobalExceptionHandlers());
     }
 
     /**

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -135,20 +135,22 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @var list<callable>
      */
-    private ?array $backupGlobalErrorHandlers = null;
+    private ?array $backupGlobalErrorHandlers      = null;
+    private ?bool $shouldBackupGlobalErrorHandlers = null;
 
     /**
      * @var list<callable>
      */
-    private ?array $backupGlobalExceptionHandlers   = null;
-    private ?bool $runClassInSeparateProcess        = null;
-    private ?bool $runTestInSeparateProcess         = null;
-    private bool $preserveGlobalState               = false;
-    private bool $inIsolation                       = false;
-    private ?string $expectedException              = null;
-    private ?string $expectedExceptionMessage       = null;
-    private ?string $expectedExceptionMessageRegExp = null;
-    private null|int|string $expectedExceptionCode  = null;
+    private ?array $backupGlobalExceptionHandlers      = null;
+    private ?bool $shouldBackupGlobalExceptionHandlers = null;
+    private ?bool $runClassInSeparateProcess           = null;
+    private ?bool $runTestInSeparateProcess            = null;
+    private bool $preserveGlobalState                  = false;
+    private bool $inIsolation                          = false;
+    private ?string $expectedException                 = null;
+    private ?string $expectedExceptionMessage          = null;
+    private ?string $expectedExceptionMessageRegExp    = null;
+    private null|int|string $expectedExceptionCode     = null;
 
     /**
      * @var list<ExecutionOrderDependency>
@@ -945,6 +947,22 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     final public function wasPrepared(): bool
     {
         return $this->wasPrepared;
+    }
+
+    /**
+     * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     */
+    final public function setShouldBackupGlobalErrorHandlers(bool $shouldBackupGlobalErrorHandlers): void
+    {
+        $this->shouldBackupGlobalErrorHandlers = $shouldBackupGlobalErrorHandlers;
+    }
+
+    /**
+     * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     */
+    final public function setShouldBackupGlobalExceptionHandlers(bool $shouldBackupGlobalExceptionHandlers): void
+    {
+        $this->shouldBackupGlobalExceptionHandlers = $shouldBackupGlobalExceptionHandlers;
     }
 
     /**
@@ -1897,8 +1915,13 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
     private function snapshotGlobalErrorExceptionHandlers(): void
     {
-        $this->backupGlobalErrorHandlers     = $this->getActiveErrorHandlers();
-        $this->backupGlobalExceptionHandlers = $this->getActiveExceptionHandlers();
+        if ($this->shouldBackupGlobalErrorHandlers) {
+            $this->backupGlobalErrorHandlers = $this->getActiveErrorHandlers();
+        }
+
+        if ($this->shouldBackupGlobalExceptionHandlers) {
+            $this->backupGlobalExceptionHandlers = $this->getActiveExceptionHandlers();
+        }
     }
 
     private function restoreGlobalErrorExceptionHandlers(): void

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -156,6 +156,8 @@ final readonly class Configuration
     private int $numberOfTestsBeforeGarbageCollection;
     private ?string $generateBaseline;
     private bool $debug;
+    private bool $backupGlobalErrorHandlers;
+    private bool $backupGlobalExceptionHandlers;
 
     /**
      * @var non-negative-int
@@ -173,7 +175,7 @@ final readonly class Configuration
      * @param non-empty-list<non-empty-string>                                        $testSuffixes
      * @param non-negative-int                                                        $shortenArraysForExportThreshold
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
+    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold, bool $backupGlobalErrorHandlers, bool $backupGlobalExceptionHandlers)
     {
         $this->cliArguments                                 = $cliArguments;
         $this->configurationFile                            = $configurationFile;
@@ -280,6 +282,8 @@ final readonly class Configuration
         $this->generateBaseline                             = $generateBaseline;
         $this->debug                                        = $debug;
         $this->shortenArraysForExportThreshold              = $shortenArraysForExportThreshold;
+        $this->backupGlobalErrorHandlers                    = $backupGlobalErrorHandlers;
+        $this->backupGlobalExceptionHandlers                = $backupGlobalExceptionHandlers;
     }
 
     /**
@@ -1251,5 +1255,15 @@ final readonly class Configuration
     public function shortenArraysForExportThreshold(): int
     {
         return $this->shortenArraysForExportThreshold;
+    }
+
+    public function backupGlobalExceptionHandlers(): bool
+    {
+        return $this->backupGlobalExceptionHandlers;
+    }
+
+    public function backupGlobalErrorHandlers(): bool
+    {
+        return $this->backupGlobalErrorHandlers;
     }
 }


### PR DESCRIPTION
This makes https://github.com/sebastianbergmann/phpunit/pull/5619 configurable and potentially mitigates https://github.com/symfony/symfony/issues/53812#issuecomment-2204410941. 
On one hand I agree that not releasing error_handlers is probably a mistake, on the other it's cpu intensive to add/remove handlers and is something that you should be able to disable.

Let me know your thought, I'm not sure how this is tested on the phpunit code base and I didn't wanted to do too much in case this is a bad idea, thanks!