### PR TITLE
Don't replace existing relative schema locations when migrating schema

### DIFF
--- a/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php
+++ b/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php
@@ -21,15 +21,23 @@ use PHPUnit\Runner\Version;
  */
 final readonly class UpdateSchemaLocation implements Migration
 {
+    private const NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
+    private const LOCAL_NAME_SCHEMA_LOCATION = 'noNamespaceSchemaLocation';
+
     public function migrate(DOMDocument $document): void
     {
         $root = $document->documentElement;
 
         assert($root instanceof DOMElement);
 
+        $existingSchemaLocation = $root->getAttributeNodeNS(self::NAMESPACE, self::LOCAL_NAME_SCHEMA_LOCATION)?->value;
+        if ($existingSchemaLocation === implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'phpunit', 'phpunit', 'phpunit.xsd'])) {
+            return;
+        }
+
         $root->setAttributeNS(
-            'http://www.w3.org/2001/XMLSchema-instance',
-            'xsi:noNamespaceSchemaLocation',
+            self::NAMESPACE,
+            'xsi:'. self::LOCAL_NAME_SCHEMA_LOCATION,
             'https://schema.phpunit.de/' . Version::series() . '/phpunit.xsd',
         );
     }

--- a/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php
+++ b/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\TextUI\XmlConfiguration;
 
 use function assert;
+use function str_contains;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Runner\Version;
@@ -21,7 +22,7 @@ use PHPUnit\Runner\Version;
  */
 final readonly class UpdateSchemaLocation implements Migration
 {
-    private const NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
+    private const NAMESPACE                  = 'http://www.w3.org/2001/XMLSchema-instance';
     private const LOCAL_NAME_SCHEMA_LOCATION = 'noNamespaceSchemaLocation';
 
     public function migrate(DOMDocument $document): void
@@ -30,14 +31,15 @@ final readonly class UpdateSchemaLocation implements Migration
 
         assert($root instanceof DOMElement);
 
-        $existingSchemaLocation = $root->getAttributeNodeNS(self::NAMESPACE, self::LOCAL_NAME_SCHEMA_LOCATION)?->value;
-        if ($existingSchemaLocation === implode(DIRECTORY_SEPARATOR, ['vendor', 'bin', 'phpunit', 'phpunit', 'phpunit.xsd'])) {
+        $existingSchemaLocation = $root->getAttributeNodeNS(self::NAMESPACE, self::LOCAL_NAME_SCHEMA_LOCATION)->value;
+
+        if (str_contains($existingSchemaLocation, '://') === false) { // If the current schema location is a relative path, don't update it
             return;
         }
 
         $root->setAttributeNS(
             self::NAMESPACE,
-            'xsi:'. self::LOCAL_NAME_SCHEMA_LOCATION,
+            'xsi:' . self::LOCAL_NAME_SCHEMA_LOCATION,
             'https://schema.phpunit.de/' . Version::series() . '/phpunit.xsd',
         );
     }

--- a/tests/_files/XmlConfigurationMigration/input-relative-schema-path.xml
+++ b/tests/_files/XmlConfigurationMigration/input-relative-schema-path.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+    <coverage cacheDirectory="var/.coverage-cache"/>
+</phpunit>

--- a/tests/_files/XmlConfigurationMigration/output-relative-schema-path.xml
+++ b/tests/_files/XmlConfigurationMigration/output-relative-schema-path.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+    <coverage/>
+</phpunit>

--- a/tests/unit/TextUI/Configuration/Xml/MigratorTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/MigratorTest.php
@@ -55,4 +55,17 @@ final class MigratorTest extends TestCase
             ),
         );
     }
+
+    #[TestDox('Keep relative schema path when present')]
+    public function testKeepRelativeSchema(): void
+    {
+        $this->assertEquals(
+            (new XmlLoader)->loadFile(__DIR__ . '/../../../../_files/XmlConfigurationMigration/output-relative-schema-path.xml'),
+            (new XmlLoader)->load(
+                (new Migrator)->migrate(
+                    __DIR__ . '/../../../../_files/XmlConfigurationMigration/input-relative-schema-path.xml',
+                ),
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Adjacent to #5934, when updating a PHPUnit version and the configured xsd path is a reference to the local xsd in the vendor folder, it currently gets replaced by an absolute path to the xsd file.

When using composer to manage phpunit, the local xsd will always exist. So when migrating, we can check if the reference is relative and skip migration if so.