### PR TITLE
Do not run `CLEAN` section of PHPT test in separate process when it is free of side effects that modify the parent process

### DIFF
--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -469,6 +469,37 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
     /**
      * @param array<non-empty-string, non-empty-string> $sections
      */
+    private function shouldRunCleanInSubprocess(array $sections, string $cleanCode): bool
+    {
+        if (isset($sections['INI'])) {
+            // to get per-test INI settings, we need a dedicated subprocess
+            return true;
+        }
+
+        $detector    = new SideEffectsDetector;
+        $sideEffects = $detector->getSideEffects($cleanCode);
+
+        if ($sideEffects === []) {
+            return false; // no side-effects
+        }
+
+        foreach ($sideEffects as $sideEffect) {
+            if (
+                $sideEffect === SideEffect::STANDARD_OUTPUT || // stdout is fine, we will catch it using output-buffering
+                $sideEffect === SideEffect::INPUT_OUTPUT // IO is fine while cleanup, as it doesn't pollute the main process
+            ) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<non-empty-string, non-empty-string> $sections
+     */
     private function shouldRunSkipIfInSubprocess(array $sections, string $skipIfCode): bool
     {
         if (isset($sections['INI'])) {
@@ -517,14 +548,20 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
             return;
         }
 
-        $result = JobRunnerRegistry::run(
-            new Job(
-                $this->render($sections['CLEAN']),
-                $this->settings($collectCoverage),
-            ),
-        );
+        $cleanCode = $this->render($sections['CLEAN']);
 
-        Facade::emitter()->testRunnerFinishedChildProcess($result->stdout(), $result->stderr());
+        if ($this->shouldRunCleanInSubprocess($sections, $cleanCode)) {
+            $result = JobRunnerRegistry::run(
+                new Job(
+                    $cleanCode,
+                    $this->settings($collectCoverage),
+                ),
+            );
+
+            Facade::emitter()->testRunnerFinishedChildProcess($result->stdout(), $result->stderr());
+        } else {
+            $this->runCodeInLocalSandbox($cleanCode);
+        }
     }
 
     /**

--- a/tests/end-to-end/_files/phpt-clean-process-polluting.phpt
+++ b/tests/end-to-end/_files/phpt-clean-process-polluting.phpt
@@ -1,0 +1,10 @@
+--TEST--
+PHPT test with a CLEAN section which pollutes process scope
+--FILE--
+<?php declare(strict_types=1);
+print 'success';
+--EXPECT--
+success
+--CLEAN--
+<?php declare(strict_types=1);
+exit(1);

--- a/tests/end-to-end/_files/phpt-clean-with-io.phpt
+++ b/tests/end-to-end/_files/phpt-clean-with-io.phpt
@@ -1,0 +1,11 @@
+--TEST--
+PHPT test with a CLEAN section with IO side-effect runs in main process
+--FILE--
+<?php declare(strict_types=1);
+file_put_contents(__DIR__.'/phpt-clean-with-io-tmp.file', 'Hello tmp file!');
+print 'success';
+--EXPECT--
+success
+--CLEAN--
+<?php declare(strict_types=1);
+@unlink(__DIR__.'/phpt-clean-with-io-tmp.file');

--- a/tests/end-to-end/_files/phpt-ini-clean.phpt
+++ b/tests/end-to-end/_files/phpt-ini-clean.phpt
@@ -1,0 +1,13 @@
+--TEST--
+PHPT uses a subprocess when --INI-- is present, even if --CLEAN-- has IO side-effect
+--INI--
+error_reporting=-1
+--FILE--
+<?php declare(strict_types=1);
+echo "Hello, World!\n";
+--EXPECT--
+Hello, World!
+--CLEAN--
+<?php declare(strict_types=1);
+@unlink('/some/non/existing/file');
+?>

--- a/tests/end-to-end/event/phpt-clean-process-polluting.phpt
+++ b/tests/end-to-end/event/phpt-clean-process-polluting.phpt
@@ -1,11 +1,11 @@
 --TEST--
-The right events are emitted in the right order for a PHPT test with a CLEAN section
+The right events are emitted in the right order for a PHPT test with a CLEAN section which pollutes the process
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--debug';
-$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-clean.phpt';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-clean-process-polluting.phpt';
 
 require __DIR__ . '/../../bootstrap.php';
 
@@ -18,14 +18,16 @@ Test Suite Loaded (1 test)
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%sphpt-clean.phpt, 1 test)
-Test Preparation Started (%sphpt-clean.phpt)
-Test Prepared (%sphpt-clean.phpt)
+Test Suite Started (%sphpt-clean-process-polluting.phpt, 1 test)
+Test Preparation Started (%sphpt-clean-process-polluting.phpt)
+Test Prepared (%sphpt-clean-process-polluting.phpt)
 Child Process Started
 Child Process Finished
-Test Passed (%sphpt-clean.phpt)
-Test Finished (%sphpt-clean.phpt)
-Test Suite Finished (%sphpt-clean.phpt, 1 test)
+Test Passed (%sphpt-clean-process-polluting.phpt)
+Child Process Started
+Child Process Finished
+Test Finished (%sphpt-clean-process-polluting.phpt)
+Test Suite Finished (%sphpt-clean-process-polluting.phpt, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/phpt-clean-with-io.phpt
+++ b/tests/end-to-end/event/phpt-clean-with-io.phpt
@@ -1,11 +1,11 @@
 --TEST--
-The right events are emitted in the right order for a PHPT test with a CLEAN section
+The right events are emitted in the right order for a PHPT test with a CLEAN section which pollutes the process
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--debug';
-$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-clean.phpt';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-clean-with-io.phpt';
 
 require __DIR__ . '/../../bootstrap.php';
 
@@ -18,14 +18,14 @@ Test Suite Loaded (1 test)
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%sphpt-clean.phpt, 1 test)
-Test Preparation Started (%sphpt-clean.phpt)
-Test Prepared (%sphpt-clean.phpt)
+Test Suite Started (%sphpt-clean-with-io.phpt, 1 test)
+Test Preparation Started (%sphpt-clean-with-io.phpt)
+Test Prepared (%sphpt-clean-with-io.phpt)
 Child Process Started
 Child Process Finished
-Test Passed (%sphpt-clean.phpt)
-Test Finished (%sphpt-clean.phpt)
-Test Suite Finished (%sphpt-clean.phpt, 1 test)
+Test Passed (%sphpt-clean-with-io.phpt)
+Test Finished (%sphpt-clean-with-io.phpt)
+Test Suite Finished (%sphpt-clean-with-io.phpt, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/phpt-ini-clean.phpt
+++ b/tests/end-to-end/event/phpt-ini-clean.phpt
@@ -1,11 +1,11 @@
 --TEST--
-The right events are emitted in the right order for a PHPT test with a CLEAN section
+The right events are emitted in the right order for a PHPT test using a subprocess via --INI--
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--debug';
-$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-clean.phpt';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-ini-clean.phpt';
 
 require __DIR__ . '/../../bootstrap.php';
 
@@ -18,14 +18,16 @@ Test Suite Loaded (1 test)
 Test Runner Started
 Test Suite Sorted
 Test Runner Execution Started (1 test)
-Test Suite Started (%sphpt-clean.phpt, 1 test)
-Test Preparation Started (%sphpt-clean.phpt)
-Test Prepared (%sphpt-clean.phpt)
+Test Suite Started (%s%ephpt-ini-clean.phpt, 1 test)
+Test Preparation Started (%s%ephpt-ini-clean.phpt)
+Test Prepared (%s%ephpt-ini-clean.phpt)
 Child Process Started
 Child Process Finished
-Test Passed (%sphpt-clean.phpt)
-Test Finished (%sphpt-clean.phpt)
-Test Suite Finished (%sphpt-clean.phpt, 1 test)
+Test Passed (%sphpt-ini-clean.phpt)
+Child Process Started
+Child Process Finished
+Test Finished (%s%ephpt-ini-clean.phpt)
+Test Suite Finished (%s%ephpt-ini-clean.phpt, 1 test)
 Test Runner Execution Finished
 Test Runner Finished
 PHPUnit Finished (Shell Exit Code: 0)


### PR DESCRIPTION
Don't use [subprocess for `—CLEAN—`](https://github.com/sebastianbergmann/phpunit/blob/e8d66de7723a905ebb741996959b09a223af9780/src/Runner/PHPT/PhptTestCase.php#L453-L468) as long as the code cannot modify the parent process (e.g. file IO is fine within the parent process).

utilizes https://github.com/staabm/side-effects-detector

followup to https://github.com/sebastianbergmann/phpunit/pull/5998
 
`php phpunit tests/end-to-end/event/phpt-clean.phpt`
before this PR 109-110ms
after this PR: 85-87ms

tested on PHP 8.3.12 macos m1 pro