### PR TITLE
fix preg_match() warning for most filter usecases

### DIFF
--- a/src/Runner/Filter/NameFilterIterator.php
+++ b/src/Runner/Filter/NameFilterIterator.php
@@ -14,6 +14,7 @@ use function implode;
 use function preg_match;
 use function sprintf;
 use function str_replace;
+use function substr;
 use Exception;
 use PHPUnit\Framework\SelfDescribing;
 use PHPUnit\Framework\Test;
@@ -77,7 +78,7 @@ final class NameFilterIterator extends RecursiveFilterIterator
      */
     private function setFilter(string $filter): void
     {
-        if (@preg_match($filter, '') === false) {
+        if (preg_match('/[a-zA-Z0-9]/', substr($filter, 0, 1)) === 1 || @preg_match($filter, '') === false) {
             // Handles:
             //  * testAssertEqualsSucceeds#4
             //  * testAssertEqualsSucceeds#4-8


### PR DESCRIPTION
when a --filter option is provided and it starts with an invalid regex-delimiter, it will emit the following warning:

    Warning: preg_match(): Delimiter must not be alphanumeric, backslash, or NUL

this is really cumbersome when xdebug.scream=true is in use. also while stepdebugging with phpstorm for example, this will spam the console output of phpstorm.
we can and should prevent that most obvious case by just checking if the supplied filter starts with an alphanumeric character.

example:

![image](https://github.com/user-attachments/assets/de687496-89a4-4fdc-b8f1-293ca8ff7abb)
