### PR TITLE
Disable Xdebug in subprocesses when it is not used

### DIFF
--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -906,8 +906,6 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         if (extension_loaded('xdebug')) {
             if ($collectCoverage) {
                 $settings[] = 'xdebug.mode=coverage';
-            } else {
-                $settings[] = 'xdebug.mode=off';
             }
         }
 

--- a/src/Util/PHP/DefaultJobRunner.php
+++ b/src/Util/PHP/DefaultJobRunner.php
@@ -27,6 +27,7 @@ use function sys_get_temp_dir;
 use function tempnam;
 use function trim;
 use function unlink;
+use PHPUnit\Runner\CodeCoverage;
 use SebastianBergmann\Environment\Runtime;
 
 /**
@@ -184,6 +185,14 @@ final readonly class DefaultJobRunner implements JobRunner
                     array_keys($xdebugSettings),
                 ),
             );
+
+            // disable xdebug if not required to reduce xdebug performance overhead in subprocesses
+            if (
+                !CodeCoverage::instance()->isActive() &&
+                xdebug_is_debugger_active() === false
+            ) {
+                $phpSettings['xdebug.mode'] = 'xdebug.mode=off';
+            }
         }
 
         $command = array_merge($command, $this->settingsToParameters($phpSettings));

--- a/tests/end-to-end/event/_files/XdebugIsDisabled.php
+++ b/tests/end-to-end/event/_files/XdebugIsDisabled.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event;
+
+use function extension_loaded;
+use function ini_get;
+use PHPUnit\Framework\TestCase;
+
+final class XdebugIsDisabled extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(extension_loaded('xdebug'));
+        $this->assertSame('', (string) ini_get('xdebug.mode'));
+    }
+}

--- a/tests/end-to-end/event/process-isolation-disable-xdebug.phpt
+++ b/tests/end-to-end/event/process-isolation-disable-xdebug.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Subprocesses auto-disable xdebug when no debugger is attached.
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug must be loaded.';
+} elseif (xdebug_is_debugger_active() === true) {
+    print 'skip: Debugger must not be attached.';
+}
+
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--process-isolation';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/_files/XdebugIsDisabled.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (PHPUnit\TestFixture\Event\XdebugIsDisabled, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\XdebugIsDisabled::testOne)
+Test Prepared (PHPUnit\TestFixture\Event\XdebugIsDisabled::testOne)
+Test Passed (PHPUnit\TestFixture\Event\XdebugIsDisabled::testOne)
+Test Finished (PHPUnit\TestFixture\Event\XdebugIsDisabled::testOne)
+Test Suite Finished (PHPUnit\TestFixture\Event\XdebugIsDisabled, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)


### PR DESCRIPTION
before this PR xdebug was only auto-disabled for PHPT.

as of this PR we disable xdebug for all sub-processes to make them faster - but only if no active debugger is attached.

this means subprocess isolated tests can still be debugged without the need for a additional cli-option or config setting changed just by attaching e.g. PHPStorm (so no change in DX).

---

I initially tried disabling xdebug for the whole sub-process by not loading the extension at all, but this would either require a new [composer/xdebug-handler](https://github.com/composer/xdebug-handler) dependency or a way more involved fix.

disabling xdebug already provides most perf benefits.

---

Benchmark (xdebug loaded, but no debugger attached): 

`/c/tools/php83/php phpunit tests/end-to-end/data-provider/log-junit-isolation.phpt` with phpunit@a82cc0548 takes 2.5 - 2.6 seconds (phpunit reported runtime)

After this PR: `/c/tools/php83/php phpunit tests/end-to-end/data-provider/log-junit-isolation.phpt` takes 0.5-0.6 seconds

tested with PHP 8.3.11 with Xdebug v3.4.0beta1 on windows11x64

php.ini settings:
```
zend_extension=xdebug
xdebug.mode=debug
xdebug.start_with_request=yes
```