### PR TITLE
strip closing PHP tags from code run in local sandbox

### DIFF
--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -528,7 +528,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
 
     private function runCodeInLocalSandbox(string $code): string
     {
-        $code = preg_replace('/^<\?(php)?/', '', $code);
+        $code = preg_replace('/^<\?(?:php)?|\?>\s*+$/', '', $code);
         $code = preg_replace('/declare\S?\([^)]+\)\S?;/', '', $code);
 
         // wrap in immediately invoked function to isolate local-side-effects of $code from our own process

--- a/tests/end-to-end/_files/phpt-skipif-closing-php-tag.phpt
+++ b/tests/end-to-end/_files/phpt-skipif-closing-php-tag.phpt
@@ -1,0 +1,10 @@
+--TEST--
+PHPT skip condition which is terminated with a closing PHP tag
+--FILE--
+<?php declare(strict_types=1);
+print "Nothing to see here, move along";
+--SKIPIF--
+<?php declare(strict_types=1);
+print "skip: something terrible happened\n";
+?>
+--EXPECT--

--- a/tests/end-to-end/event/phpt-skipif-closing-php-tag.phpt
+++ b/tests/end-to-end/event/phpt-skipif-closing-php-tag.phpt
@@ -1,0 +1,30 @@
+--TEST--
+The right events are emitted in the right order for a skipped PHPT test
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-skipif-closing-php-tag.phpt';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%s%ephpt-skipif-closing-php-tag.phpt, 1 test)
+Test Preparation Started (%s%ephpt-skipif-closing-php-tag.phpt)
+Test Prepared (%s%ephpt-skipif-closing-php-tag.phpt)
+Test Skipped (%s%ephpt-skipif-closing-php-tag.phpt)
+something terrible happened
+Test Finished (%s%ephpt-skipif-closing-php-tag.phpt)
+Test Suite Finished (%s%ephpt-skipif-closing-php-tag.phpt, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)


### PR DESCRIPTION
According to https://qa.php.net/phpt_details.php#skipif_section the code in this section is enclosed by PHP tags. While it's perfectly valid to omit the closing tag we need to make sure that running the skipif section does not fail when a closing tag is used.