### PR TITLE
Remove empty lines between TeamCity events

### DIFF
--- a/src/Logging/TeamCity/TeamCityLogger.php
+++ b/src/Logging/TeamCity/TeamCityLogger.php
@@ -299,7 +299,7 @@ final class TeamCityLogger
     {
         $this->printer->print(
             sprintf(
-                "\n##teamcity[%s",
+                "##teamcity[%s",
                 $eventName,
             ),
         );

--- a/src/Logging/TeamCity/TeamCityLogger.php
+++ b/src/Logging/TeamCity/TeamCityLogger.php
@@ -299,7 +299,7 @@ final class TeamCityLogger
     {
         $this->printer->print(
             sprintf(
-                "##teamcity[%s",
+                '##teamcity[%s',
                 $eventName,
             ),
         );

--- a/tests/end-to-end/logging/log-teamcity-comparisonfailure.phpt
+++ b/tests/end-to-end/logging/log-teamcity-comparisonfailure.phpt
@@ -14,13 +14,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='1' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\ComparisonFailureTest' locationHint='php_qn:%sComparisonFailureTest.php::\PHPUnit\TestFixture\ComparisonFailureTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='php_qn:%sComparisonFailureTest.php::\PHPUnit\TestFixture\ComparisonFailureTest::testOne' flowId='%d']
-
 ##teamcity[testFailed name='testOne' message='Failed asserting that false matches expected true.' details='%sComparisonFailureTest.php:%d|n' duration='%s' type='comparisonFailure' actual='false' expected='true' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%s' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\ComparisonFailureTest' flowId='%d']

--- a/tests/end-to-end/logging/log-teamcity.phpt
+++ b/tests/end-to-end/logging/log-teamcity.phpt
@@ -14,77 +14,40 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='13' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Basic\StatusTest' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest' flowId='%d']
-
 ##teamcity[testStarted name='testSuccess' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSuccess' flowId='%d']
-
 ##teamcity[testFinished name='testSuccess' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testFailure' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testFailure' flowId='%d']
-
 ##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailure' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testError' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testError' flowId='%d']
-
 ##teamcity[testFailed name='testError' message='RuntimeException' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testError' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testIncomplete' flowId='%d']
-
 ##teamcity[testIgnored name='testIncomplete' message='' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncomplete' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSkipped' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSkipped' flowId='%d']
-
 ##teamcity[testIgnored name='testSkipped' message='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkipped' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testRisky' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testRisky' flowId='%d']
-
 ##teamcity[testFailed name='testRisky' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRisky' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSuccessWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSuccessWithMessage' flowId='%d']
-
 ##teamcity[testFinished name='testSuccessWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testFailureWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testFailureWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testFailureWithMessage' message='failure with custom message|nFailed asserting that false is true.' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailureWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testErrorWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testErrorWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testErrorWithMessage' message='RuntimeException: error with custom message' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testErrorWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testIncompleteWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testIncompleteWithMessage' flowId='%d']
-
 ##teamcity[testIgnored name='testIncompleteWithMessage' message='incomplete with custom message' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncompleteWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testIgnored name='testSkippedByMetadata' message='PHP > 9000 is required.' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSkippedWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSkippedWithMessage' flowId='%d']
-
 ##teamcity[testIgnored name='testSkippedWithMessage' message='skipped with custom message' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkippedWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testRiskyWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testRiskyWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testRiskyWithMessage' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRiskyWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\Basic\StatusTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-data-provider.phpt
+++ b/tests/end-to-end/logging/teamcity-data-provider.phpt
@@ -15,25 +15,15 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TeamCity\DataProviderTest' locationHint='php_qn://%sDataProviderTest.php::\PHPUnit\TestFixture\TeamCity\DataProviderTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='testOne' locationHint='php_qn://%sDataProviderTest.php::\PHPUnit\TestFixture\TeamCity\DataProviderTest::testOne' flowId='%d']
-
 ##teamcity[testStarted name='testOne with data set #0' locationHint='php_qn://%sDataProviderTest.php::\PHPUnit\TestFixture\TeamCity\DataProviderTest::testOne with data set #0' flowId='%d']
-
 ##teamcity[testFinished name='testOne with data set #0' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testOne with data set #1' locationHint='php_qn://%sDataProviderTest.php::\PHPUnit\TestFixture\TeamCity\DataProviderTest::testOne with data set #1' flowId='%d']
-
 ##teamcity[testFailed name='testOne with data set #1' message='Failed asserting that false is true.' details='%sDataProviderTest.php:28|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testOne with data set #1' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='testOne' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TeamCity\DataProviderTest' flowId='%d']
 Time: %s, Memory: %s
 

--- a/tests/end-to-end/logging/teamcity-directory.phpt
+++ b/tests/end-to-end/logging/teamcity-directory.phpt
@@ -15,107 +15,56 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-
 ##teamcity[testCount count='19' flowId='%d']
-
 ##teamcity[testSuiteStarted name='CLI Arguments' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Basic\SetUpBeforeClassTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eSetUpBeforeClassTest.php::\PHPUnit\TestFixture\Basic\SetUpBeforeClassTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Basic\SetUpTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eSetUpTest.php::\PHPUnit\TestFixture\Basic\SetUpTest' flowId='%d']
-
 ##teamcity[testFailed name='testOneWithSetUpException' message='RuntimeException: throw exception in setUp' details='%stests%eend-to-end%e_files%ebasic%eunit%eSetUpTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFailed name='testTwoWithSetUpException' message='RuntimeException: throw exception in setUp' details='%stests%eend-to-end%e_files%ebasic%eunit%eSetUpTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\Basic\SetUpTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Basic\StatusTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest' flowId='%d']
-
 ##teamcity[testStarted name='testSuccess' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSuccess' flowId='%d']
-
 ##teamcity[testFinished name='testSuccess' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testFailure' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testFailure' flowId='%d']
-
 ##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailure' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testError' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testError' flowId='%d']
-
 ##teamcity[testFailed name='testError' message='RuntimeException' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testError' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testIncomplete' flowId='%d']
-
 ##teamcity[testIgnored name='testIncomplete' message='' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncomplete' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSkipped' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSkipped' flowId='%d']
-
 ##teamcity[testIgnored name='testSkipped' message='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkipped' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testRisky' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testRisky' flowId='%d']
-
 ##teamcity[testFailed name='testRisky' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRisky' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSuccessWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSuccessWithMessage' flowId='%d']
-
 ##teamcity[testFinished name='testSuccessWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testFailureWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testFailureWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testFailureWithMessage' message='failure with custom message|nFailed asserting that false is true.' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailureWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testErrorWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testErrorWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testErrorWithMessage' message='RuntimeException: error with custom message' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testErrorWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testIncompleteWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testIncompleteWithMessage' flowId='%d']
-
 ##teamcity[testIgnored name='testIncompleteWithMessage' message='incomplete with custom message' details='%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncompleteWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testIgnored name='testSkippedByMetadata' message='PHP > 9000 is required.' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSkippedWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSkippedWithMessage' flowId='%d']
-
 ##teamcity[testIgnored name='testSkippedWithMessage' message='skipped with custom message' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkippedWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testRiskyWithMessage' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testRiskyWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testRiskyWithMessage' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRiskyWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\Basic\StatusTest' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Basic\TearDownAfterClassTest' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eTearDownAfterClassTest.php::\PHPUnit\TestFixture\Basic\TearDownAfterClassTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eTearDownAfterClassTest.php::\PHPUnit\TestFixture\Basic\TearDownAfterClassTest::testOne' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='php_qn://%stests%eend-to-end%e_files%ebasic%eunit%eTearDownAfterClassTest.php::\PHPUnit\TestFixture\Basic\TearDownAfterClassTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\Basic\TearDownAfterClassTest' flowId='%d']
-
 ##teamcity[testSuiteFinished name='CLI Arguments' flowId='%d']
 Time: %s, Memory: %s
 

--- a/tests/end-to-end/logging/teamcity-file.phpt
+++ b/tests/end-to-end/logging/teamcity-file.phpt
@@ -15,81 +15,43 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-
 ##teamcity[testCount count='13' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Basic\StatusTest' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest' flowId='%d']
-
 ##teamcity[testStarted name='testSuccess' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSuccess' flowId='%d']
-
 ##teamcity[testFinished name='testSuccess' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testFailure' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testFailure' flowId='%d']
-
 ##teamcity[testFailed name='testFailure' message='Failed asserting that false is true.' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailure' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testError' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testError' flowId='%d']
-
 ##teamcity[testFailed name='testError' message='RuntimeException' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testError' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testIncomplete' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testIncomplete' flowId='%d']
-
 ##teamcity[testIgnored name='testIncomplete' message='' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncomplete' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSkipped' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSkipped' flowId='%d']
-
 ##teamcity[testIgnored name='testSkipped' message='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkipped' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testRisky' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testRisky' flowId='%d']
-
 ##teamcity[testFailed name='testRisky' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRisky' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSuccessWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSuccessWithMessage' flowId='%d']
-
 ##teamcity[testFinished name='testSuccessWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testFailureWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testFailureWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testFailureWithMessage' message='failure with custom message|nFailed asserting that false is true.' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testFailureWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testErrorWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testErrorWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testErrorWithMessage' message='RuntimeException: error with custom message' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testErrorWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testIncompleteWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testIncompleteWithMessage' flowId='%d']
-
 ##teamcity[testIgnored name='testIncompleteWithMessage' message='incomplete with custom message' details='%sStatusTest.php:%d|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testIncompleteWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testIgnored name='testSkippedByMetadata' message='PHP > 9000 is required.' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testSkippedWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testSkippedWithMessage' flowId='%d']
-
 ##teamcity[testIgnored name='testSkippedWithMessage' message='skipped with custom message' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testSkippedWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testRiskyWithMessage' locationHint='php_qn://%sStatusTest.php::\PHPUnit\TestFixture\Basic\StatusTest::testRiskyWithMessage' flowId='%d']
-
 ##teamcity[testFailed name='testRiskyWithMessage' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testRiskyWithMessage' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\Basic\StatusTest' flowId='%d']
 Time: %s, Memory: %s
 

--- a/tests/end-to-end/logging/teamcity-inner-exceptions.phpt
+++ b/tests/end-to-end/logging/teamcity-inner-exceptions.phpt
@@ -15,19 +15,11 @@ require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\ExceptionStackTest' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\PHPUnit\TestFixture\ExceptionStackTest' flowId='%d']
-
 ##teamcity[testStarted name='testPrintingChildException' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\PHPUnit\TestFixture\ExceptionStackTest::testPrintingChildException' flowId='%d']
-
 ##teamcity[testFailed name='testPrintingChildException' message='Child exception|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n )|n' details='%s%etests%e_files%eExceptionStackTest.php:27|n|nCaused by|nmessage|nFailed asserting that two arrays are equal.|n--- Expected|n+++ Actual|n@@ @@|n Array (|n-    0 => 1|n+    0 => 2|n )|n|n%s%etests%e_files%eExceptionStackTest.php:23|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testPrintingChildException' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testNestedExceptions' locationHint='php_qn://%s%etests%e_files%eExceptionStackTest.php::\PHPUnit\TestFixture\ExceptionStackTest::testNestedExceptions' flowId='%d']
-
 ##teamcity[testFailed name='testNestedExceptions' message='Exception: One' details='%s%etests%e_files%eExceptionStackTest.php:35|n|nCaused by|nInvalidArgumentException: Two|n|n%s%etests%e_files%eExceptionStackTest.php:34|n|nCaused by|nException: Three|n|n%s%etests%e_files%eExceptionStackTest.php:33|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testNestedExceptions' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\ExceptionStackTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-deprecation.phpt
+++ b/tests/end-to-end/logging/teamcity-print-deprecation.phpt
@@ -18,19 +18,11 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='%d' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest' locationHint='%sDeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sDeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest::testOne' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sDeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testThree' locationHint='php_qn:%sDeprecationTest.php::\PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest::testThree' flowId='%d']
-
 ##teamcity[testFinished name='testThree' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\DeprecationTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-error.phpt
+++ b/tests/end-to-end/logging/teamcity-print-error.phpt
@@ -18,17 +18,10 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\ErrorTest' locationHint='%sErrorTest.php::\PHPUnit\TestFixture\TestRunnerStopping\ErrorTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sErrorTest.php::\PHPUnit\TestFixture\TestRunnerStopping\ErrorTest::testOne' flowId='%d']
-
 ##teamcity[testFailed name='testOne' message='Exception: message' details='%sErrorTest.php:19|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sErrorTest.php::\PHPUnit\TestFixture\TestRunnerStopping\ErrorTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\ErrorTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-failure.phpt
+++ b/tests/end-to-end/logging/teamcity-print-failure.phpt
@@ -17,17 +17,10 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='%d' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\FailureTest' locationHint='%sFailureTest.php::\PHPUnit\TestFixture\TestRunnerStopping\FailureTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sFailureTest.php::\PHPUnit\TestFixture\TestRunnerStopping\FailureTest::testOne' flowId='%d']
-
 ##teamcity[testFailed name='testOne' message='Failed asserting that false is true.' details='%sFailureTest.php:18|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sFailureTest.php::\PHPUnit\TestFixture\TestRunnerStopping\FailureTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\FailureTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-incomplete.phpt
+++ b/tests/end-to-end/logging/teamcity-print-incomplete.phpt
@@ -18,17 +18,10 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest' locationHint='%sIncompleteTest.php::\PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sIncompleteTest.php::\PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest::testOne' flowId='%d']
-
 ##teamcity[testIgnored name='testOne' message='message' details='%sIncompleteTest.php:18|n' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sIncompleteTest.php::\PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\IncompleteTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-notice.phpt
+++ b/tests/end-to-end/logging/teamcity-print-notice.phpt
@@ -18,15 +18,9 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\NoticeTest' locationHint='%sNoticeTest.php::\PHPUnit\TestFixture\TestRunnerStopping\NoticeTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sNoticeTest.php::\PHPUnit\TestFixture\TestRunnerStopping\NoticeTest::testOne' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sNoticeTest.php::\PHPUnit\TestFixture\TestRunnerStopping\NoticeTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\NoticeTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-risky.phpt
+++ b/tests/end-to-end/logging/teamcity-print-risky.phpt
@@ -17,17 +17,10 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\RiskyTest' locationHint='%sRiskyTest.php::\PHPUnit\TestFixture\TestRunnerStopping\RiskyTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sRiskyTest.php::\PHPUnit\TestFixture\TestRunnerStopping\RiskyTest::testOne' flowId='%d']
-
 ##teamcity[testFailed name='testOne' message='This test did not perform any assertions' details='' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sRiskyTest.php::\PHPUnit\TestFixture\TestRunnerStopping\RiskyTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\RiskyTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-skipped.phpt
+++ b/tests/end-to-end/logging/teamcity-print-skipped.phpt
@@ -18,17 +18,10 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\SkippedTest' locationHint='%sSkippedTest.php::\PHPUnit\TestFixture\TestRunnerStopping\SkippedTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sSkippedTest.php::\PHPUnit\TestFixture\TestRunnerStopping\SkippedTest::testOne' flowId='%d']
-
 ##teamcity[testIgnored name='testOne' message='message' duration='%d' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sSkippedTest.php::\PHPUnit\TestFixture\TestRunnerStopping\SkippedTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\SkippedTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-print-warning.phpt
+++ b/tests/end-to-end/logging/teamcity-print-warning.phpt
@@ -18,15 +18,9 @@ require realpath($parentDirectory . '/../bootstrap.php');
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
 ##teamcity[testCount count='2' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\TestRunnerStopping\WarningTest' locationHint='%sWarningTest.php::\PHPUnit\TestFixture\TestRunnerStopping\WarningTest' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='%sWarningTest.php::\PHPUnit\TestFixture\TestRunnerStopping\WarningTest::testOne' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%d' flowId='%d']
-
 ##teamcity[testStarted name='testTwo' locationHint='%sWarningTest.php::\PHPUnit\TestFixture\TestRunnerStopping\WarningTest::testTwo' flowId='%d']
-
 ##teamcity[testFinished name='testTwo' duration='%d' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\TestRunnerStopping\WarningTest' flowId='%d']

--- a/tests/end-to-end/logging/teamcity-warning.phpt
+++ b/tests/end-to-end/logging/teamcity-warning.phpt
@@ -16,23 +16,14 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Runtime: %s
 Configuration: %s
 
-
 ##teamcity[testCount count='1' flowId='%d']
-
 ##teamcity[testSuiteStarted name='%s%etests%eend-to-end%elogging%e_files%eteamcity-warning%ephpunit.xml' flowId='%d']
-
 ##teamcity[testSuiteStarted name='default' flowId='%d']
-
 ##teamcity[testSuiteStarted name='PHPUnit\TestFixture\Test' locationHint='php_qn://%s%eteamcity-warning%etests%eTest.php::\PHPUnit\TestFixture\Test' flowId='%d']
-
 ##teamcity[testStarted name='testOne' locationHint='php_qn://%s%eteamcity-warning%etests%eTest.php::\PHPUnit\TestFixture\Test::testOne' flowId='%d']
-
 ##teamcity[testFinished name='testOne' duration='%s' flowId='%d']
-
 ##teamcity[testSuiteFinished name='PHPUnit\TestFixture\Test' flowId='%d']
-
 ##teamcity[testSuiteFinished name='default' flowId='%d']
-
 ##teamcity[testSuiteFinished name='%s%etests%eend-to-end%elogging%e_files%eteamcity-warning%ephpunit.xml' flowId='%d']
 Time: %s, Memory: %s
 


### PR DESCRIPTION
Hi, PhpStorm is here!

[TeamCity output](https://www.jetbrains.com/help/teamcity/service-messages.html) support was introduced on #1858. We have a workaround that allows us to cut such lines out. However, it's better for our internal events processing to avoid empty lines between teamcity events.