### PR TITLE
Better error message when data provider is invalid

### DIFF
--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -79,8 +79,9 @@ final readonly class DataProvider
             if (!is_array($value)) {
                 throw new InvalidDataProviderException(
                     sprintf(
-                        'Data set %s is invalid',
+                        'Data set %s is invalid, expected array but got %s',
                         is_int($key) ? '#' . $key : '"' . $key . '"',
+                        get_debug_type($value),
                     ),
                 );
             }

--- a/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
+++ b/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
@@ -27,7 +27,7 @@ Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderW
 - PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne)
 The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
-Data set #0 is invalid
+Data set #0 is invalid, expected array but got int
 Test Suite Loaded (1 test)
 Test Runner Started
 Test Suite Sorted

--- a/tests/end-to-end/event/invalid-data-provider.phpt
+++ b/tests/end-to-end/event/invalid-data-provider.phpt
@@ -27,7 +27,7 @@ Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderT
 - PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne)
 The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne is invalid
-Data set #0 is invalid
+Data set #0 is invalid, expected array but got int
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\InvalidDataProviderTest".)
 Test Suite Loaded (0 tests)
 Test Runner Started

--- a/tests/end-to-end/regression/2137-filter.phpt
+++ b/tests/end-to-end/regression/2137-filter.phpt
@@ -19,13 +19,13 @@ There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
 The data provider specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
-Data set #0 is invalid
+Data set #0 is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
 The data provider specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
-Data set #0 is invalid
+Data set #0 is invalid, expected array but got stdClass
 
 %s:%d
 

--- a/tests/end-to-end/regression/2137-no_filter.phpt
+++ b/tests/end-to-end/regression/2137-no_filter.phpt
@@ -17,13 +17,13 @@ There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
 The data provider specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
-Data set #0 is invalid
+Data set #0 is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
 The data provider specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
-Data set #0 is invalid
+Data set #0 is invalid, expected array but got stdClass
 
 %s:%d
 


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/5963

I did not provide a new test, because I think adjustments of expectations of existing tests already cover everything needed.