### PR TITLE
TestDox result collector does not correctly handle baseline-ignored `E_DEPRECATED` issues

### DIFF
--- a/src/Logging/TestDox/TestResult/TestResultCollector.php
+++ b/src/Logging/TestDox/TestResult/TestResultCollector.php
@@ -258,7 +258,7 @@ final class TestResultCollector
             return;
         }
 
-        if ($event->ignoredByTest()) {
+        if ($event->ignoredByBaseline()) {
             return;
         }
 


### PR DESCRIPTION
When comparing versions [11.3.6...11.4.0](https://github.com/sebastianbergmann/phpunit/compare/11.3.6...11.4.0), I noticed the change from commit https://github.com/sebastianbergmann/phpunit/commit/f36e89b74a7d19726ea2ebd1626a8c035a9e752d.
I think in the method `testTriggeredPhpDeprecation` the wrong line was deleted?



