### PR TITLE
Do not fail with "An error occurred inside PHPUnit" when data provider key is not int or string

### DIFF
--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -14,8 +14,10 @@ use const PREG_OFFSET_CAPTURE;
 use function array_key_exists;
 use function assert;
 use function explode;
+use function get_debug_type;
 use function is_array;
 use function is_int;
+use function is_string;
 use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
@@ -181,20 +183,28 @@ final class DataProvider
             foreach ($data as $key => $value) {
                 if (is_int($key)) {
                     $result[] = $value;
-                } elseif (array_key_exists($key, $result)) {
-                    Event\Facade::emitter()->dataProviderMethodFinished(
-                        $testMethod,
-                        ...$methodsCalled,
-                    );
+                } elseif (is_string($key)) {
+                    if (array_key_exists($key, $result)) {
+                        Event\Facade::emitter()->dataProviderMethodFinished(
+                            $testMethod,
+                            ...$methodsCalled,
+                        );
 
+                        throw new InvalidDataProviderException(
+                            sprintf(
+                                'The key "%s" has already been defined by a previous data provider',
+                                $key,
+                            ),
+                        );
+                    }
+                    $result[$key] = $value;
+                } else {
                     throw new InvalidDataProviderException(
                         sprintf(
-                            'The key "%s" has already been defined by a previous data provider',
-                            $key,
+                            'The key must be int or string, %s given',
+                            get_debug_type($key),
                         ),
                     );
-                } else {
-                    $result[$key] = $value;
                 }
             }
         }

--- a/tests/end-to-end/data-provider/_files/4625/Issue4625Test.php
+++ b/tests/end-to-end/data-provider/_files/4625/Issue4625Test.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue4625;
+
+use PHPUnit\Framework\TestCase;
+
+class Issue4625Test extends TestCase
+{
+    public static function dataProvider(): iterable
+    {
+        yield 'a' => [1];
+
+        // the key below is an array
+        yield ['b'] => [2];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testSomething(int $x): void
+    {
+        $this->assertGreaterThan(0, $x);
+    }
+}

--- a/tests/end-to-end/data-provider/_files/4625/Issue4625Test.php
+++ b/tests/end-to-end/data-provider/_files/4625/Issue4625Test.php
@@ -24,8 +24,13 @@ class Issue4625Test extends TestCase
     /**
      * @dataProvider dataProvider
      */
-    public function testSomething(int $x): void
+    public function testOne(int $x): void
     {
         $this->assertGreaterThan(0, $x);
+    }
+
+    public function testTwo(): void
+    {
+        $this->assertTrue(true);
     }
 }

--- a/tests/end-to-end/data-provider/issue-4625.phpt
+++ b/tests/end-to-end/data-provider/issue-4625.phpt
@@ -1,0 +1,34 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/4625
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/4625';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--SKIPIF--
+<?php declare(strict_types=1);
+if (version_compare('8.3.0-dev', PHP_VERSION, '>')) {
+    print 'skip: PHP 8.3 is required (due to different message).'; 
+}
+--EXPECTF--
+An error occurred inside PHPUnit.
+
+Message:  Cannot access offset of type array on array
+Location: %sDataProvider.php:%d
+
+#0 %sDataProvider.php(%d): PHPUnit\Metadata\Api\DataProvider->dataProvidedByMethods()
+#1 %sTestBuilder.php(%d): PHPUnit\Metadata\Api\DataProvider->providedData()
+#2 %sTestSuite.php(%d): PHPUnit\Framework\TestBuilder->build()
+#3 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite->addTestMethod()
+#4 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite::fromClassReflector()
+#5 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite->addTestSuite()
+#6 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite->addTestFile()
+#7 %sTestSuiteBuilder.php(%d): PHPUnit\Framework\TestSuite->addTestFiles()
+#8 %sTestSuiteBuilder.php(%d): PHPUnit\TextUI\Configuration\TestSuiteBuilder->testSuiteFromPath()
+#9 %sApplication.php(%d): PHPUnit\TextUI\Configuration\TestSuiteBuilder->build()
+#10 %sApplication.php(%d): PHPUnit\TextUI\Application->buildTestSuite()
+#11 Standard input code(%d): PHPUnit\TextUI\Application->run()
+#12 {main}

--- a/tests/end-to-end/data-provider/issue-4625.phpt
+++ b/tests/end-to-end/data-provider/issue-4625.phpt
@@ -8,27 +8,22 @@ $_SERVER['argv'][] = __DIR__ . '/_files/4625';
 
 require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
---SKIPIF--
-<?php declare(strict_types=1);
-if (version_compare('8.3.0-dev', PHP_VERSION, '>')) {
-    print 'skip: PHP 8.3 is required (due to different message).'; 
-}
 --EXPECTF--
-An error occurred inside PHPUnit.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
-Message:  Cannot access offset of type array on array
-Location: %sDataProvider.php:%d
+Runtime: %s
 
-#0 %sDataProvider.php(%d): PHPUnit\Metadata\Api\DataProvider->dataProvidedByMethods()
-#1 %sTestBuilder.php(%d): PHPUnit\Metadata\Api\DataProvider->providedData()
-#2 %sTestSuite.php(%d): PHPUnit\Framework\TestBuilder->build()
-#3 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite->addTestMethod()
-#4 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite::fromClassReflector()
-#5 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite->addTestSuite()
-#6 %sTestSuite.php(%d): PHPUnit\Framework\TestSuite->addTestFile()
-#7 %sTestSuiteBuilder.php(%d): PHPUnit\Framework\TestSuite->addTestFiles()
-#8 %sTestSuiteBuilder.php(%d): PHPUnit\TextUI\Configuration\TestSuiteBuilder->testSuiteFromPath()
-#9 %sApplication.php(%d): PHPUnit\TextUI\Configuration\TestSuiteBuilder->build()
-#10 %sApplication.php(%d): PHPUnit\TextUI\Application->buildTestSuite()
-#11 Standard input code(%d): PHPUnit\TextUI\Application->run()
-#12 {main}
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit error:
+
+1) PHPUnit\TestFixture\Issue4625\Issue4625Test::testOne
+The data provider specified for PHPUnit\TestFixture\Issue4625\Issue4625Test::testOne is invalid
+The key must be int or string, array given
+
+%s:%d
+
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/4625