### PR TITLE
Deprecation Triggers are not registered when process isolation is used

### DIFF
--- a/src/Framework/TestRunner/templates/class.tpl
+++ b/src/Framework/TestRunner/templates/class.tpl
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 use PHPUnit\Event\Facade;
 use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use PHPUnit\TextUI\Configuration\PhpHandler;
@@ -41,10 +42,32 @@ function __phpunit_run_isolated_test()
 
     require_once '{filename}';
 
+    $configuration = ConfigurationRegistry::get();
+
     if ({collectCodeCoverageInformation}) {
-        CodeCoverage::instance()->init(ConfigurationRegistry::get(), CodeCoverageFilterRegistry::instance(), true);
+        CodeCoverage::instance()->init($configuration, CodeCoverageFilterRegistry::instance(), true);
         CodeCoverage::instance()->ignoreLines({linesToBeIgnored});
     }
+
+    $deprecationTriggers = [
+        'functions' => [],
+        'methods'   => [],
+    ];
+
+    foreach ($configuration->source()->deprecationTriggers()['functions'] as $function) {
+        $deprecationTriggers['functions'][] = $function;
+    }
+
+    foreach ($configuration->source()->deprecationTriggers()['methods'] as $method) {
+        [$className, $methodName] = explode('::', $method);
+
+        $deprecationTriggers['methods'][] = [
+            'className'  => $className,
+            'methodName' => $methodName,
+        ];
+    }
+
+    ErrorHandler::instance()->useDeprecationTriggers($deprecationTriggers);
 
     $test = new {className}('{name}');
 

--- a/src/Framework/TestRunner/templates/method.tpl
+++ b/src/Framework/TestRunner/templates/method.tpl
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 use PHPUnit\Event\Facade;
 use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use PHPUnit\TextUI\Configuration\PhpHandler;
@@ -41,10 +42,32 @@ function __phpunit_run_isolated_test()
 
     require_once '{filename}';
 
+    $configuration = ConfigurationRegistry::get();
+
     if ({collectCodeCoverageInformation}) {
-        CodeCoverage::instance()->init(ConfigurationRegistry::get(), CodeCoverageFilterRegistry::instance(), true);
+        CodeCoverage::instance()->init($configuration, CodeCoverageFilterRegistry::instance(), true);
         CodeCoverage::instance()->ignoreLines({linesToBeIgnored});
     }
+
+    $deprecationTriggers = [
+        'functions' => [],
+        'methods'   => [],
+    ];
+
+    foreach ($configuration->source()->deprecationTriggers()['functions'] as $function) {
+        $deprecationTriggers['functions'][] = $function;
+    }
+
+    foreach ($configuration->source()->deprecationTriggers()['methods'] as $method) {
+        [$className, $methodName] = explode('::', $method);
+
+        $deprecationTriggers['methods'][] = [
+            'className'  => $className,
+            'methodName' => $methodName,
+        ];
+    }
+
+    ErrorHandler::instance()->useDeprecationTriggers($deprecationTriggers);
 
     $test = new {className}('{methodName}');
 

--- a/tests/end-to-end/deprecation-trigger/_files/details-process-isolation/phpunit.xml
+++ b/tests/end-to-end/deprecation-trigger/_files/details-process-isolation/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         cacheResult="false"
+         processIsolation="true"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <deprecationTrigger>
+            <method>PHPUnit\TestFixture\DeprecationTrigger\Test::triggerDeprecation</method>
+            <function>PHPUnit\TestFixture\DeprecationTrigger\triggerDeprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/tests/end-to-end/deprecation-trigger/_files/details-process-isolation/tests/Test.php
+++ b/tests/end-to-end/deprecation-trigger/_files/details-process-isolation/tests/Test.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\DeprecationTrigger;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class Test extends TestCase
+{
+    public static function triggerDeprecation(): void
+    {
+        trigger_error('deprecation triggered by method', E_USER_DEPRECATED);
+    }
+
+    public function testDeprecation(): void
+    {
+        self::triggerDeprecation();
+        triggerDeprecation();
+
+        $this->assertTrue(true);
+    }
+}
+
+function triggerDeprecation(): void
+{
+    trigger_error('deprecation triggered by function', E_USER_DEPRECATED);
+}

--- a/tests/end-to-end/deprecation-trigger/details-process-isolation.phpt
+++ b/tests/end-to-end/deprecation-trigger/details-process-isolation.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Configured deprecation triggers are filtered when displaying deprecation details in process isolation
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/details-process-isolation/phpunit.xml';
+$_SERVER['argv'][] = '--display-deprecations';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+D                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 2 deprecations:
+
+1) %sTest.php:25
+deprecation triggered by method
+
+Triggered by:
+
+* PHPUnit\TestFixture\DeprecationTrigger\Test::testDeprecation
+  %sTest.php:23
+
+2) %sTest.php:26
+deprecation triggered by function
+
+Triggered by:
+
+* PHPUnit\TestFixture\DeprecationTrigger\Test::testDeprecation
+  %sTest.php:23
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Deprecations: 2.


### PR DESCRIPTION
When process isolation is used, the deprecation triggers are not registered on the ErrorHandler.

Related to https://github.com/sebastianbergmann/phpunit/pull/5923