### PR TITLE
Constraint: improve valueToTypeStringFragment for objects

### DIFF
--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -247,7 +247,7 @@ abstract class Constraint implements Countable, SelfDescribing
         }
 
         return match ($type) {
-            'array', 'integer', 'object' => 'an ' . $type . ' ',
+            'array', 'integer', 'object' => 'an ' . get_debug_type($type) . ' ',
             'boolean', 'closed resource', 'float', 'resource', 'string' => 'a ' . $type . ' ',
             'null'  => 'null ',
             default => 'a value of ' . $type . ' ',

--- a/src/Framework/Constraint/Constraint.php
+++ b/src/Framework/Constraint/Constraint.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
+use function get_debug_type;
 use function gettype;
 use function sprintf;
 use function strtolower;
@@ -247,7 +248,8 @@ abstract class Constraint implements Countable, SelfDescribing
         }
 
         return match ($type) {
-            'array', 'integer', 'object' => 'an ' . get_debug_type($type) . ' ',
+            'object' => get_debug_type($value) . ' ',
+            'array', 'integer' => 'an ' . $type . ' ',
             'boolean', 'closed resource', 'float', 'resource', 'string' => 'a ' . $type . ' ',
             'null'  => 'null ',
             default => 'a value of ' . $type . ' ',

--- a/tests/unit/Framework/Constraint/Traversable/IsListTest.php
+++ b/tests/unit/Framework/Constraint/Traversable/IsListTest.php
@@ -46,7 +46,7 @@ final class IsListTest extends TestCase
 
             [
                 false,
-                'Failed asserting that an object is a list.',
+                'Failed asserting that stdClass is a list.',
                 new stdClass,
             ],
 

--- a/tests/unit/Framework/Constraint/Type/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/Type/IsInstanceOfTest.php
@@ -37,14 +37,14 @@ final class IsInstanceOfTest extends TestCase
 
             [
                 false,
-                'Failed asserting that an object is an instance of class stdClass.',
+                'Failed asserting that Exception is an instance of class stdClass.',
                 stdClass::class,
                 new Exception,
             ],
 
             [
                 false,
-                'Failed asserting that an object is an instance of interface Throwable.',
+                'Failed asserting that stdClass is an instance of interface Throwable.',
                 Throwable::class,
                 new stdClass,
             ],


### PR DESCRIPTION
This improves default message of e.g. `self::assertInstanceOf(LogicException::class, $e);`. Previously, it gave no info about which object was actually asserted:

`Failed asserting that an `**`object`**` is an instance of class LogicException.`