### PR TITLE
Do not run `SKIPIF` section of PHPT test in separate process when it is free of side effects

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -272,6 +272,13 @@
             </fileset>
         </copy>
 
+        <copy file="${basedir}/vendor/staabm/side-effects-detector/LICENSE" tofile="${basedir}/build/tmp/phar/staabm-side-effects-detector/LICENSE"/>
+        <copy todir="${basedir}/build/tmp/phar/staabm-side-effects-detector">
+            <fileset dir="${basedir}/vendor/staabm/side-effects-detector/lib">
+                <include name="**/*.php" />
+            </fileset>
+        </copy>
+
         <copy file="${basedir}/vendor/myclabs/deep-copy/LICENSE" tofile="${basedir}/build/tmp/phar/myclabs-deep-copy/LICENSE"/>
         <copy todir="${basedir}/build/tmp/phar/myclabs-deep-copy">
             <fileset dir="${basedir}/vendor/myclabs/deep-copy/src">

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "sebastian/global-state": "^7.0.2",
         "sebastian/object-enumerator": "^6.0.1",
         "sebastian/type": "^5.1.0",
-        "sebastian/version": "^5.0.2"
+        "sebastian/version": "^5.0.2",
+        "staabm/side-effects-detector": "^1.0"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75c757e2d7d7e1610277d8574dc8e7f4",
+    "content-hash": "50bd4710de2feb2687ad2fe3bf35b74d",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1489,6 +1489,58 @@
             "time": "2024-10-09T05:16:32+00:00"
         },
         {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "863968bf57936b3de18be192545c0ca2c7d2b8ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/863968bf57936b3de18be192545c0ca2c7d2b8ba",
+                "reference": "863968bf57936b3de18be192545c0ca2c7d2b8ba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-18T15:09:59+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -1542,7 +1594,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -1554,7 +1606,7 @@
         "ext-xml": "*",
         "ext-xmlwriter": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2.0"
     },

--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -27,6 +27,8 @@ use function is_file;
 use function is_readable;
 use function is_string;
 use function ltrim;
+use function ob_get_clean;
+use function ob_start;
 use function preg_match;
 use function preg_replace;
 use function preg_split;
@@ -67,6 +69,8 @@ use SebastianBergmann\CodeCoverage\Test\TestStatus\TestStatus;
 use SebastianBergmann\CodeCoverage\TestIdMissingException;
 use SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException;
 use SebastianBergmann\Template\Template;
+use staabm\SideEffectsDetector\SideEffect;
+use staabm\SideEffectsDetector\SideEffectsDetector;
 use Throwable;
 
 /**
@@ -426,19 +430,26 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
             return false;
         }
 
-        $jobResult = JobRunnerRegistry::run(
-            new Job(
-                $this->render($sections['SKIPIF']),
-                $this->stringifyIni($settings),
-            ),
-        );
+        $skipIfCode = $this->render($sections['SKIPIF']);
 
-        Facade::emitter()->testRunnerFinishedChildProcess($jobResult->stdout(), $jobResult->stderr());
+        if ($this->shouldRunSkipIfInSubprocess($sections, $skipIfCode)) {
+            $jobResult = JobRunnerRegistry::run(
+                new Job(
+                    $skipIfCode,
+                    $this->stringifyIni($settings),
+                ),
+            );
+            $output = $jobResult->stdout();
 
-        if (!strncasecmp('skip', ltrim($jobResult->stdout()), 4)) {
+            Facade::emitter()->testRunnerFinishedChildProcess($output, $jobResult->stderr());
+        } else {
+            $output = $this->runCodeInLocalSandbox($skipIfCode);
+        }
+
+        if (!strncasecmp('skip', ltrim($output), 4)) {
             $message = '';
 
-            if (preg_match('/^\s*skip\s*(.+)\s*/i', $jobResult->stdout(), $skipMatch)) {
+            if (preg_match('/^\s*skip\s*(.+)\s*/i', $output, $skipMatch)) {
                 $message = substr($skipMatch[1], 2);
             }
 
@@ -453,6 +464,48 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         }
 
         return false;
+    }
+
+    /**
+     * @param array<non-empty-string, non-empty-string> $sections
+     */
+    private function shouldRunSkipIfInSubprocess(array $sections, string $skipIfCode): bool
+    {
+        if (isset($sections['INI'])) {
+            // to get per-test INI settings, we need a dedicated subprocess
+            return true;
+        }
+
+        $detector    = new SideEffectsDetector;
+        $sideEffects = $detector->getSideEffects($skipIfCode);
+
+        if ($sideEffects === []) {
+            return false; // no side-effects
+        }
+
+        foreach ($sideEffects as $sideEffect) {
+            if ($sideEffect === SideEffect::STANDARD_OUTPUT) {
+                // stdout is fine, we will catch it using output-buffering
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function runCodeInLocalSandbox(string $code): string
+    {
+        $code = preg_replace('/^<\?(php)?/', '', $code);
+        $code = preg_replace('/declare\S?\([^)]+\)\S?;/', '', $code);
+
+        // wrap in immediately invoked function to isolate local-side-effects of $code from our own process
+        $code = '(function() {' . $code . '})();';
+        ob_start();
+        @eval($code);
+
+        return ob_get_clean();
     }
 
     /**

--- a/tests/end-to-end/_files/phpt-ini-subprocess.phpt
+++ b/tests/end-to-end/_files/phpt-ini-subprocess.phpt
@@ -1,0 +1,14 @@
+--TEST--
+PHPT uses a subprocess when --INI-- is present, even if --SKIPIF-- has no side-effect
+--INI--
+error_reporting=-1
+--SKIPIF--
+<?php declare(strict_types=1);
+if (1 == 2) {
+   echo "skip this test\n";
+}
+--FILE--
+<?php declare(strict_types=1);
+echo "Hello, World!\n";
+--EXPECT--
+Hello, World!

--- a/tests/end-to-end/_files/phpt-skipif-exit-subprocess.phpt
+++ b/tests/end-to-end/_files/phpt-skipif-exit-subprocess.phpt
@@ -1,0 +1,9 @@
+--TEST--
+PHPT skip condition which exits the subprocess (side-effect)
+--FILE--
+<?php declare(strict_types=1);
+--SKIPIF--
+<?php declare(strict_types=1);
+echo "skip this test\n";
+exit(1);
+--EXPECT--

--- a/tests/end-to-end/event/phpt-ini-subprocess.phpt
+++ b/tests/end-to-end/event/phpt-ini-subprocess.phpt
@@ -1,0 +1,33 @@
+--TEST--
+The right events are emitted in the right order for a PHPT test using a subprocess via --INI--
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-ini-subprocess.phpt';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%s%ephpt-ini-subprocess.phpt, 1 test)
+Test Preparation Started (%s%ephpt-ini-subprocess.phpt)
+Test Prepared (%s%ephpt-ini-subprocess.phpt)
+Child Process Started
+Child Process Finished
+Child Process Started
+Child Process Finished
+Test Passed (%s%ephpt-ini-subprocess.phpt)
+Test Finished (%s%ephpt-ini-subprocess.phpt)
+Test Suite Finished (%s%ephpt-ini-subprocess.phpt, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/phpt-skipif-subprocess.phpt
+++ b/tests/end-to-end/event/phpt-skipif-subprocess.phpt
@@ -1,0 +1,32 @@
+--TEST--
+The right events are emitted in the right order for a skipped PHPT test using a skipif subprocess
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-skipif-exit-subprocess.phpt';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%s%ephpt-skipif-exit-subprocess.phpt, 1 test)
+Test Preparation Started (%s%ephpt-skipif-exit-subprocess.phpt)
+Test Prepared (%s%ephpt-skipif-exit-subprocess.phpt)
+Child Process Started
+Child Process Finished
+Test Skipped (%s%ephpt-skipif-exit-subprocess.phpt)
+is test
+Test Finished (%s%ephpt-skipif-exit-subprocess.phpt)
+Test Suite Finished (%s%ephpt-skipif-exit-subprocess.phpt, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/phpt-skipif.phpt
+++ b/tests/end-to-end/event/phpt-skipif.phpt
@@ -21,8 +21,6 @@ Test Runner Execution Started (1 test)
 Test Suite Started (%s%ephpt-skipif-location-hint-example.phpt, 1 test)
 Test Preparation Started (%s%ephpt-skipif-location-hint-example.phpt)
 Test Prepared (%s%ephpt-skipif-location-hint-example.phpt)
-Child Process Started
-Child Process Finished
 Test Skipped (%s%ephpt-skipif-location-hint-example.phpt)
 something terrible happened
 Test Finished (%s%ephpt-skipif-location-hint-example.phpt)


### PR DESCRIPTION
while looking into PHPT performance, I realized that the `--SKIPIF--` condition is evaluated in a separate subprocess.

this means a major overhead for a maybe pretty simple side-effect-less condition like:

```php
--SKIPIF--
<?php version_compare(PHP_VERSION, "8.0", ">=")
      or echo "skip because attributes are only available since PHP 8.0"; ?>

```

I [built a small class](https://github.com/staabm/side-effects-detector) in which you can pass a string of source-code and it returns whether the given code would have side-effects when evaluated.

In PHPUnit I utilize the detected side-effect-free SKIPIF conditions and evaluate such code in the main-process instead of creating a new one. In case we cannot say with 100% certainty the code does not have side-effects we play save and run it in the subprocess.

----

when running `php ./phpunit tests/end-to-end/event/assert-failure.phpt` I can see the following results:

macos:

after this PR: `00:00.070 - 00:00.077`
before this PR: `00:00.092 - 00:00.098`

-> which means ~20% faster on my mac m1pro on a single test-case.

on windows with

```
PHP 8.3.11 (cli) (built: Aug 27 2024 21:28:35) (NTS Visual C++ 2019 x64)
Copyright (c) The PHP Group
Zend Engine v4.3.11, Copyright (c) Zend Technologies
```

after this PR: `00:00.360 - 00:00.395`
before this PR: `00:00.406 - 00:00.443`

-> seems also roughly ~20% faster
(see how slow running the same test is on windows vs. macos)

refs https://github.com/sebastianbergmann/phpunit/issues/5973