### PR TITLE
Priority for hook methods

### DIFF
--- a/src/Framework/Attributes/After.php
+++ b/src/Framework/Attributes/After.php
@@ -19,4 +19,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class After
 {
+    private int $priority;
+
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
+    }
 }

--- a/src/Framework/Attributes/AfterClass.php
+++ b/src/Framework/Attributes/AfterClass.php
@@ -19,4 +19,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class AfterClass
 {
+    private int $priority;
+
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
+    }
 }

--- a/src/Framework/Attributes/Before.php
+++ b/src/Framework/Attributes/Before.php
@@ -19,4 +19,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class Before
 {
+    private int $priority;
+
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
+    }
 }

--- a/src/Framework/Attributes/BeforeClass.php
+++ b/src/Framework/Attributes/BeforeClass.php
@@ -19,4 +19,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class BeforeClass
 {
+    private int $priority;
+
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
+    }
 }

--- a/src/Framework/Attributes/PostCondition.php
+++ b/src/Framework/Attributes/PostCondition.php
@@ -19,4 +19,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class PostCondition
 {
+    private int $priority;
+
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
+    }
 }

--- a/src/Framework/Attributes/PreCondition.php
+++ b/src/Framework/Attributes/PreCondition.php
@@ -19,4 +19,15 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class PreCondition
 {
+    private int $priority;
+
+    public function __construct(int $priority = 0)
+    {
+        $this->priority = $priority;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
+    }
 }

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -89,6 +89,7 @@ use PHPUnit\Framework\TestSize\TestSize;
 use PHPUnit\Framework\TestStatus\TestStatus;
 use PHPUnit\Metadata\Api\Groups;
 use PHPUnit\Metadata\Api\HookMethods;
+use PHPUnit\Metadata\Api\HookMethodsCollection;
 use PHPUnit\Metadata\Api\Requirements;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Runner\DeprecationCollector\Facade as DeprecationCollector;
@@ -2294,7 +2295,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
+     * @param array{beforeClass: HookMethodsCollection, before: HookMethodsCollection, preCondition: HookMethodsCollection, postCondition: HookMethodsCollection, after: HookMethodsCollection, afterClass: HookMethodsCollection} $hookMethods
      *
      * @throws Throwable
      *
@@ -2311,7 +2312,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
+     * @param array{beforeClass: HookMethodsCollection, before: HookMethodsCollection, preCondition: HookMethodsCollection, postCondition: HookMethodsCollection, after: HookMethodsCollection, afterClass: HookMethodsCollection} $hookMethods
      *
      * @throws Throwable
      */
@@ -2326,7 +2327,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
+     * @param array{beforeClass: HookMethodsCollection, before: HookMethodsCollection, preCondition: HookMethodsCollection, postCondition: HookMethodsCollection, after: HookMethodsCollection, afterClass: HookMethodsCollection} $hookMethods
      *
      * @throws Throwable
      */
@@ -2341,7 +2342,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
+     * @param array{beforeClass: HookMethodsCollection, before: HookMethodsCollection, preCondition: HookMethodsCollection, postCondition: HookMethodsCollection, after: HookMethodsCollection, afterClass: HookMethodsCollection} $hookMethods
      *
      * @throws Throwable
      */
@@ -2356,7 +2357,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
+     * @param array{beforeClass: HookMethodsCollection, before: HookMethodsCollection, preCondition: HookMethodsCollection, postCondition: HookMethodsCollection, after: HookMethodsCollection, afterClass: HookMethodsCollection} $hookMethods
      *
      * @throws Throwable
      */
@@ -2371,7 +2372,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
+     * @param array{beforeClass: HookMethodsCollection, before: HookMethodsCollection, preCondition: HookMethodsCollection, postCondition: HookMethodsCollection, after: HookMethodsCollection, afterClass: HookMethodsCollection} $hookMethods
      *
      * @throws Throwable
      *
@@ -2388,18 +2389,16 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     }
 
     /**
-     * @param array{beforeClass: list<non-empty-string>, before: list<non-empty-string>, preCondition: list<non-empty-string>, postCondition: list<non-empty-string>, after: list<non-empty-string>, afterClass: list<non-empty-string>} $hookMethods
-     * @param 'testAfterLastTestMethodCalled'|'testAfterTestMethodCalled'|'testBeforeFirstTestMethodCalled'|'testBeforeTestMethodCalled'|'testPostConditionCalled'|'testPreConditionCalled'                                              $calledMethod
-     * @param 'testAfterLastTestMethodFinished'|'testAfterTestMethodFinished'|'testBeforeFirstTestMethodFinished'|'testBeforeTestMethodFinished'|'testPostConditionFinished'|'testPreConditionFinished'                                  $finishedMethod
-     * @param list<non-empty-string>                                                                                                                                                                                                     $hookMethods
+     * @param 'testAfterLastTestMethodCalled'|'testAfterTestMethodCalled'|'testBeforeFirstTestMethodCalled'|'testBeforeTestMethodCalled'|'testPostConditionCalled'|'testPreConditionCalled'             $calledMethod
+     * @param 'testAfterLastTestMethodFinished'|'testAfterTestMethodFinished'|'testBeforeFirstTestMethodFinished'|'testBeforeTestMethodFinished'|'testPostConditionFinished'|'testPreConditionFinished' $finishedMethod
      *
      * @throws Throwable
      */
-    private function invokeHookMethods(array $hookMethods, Event\Emitter $emitter, string $calledMethod, string $finishedMethod): void
+    private function invokeHookMethods(HookMethodsCollection $hookMethodsCollection, Event\Emitter $emitter, string $calledMethod, string $finishedMethod): void
     {
         $methodsInvoked = [];
 
-        foreach ($hookMethods as $methodName) {
+        foreach ($hookMethodsCollection as $methodName) {
             if ($this->methodDoesNotExistOrIsDeclaredInTestCase($methodName)) {
                 continue;
             }

--- a/src/Metadata/After.php
+++ b/src/Metadata/After.php
@@ -16,8 +16,25 @@ namespace PHPUnit\Metadata;
  */
 final readonly class After extends Metadata
 {
+    private int $priority;
+
+    /**
+     * @param 0|1 $level
+     */
+    protected function __construct(int $level, int $priority)
+    {
+        parent::__construct($level);
+
+        $this->priority = $priority;
+    }
+
     public function isAfter(): bool
     {
         return true;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
     }
 }

--- a/src/Metadata/AfterClass.php
+++ b/src/Metadata/AfterClass.php
@@ -16,8 +16,25 @@ namespace PHPUnit\Metadata;
  */
 final readonly class AfterClass extends Metadata
 {
+    private int $priority;
+
+    /**
+     * @param 0|1 $level
+     */
+    protected function __construct(int $level, int $priority)
+    {
+        parent::__construct($level);
+
+        $this->priority = $priority;
+    }
+
     public function isAfterClass(): bool
     {
         return true;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
     }
 }

--- a/src/Metadata/Api/HookMethod.php
+++ b/src/Metadata/Api/HookMethod.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata\Api;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class HookMethod
+{
+    public function __construct(
+        public string $methodName,
+        public int $priority = 0,
+    ) {
+    }
+}

--- a/src/Metadata/Api/HookMethodsCollection.php
+++ b/src/Metadata/Api/HookMethodsCollection.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata\Api;
+
+use function array_map;
+use function usort;
+use ArrayObject;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ *
+ * @implements IteratorAggregate<int, string>
+ */
+final class HookMethodsCollection implements IteratorAggregate
+{
+    /**
+     * @var non-empty-list<HookMethod>
+     */
+    private array $hookMethods;
+
+    public static function defaultBeforeClass(): static
+    {
+        return new self(new HookMethod('setUpBeforeClass', priority: 0), shouldPrepend: true);
+    }
+
+    public static function defaultBefore(): static
+    {
+        return new self(new HookMethod('setUp', priority: 0), shouldPrepend: true);
+    }
+
+    public static function defaultPreCondition(): static
+    {
+        return new self(new HookMethod('assertPreConditions', priority: 0), shouldPrepend: true);
+    }
+
+    public static function defaultPostCondition(): static
+    {
+        return new self(new HookMethod('assertPostConditions', priority: 0));
+    }
+
+    public static function defaultAfter(): static
+    {
+        return new self(new HookMethod('tearDown', priority: 0));
+    }
+
+    public static function defaultAfterClass(): static
+    {
+        return new self(new HookMethod('tearDownAfterClass', priority: 0));
+    }
+
+    private function __construct(HookMethod $default, private bool $shouldPrepend = false)
+    {
+        $this->hookMethods = [$default];
+    }
+
+    public function add(HookMethod $hookMethod): static
+    {
+        if ($this->shouldPrepend) {
+            $this->hookMethods = [$hookMethod, ...$this->hookMethods];
+        } else {
+            $this->hookMethods[] = $hookMethod;
+        }
+
+        return $this;
+    }
+
+    public function getIterator(): Traversable
+    {
+        $hookMethods = $this->hookMethods;
+
+        usort($hookMethods, static fn (HookMethod $hookMethod1, HookMethod $hookMethod2) => $hookMethod2->priority <=> $hookMethod1->priority);
+
+        return new ArrayObject(
+            array_map(static fn (HookMethod $hookMethod) => $hookMethod->methodName, $hookMethods),
+        );
+    }
+}

--- a/src/Metadata/Before.php
+++ b/src/Metadata/Before.php
@@ -16,8 +16,25 @@ namespace PHPUnit\Metadata;
  */
 final readonly class Before extends Metadata
 {
+    private int $priority;
+
+    /**
+     * @param 0|1 $level
+     */
+    protected function __construct(int $level, int $priority)
+    {
+        parent::__construct($level);
+
+        $this->priority = $priority;
+    }
+
     public function isBefore(): bool
     {
         return true;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
     }
 }

--- a/src/Metadata/BeforeClass.php
+++ b/src/Metadata/BeforeClass.php
@@ -16,8 +16,25 @@ namespace PHPUnit\Metadata;
  */
 final readonly class BeforeClass extends Metadata
 {
+    private int $priority;
+
+    /**
+     * @param 0|1 $level
+     */
+    protected function __construct(int $level, int $priority)
+    {
+        parent::__construct($level);
+
+        $this->priority = $priority;
+    }
+
     public function isBeforeClass(): bool
     {
         return true;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -26,14 +26,14 @@ abstract readonly class Metadata
      */
     private int $level;
 
-    public static function after(): After
+    public static function after(int $priority = 0): After
     {
-        return new After(self::METHOD_LEVEL);
+        return new After(self::METHOD_LEVEL, $priority);
     }
 
-    public static function afterClass(): AfterClass
+    public static function afterClass(int $priority = 0): AfterClass
     {
-        return new AfterClass(self::METHOD_LEVEL);
+        return new AfterClass(self::METHOD_LEVEL, $priority);
     }
 
     public static function backupGlobalsOnClass(bool $enabled): BackupGlobals
@@ -56,14 +56,14 @@ abstract readonly class Metadata
         return new BackupStaticProperties(self::METHOD_LEVEL, $enabled);
     }
 
-    public static function before(): Before
+    public static function before(int $priority = 0): Before
     {
-        return new Before(self::METHOD_LEVEL);
+        return new Before(self::METHOD_LEVEL, $priority);
     }
 
-    public static function beforeClass(): BeforeClass
+    public static function beforeClass(int $priority = 0): BeforeClass
     {
-        return new BeforeClass(self::METHOD_LEVEL);
+        return new BeforeClass(self::METHOD_LEVEL, $priority);
     }
 
     /**
@@ -250,14 +250,14 @@ abstract readonly class Metadata
         return new IgnorePhpunitDeprecations(self::METHOD_LEVEL);
     }
 
-    public static function postCondition(): PostCondition
+    public static function postCondition(int $priority = 0): PostCondition
     {
-        return new PostCondition(self::METHOD_LEVEL);
+        return new PostCondition(self::METHOD_LEVEL, $priority);
     }
 
-    public static function preCondition(): PreCondition
+    public static function preCondition(int $priority = 0): PreCondition
     {
-        return new PreCondition(self::METHOD_LEVEL);
+        return new PreCondition(self::METHOD_LEVEL, $priority);
     }
 
     public static function preserveGlobalStateOnClass(bool $enabled): PreserveGlobalState

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -378,12 +378,16 @@ final readonly class AttributeParser implements Parser
 
             switch ($attribute->getName()) {
                 case After::class:
-                    $result[] = Metadata::after();
+                    assert($attributeInstance instanceof After);
+
+                    $result[] = Metadata::after($attributeInstance->priority());
 
                     break;
 
                 case AfterClass::class:
-                    $result[] = Metadata::afterClass();
+                    assert($attributeInstance instanceof AfterClass);
+
+                    $result[] = Metadata::afterClass($attributeInstance->priority());
 
                     break;
 
@@ -402,12 +406,16 @@ final readonly class AttributeParser implements Parser
                     break;
 
                 case Before::class:
-                    $result[] = Metadata::before();
+                    assert($attributeInstance instanceof Before);
+
+                    $result[] = Metadata::before($attributeInstance->priority());
 
                     break;
 
                 case BeforeClass::class:
-                    $result[] = Metadata::beforeClass();
+                    assert($attributeInstance instanceof BeforeClass);
+
+                    $result[] = Metadata::beforeClass($attributeInstance->priority());
 
                     break;
 
@@ -541,12 +549,16 @@ final readonly class AttributeParser implements Parser
                     break;
 
                 case PostCondition::class:
-                    $result[] = Metadata::postCondition();
+                    assert($attributeInstance instanceof PostCondition);
+
+                    $result[] = Metadata::postCondition($attributeInstance->priority());
 
                     break;
 
                 case PreCondition::class:
-                    $result[] = Metadata::preCondition();
+                    assert($attributeInstance instanceof PreCondition);
+
+                    $result[] = Metadata::preCondition($attributeInstance->priority());
 
                     break;
 

--- a/src/Metadata/PostCondition.php
+++ b/src/Metadata/PostCondition.php
@@ -16,8 +16,25 @@ namespace PHPUnit\Metadata;
  */
 final readonly class PostCondition extends Metadata
 {
+    private int $priority;
+
+    /**
+     * @param 0|1 $level
+     */
+    protected function __construct(int $level, int $priority)
+    {
+        parent::__construct($level);
+
+        $this->priority = $priority;
+    }
+
     public function isPostCondition(): bool
     {
         return true;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
     }
 }

--- a/src/Metadata/PreCondition.php
+++ b/src/Metadata/PreCondition.php
@@ -16,8 +16,25 @@ namespace PHPUnit\Metadata;
  */
 final readonly class PreCondition extends Metadata
 {
+    private int $priority;
+
+    /**
+     * @param 0|1 $level
+     */
+    protected function __construct(int $level, int $priority)
+    {
+        parent::__construct($level);
+
+        $this->priority = $priority;
+    }
+
     public function isPreCondition(): bool
     {
         return true;
+    }
+
+    public function priority(): int
+    {
+        return $this->priority;
     }
 }

--- a/tests/_files/TestWithHookMethodsPrioritizedTest.php
+++ b/tests/_files/TestWithHookMethodsPrioritizedTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\Attributes\PostCondition;
+use PHPUnit\Framework\Attributes\PreCondition;
+use PHPUnit\Framework\TestCase;
+
+final class TestWithHookMethodsPrioritizedTest extends TestCase
+{
+    #[BeforeClass(priority: 1)]
+    public static function beforeFirstTest(): void
+    {
+    }
+
+    #[AfterClass(priority: 6)]
+    public static function afterLastTest(): void
+    {
+    }
+
+    #[Before(priority: 2)]
+    protected function beforeEachTest(): void
+    {
+    }
+
+    #[PreCondition(priority: 3)]
+    protected function preConditions(): void
+    {
+    }
+
+    #[PostCondition(priority: 4)]
+    protected function postConditions(): void
+    {
+    }
+
+    #[After(priority: 5)]
+    protected function afterEachTest(): void
+    {
+    }
+}

--- a/tests/end-to-end/_files/BeforeTestMethodWithPrioritizedAttributeTest.php
+++ b/tests/end-to-end/_files/BeforeTestMethodWithPrioritizedAttributeTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\DeprecatedAnnotationsTestFixture;
+
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\TestCase;
+
+final class BeforeTestMethodWithPrioritizedAttributeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+    }
+
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[Before(priority: 1)]
+    protected function beforeMethodWithHighPriority(): void
+    {
+    }
+
+    #[Before(priority: -1)]
+    protected function beforeMethodWithLowPriority(): void
+    {
+    }
+}

--- a/tests/end-to-end/_files/HookMethodsOrderTest.php
+++ b/tests/end-to-end/_files/HookMethodsOrderTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\DeprecatedAnnotationsTestFixture;
+
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\TestCase;
+
+final class HookMethodsOrderTest extends HookMethodsOrderTestCase
+{
+    protected function setUp(): void
+    {
+    }
+
+    protected function tearDown(): void
+    {
+    }
+
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[Before]
+    protected function beforeSecond(): void
+    {
+    }
+
+    #[Before]
+    protected function beforeFirst(): void
+    {
+    }
+
+    #[Before(priority: 1)]
+    protected function beforeWithPriority(): void
+    {
+    }
+
+    #[After]
+    protected function afterFirst(): void
+    {
+    }
+
+    #[After]
+    protected function afterSecond(): void
+    {
+    }
+
+    #[After(priority: 1)]
+    protected function afterWithPriority(): void
+    {
+    }
+}
+
+abstract class HookMethodsOrderTestCase extends TestCase
+{
+    #[Before]
+    protected function beforeInParent(): void
+    {
+    }
+
+    #[Before(priority: 1)]
+    protected function beforeWithPriorityInParent(): void
+    {
+    }
+
+    #[After]
+    protected function afterInParent(): void
+    {
+    }
+
+    #[After(priority: 1)]
+    protected function afterWithPriorityInParent(): void
+    {
+    }
+}

--- a/tests/end-to-end/metadata/before-test-method-configured-with-prioritized-attribute.phpt
+++ b/tests/end-to-end/metadata/before-test-method-configured-with-prioritized-attribute.phpt
@@ -1,0 +1,44 @@
+--TEST--
+The right events are emitted in the right order for a successful test that has a before-test method that is configured with attribute
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = __DIR__ . '/../_files/BeforeTestMethodWithPrioritizedAttributeTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Test Suite Loaded (1 test)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest, 1 test)
+Test Preparation Started (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::testOne)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::beforeMethodWithHighPriority)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::setUp)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::beforeMethodWithLowPriority)
+Before Test Method Finished:
+- PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::beforeMethodWithHighPriority
+- PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::setUp
+- PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::beforeMethodWithLowPriority
+Test Prepared (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::testOne)
+Test Passed (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::testOne)
+Test Finished (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest::testOne)
+Test Suite Finished (PHPUnit\DeprecatedAnnotationsTestFixture\BeforeTestMethodWithPrioritizedAttributeTest, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/metadata/hook-methods-order.phpt
+++ b/tests/end-to-end/metadata/hook-methods-order.phpt
@@ -1,0 +1,63 @@
+--TEST--
+The right events are emitted in the right order for a successful test that has a before-test method that is configured with annotation
+--FILE--
+<?php declare(strict_types=1);
+$traceFile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-events-text';
+$_SERVER['argv'][] = $traceFile;
+$_SERVER['argv'][] = __DIR__ . '/../_files/HookMethodsOrderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($traceFile);
+
+unlink($traceFile);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Test Suite Loaded (1 test)
+Event Facade Sealed
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest, 1 test)
+Test Preparation Started (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::testOne)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeWithPriorityInParent)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeWithPriority)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeInParent)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeFirst)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeSecond)
+Before Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::setUp)
+Before Test Method Finished:
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeWithPriorityInParent
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeWithPriority
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeInParent
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeFirst
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::beforeSecond
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::setUp
+Test Prepared (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::testOne)
+Test Passed (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::testOne)
+After Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterWithPriority)
+After Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterWithPriorityInParent)
+After Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::tearDown)
+After Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterFirst)
+After Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterSecond)
+After Test Method Called (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterInParent)
+After Test Method Finished:
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterWithPriority
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterWithPriorityInParent
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::tearDown
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterFirst
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterSecond
+- PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::afterInParent
+Test Finished (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest::testOne)
+Test Suite Finished (PHPUnit\DeprecatedAnnotationsTestFixture\HookMethodsOrderTest, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Metadata/Api/HookMethodsCollectionTest.php
+++ b/tests/unit/Metadata/Api/HookMethodsCollectionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace unit\Metadata\Api;
+
+use function iterator_to_array;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Metadata\Api\HookMethod;
+use PHPUnit\Metadata\Api\HookMethodsCollection;
+
+#[CoversClass(HookMethodsCollection::class)]
+#[Small]
+#[Group('metadata')]
+final class HookMethodsCollectionTest extends TestCase
+{
+    public static function provider(): iterable
+    {
+        return [
+            [
+                HookMethodsCollection::defaultBeforeClass()->add(new HookMethod('someMethod')),
+                ['someMethod', 'setUpBeforeClass'],
+            ],
+            [
+                HookMethodsCollection::defaultBefore()->add(new HookMethod('someMethod')),
+                ['someMethod', 'setUp'],
+            ],
+            [
+                HookMethodsCollection::defaultPreCondition()->add(new HookMethod('someMethod')),
+                ['someMethod', 'assertPreConditions'],
+            ],
+            [
+                HookMethodsCollection::defaultPostCondition()->add(new HookMethod('someMethod')),
+                ['assertPostConditions', 'someMethod'],
+            ],
+            [
+                HookMethodsCollection::defaultAfter()->add(new HookMethod('someMethod')),
+                ['tearDown', 'someMethod'],
+            ],
+            [
+                HookMethodsCollection::defaultAfterClass()->add(new HookMethod('someMethod')),
+                ['tearDownAfterClass', 'someMethod'],
+            ],
+            [
+                HookMethodsCollection::defaultBeforeClass()
+                    ->add(new HookMethod('methodWithHighPriority', priority: 1))
+                    ->add(new HookMethod('methodWithVeryLowPriority', priority: -10))
+                    ->add(new HookMethod('methodWithLowPriority', priority: -1))
+                    ->add(new HookMethod('methodWithVeryHighPriority', priority: 10))
+                    ->add(new HookMethod('methodWithoutPriority')),
+                [
+                    'methodWithVeryHighPriority',
+                    'methodWithHighPriority',
+                    'methodWithoutPriority',
+                    'setUpBeforeClass',
+                    'methodWithLowPriority',
+                    'methodWithVeryLowPriority',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provider')]
+    public function testIterator(HookMethodsCollection $hookMethodsCollection, array $expected): void
+    {
+        $this->assertSame($expected, iterator_to_array($hookMethodsCollection));
+    }
+}


### PR DESCRIPTION
fixes #5889

I've introduced two new classes:
- `PHPUnit\Metadata\Api\HookMethod`: which is a value object with method's name and its priority
- `PHPUnit\Metadata\Api\HookMethodsCollection` which holds a collection of `HookMethod`s, and will return methods as string with the right priority when iterating on it

`HookMethods::hookMethods()` will now return an array of `HookCollections`, and the handling of the priority will be delegated to this class.

BTW, I'm not really sure that `PHPUnit\Metadata\Api\` is the right namespace for those classes.