### PR TITLE
Do not trim testdox text when it contains `$` character

### DIFF
--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -194,7 +194,7 @@ final class NamePrettifier
                     array_keys($providedData),
                 );
 
-                $result = trim(preg_replace($variables, $providedData, $annotation));
+                $result = preg_replace($variables, $providedData, $annotation);
 
                 $annotationWithPlaceholders = true;
             }

--- a/tests/end-to-end/regression/5949.phpt
+++ b/tests/end-to-end/regression/5949.phpt
@@ -1,0 +1,39 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/5949
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = __DIR__ . '/5949/';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+........                                                            8 / 8 (100%)
+
+Time: %s, Memory: %s
+
+Issue5949 (PHPUnit\TestFixture\Issue5949\Issue5949)
+ ✔ Test 1. No dollar sign.
+
+ ✔ Test 2. No dollar sign.
+
+ ✔ Test 3. Dollar sign ($).
+ ✔ Test 4. No dollar sign.
+
+ ✔ Test 5. Dollar $ sign.
+           More text.
+ ✔ Test 6. No dollar sign.
+
+ ✔ Test 7. No dollar sign.
+
+ ✔ Test 8. No dollar sign.
+
+
+OK (8 tests, 8 assertions)

--- a/tests/end-to-end/regression/5949.phpt
+++ b/tests/end-to-end/regression/5949.phpt
@@ -25,10 +25,12 @@ Issue5949 (PHPUnit\TestFixture\Issue5949\Issue5949)
  ✔ Test 2. No dollar sign.
 
  ✔ Test 3. Dollar sign ($).
+
  ✔ Test 4. No dollar sign.
 
  ✔ Test 5. Dollar $ sign.
            More text.
+
  ✔ Test 6. No dollar sign.
 
  ✔ Test 7. No dollar sign.

--- a/tests/end-to-end/regression/5949/Issue5949Test.php
+++ b/tests/end-to-end/regression/5949/Issue5949Test.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue5949;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+class Issue5949Test extends TestCase
+{
+    #[TestDox("Test 1. No dollar sign.\n")]
+    public function test1(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 2. No dollar sign.\n")]
+    public function test2(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 3. Dollar sign (\$).\n")]
+    public function test3(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 4. No dollar sign.\n")]
+    public function test4(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 5. Dollar \$ sign.\n           More text.\n")]
+    public function test5(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 6. No dollar sign.\n")]
+    public function test6(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 7. No dollar sign.\n")]
+    public function test7(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[TestDox("Test 8. No dollar sign.\n")]
+    public function test8(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/5949