### PR TITLE
Remove `*\ResultPrinter::flush()` which is only used from tests

### DIFF
--- a/src/TextUI/Output/Default/ResultPrinter.php
+++ b/src/TextUI/Output/Default/ResultPrinter.php
@@ -146,11 +146,6 @@ final class ResultPrinter
         }
     }
 
-    public function flush(): void
-    {
-        $this->printer->flush();
-    }
-
     private function printPhpunitErrors(TestResult $result): void
     {
         if (!$result->hasTestTriggeredPhpunitErrorEvents()) {

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -60,11 +60,6 @@ final readonly class ResultPrinter
         }
     }
 
-    public function flush(): void
-    {
-        $this->printer->flush();
-    }
-
     /**
      * @param array<string, TestResultCollection> $tests
      */

--- a/tests/unit/TextUI/Output/Default/ResultPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/ResultPrinterTest.php
@@ -383,7 +383,6 @@ final class ResultPrinterTest extends TestCase
         );
 
         $resultPrinter->print($result);
-        $resultPrinter->flush();
 
         $summaryPrinter = new SummaryPrinter(
             $printer,


### PR DESCRIPTION
I guess this method mistakenly exists because we have a `Printer` interface which requires a `flush` method.
since the changed printers don't implement said interface, I think the methods are obsolete.