### PR TITLE
Add support for external logger

### DIFF
--- a/schema/11.3.xsd
+++ b/schema/11.3.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:annotation>
         <xs:documentation source="https://phpunit.de/documentation.html">
-            This Schema file defines the rules by which the XML configuration file of PHPUnit 11.3 may be structured.
+            This Schema file defines the rules by which the XML configuration file of PHPUnit 11.2 may be structured.
         </xs:documentation>
         <xs:appinfo source="https://phpunit.de/documentation.html"/>
     </xs:annotation>
@@ -172,6 +172,7 @@
         <xs:attribute name="bootstrap" type="xs:anyURI"/>
         <xs:attribute name="cacheDirectory" type="xs:anyURI"/>
         <xs:attribute name="cacheResult" type="xs:boolean" default="true"/>
+        <xs:attribute name="cacheResultFile" type="xs:anyURI"/>
         <xs:attribute name="colors" type="xs:boolean" default="false"/>
         <xs:attribute name="columns" type="columnsType" default="80"/>
         <xs:attribute name="controlGarbageCollector" type="xs:boolean" default="false"/>
@@ -197,6 +198,7 @@
         <xs:attribute name="beStrictAboutChangesToGlobalState" type="xs:boolean" default="false"/>
         <xs:attribute name="beStrictAboutOutputDuringTests" type="xs:boolean" default="false"/>
         <xs:attribute name="beStrictAboutTestsThatDoNotTestAnything" type="xs:boolean" default="true"/>
+        <xs:attribute name="beStrictAboutTodoAnnotatedTests" type="xs:boolean" default="false"/>
         <xs:attribute name="beStrictAboutCoverageMetadata" type="xs:boolean" default="false"/>
         <xs:attribute name="defaultTimeLimit" type="xs:integer" default="0"/>
         <xs:attribute name="enforceTimeLimit" type="xs:boolean" default="false"/>
@@ -205,7 +207,6 @@
         <xs:attribute name="timeoutForLargeTests" type="xs:integer" default="60"/>
         <xs:attribute name="defaultTestSuite" type="xs:string" default=""/>
         <xs:attribute name="testdox" type="xs:boolean" default="false"/>
-        <xs:attribute name="testdoxSummary" type="xs:boolean" default="false"/>
         <xs:attribute name="stderr" type="xs:boolean" default="false"/>
         <xs:attribute name="reverseDefectList" type="xs:boolean" default="false"/>
         <xs:attribute name="extensionsDirectory" type="xs:anyURI"/>
@@ -217,7 +218,6 @@
         <xs:attribute name="displayDetailsOnTestsThatTriggerErrors" type="xs:boolean" default="false"/>
         <xs:attribute name="displayDetailsOnTestsThatTriggerNotices" type="xs:boolean" default="false"/>
         <xs:attribute name="displayDetailsOnTestsThatTriggerWarnings" type="xs:boolean" default="false"/>
-        <xs:attribute name="shortenArraysForExportThreshold" type="xs:integer" default="0"/>
     </xs:attributeGroup>
     <xs:group name="configGroup">
         <xs:all>

--- a/src/Logging/ExternalLogger.php
+++ b/src/Logging/ExternalLogger.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging;
+
+use PHPUnit\Event\EventFacadeIsSealedException;
+use PHPUnit\Event\Facade;
+use PHPUnit\Event\UnknownSubscriberTypeException;
+use PHPUnit\TextUI\Output\Printer;
+
+interface ExternalLogger
+{
+    /**
+     * @throws EventFacadeIsSealedException
+     * @throws UnknownSubscriberTypeException
+     */
+    public static function createInstance(Facade $facade): object;
+}

--- a/src/TextUI/Configuration/Cli/Builder.php
+++ b/src/TextUI/Configuration/Cli/Builder.php
@@ -86,6 +86,7 @@ final class Builder
         'list-tests-xml=',
         'log-junit=',
         'log-teamcity=',
+        'log-external=',
         'migrate-configuration',
         'no-configuration',
         'no-coverage',
@@ -250,6 +251,7 @@ final class Builder
         $teamcityLogfile                   = null;
         $testdoxHtmlFile                   = null;
         $testdoxTextFile                   = null;
+        $externalLogger                    = null;
         $testSuffixes                      = null;
         $testSuite                         = null;
         $excludeTestSuite                  = null;
@@ -568,6 +570,11 @@ final class Builder
 
                     break;
 
+                case '--log-external':
+                    $externalLogger = $option[1];
+                    
+                    break;
+                    
                 case '--order-by':
                     foreach (explode(',', $option[1]) as $order) {
                         switch ($order) {
@@ -1053,6 +1060,7 @@ final class Builder
             $printerTestDox,
             $printerTestDoxSummary,
             $debug,
+            $externalLogger,
         );
     }
 

--- a/src/TextUI/Configuration/Cli/Configuration.php
+++ b/src/TextUI/Configuration/Cli/Configuration.php
@@ -130,7 +130,8 @@ final readonly class Configuration
     private ?string $testdoxTextFile;
     private ?bool $testdoxPrinter;
     private ?bool $testdoxPrinterSummary;
-
+    private ?string $externalLogger;
+    
     /**
      * @var ?non-empty-list<non-empty-string>
      */
@@ -159,7 +160,7 @@ final readonly class Configuration
      * @param ?non-empty-list<non-empty-string>                    $testSuffixes
      * @param ?non-empty-list<non-empty-string>                    $coverageFilter
      */
-    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug)
+    public function __construct(array $arguments, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnDeprecation, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug, ?string $externalLogger)
     {
         $this->arguments                                    = $arguments;
         $this->atLeastVersion                               = $atLeastVersion;
@@ -260,6 +261,7 @@ final readonly class Configuration
         $this->testdoxPrinter                               = $testdoxPrinter;
         $this->testdoxPrinterSummary                        = $testdoxPrinterSummary;
         $this->debug                                        = $debug;
+        $this->externalLogger                               = $externalLogger;
     }
 
     /**
@@ -2047,5 +2049,25 @@ final readonly class Configuration
     public function debug(): bool
     {
         return $this->debug;
+    }
+
+    /**
+     * @phpstan-assert-if-true !null $this->externalLogger
+     */
+    public function hasExternalLogger(): bool
+    {
+        return $this->externalLogger !== null;
+    }
+    
+    /**
+     * @throws Exception
+     */
+    public function externalLogger(): string
+    {
+        if (!$this->hasExternalLogger()) {
+            throw new Exception;
+        }
+        
+        return $this->externalLogger;
     }
 }

--- a/src/TextUI/Configuration/Configuration.php
+++ b/src/TextUI/Configuration/Configuration.php
@@ -115,7 +115,8 @@ final readonly class Configuration
     private ?string $logfileTestdoxText;
     private ?string $logEventsText;
     private ?string $logEventsVerboseText;
-
+    private ?string $externalLogger;
+    
     /**
      * @var ?non-empty-list<non-empty-string>
      */
@@ -173,7 +174,7 @@ final readonly class Configuration
      * @param non-empty-list<non-empty-string>                                            $testSuffixes
      * @param non-negative-int                                                            $shortenArraysForExportThreshold
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold)
+    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnDeprecation, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int|string $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, array $testSuffixes, Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, int $shortenArraysForExportThreshold, ?string $externalLogger)
     {
         $this->cliArguments                                 = $cliArguments;
         $this->configurationFile                            = $configurationFile;
@@ -280,6 +281,7 @@ final readonly class Configuration
         $this->generateBaseline                             = $generateBaseline;
         $this->debug                                        = $debug;
         $this->shortenArraysForExportThreshold              = $shortenArraysForExportThreshold;
+        $this->externalLogger                               = $externalLogger;
     }
 
     /**
@@ -1251,5 +1253,25 @@ final readonly class Configuration
     public function shortenArraysForExportThreshold(): int
     {
         return $this->shortenArraysForExportThreshold;
+    }
+
+    /**
+     * @phpstan-assert-if-true !null $this->externalLogger
+     */
+    public function hasExternalLogger(): bool
+    {
+        return $this->externalLogger !== null;
+    }
+    
+    /**
+     * @throws LoggingNotConfiguredException
+     */
+    public function externalLogger(): string
+    {
+        if (!$this->hasExternalLogger()) {
+            throw new LoggingNotConfiguredException;
+        }
+        
+        return $this->externalLogger;
     }
 }

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -504,7 +504,8 @@ final readonly class Merger
         $logfileTestdoxHtml          = null;
         $logfileTestdoxText          = null;
         $loggingFromXmlConfiguration = true;
-
+        $externalLogger              = null;
+        
         if ($cliConfiguration->hasNoLogging() && $cliConfiguration->noLogging()) {
             $loggingFromXmlConfiguration = false;
         }
@@ -533,6 +534,12 @@ final readonly class Merger
             $logfileTestdoxText = $xmlConfiguration->logging()->testDoxText()->target()->path();
         }
 
+        if ($cliConfiguration->hasExternalLogger()) {
+            $externalLogger = $cliConfiguration->externalLogger();
+        } elseif ($loggingFromXmlConfiguration && $xmlConfiguration->logging()->hasExternal()) {
+            $externalLogger = $xmlConfiguration->logging()->external()->target();
+        }
+        
         $logEventsText = null;
 
         if ($cliConfiguration->hasLogEventsText()) {
@@ -875,6 +882,7 @@ final readonly class Merger
             $generateBaseline,
             $cliConfiguration->debug(),
             $xmlConfiguration->phpunit()->shortenArraysForExportThreshold(),
+            $externalLogger,
         );
     }
 }

--- a/src/TextUI/Configuration/Xml/DefaultConfiguration.php
+++ b/src/TextUI/Configuration/Xml/DefaultConfiguration.php
@@ -84,7 +84,8 @@ final readonly class DefaultConfiguration extends Configuration
                 null,
                 null,
                 null,
-            ),
+                null,
+                ),
             new Php(
                 DirectoryCollection::fromArray([]),
                 IniSettingCollection::fromArray([]),

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -64,6 +64,7 @@ use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Html as CodeCoverageHtml
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Php as CodeCoveragePhp;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Text as CodeCoverageText;
 use PHPUnit\TextUI\XmlConfiguration\CodeCoverage\Report\Xml as CodeCoverageXml;
+use PHPUnit\TextUI\XmlConfiguration\Logging\External;
 use PHPUnit\TextUI\XmlConfiguration\Logging\Junit;
 use PHPUnit\TextUI\XmlConfiguration\Logging\Logging;
 use PHPUnit\TextUI\XmlConfiguration\Logging\TeamCity;
@@ -185,11 +186,19 @@ final readonly class Loader
             );
         }
 
+        $externalLogger = null;
+        $element  = $this->element($xpath, 'logging/externalLogger');
+        
+        if ($element) {
+            $externalLogger = new External((string) $this->getStringAttribute($element, 'class'));
+        }
+        
         return new Logging(
             $junit,
             $teamCity,
             $testDoxHtml,
             $testDoxText,
+            $externalLogger,
         );
     }
 

--- a/src/TextUI/Configuration/Xml/Logging/External.php
+++ b/src/TextUI/Configuration/Xml/Logging/External.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\XmlConfiguration\Logging;
+
+use PHPUnit\TextUI\Configuration\File;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ *
+ * @immutable
+ */
+final readonly class External
+{
+    private string $target;
+
+    /**
+     * The target parameter is expected to be a fully qualifiy class name implementing the ExternalLogger
+     * interface.
+     *
+     * @param string $target The external logger class name
+     *
+     * @see \PHPUnit\Logging\ExternalLogger
+     */
+    public function __construct(string $target)
+    {
+        $this->target = $target;
+    }
+
+    public function target(): string
+    {
+        return $this->target;
+    }
+}

--- a/src/TextUI/Configuration/Xml/Logging/Logging.php
+++ b/src/TextUI/Configuration/Xml/Logging/Logging.php
@@ -26,13 +26,15 @@ final readonly class Logging
     private ?TeamCity $teamCity;
     private ?TestDoxHtml $testDoxHtml;
     private ?TestDoxText $testDoxText;
-
-    public function __construct(?Junit $junit, ?TeamCity $teamCity, ?TestDoxHtml $testDoxHtml, ?TestDoxText $testDoxText)
+    private ?External $external;
+    
+    public function __construct(?Junit $junit, ?TeamCity $teamCity, ?TestDoxHtml $testDoxHtml, ?TestDoxText $testDoxText, ?External $external)
     {
         $this->junit       = $junit;
         $this->teamCity    = $teamCity;
         $this->testDoxHtml = $testDoxHtml;
         $this->testDoxText = $testDoxText;
+        $this->external    = $external;
     }
 
     public function hasJunit(): bool
@@ -101,5 +103,22 @@ final readonly class Logging
         }
 
         return $this->testDoxText;
+    }
+    
+    public function hasExternal(): bool
+    {
+        return $this->external !== null;
+    }
+    
+    /**
+     * @throws Exception
+     */
+    public function external(): External
+    {
+        if ($this->external === null) {
+            throw new Exception('Logger "External" is not configured');
+        }
+        
+        return $this->external;
     }
 }

--- a/src/TextUI/Configuration/Xml/Migration/Migrations/ConvertLogTypes.php
+++ b/src/TextUI/Configuration/Xml/Migration/Migrations/ConvertLogTypes.php
@@ -33,6 +33,7 @@ final readonly class ConvertLogTypes implements Migration
             'testdox-text' => 'testdoxText',
             'testdox-xml'  => 'testdoxXml',
             'plain'        => 'text',
+            'external'     => 'external',
         ];
 
         $logNodes = [];

--- a/src/TextUI/Exception/InvalidExternalLoggerException.php
+++ b/src/TextUI/Exception/InvalidExternalLoggerException.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI;
+
+use function sprintf;
+use RuntimeException;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class InvalidExternalLoggerException extends RuntimeException implements Exception
+{
+    public function __construct(string $class, bool $notFound = true)
+    {
+        parent::__construct(
+            sprintf(
+                $notFound ?
+                    '"%s" class not found' :
+                    '"%s" does not implement ' . \PHPUnit\Logging\ExternalLogger::class,
+                $class,
+            ),
+        );
+    }
+}

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -263,6 +263,7 @@ final class Help
                 ['arg' => '--testdox-text <file>', 'desc' => 'Write test results in TestDox format (plain text) to file'],
                 ['arg' => '--log-events-text <file>', 'desc' => 'Stream events as plain text to file'],
                 ['arg' => '--log-events-verbose-text <file>', 'desc' => 'Stream events as plain text with extended information to file'],
+                ['arg' => '--log-external <class>', 'desc' => 'Write test results to an external logger'],
                 ['arg' => '--no-logging', 'desc' => 'Ignore logging configured in the XML configuration file'],
             ],
 

--- a/tests/_files/ExternalLogger.php
+++ b/tests/_files/ExternalLogger.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Event\Facade;
+use PHPUnit\Event\TestSuite\Started;
+use PHPUnit\Event\TestSuite\StartedSubscriber;
+use PHPUnit\Event\Subscriber;
+
+/**
+ * Represents a valid external logger as it implements \PHPUnit\Logger\ExternalLogger.
+ */
+class ExternalLogger implements \PHPUnit\Logging\ExternalLogger
+{
+    public static function createInstance(Facade $facade): object
+    {
+        return new ExternalLogger($facade);
+    }
+    
+    public function __construct(Facade $facade)
+    {
+        $facade->registerSubscriber(new class implements Subscriber, StartedSubscriber
+        {
+            public function notify(Started $event): void
+            {
+                // $this->logger()->testSuiteStarted($event);
+            }
+        });
+    }
+}

--- a/tests/_files/ExternalLoggerInvalid.php
+++ b/tests/_files/ExternalLoggerInvalid.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+/**
+ * Represents an invalid external logger as it does not implement
+ * \PHPUnit\Logger\ExternalLogger.
+ */
+class ExternalLoggerInvalid
+{
+}

--- a/tests/_files/configuration_logging.xml
+++ b/tests/_files/configuration_logging.xml
@@ -5,5 +5,6 @@
         <teamcity outputFile="teamcity.txt"/>
         <testdoxHtml outputFile="testdox.html"/>
         <testdoxText outputFile="testdox.txt"/>
+        <externalLogger class="\PHPUnit\TestFixture\ExternalLogger"/>
     </logging>
 </phpunit>

--- a/tests/end-to-end/_files/no-log-cc-override/phpunit.xml
+++ b/tests/end-to-end/_files/no-log-cc-override/phpunit.xml
@@ -22,5 +22,6 @@
         <teamcity outputFile="php://stdout"/>
         <testdoxHtml outputFile="php://stdout"/>
         <testdoxText outputFile="php://stdout"/>
+        <external class="\PHPUnit\TestFixture\ExternalLogger"/>
     </logging>
 </phpunit>

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -144,6 +144,7 @@
   [32m--log-events-text [36m<file>[0m          [0m Stream events as plain text to file
   [32m--log-events-verbose-text [36m<file>[0m  [0m Stream events as plain text with extended
                                      information to file
+  [32m--log-external [36m<class>[0m            [0m Write test results to an external logger
   [32m--no-logging                      [0m Ignore logging configured in the XML
                                      configuration file
 

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -105,6 +105,7 @@ Logging:
   --testdox-text <file>              Write test results in TestDox format (plain text) to file
   --log-events-text <file>           Stream events as plain text to file
   --log-events-verbose-text <file>   Stream events as plain text with extended information to file
+  --log-external <class>             Write test results to an external logger
   --no-logging                       Ignore logging configured in the XML configuration file
 
 Code Coverage:

--- a/tests/end-to-end/logging/log-external-invalid-class.phpt
+++ b/tests/end-to-end/logging/log-external-invalid-class.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test runner emits warning when --log-external is used with an invalid target path
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--log-external';
+$_SERVER['argv'][] = '\PHPUnit\TestFixture\ExternalLoggerInvalid';
+$_SERVER['argv'][] = __DIR__ . '/../_files/basic/SuccessTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) Cannot log test results to external logger: "\PHPUnit\TestFixture\ExternalLoggerInvalid" does not implement PHPUnit\Logging\ExternalLogger
+
+WARNINGS!
+Tests: 1, Assertions: 1, Warnings: 1.

--- a/tests/end-to-end/logging/log-external-missing-class.phpt
+++ b/tests/end-to-end/logging/log-external-missing-class.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test runner emits warning when --log-external is used with an invalid target path
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--log-external';
+$_SERVER['argv'][] = '\PHPUnit\TextFixture\ExternalLoggerMissing';
+$_SERVER['argv'][] = __DIR__ . '/../_files/basic/SuccessTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) Cannot log test results to external logger: "\PHPUnit\TextFixture\ExternalLoggerMissing" class not found
+
+WARNINGS!
+Tests: 1, Assertions: 1, Warnings: 1.

--- a/tests/end-to-end/logging/log-external.phpt
+++ b/tests/end-to-end/logging/log-external.phpt
@@ -1,0 +1,15 @@
+--TEST--
+phpunit --log-teamcity php://stdout ../../basic/unit/StatusTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-external';
+$_SERVER['argv'][] = '\PHPUnit\TestFixture\ExternalLogger';
+$_SERVER['argv'][] = __DIR__ . '/../_files/basic/unit/StatusTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--

--- a/tests/unit/TextUI/Configuration/Cli/BuilderTest.php
+++ b/tests/unit/TextUI/Configuration/Cli/BuilderTest.php
@@ -930,6 +930,26 @@ final class BuilderTest extends TestCase
         $configuration->teamcityLogfile();
     }
 
+    #[TestDox('--log-external class')]
+    public function testLogExternal(): void
+    {
+        $configuration = (new Builder)->fromParameters(['--log-external', '\PHPUnit\TestFixture\ExternalLogger']);
+        
+        $this->assertTrue($configuration->hasExternalLogger());
+        $this->assertSame('\PHPUnit\TestFixture\ExternalLogger', $configuration->externalLogger());
+    }
+
+    public function testLogExternalMayNotBeConfigured(): void
+    {
+        $configuration = (new Builder)->fromParameters([]);
+        
+        $this->assertFalse($configuration->hasExternalLogger());
+        
+        $this->expectException(Exception::class);
+        
+        $configuration->externalLogger();
+    }
+
     #[TestDox('--order-by default')]
     public function testOrderByDefault(): void
     {

--- a/tests/unit/TextUI/Configuration/MergerTest.php
+++ b/tests/unit/TextUI/Configuration/MergerTest.php
@@ -28,7 +28,8 @@ final class MergerTest extends TestCase
         $this->assertTrue($fromFile->logging()->hasTeamCity());
         $this->assertTrue($fromFile->logging()->hasTestDoxHtml());
         $this->assertTrue($fromFile->logging()->hasTestDoxText());
-
+        $this->assertTrue($fromFile->logging()->hasExternal());
+        
         $this->assertTrue($fromFile->logging()->hasJunit());
         $this->assertNotSame($junitLog, $fromFile->logging()->junit()->target()->path());
 
@@ -43,7 +44,8 @@ final class MergerTest extends TestCase
         $this->assertFalse($mergedConfig->hasLogfileTeamcity());
         $this->assertFalse($mergedConfig->hasLogfileTestdoxHtml());
         $this->assertFalse($mergedConfig->hasLogfileTestdoxText());
-
+        $this->assertFalse($mergedConfig->hasExternalLogger());
+        
         $this->assertTrue($mergedConfig->hasLogfileJunit());
         $this->assertSame($junitLog, $mergedConfig->logfileJunit());
     }

--- a/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
@@ -270,6 +270,9 @@ final class LoaderTest extends TestCase
 
         $this->assertTrue($logging->hasTestDoxText());
         $this->assertSame(TEST_FILES_PATH . 'testdox.txt', $logging->testDoxText()->target()->path());
+        
+        $this->assertTrue($logging->hasExternal());
+        $this->assertSame('\PHPUnit\TestFixture\ExternalLogger', $logging->external()->target());
     }
 
     public function testPHPConfigurationIsReadCorrectly(): void


### PR DESCRIPTION
---
name: ⚙ Add support for external logger
labels: type/enhancement
about: Added support for both XML and CLI definition of an external logger. This --log-external option adds similar functionality that existed with the --printer option in 9.x and earlier.
---
resolve #5903 

Implementations of an external logger do need to implement the \PHPUnit\Logger\ExternalLogger interface and must use the PHPUnit 10.x and later event mechanism for capturing logging events.