### PR TITLE
When generating phpunit.xml, use phpunit.xsd from vendor folder if it exists

### DIFF
--- a/src/TextUI/Command/Commands/GenerateConfigurationCommand.php
+++ b/src/TextUI/Command/Commands/GenerateConfigurationCommand.php
@@ -62,12 +62,17 @@ final readonly class GenerateConfigurationCommand implements Command
             $cacheDirectory = '.phpunit.cache';
         }
 
+        $vendorSchemaLocation = implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'phpunit', 'phpunit', 'phpunit.xsd']);
+        $schemaLocation = file_exists($vendorSchemaLocation)
+            ? $vendorSchemaLocation
+            : sprintf('https://schema.phpunit.de/%s/phpunit.xsd', Version::series());
+
         $generator = new Generator;
 
         $result = @file_put_contents(
             'phpunit.xml',
             $generator->generateDefaultConfiguration(
-                Version::series(),
+                $schemaLocation,
                 $bootstrapScript,
                 $testsDirectory,
                 $src,

--- a/src/TextUI/Command/Commands/GenerateConfigurationCommand.php
+++ b/src/TextUI/Command/Commands/GenerateConfigurationCommand.php
@@ -9,12 +9,15 @@
  */
 namespace PHPUnit\TextUI\Command;
 
+use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 use const STDIN;
 use function assert;
 use function fgets;
+use function file_exists;
 use function file_put_contents;
 use function getcwd;
+use function implode;
 use function sprintf;
 use function trim;
 use PHPUnit\Runner\Version;
@@ -63,7 +66,7 @@ final readonly class GenerateConfigurationCommand implements Command
         }
 
         $vendorSchemaLocation = implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'phpunit', 'phpunit', 'phpunit.xsd']);
-        $schemaLocation = file_exists($vendorSchemaLocation)
+        $schemaLocation       = file_exists($vendorSchemaLocation)
             ? $vendorSchemaLocation
             : sprintf('https://schema.phpunit.de/%s/phpunit.xsd', Version::series());
 

--- a/src/TextUI/Configuration/Xml/Generator.php
+++ b/src/TextUI/Configuration/Xml/Generator.php
@@ -24,7 +24,7 @@ final readonly class Generator
     private const TEMPLATE = <<<'EOT'
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/{phpunit_version}/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="{schema_location}"
          bootstrap="{bootstrap_script}"
          cacheDirectory="{cache_directory}"
          executionOrder="depends,defects"
@@ -49,18 +49,18 @@ final readonly class Generator
 
 EOT;
 
-    public function generateDefaultConfiguration(string $phpunitVersion, string $bootstrapScript, string $testsDirectory, string $srcDirectory, string $cacheDirectory): string
+    public function generateDefaultConfiguration(string $schemaLocation, string $bootstrapScript, string $testsDirectory, string $srcDirectory, string $cacheDirectory): string
     {
         return str_replace(
             [
-                '{phpunit_version}',
+                '{schema_location}',
                 '{bootstrap_script}',
                 '{tests_directory}',
                 '{src_directory}',
                 '{cache_directory}',
             ],
             [
-                $phpunitVersion,
+                $schemaLocation,
                 $bootstrapScript,
                 $testsDirectory,
                 $srcDirectory,

--- a/tests/unit/TextUI/Configuration/Xml/GeneratorTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/GeneratorTest.php
@@ -48,7 +48,7 @@ final class GeneratorTest extends TestCase
 </phpunit>
 ',
             $generator->generateDefaultConfiguration(
-                'X.Y.Z',
+                'https://schema.phpunit.de/X.Y.Z/phpunit.xsd',
                 'vendor/autoload.php',
                 'tests',
                 'src',


### PR DESCRIPTION
When working in a lot of projects, it becomes quite cumbersome to download the xsd for every project the phpunit.xml file is edited in.

It is already possible to replace the absolute url with a relative one while editing the file manually (currently the only option when developing without a stable internet connection). I think this should be the default for when phpunit is actually used together with composer.

In #5140 there was already an attempt to implement this, but that was closed by the author for lack of support for multiple xsds in the spec.

Instead, I think it's fair to check for the existence of the xsd from the vendor folder and to use it if it exists, and not set a default otherwise.