### PR TITLE
Test Anything Protocol (TAP)

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -291,6 +291,7 @@
     <xs:group name="loggingGroup">
         <xs:all>
             <xs:element name="junit" type="logToFileType" minOccurs="0" />
+            <xs:element name="tap" type="logToFileType" minOccurs="0" />
             <xs:element name="teamcity" type="logToFileType" minOccurs="0" />
             <xs:element name="testdoxHtml" type="logToFileType" minOccurs="0" />
             <xs:element name="testdoxText" type="logToFileType" minOccurs="0" />

--- a/src/Logging/TAP/Subscriber/Subscriber.php
+++ b/src/Logging/TAP/Subscriber/Subscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+abstract readonly class Subscriber
+{
+    private TapLogger $logger;
+
+    public function __construct(TapLogger $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    protected function logger(): TapLogger
+    {
+        return $this->logger;
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestErroredSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestErroredSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\Test\Errored;
+use PHPUnit\Event\Test\ErroredSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestErroredSubscriber extends Subscriber implements ErroredSubscriber
+{
+    public function notify(Errored $event): void
+    {
+        $this->logger()->testErrored($event);
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestFailedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestFailedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\Test\Failed;
+use PHPUnit\Event\Test\FailedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestFailedSubscriber extends Subscriber implements FailedSubscriber
+{
+    public function notify(Failed $event): void
+    {
+        $this->logger()->testFailed($event);
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestPassedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestPassedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\Test\Passed;
+use PHPUnit\Event\Test\PassedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPassedSubscriber extends Subscriber implements PassedSubscriber
+{
+    public function notify(Passed $event): void
+    {
+        $this->logger()->testPassed($event);
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestPreparationFailedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestPreparationFailedSubscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\InvalidArgumentException;
+use PHPUnit\Event\Test\PreparationFailed;
+use PHPUnit\Event\Test\PreparationFailedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPreparationFailedSubscriber extends Subscriber implements PreparationFailedSubscriber
+{
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function notify(PreparationFailed $event): void
+    {
+        $this->logger()->testPreparationFailed($event);
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestPreparationStartedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestPreparationStartedSubscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\InvalidArgumentException;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPreparationStartedSubscriber extends Subscriber implements PreparationStartedSubscriber
+{
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function notify(PreparationStarted $event): void
+    {
+        $this->logger()->testPreparationStarted($event);
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestPreparedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestPreparedSubscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\InvalidArgumentException;
+use PHPUnit\Event\Test\Prepared;
+use PHPUnit\Event\Test\PreparedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPreparedSubscriber extends Subscriber implements PreparedSubscriber
+{
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function notify(Prepared $event): void
+    {
+        $this->logger()->testPrepared($event);
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestRunnerExecutionFinishedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestRunnerExecutionFinishedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestRunnerExecutionFinishedSubscriber extends Subscriber implements ExecutionFinishedSubscriber
+{
+    public function notify(ExecutionFinished $event): void
+    {
+        $this->logger()->flush();
+    }
+}

--- a/src/Logging/TAP/Subscriber/TestRunnerExecutionFinishedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestRunnerExecutionFinishedSubscriber.php
@@ -19,6 +19,6 @@ final readonly class TestRunnerExecutionFinishedSubscriber extends Subscriber im
 {
     public function notify(ExecutionFinished $event): void
     {
-        $this->logger()->flush();
+        $this->logger()->executionFinished();
     }
 }

--- a/src/Logging/TAP/Subscriber/TestRunnerExecutionStartedSubscriber.php
+++ b/src/Logging/TAP/Subscriber/TestRunnerExecutionStartedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\TestRunner\ExecutionStarted;
+use PHPUnit\Event\TestRunner\ExecutionStartedSubscriber;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestRunnerExecutionStartedSubscriber extends Subscriber implements ExecutionStartedSubscriber
+{
+    public function notify(ExecutionStarted $event): void
+    {
+        $this->logger()->executionStarted();
+    }
+}

--- a/src/Logging/TAP/TapLogger.php
+++ b/src/Logging/TAP/TapLogger.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Logging\Tap;
 
 use PHPUnit\Event\EventFacadeIsSealedException;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Test\PreparationStarted;
 use PHPUnit\Event\UnknownSubscriberTypeException;
 use PHPUnit\TextUI\Output\Printer;
 
@@ -20,6 +21,11 @@ use PHPUnit\TextUI\Output\Printer;
 final class TapLogger
 {
     private readonly Printer $printer;
+
+    /**
+     * @var non-negative-int
+     */
+    private int $numberOfTests = 0;
 
     /**
      * @throws EventFacadeIsSealedException
@@ -32,14 +38,21 @@ final class TapLogger
         $this->registerSubscribers($facade);
     }
 
-    public function flush(): void
-    {
-        $this->printer->flush();
-    }
-
     public function executionStarted(): void
     {
         $this->printer->print('TAP version 14' . PHP_EOL);
+    }
+
+    public function executionFinished(): void
+    {
+        $this->printer->print('1..' . $this->numberOfTests . PHP_EOL);
+
+        $this->printer->flush();
+    }
+
+    public function testPreparationStarted(PreparationStarted $event): void
+    {
+        $this->numberOfTests++;
     }
 
     /**
@@ -51,6 +64,7 @@ final class TapLogger
         $facade->registerSubscribers(
             new TestRunnerExecutionStartedSubscriber($this),
             new TestRunnerExecutionFinishedSubscriber($this),
+            new TestPreparationStartedSubscriber($this),
         );
     }
 }

--- a/src/Logging/TAP/TapLogger.php
+++ b/src/Logging/TAP/TapLogger.php
@@ -48,7 +48,7 @@ final class TapLogger
 
     public function executionFinished(): void
     {
-        $this->printer->print('1..' . $this->numberOfTests . PHP_EOL);
+        $this->printer->print(PHP_EOL . '1..' . $this->numberOfTests . PHP_EOL);
 
         $this->printer->flush();
     }
@@ -62,7 +62,7 @@ final class TapLogger
     {
         $this->printer->print(
             sprintf(
-                '# successfully prepared %s' . PHP_EOL,
+                PHP_EOL . '# successfully prepared %s' . PHP_EOL,
                 $event->test()->id(),
             ),
         );
@@ -72,7 +72,7 @@ final class TapLogger
     {
         $this->printer->print(
             sprintf(
-                '# failed to prepare %s' . PHP_EOL,
+                PHP_EOL . '# failed to prepare %s' . PHP_EOL,
                 $event->test()->id(),
             ),
         );

--- a/src/Logging/TAP/TapLogger.php
+++ b/src/Logging/TAP/TapLogger.php
@@ -9,9 +9,12 @@
  */
 namespace PHPUnit\Logging\Tap;
 
+use function sprintf;
 use PHPUnit\Event\EventFacadeIsSealedException;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Test\PreparationFailed;
 use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\Prepared;
 use PHPUnit\Event\UnknownSubscriberTypeException;
 use PHPUnit\TextUI\Output\Printer;
 
@@ -55,6 +58,26 @@ final class TapLogger
         $this->numberOfTests++;
     }
 
+    public function testPrepared(Prepared $event): void
+    {
+        $this->printer->print(
+            sprintf(
+                '# successfully prepared %s' . PHP_EOL,
+                $event->test()->id(),
+            ),
+        );
+    }
+
+    public function testPreparationFailed(PreparationFailed $event): void
+    {
+        $this->printer->print(
+            sprintf(
+                '# failed to prepare %s' . PHP_EOL,
+                $event->test()->id(),
+            ),
+        );
+    }
+
     /**
      * @throws EventFacadeIsSealedException
      * @throws UnknownSubscriberTypeException
@@ -65,6 +88,8 @@ final class TapLogger
             new TestRunnerExecutionStartedSubscriber($this),
             new TestRunnerExecutionFinishedSubscriber($this),
             new TestPreparationStartedSubscriber($this),
+            new TestPreparedSubscriber($this),
+            new TestPreparationFailedSubscriber($this),
         );
     }
 }

--- a/src/Logging/TAP/TapLogger.php
+++ b/src/Logging/TAP/TapLogger.php
@@ -37,6 +37,11 @@ final class TapLogger
         $this->printer->flush();
     }
 
+    public function executionStarted(): void
+    {
+        $this->printer->print('TAP version 14' . PHP_EOL);
+    }
+
     /**
      * @throws EventFacadeIsSealedException
      * @throws UnknownSubscriberTypeException
@@ -44,6 +49,7 @@ final class TapLogger
     private function registerSubscribers(Facade $facade): void
     {
         $facade->registerSubscribers(
+            new TestRunnerExecutionStartedSubscriber($this),
             new TestRunnerExecutionFinishedSubscriber($this),
         );
     }

--- a/src/Logging/TAP/TapLogger.php
+++ b/src/Logging/TAP/TapLogger.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\Tap;
+
+use PHPUnit\Event\EventFacadeIsSealedException;
+use PHPUnit\Event\Facade;
+use PHPUnit\Event\UnknownSubscriberTypeException;
+use PHPUnit\TextUI\Output\Printer;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class TapLogger
+{
+    private readonly Printer $printer;
+
+    /**
+     * @throws EventFacadeIsSealedException
+     * @throws UnknownSubscriberTypeException
+     */
+    public function __construct(Printer $printer, Facade $facade)
+    {
+        $this->printer = $printer;
+
+        $this->registerSubscribers($facade);
+    }
+
+    public function flush(): void
+    {
+        $this->printer->flush();
+    }
+
+    /**
+     * @throws EventFacadeIsSealedException
+     * @throws UnknownSubscriberTypeException
+     */
+    private function registerSubscribers(Facade $facade): void
+    {
+        $facade->registerSubscribers(
+            new TestRunnerExecutionFinishedSubscriber($this),
+        );
+    }
+}

--- a/src/Logging/TAP/TapLogger.php
+++ b/src/Logging/TAP/TapLogger.php
@@ -12,6 +12,9 @@ namespace PHPUnit\Logging\Tap;
 use function sprintf;
 use PHPUnit\Event\EventFacadeIsSealedException;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Test\Errored;
+use PHPUnit\Event\Test\Failed;
+use PHPUnit\Event\Test\Passed;
 use PHPUnit\Event\Test\PreparationFailed;
 use PHPUnit\Event\Test\PreparationStarted;
 use PHPUnit\Event\Test\Prepared;
@@ -78,6 +81,39 @@ final class TapLogger
         );
     }
 
+    public function testPassed(Passed $event): void
+    {
+        $this->printer->print(
+            sprintf(
+                'ok %d - %s' . PHP_EOL,
+                $this->numberOfTests,
+                $event->test()->id(),
+            ),
+        );
+    }
+
+    public function testErrored(Errored $event): void
+    {
+        $this->printer->print(
+            sprintf(
+                'not ok %d - %s' . PHP_EOL,
+                $this->numberOfTests,
+                $event->test()->id(),
+            ),
+        );
+    }
+
+    public function testFailed(Failed $event): void
+    {
+        $this->printer->print(
+            sprintf(
+                'not ok %d - %s' . PHP_EOL,
+                $this->numberOfTests,
+                $event->test()->id(),
+            ),
+        );
+    }
+
     /**
      * @throws EventFacadeIsSealedException
      * @throws UnknownSubscriberTypeException
@@ -90,6 +126,9 @@ final class TapLogger
             new TestPreparationStartedSubscriber($this),
             new TestPreparedSubscriber($this),
             new TestPreparationFailedSubscriber($this),
+            new TestErroredSubscriber($this),
+            new TestFailedSubscriber($this),
+            new TestPassedSubscriber($this),
         );
     }
 }

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -82,6 +82,7 @@ final class Builder
         'list-tests',
         'list-tests-xml=',
         'log-junit=',
+        'log-tap=',
         'log-teamcity=',
         'migrate-configuration',
         'no-configuration',
@@ -119,6 +120,7 @@ final class Builder
         'strict-coverage',
         'disable-coverage-ignore',
         'strict-global-state',
+        'tap',
         'teamcity',
         'testdox',
         'testdox-summary',
@@ -244,6 +246,7 @@ final class Builder
         $reverseList                       = null;
         $stderr                            = null;
         $strictCoverage                    = null;
+        $tapLogfile                        = null;
         $teamcityLogfile                   = null;
         $testdoxHtmlFile                   = null;
         $testdoxTextFile                   = null;
@@ -254,6 +257,7 @@ final class Builder
         $version                           = false;
         $logEventsText                     = null;
         $logEventsVerboseText              = null;
+        $printerTap                        = null;
         $printerTeamCity                   = null;
         $printerTestDox                    = null;
         $printerTestDoxSummary             = null;
@@ -560,6 +564,11 @@ final class Builder
 
                     break;
 
+                case '--log-tap':
+                    $tapLogfile = $option[1];
+
+                    break;
+
                 case '--log-teamcity':
                     $teamcityLogfile = $option[1];
 
@@ -709,6 +718,11 @@ final class Builder
 
                 case '--stop-on-warning':
                     $stopOnWarning = true;
+
+                    break;
+
+                case '--tap':
+                    $printerTap = true;
 
                     break;
 
@@ -1027,6 +1041,8 @@ final class Builder
             $reverseList,
             $stderr,
             $strictCoverage,
+            $tapLogfile,
+            $printerTap,
             $teamcityLogfile,
             $testdoxHtmlFile,
             $testdoxTextFile,

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -122,6 +122,8 @@ final readonly class Configuration
     private ?bool $reverseList;
     private ?bool $stderr;
     private ?bool $strictCoverage;
+    private ?string $tapTextFile;
+    private ?bool $tapPrinter;
     private ?string $teamcityLogfile;
     private ?bool $teamCityPrinter;
     private ?string $testdoxHtmlFile;
@@ -157,7 +159,7 @@ final readonly class Configuration
      * @param ?non-empty-list<non-empty-string>                    $testSuffixes
      * @param ?non-empty-list<non-empty-string>                    $coverageFilter
      */
-    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug)
+    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $tapTextFile, ?bool $tapPrinter, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug)
     {
         $this->arguments                                    = $arguments;
         $this->atLeastVersion                               = $atLeastVersion;
@@ -238,6 +240,8 @@ final readonly class Configuration
         $this->reverseList                                  = $reverseList;
         $this->stderr                                       = $stderr;
         $this->strictCoverage                               = $strictCoverage;
+        $this->tapTextFile                                  = $tapTextFile;
+        $this->tapPrinter                                   = $tapPrinter;
         $this->teamcityLogfile                              = $teamcityLogfile;
         $this->testdoxHtmlFile                              = $testdoxHtmlFile;
         $this->testdoxTextFile                              = $testdoxTextFile;
@@ -1688,6 +1692,46 @@ final readonly class Configuration
         }
 
         return $this->strictCoverage;
+    }
+
+    /**
+     * @phpstan-assert-if-true !null $this->tapTextFile
+     */
+    public function hasTapLogfile(): bool
+    {
+        return $this->tapTextFile !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function tapLogfile(): string
+    {
+        if (!$this->hasTapLogfile()) {
+            throw new Exception;
+        }
+
+        return $this->tapTextFile;
+    }
+
+    /**
+     * @phpstan-assert-if-true !null $this->tapPrinter
+     */
+    public function hasTapPrinter(): bool
+    {
+        return $this->tapPrinter !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function tapPrinter(): bool
+    {
+        if (!$this->hasTapPrinter()) {
+            throw new Exception;
+        }
+
+        return $this->tapPrinter;
     }
 
     /**

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -109,6 +109,7 @@ final readonly class Configuration
     private int $executionOrder;
     private int $executionOrderDefects;
     private bool $resolveDependencies;
+    private ?string $logfileTap;
     private ?string $logfileTeamcity;
     private ?string $logfileJunit;
     private ?string $logfileTestdoxHtml;
@@ -125,6 +126,7 @@ final readonly class Configuration
      * @var ?non-empty-list<non-empty-string>
      */
     private ?array $testsUsing;
+    private bool $tapOutput;
     private bool $teamCityOutput;
     private bool $testDoxOutput;
     private bool $testDoxOutputSummary;
@@ -173,7 +175,7 @@ final readonly class Configuration
      * @param non-empty-list<non-empty-string>                                        $testSuffixes
      * @param non-negative-int                                                        $shortenArraysForExportThreshold
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
+    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTap, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $tapOutput, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
     {
         $this->cliArguments                                 = $cliArguments;
         $this->configurationFile                            = $configurationFile;
@@ -252,12 +254,14 @@ final readonly class Configuration
         $this->executionOrder                               = $executionOrder;
         $this->executionOrderDefects                        = $executionOrderDefects;
         $this->resolveDependencies                          = $resolveDependencies;
+        $this->logfileTap                                   = $logfileTap;
         $this->logfileTeamcity                              = $logfileTeamcity;
         $this->logfileJunit                                 = $logfileJunit;
         $this->logfileTestdoxHtml                           = $logfileTestdoxHtml;
         $this->logfileTestdoxText                           = $logfileTestdoxText;
         $this->logEventsText                                = $logEventsText;
         $this->logEventsVerboseText                         = $logEventsVerboseText;
+        $this->tapOutput                                    = $tapOutput;
         $this->teamCityOutput                               = $teamCityOutput;
         $this->testDoxOutput                                = $testDoxOutput;
         $this->testDoxOutputSummary                         = $testDoxOutputSummary;
@@ -890,6 +894,26 @@ final readonly class Configuration
     }
 
     /**
+     * @phpstan-assert-if-true !null $this->logfileTap
+     */
+    public function hasLogfileTap(): bool
+    {
+        return $this->logfileTap !== null;
+    }
+
+    /**
+     * @throws LoggingNotConfiguredException
+     */
+    public function logfileTap(): string
+    {
+        if (!$this->hasLogfileTap()) {
+            throw new LoggingNotConfiguredException;
+        }
+
+        return $this->logfileTap;
+    }
+
+    /**
      * @phpstan-assert-if-true !null $this->logfileTeamcity
      */
     public function hasLogfileTeamcity(): bool
@@ -1007,6 +1031,11 @@ final readonly class Configuration
         }
 
         return $this->logEventsVerboseText;
+    }
+
+    public function outputIsTap(): bool
+    {
+        return $this->tapOutput;
     }
 
     public function outputIsTeamCity(): bool

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -496,6 +496,7 @@ final readonly class Merger
             $colors = true;
         }
 
+        $logfileTap                  = null;
         $logfileTeamcity             = null;
         $logfileJunit                = null;
         $logfileTestdoxHtml          = null;
@@ -504,6 +505,12 @@ final readonly class Merger
 
         if ($cliConfiguration->hasNoLogging() && $cliConfiguration->noLogging()) {
             $loggingFromXmlConfiguration = false;
+        }
+
+        if ($cliConfiguration->hasTapLogfile()) {
+            $logfileTap = $cliConfiguration->tapLogfile();
+        } elseif ($loggingFromXmlConfiguration && $xmlConfiguration->logging()->hasTap()) {
+            $logfileTap = $xmlConfiguration->logging()->tap()->target()->path();
         }
 
         if ($cliConfiguration->hasTeamcityLogfile()) {
@@ -540,6 +547,12 @@ final readonly class Merger
 
         if ($cliConfiguration->hasLogEventsVerboseText()) {
             $logEventsVerboseText = $cliConfiguration->logEventsVerboseText();
+        }
+
+        $tapOutput = false;
+
+        if ($cliConfiguration->hasTapPrinter() && $cliConfiguration->tapPrinter()) {
+            $tapOutput = true;
         }
 
         $teamCityOutput = false;
@@ -812,12 +825,14 @@ final readonly class Merger
             $executionOrder,
             $executionOrderDefects,
             $resolveDependencies,
+            $logfileTap,
             $logfileTeamcity,
             $logfileJunit,
             $logfileTestdoxHtml,
             $logfileTestdoxText,
             $logEventsText,
             $logEventsVerboseText,
+            $tapOutput,
             $teamCityOutput,
             $testDoxOutput,
             $testDoxOutputSummary,

--- a/src/TextUI/Configuration/Xml/DefaultConfiguration.php
+++ b/src/TextUI/Configuration/Xml/DefaultConfiguration.php
@@ -82,6 +82,7 @@ final readonly class DefaultConfiguration extends Configuration
                 null,
                 null,
                 null,
+                null,
             ),
             new Php(
                 DirectoryCollection::fromArray([]),

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -66,6 +66,7 @@ use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Text as CodeCoverageText
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Xml as CodeCoverageXml;
 use PHPUnit\TextUI\XmlConfiguration\Logging\Junit;
 use PHPUnit\TextUI\XmlConfiguration\Logging\Logging;
+use PHPUnit\TextUI\XmlConfiguration\Logging\Tap;
 use PHPUnit\TextUI\XmlConfiguration\Logging\TeamCity;
 use PHPUnit\TextUI\XmlConfiguration\Logging\TestDox\Html as TestDoxHtml;
 use PHPUnit\TextUI\XmlConfiguration\Logging\TestDox\Text as TestDoxText;
@@ -183,8 +184,23 @@ final readonly class Loader
             );
         }
 
+        $tap     = null;
+        $element = $this->element($xpath, 'logging/tap');
+
+        if ($element) {
+            $tap = new Tap(
+                new File(
+                    $this->toAbsolutePath(
+                        $filename,
+                        (string) $this->getStringAttribute($element, 'outputFile'),
+                    ),
+                ),
+            );
+        }
+
         return new Logging(
             $junit,
+            $tap,
             $teamCity,
             $testDoxHtml,
             $testDoxText,

--- a/src/TextUI/Configuration/Xml/Logging/Logging.php
+++ b/src/TextUI/Configuration/Xml/Logging/Logging.php
@@ -21,13 +21,15 @@ use PHPUnit\TextUI\XmlConfiguration\Logging\TestDox\Text as TestDoxText;
 final readonly class Logging
 {
     private ?Junit $junit;
+    private ?Tap $tap;
     private ?TeamCity $teamCity;
     private ?TestDoxHtml $testDoxHtml;
     private ?TestDoxText $testDoxText;
 
-    public function __construct(?Junit $junit, ?TeamCity $teamCity, ?TestDoxHtml $testDoxHtml, ?TestDoxText $testDoxText)
+    public function __construct(?Junit $junit, ?Tap $tap, ?TeamCity $teamCity, ?TestDoxHtml $testDoxHtml, ?TestDoxText $testDoxText)
     {
         $this->junit       = $junit;
+        $this->tap         = $tap;
         $this->teamCity    = $teamCity;
         $this->testDoxHtml = $testDoxHtml;
         $this->testDoxText = $testDoxText;
@@ -48,6 +50,23 @@ final readonly class Logging
         }
 
         return $this->junit;
+    }
+
+    public function hasTap(): bool
+    {
+        return $this->tap !== null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function tap(): Tap
+    {
+        if ($this->tap === null) {
+            throw new Exception('Logger "TAP" is not configured');
+        }
+
+        return $this->tap;
     }
 
     public function hasTeamCity(): bool

--- a/src/TextUI/Configuration/Xml/Logging/Tap.php
+++ b/src/TextUI/Configuration/Xml/Logging/Tap.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\XmlConfiguration\Logging;
+
+use PHPUnit\TextUI\Configuration\File;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ *
+ * @immutable
+ */
+final readonly class Tap
+{
+    private File $target;
+
+    public function __construct(File $target)
+    {
+        $this->target = $target;
+    }
+
+    public function target(): File
+    {
+        return $this->target;
+    }
+}

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -246,6 +246,7 @@ final class Help
                 ['arg'    => '--reverse-list', 'desc' => 'Print defects in reverse order'],
                 ['spacer' => ''],
 
+                ['arg'    => '--tap', 'desc' => 'Replace default progress and result output with TAP format'],
                 ['arg'    => '--teamcity', 'desc' => 'Replace default progress and result output with TeamCity format'],
                 ['arg'    => '--testdox', 'desc' => 'Replace default result output with TestDox format'],
                 ['arg'    => '--testdox-summary', 'desc' => 'Repeat TestDox output for tests with errors, failures, or issues'],
@@ -256,6 +257,7 @@ final class Help
 
             'Logging' => [
                 ['arg' => '--log-junit <file>', 'desc' => 'Write test results in JUnit XML format to file'],
+                ['arg' => '--log-tap <file>', 'desc' => 'Write test results in TAP format to file'],
                 ['arg' => '--log-teamcity <file>', 'desc' => 'Write test results in TeamCity format to file'],
                 ['arg' => '--testdox-html <file>', 'desc' => 'Write test results in TestDox format (HTML) to file'],
                 ['arg' => '--testdox-text <file>', 'desc' => 'Write test results in TestDox format (plain text) to file'],

--- a/src/TextUI/Output/Facade.php
+++ b/src/TextUI/Output/Facade.php
@@ -13,6 +13,7 @@ use function assert;
 use PHPUnit\Event\EventFacadeIsSealedException;
 use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Event\UnknownSubscriberTypeException;
+use PHPUnit\Logging\Tap\TapLogger;
 use PHPUnit\Logging\TeamCity\TeamCityLogger;
 use PHPUnit\Logging\TestDox\TestResultCollection;
 use PHPUnit\Runner\DirectoryDoesNotExistException;
@@ -63,7 +64,12 @@ final class Facade
             self::createSummaryPrinter($configuration);
         }
 
-        if ($configuration->outputIsTeamCity()) {
+        if ($configuration->outputIsTap()) {
+            new TapLogger(
+                DefaultPrinter::standardOutput(),
+                EventFacade::instance(),
+            );
+        } elseif ($configuration->outputIsTeamCity()) {
             new TeamCityLogger(
                 DefaultPrinter::standardOutput(),
                 EventFacade::instance(),
@@ -127,6 +133,10 @@ final class Facade
             $printerNeeded = true;
         }
 
+        if ($configuration->outputIsTap()) {
+            $printerNeeded = true;
+        }
+
         if ($configuration->outputIsTeamCity()) {
             $printerNeeded = true;
         }
@@ -184,6 +194,10 @@ final class Facade
         }
 
         if ($configuration->noProgress()) {
+            return false;
+        }
+
+        if ($configuration->outputIsTap()) {
             return false;
         }
 
@@ -257,7 +271,7 @@ final class Facade
         assert(self::$printer !== null);
 
         if (($configuration->noOutput() || $configuration->noResults()) &&
-            !($configuration->outputIsTeamCity() || $configuration->outputIsTestDox())) {
+            !($configuration->outputIsTap() || $configuration->outputIsTeamCity() || $configuration->outputIsTestDox())) {
             return;
         }
 

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -121,6 +121,8 @@
                                      tests
   [32m--reverse-list                    [0m Print defects in reverse order
 
+  [32m--tap                             [0m Replace default progress and result output
+                                     with TAP format
   [32m--teamcity                        [0m Replace default progress and result output
                                      with TeamCity format
   [32m--testdox                         [0m Replace default result output with TestDox
@@ -135,6 +137,7 @@
 
   [32m--log-junit [36m<file>[0m                [0m Write test results in JUnit XML format to
                                      file
+  [32m--log-tap [36m<file>[0m                  [0m Write test results in TAP format to file
   [32m--log-teamcity [36m<file>[0m             [0m Write test results in TeamCity format to
                                      file
   [32m--testdox-html [36m<file>[0m             [0m Write test results in TestDox format

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -91,6 +91,7 @@ Reporting:
   --display-warnings                 Display details for warnings triggered by tests
   --reverse-list                     Print defects in reverse order
 
+  --tap                              Replace default progress and result output with TAP format
   --teamcity                         Replace default progress and result output with TeamCity format
   --testdox                          Replace default result output with TestDox format
   --testdox-summary                  Repeat TestDox output for tests with errors, failures, or issues
@@ -100,6 +101,7 @@ Reporting:
 Logging:
 
   --log-junit <file>                 Write test results in JUnit XML format to file
+  --log-tap <file>                   Write test results in TAP format to file
   --log-teamcity <file>              Write test results in TeamCity format to file
   --testdox-html <file>              Write test results in TestDox format (HTML) to file
   --testdox-text <file>              Write test results in TestDox format (plain text) to file

--- a/tests/end-to-end/logging/tap.phpt
+++ b/tests/end-to-end/logging/tap.phpt
@@ -14,26 +14,37 @@ require_once __DIR__ . '/../../bootstrap.php';
 TAP version 14
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithoutIssues
+ok 1 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithoutIssues
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithRisky
+ok 2 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithRisky
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithDeprecation
+ok 3 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithDeprecation
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithNotice
+ok 4 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithNotice
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithWarning
+ok 5 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithWarning
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithDeprecation
+not ok 6 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithDeprecation
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithNotice
+not ok 7 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithNotice
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithWarning
+not ok 8 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithWarning
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithDeprecation
+not ok 9 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithDeprecation
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithNotice
+not ok 10 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithNotice
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithWarning
+not ok 11 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithWarning
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithDeprecation
 

--- a/tests/end-to-end/logging/tap.phpt
+++ b/tests/end-to-end/logging/tap.phpt
@@ -12,21 +12,39 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 TAP version 14
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithoutIssues
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithRisky
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithDeprecation
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithNotice
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithWarning
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithDeprecation
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithNotice
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithWarning
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithDeprecation
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithNotice
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithWarning
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithDeprecation
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithNotice
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithWarning
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSkippedWithDeprecation
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSkippedWithNotice
+
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSkippedWithWarning
+
 1..17

--- a/tests/end-to-end/logging/tap.phpt
+++ b/tests/end-to-end/logging/tap.phpt
@@ -1,0 +1,14 @@
+--TEST--
+TAP
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--tap';
+$_SERVER['argv'][] = __DIR__ . '/../_files/OutcomesAndIssuesTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+TAP version 14

--- a/tests/end-to-end/logging/tap.phpt
+++ b/tests/end-to-end/logging/tap.phpt
@@ -12,4 +12,21 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 TAP version 14
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithoutIssues
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithRisky
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithDeprecation
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithNotice
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithWarning
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithDeprecation
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithNotice
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithWarning
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithDeprecation
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithNotice
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithWarning
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithDeprecation
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithNotice
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithWarning
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSkippedWithDeprecation
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSkippedWithNotice
+# successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testSkippedWithWarning
 1..17

--- a/tests/end-to-end/logging/tap.phpt
+++ b/tests/end-to-end/logging/tap.phpt
@@ -30,21 +30,69 @@ ok 5 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testSuccessWithWarning
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithDeprecation
 not ok 6 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithDeprecation
+  ---
+  severity: failure
+  message: |
+    Failed asserting that false is true.
+
+  stackTrace: |
+    %sOutcomesAndIssuesTest.php:55
+  ...
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithNotice
 not ok 7 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithNotice
+  ---
+  severity: failure
+  message: |
+    Failed asserting that false is true.
+
+  stackTrace: |
+    %sOutcomesAndIssuesTest.php:62
+  ...
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithWarning
 not ok 8 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testFailWithWarning
+  ---
+  severity: failure
+  message: |
+    Failed asserting that false is true.
+
+  stackTrace: |
+    %sOutcomesAndIssuesTest.php:69
+  ...
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithDeprecation
 not ok 9 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithDeprecation
+  ---
+  severity: error
+  message: |
+    exception message
+
+  stackTrace: |
+    %sOutcomesAndIssuesTest.php:76
+  ...
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithNotice
 not ok 10 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithNotice
+  ---
+  severity: error
+  message: |
+    exception message
+
+  stackTrace: |
+    %sOutcomesAndIssuesTest.php:83
+  ...
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithWarning
 not ok 11 - PHPUnit\TestFixture\OutcomesAndIssuesTest::testErrorWithWarning
+  ---
+  severity: error
+  message: |
+    exception message
+
+  stackTrace: |
+    %sOutcomesAndIssuesTest.php:90
+  ...
 
 # successfully prepared PHPUnit\TestFixture\OutcomesAndIssuesTest::testIncompleteWithDeprecation
 

--- a/tests/end-to-end/logging/tap.phpt
+++ b/tests/end-to-end/logging/tap.phpt
@@ -12,3 +12,4 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 TAP version 14
+1..17


### PR DESCRIPTION
> [TAP, the Test Anything Protocol](https://testanything.org/tap-version-14-specification.html), is a simple text-based interface between testing modules in a test harness. It decouples the reporting of errors from the presentation of the reports.

In other words: TAP is a plain text log file format for test results that is agnostic to the test framework or test runner used.

Earlier versions of PHPUnit had support for TAP, but this support was removed some time ago.

[I think that "output in CI pipelines" is a separate use case and as such should be addressed using a new/separate output printer](https://github.com/sebastianbergmann/phpunit/issues/5883#issuecomment-2219890403) and I think that the TAP format might be suitable for that purpose.

So far, this PR implements

- an XML configuration option for logging test results in TAP format to a file
- a `--tap` CLI option for replacing the default test runner output with output in TAP format
- a `--log-tap` CLI option for logging test results in TAP format to a file
- a minimal implementation of a TAP logger (which does not handle all possible outcomes and issues a test may have)

Here is an example of what the TAP output currently looks like:

https://github.com/sebastianbergmann/phpunit/blob/4cf45887d298eb07b2ee44a81aaa1819009a3cb4/tests/end-to-end/logging/tap.phpt#L14-L109

@TimWolla @edorian @Bilge What do you think?

I will not pursue this further if the consensus is that TAP does not solve the "output in CI pipelines" use case.