### PR TITLE
Improve parameter name for `assertGreaterThan()`, `assertGreaterThanOrEqual()`, `assertLessThan()`, and `assertLessThanOrEqual()`

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -553,9 +553,9 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      */
-    final public static function assertGreaterThan(mixed $expected, mixed $actual, string $message = ''): void
+    final public static function assertGreaterThan(mixed $minimum, mixed $actual, string $message = ''): void
     {
-        self::assertThat($actual, self::greaterThan($expected), $message);
+        self::assertThat($actual, self::greaterThan($minimum), $message);
     }
 
     /**
@@ -563,11 +563,11 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      */
-    final public static function assertGreaterThanOrEqual(mixed $expected, mixed $actual, string $message = ''): void
+    final public static function assertGreaterThanOrEqual(mixed $minimum, mixed $actual, string $message = ''): void
     {
         self::assertThat(
             $actual,
-            self::greaterThanOrEqual($expected),
+            self::greaterThanOrEqual($minimum),
             $message,
         );
     }
@@ -577,9 +577,9 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      */
-    final public static function assertLessThan(mixed $expected, mixed $actual, string $message = ''): void
+    final public static function assertLessThan(mixed $maximum, mixed $actual, string $message = ''): void
     {
-        self::assertThat($actual, self::lessThan($expected), $message);
+        self::assertThat($actual, self::lessThan($maximum), $message);
     }
 
     /**
@@ -587,9 +587,9 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      */
-    final public static function assertLessThanOrEqual(mixed $expected, mixed $actual, string $message = ''): void
+    final public static function assertLessThanOrEqual(mixed $maximum, mixed $actual, string $message = ''): void
     {
-        self::assertThat($actual, self::lessThanOrEqual($expected), $message);
+        self::assertThat($actual, self::lessThanOrEqual($maximum), $message);
     }
 
     /**

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -576,7 +576,7 @@ if (!function_exists('PHPUnit\Framework\assertGreaterThan')) {
      *
      * @see Assert::assertGreaterThan
      */
-    function assertGreaterThan(mixed $expected, mixed $actual, string $message = ''): void
+    function assertGreaterThan(mixed $minimum, mixed $actual, string $message = ''): void
     {
         Assert::assertGreaterThan(...func_get_args());
     }
@@ -592,7 +592,7 @@ if (!function_exists('PHPUnit\Framework\assertGreaterThanOrEqual')) {
      *
      * @see Assert::assertGreaterThanOrEqual
      */
-    function assertGreaterThanOrEqual(mixed $expected, mixed $actual, string $message = ''): void
+    function assertGreaterThanOrEqual(mixed $minimum, mixed $actual, string $message = ''): void
     {
         Assert::assertGreaterThanOrEqual(...func_get_args());
     }
@@ -608,7 +608,7 @@ if (!function_exists('PHPUnit\Framework\assertLessThan')) {
      *
      * @see Assert::assertLessThan
      */
-    function assertLessThan(mixed $expected, mixed $actual, string $message = ''): void
+    function assertLessThan(mixed $maximum, mixed $actual, string $message = ''): void
     {
         Assert::assertLessThan(...func_get_args());
     }
@@ -624,7 +624,7 @@ if (!function_exists('PHPUnit\Framework\assertLessThanOrEqual')) {
      *
      * @see Assert::assertLessThanOrEqual
      */
-    function assertLessThanOrEqual(mixed $expected, mixed $actual, string $message = ''): void
+    function assertLessThanOrEqual(mixed $maximum, mixed $actual, string $message = ''): void
     {
         Assert::assertLessThanOrEqual(...func_get_args());
     }


### PR DESCRIPTION
Resolves #5849 

Improved the `$expected` parameter name for the following constraints:
- `assertGreaterThan()`
- `assertGreaterThanOrEqual()`
- `assertLessThan()`
- `assertLessThanOrEqual()`

I decided to use `minimum` and `maximum` as parameter names as these make the comparisons clear and intuitive.

