### PR TITLE
Enhancement: Configure `target_commitish` to target branch to show commits to branch since release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
           tag: ${{ env.RELEASE_TAG }}
           name: PHPUnit ${{ env.RELEASE_TAG }}
           bodyFile: release-notes.md
+          commit: "8.5"
 
       - name: Announce release
         id: mastodon


### PR DESCRIPTION
This pull request

- [x] indirectly configures the `target_commitish` field to show commits to branch since last release to that branch

Fixes https://github.com/sebastianbergmann/phpunit/issues/5761.

💁‍♂️ For reference, see

- https://github.com/ncipollo/release-action/blob/v1.14.0/src/Action.ts#L128-L140
- https://github.com/ncipollo/release-action/blob/v1.14.0/src/Releases.ts#L72-L97
- https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release--parameters

Also see https://github.com/ergebnis/playground/releases/tag/0.14.0 for a demonstration:

![CleanShot 2024-10-19 at 11 01 32@2x](https://github.com/user-attachments/assets/442ef553-2b5f-4b4d-9e8b-513caf228bb6)

