### PR TITLE
`name` property on `<testsuites>` element in JUnit XML logfile

### DIFF
--- a/src/Logging/JUnit/JunitXmlLogger.php
+++ b/src/Logging/JUnit/JunitXmlLogger.php
@@ -309,6 +309,7 @@ final class JunitXmlLogger
         $this->document->formatOutput = true;
 
         $this->root = $this->document->createElement('testsuites');
+        $this->root->setAttribute('name', 'PHPUnit tests');
         $this->document->appendChild($this->root);
     }
 

--- a/tests/end-to-end/cli/no-log-no-cc.phpt
+++ b/tests/end-to-end/cli/no-log-no-cc.phpt
@@ -22,7 +22,7 @@ print file_get_contents($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\NoLogNoCcTest" file="%sNoLogNoCcTest.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="%f">
     <testcase name="testSuccess" file="%sNoLogNoCcTest.php" line="18" class="PHPUnit\TestFixture\NoLogNoCcTest" classname="PHPUnit.TestFixture.NoLogNoCcTest" assertions="1" time="%f"/>
   </testsuite>

--- a/tests/end-to-end/data-provider/log-junit-isolation.phpt
+++ b/tests/end-to-end/data-provider/log-junit-isolation.phpt
@@ -21,7 +21,7 @@ print file_get_contents($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
     <testsuite name="PHPUnit\TestFixture\DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%f">
       <testcase name="testAdd with data set #0" file="%sDataProviderTest.php" line="%d" class="PHPUnit\TestFixture\DataProviderTest" classname="PHPUnit.TestFixture.DataProviderTest" assertions="1" time="%f"/>

--- a/tests/end-to-end/data-provider/log-junit.phpt
+++ b/tests/end-to-end/data-provider/log-junit.phpt
@@ -23,7 +23,7 @@ print file_get_contents($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="CLI Arguments" tests="10" assertions="10" errors="0" failures="3" skipped="0" time="%s">
     <testsuite name="PHPUnit\TestFixture\DataProviderTest" file="%sDataProviderTest.php" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%s">
       <testsuite name="PHPUnit\TestFixture\DataProviderTest::testAdd" tests="4" assertions="4" errors="0" failures="1" skipped="0" time="%s">

--- a/tests/end-to-end/logging/log-junit-to-file.phpt
+++ b/tests/end-to-end/logging/log-junit-to-file.phpt
@@ -20,7 +20,7 @@ print file_get_contents($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\Basic\StatusTest" file="%sStatusTest.php" tests="13" assertions="4" errors="2" failures="2" skipped="5" time="%f">
     <testcase name="testSuccess" file="%sStatusTest.php" line="%d" class="PHPUnit\TestFixture\Basic\StatusTest" classname="PHPUnit.TestFixture.Basic.StatusTest" assertions="1" time="%f"/>
     <testcase name="testFailure" file="%sStatusTest.php" line="%d" class="PHPUnit\TestFixture\Basic\StatusTest" classname="PHPUnit.TestFixture.Basic.StatusTest" assertions="1" time="%f">

--- a/tests/end-to-end/logging/log-junit-to-stdout.phpt
+++ b/tests/end-to-end/logging/log-junit-to-stdout.phpt
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\Basic\StatusTest" file="%sStatusTest.php" tests="13" assertions="4" errors="2" failures="2" skipped="5" time="%f">
     <testcase name="testSuccess" file="%sStatusTest.php" line="%d" class="PHPUnit\TestFixture\Basic\StatusTest" classname="PHPUnit.TestFixture.Basic.StatusTest" assertions="1" time="%f"/>
     <testcase name="testFailure" file="%sStatusTest.php" line="%d" class="PHPUnit\TestFixture\Basic\StatusTest" classname="PHPUnit.TestFixture.Basic.StatusTest" assertions="1" time="%f">

--- a/tests/end-to-end/logging/log-junit-with-progress-with-errors.phpt
+++ b/tests/end-to-end/logging/log-junit-with-progress-with-errors.phpt
@@ -42,7 +42,7 @@ TypeError: Cannot assign DateTime to property PHPUnit\TestFixture\TypeErrorTest:
 ERRORS!
 Tests: 1, Assertions: 0, Errors: 1.
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\TypeErrorTest" file="%sTypeErrorTest.php" tests="1" assertions="0" errors="1" failures="0" skipped="0" time="%f">
     <testcase name="testMe" file="%sTypeErrorTest.php" line="%d" class="PHPUnit\TestFixture\TypeErrorTest" classname="PHPUnit.TestFixture.TypeErrorTest" assertions="0" time="%f">
       <error type="TypeError">PHPUnit\TestFixture\TypeErrorTest::testMe

--- a/tests/end-to-end/regression/5258.phpt
+++ b/tests/end-to-end/regression/5258.phpt
@@ -29,7 +29,7 @@ Time: %s, Memory: %s MB
 OK, but some tests were skipped!
 Tests: 2, Assertions: 1, Skipped: 1.
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\Issue5258\Issue5258Test" file="%sIssue5258Test.php" tests="2" assertions="1" errors="0" failures="0" skipped="1" time="%f">
     <testcase name="testOne" file="%sIssue5258Test.php" line="%d" class="PHPUnit\TestFixture\Issue5258\Issue5258Test" classname="PHPUnit.TestFixture.Issue5258.Issue5258Test" assertions="1" time="%f"/>
     <testcase name="testTwo" file="%sIssue5258Test.php" line="%d" class="PHPUnit\TestFixture\Issue5258\Issue5258Test" classname="PHPUnit.TestFixture.Issue5258.Issue5258Test" assertions="0" time="0.000000">

--- a/tests/end-to-end/regression/5561.phpt
+++ b/tests/end-to-end/regression/5561.phpt
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\Issue5561\Issue5561Test" file="%sIssue5561Test.php" tests="1" assertions="0" errors="0" failures="1" skipped="0" time="%s">
     <testcase name="testOne" file="%sIssue5561Test.php" line="21" class="PHPUnit\TestFixture\Issue5561\Issue5561Test" classname="PHPUnit.TestFixture.Issue5561.Issue5561Test" assertions="0" time="%s">
       <failure type="PHPUnit\Framework\ExpectationFailedException">PHPUnit\TestFixture\Issue5561\Issue5561Test::testOne%A

--- a/tests/end-to-end/regression/5771.phpt
+++ b/tests/end-to-end/regression/5771.phpt
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="PHPUnit tests">
   <testsuite name="PHPUnit\TestFixture\Issue5771\Issue5771Test" file="%sIssue5771Test.php" tests="1" assertions="0" errors="1" failures="0" skipped="0" time="%s">
     <testcase name="testOne" file="%sIssue5771Test.php" line="18" class="PHPUnit\TestFixture\Issue5771\Issue5771Test" classname="PHPUnit.TestFixture.Issue5771.Issue5771Test" assertions="0" time="%s">
       <error type="PHPUnit\Framework\AssertionFailedError">PHPUnit\TestFixture\Issue5771\Issue5771Test::testOne%A


### PR DESCRIPTION
This commit adds and sets the name property on the testsuites element of the generated JUnit report to 'PHPUnit tests'. This is in line with behaviour in Jest and Vitest where the tools set that property to their respective names.

This is helpful for processing JUnit XMLs depending on the framework that 
generated the file.