### PR TITLE
Inline SKIPIF evaluation without side-effects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "sebastian/global-state": "^7.0.2",
         "sebastian/object-enumerator": "^6.0.1",
         "sebastian/type": "^5.1.0",
-        "sebastian/version": "^5.0.2"
+        "sebastian/version": "^5.0.2",
+        "staabm/side-effects-detector": "^0.1"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdfd04c2cc8d0d3dded4c9a9fdb084da",
+    "content-hash": "07b62e2cf18284b56a615886ed97f7c8",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1489,6 +1489,57 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
+            "name": "staabm/side-effects-detector",
+            "version": "0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "ac16d5adbd387142efa2fb5014d8b2201cc2a8b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/ac16d5adbd387142efa2fb5014d8b2201cc2a8b2",
+                "reference": "ac16d5adbd387142efa2fb5014d8b2201cc2a8b2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-17T13:48:18+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -1542,7 +1593,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -1554,7 +1605,7 @@
         "ext-xml": "*",
         "ext-xmlwriter": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3.0"
     },


### PR DESCRIPTION
## Proof of concept

while looking into PHPT performance, I realized that the `--SKIPIF--` condition is evaluated in a separate subprocess.

this means a major overhead for a maybe pretty simple side-effect-less condition like:

```php
--SKIPIF--
<?php version_compare(PHP_VERSION, "8.0", ">=")
      or echo "skip because attributes are only available since PHP 8.0"; ?>

```

I [built a small class](https://github.com/staabm/side-effects-detector) in which you can pass a string of source-code and it returns whether the given code would have side-effects when evaluated.

In PHPUnit I utilize the detected side-effect-free SKIPIF conditions and evaluate such code in the main-process instead of creating a new one. In case we cannot say with 100% certainty the code does not have side-effects we play save and run it in the subprocess.

----

when running `php ./phpunit tests/end-to-end/event/assert-failure.phpt` I can see the following results:

macos:

after this PR: `00:00.070 - 00:00.077`
before this PR: `00:00.092 - 00:00.098`

-> which means ~20% faster on my mac m1pro on a single test-case.

on windows with

```
PHP 8.3.11 (cli) (built: Aug 27 2024 21:28:35) (NTS Visual C++ 2019 x64)
Copyright (c) The PHP Group
Zend Engine v4.3.11, Copyright (c) Zend Technologies
```

after this PR: `00:00.360 - 00:00.395`
before this PR: `00:00.406 - 00:00.443`

-> seems also roughly ~20% faster
(see how slow running the same test is on windows vs. macos)

----

Possible future idea
- Don't use [subprocess for `—CLEAN—`](https://github.com/sebastianbergmann/phpunit/blob/e8d66de7723a905ebb741996959b09a223af9780/src/Runner/PHPT/PhptTestCase.php#L453-L468) as long as the code cannot modify the parent process (e.g. file IO is fine within the parent process)

----

I am pretty sure this needs more work but wanted to have opinions first, whether this is acceptable.

refs https://github.com/sebastianbergmann/phpunit/issues/5973