### PR TITLE
Add `TARGET` to Covers attributes

### DIFF
--- a/src/Framework/Attributes/CoversFunction.php
+++ b/src/Framework/Attributes/CoversFunction.php
@@ -16,7 +16,7 @@ use Attribute;
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_FUNCTION | Attribute::IS_REPEATABLE)]
 final readonly class CoversFunction
 {
     /**

--- a/src/Framework/Attributes/CoversMethod.php
+++ b/src/Framework/Attributes/CoversMethod.php
@@ -16,7 +16,7 @@ use Attribute;
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final readonly class CoversMethod
 {
     /**


### PR DESCRIPTION
I'm writing some tests for a project and I migrated from `@cover` annotate to Covers attributes.
So when I want to use the `CoversMethod` attribute for the test function, I get an error because I need to add a target to that attribute.

```php
#[CoverMethod($className, $methodName)]
public function testRecurring()
{
    $user = User::factory()->create();
    $account = Account::factory()
        ->for($user)
        ->create();
        
     ........
}
```