### PR TITLE
Fix: Do not configure deprecated `use_trait` option of `no_extra_blank_lines` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -178,7 +178,6 @@ $config->setFinder($finder)
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,


### PR DESCRIPTION
This pull request

- [x] stops configuring the deprecated `use_trait` option of `no_extra_blank_lines` fixer

Follows #5997.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.64.0/doc/rules/whitespace/no_extra_blank_lines.rst.