### PR TITLE
Skip data provider build when requirements are not satisfied

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Framework;
 use function assert;
 use PHPUnit\Metadata\Api\DataProvider;
 use PHPUnit\Metadata\Api\Groups;
+use PHPUnit\Metadata\Api\Requirements;
 use PHPUnit\Metadata\BackupGlobals;
 use PHPUnit\Metadata\BackupStaticProperties;
 use PHPUnit\Metadata\ExcludeGlobalVariableFromBackup;
@@ -37,10 +38,11 @@ final class TestBuilder
     {
         $className = $theClass->getName();
 
-        $data = (new DataProvider)->providedData(
-            $className,
-            $methodName,
-        );
+        $data = null;
+
+        if ((new Requirements)->requirementsNotSatisfiedFor($className, $methodName) === []) {
+            $data = (new DataProvider)->providedData($className, $methodName);
+        }
 
         if ($data !== null) {
             return $this->buildDataProviderTestSuite(

--- a/tests/_files/DataProviderRequiresPhpUnitTest.php
+++ b/tests/_files/DataProviderRequiresPhpUnitTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
+use PHPUnit\Framework\TestCase;
+
+final class DataProviderRequiresPhpUnitTest extends TestCase
+{
+    public static function providerThatThrows(): array
+    {
+        throw new Exception('Should have been skipped.');
+    }
+
+    public static function validProvider(): array
+    {
+        return [[true], [true]];
+    }
+
+    public function invalidProvider(): array
+    {
+        return [[true], [true]];
+    }
+
+    #[RequiresPhpunit('< 10')]
+    #[DataProvider('invalidProvider')]
+    public function testWithInvalidDataProvider(bool $param): void
+    {
+        $this->assertTrue($param);
+    }
+
+    #[RequiresPhpunit('>= 10')]
+    #[DataProvider('validProvider')]
+    public function testWithValidDataProvider(bool $param): void
+    {
+        $this->assertTrue($param);
+    }
+
+    #[RequiresPhpunit('< 10')]
+    #[DataProvider('providerThatThrows')]
+    public function testWithDataProviderThatThrows(): void
+    {
+    }
+
+    #[RequiresPhpunit('< 10')]
+    #[DataProviderExternal(self::class, 'providerThatThrows')]
+    public function testWithDataProviderExternalThatThrows(): void
+    {
+    }
+}

--- a/tests/end-to-end/data-provider/requires-phpunit.phpt
+++ b/tests/end-to-end/data-provider/requires-phpunit.phpt
@@ -14,34 +14,21 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-SSD.                                                                4 / 4 (100%)
+S..SS                                                               5 / 5 (100%)
 
 Time: %s, Memory: %s
 
-There were 2 PHPUnit errors:
+There were 3 skipped tests:
 
-1) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderThatThrows
-The data provider specified for PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderThatThrows is invalid
-Should have been skipped.
-
-%s:%d
-
-2) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderExternalThatThrows
-The data provider specified for PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderExternalThatThrows is invalid
-Should have been skipped.
-
-%s:%d
-
---
-
-There were 2 skipped tests:
-
-1) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithInvalidDataProvider with data set #0 (true)
+1) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithInvalidDataProvider
 PHPUnit < 10 is required.
 
-2) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithInvalidDataProvider with data set #1 (true)
+2) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderThatThrows
 PHPUnit < 10 is required.
 
-ERRORS!
-Tests: 4, Assertions: 2, Errors: 2, PHPUnit Deprecations: 1, Skipped: 2.
+3) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderExternalThatThrows
+PHPUnit < 10 is required.
+
+OK, but some tests were skipped!
+Tests: 5, Assertions: 2, Skipped: 3.
 

--- a/tests/end-to-end/data-provider/requires-phpunit.phpt
+++ b/tests/end-to-end/data-provider/requires-phpunit.phpt
@@ -1,0 +1,47 @@
+--TEST--
+phpunit ../../_files/DataProviderRequiresPhpUnitTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderRequiresPhpUnitTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+SSD.                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 PHPUnit errors:
+
+1) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderThatThrows
+The data provider specified for PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderThatThrows is invalid
+Should have been skipped.
+
+%s:%d
+
+2) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderExternalThatThrows
+The data provider specified for PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithDataProviderExternalThatThrows is invalid
+Should have been skipped.
+
+%s:%d
+
+--
+
+There were 2 skipped tests:
+
+1) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithInvalidDataProvider with data set #0 (true)
+PHPUnit < 10 is required.
+
+2) PHPUnit\TestFixture\DataProviderRequiresPhpUnitTest::testWithInvalidDataProvider with data set #1 (true)
+PHPUnit < 10 is required.
+
+ERRORS!
+Tests: 4, Assertions: 2, Errors: 2, PHPUnit Deprecations: 1, Skipped: 2.
+

--- a/tests/end-to-end/generic/invalid-requirements.phpt
+++ b/tests/end-to-end/generic/invalid-requirements.phpt
@@ -20,9 +20,9 @@ Time: %s, Memory: %s
 
 There were 2 PHPUnit test runner warnings:
 
-1) Method PHPUnit\TestFixture\InvalidRequirementsTest::testInvalidVersionConstraint is annotated using an invalid version requirement: Version constraint ~~9.0 is not supported.
+1) Class PHPUnit\TestFixture\InvalidRequirementsTest is annotated using an invalid version requirement: Version constraint ~~9.0 is not supported.
 
-2) Class PHPUnit\TestFixture\InvalidRequirementsTest is annotated using an invalid version requirement: Version constraint ~~9.0 is not supported.
+2) Method PHPUnit\TestFixture\InvalidRequirementsTest::testInvalidVersionConstraint is annotated using an invalid version requirement: Version constraint ~~9.0 is not supported.
 
 WARNINGS!
 Tests: 1, Assertions: 1, Warnings: 2.


### PR DESCRIPTION
There is no reason to build the data provider if the test will be skipped anyway.

This also makes it easier to support a wide range of PHPUnit versions, as a data provider method that is incompatible with newer PHPUnit versions will not cause an error.