### PR TITLE
Avoid subprocess when SKIPIF triggers IO

### DIFF
--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -432,7 +432,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
 
         $skipIfCode = $this->render($sections['SKIPIF']);
 
-        if ($this->shouldRunSkipIfInSubprocess($sections, $skipIfCode)) {
+        if ($this->shouldRunInSubprocess($sections, $skipIfCode)) {
             $jobResult = JobRunnerRegistry::run(
                 new Job(
                     $skipIfCode,
@@ -469,7 +469,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
     /**
      * @param array<non-empty-string, non-empty-string> $sections
      */
-    private function shouldRunCleanInSubprocess(array $sections, string $cleanCode): bool
+    private function shouldRunInSubprocess(array $sections, string $cleanCode): bool
     {
         if (isset($sections['INI'])) {
             // to get per-test INI settings, we need a dedicated subprocess
@@ -488,35 +488,6 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                 $sideEffect === SideEffect::STANDARD_OUTPUT || // stdout is fine, we will catch it using output-buffering
                 $sideEffect === SideEffect::INPUT_OUTPUT // IO is fine while cleanup, as it doesn't pollute the main process
             ) {
-                continue;
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param array<non-empty-string, non-empty-string> $sections
-     */
-    private function shouldRunSkipIfInSubprocess(array $sections, string $skipIfCode): bool
-    {
-        if (isset($sections['INI'])) {
-            // to get per-test INI settings, we need a dedicated subprocess
-            return true;
-        }
-
-        $detector    = new SideEffectsDetector;
-        $sideEffects = $detector->getSideEffects($skipIfCode);
-
-        if ($sideEffects === []) {
-            return false; // no side-effects
-        }
-
-        foreach ($sideEffects as $sideEffect) {
-            if ($sideEffect === SideEffect::STANDARD_OUTPUT) {
-                // stdout is fine, we will catch it using output-buffering
                 continue;
             }
 
@@ -550,7 +521,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
 
         $cleanCode = $this->render($sections['CLEAN']);
 
-        if ($this->shouldRunCleanInSubprocess($sections, $cleanCode)) {
+        if ($this->shouldRunInSubprocess($sections, $cleanCode)) {
             $result = JobRunnerRegistry::run(
                 new Job(
                     $cleanCode,

--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -486,7 +486,7 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
         foreach ($sideEffects as $sideEffect) {
             if (
                 $sideEffect === SideEffect::STANDARD_OUTPUT || // stdout is fine, we will catch it using output-buffering
-                $sideEffect === SideEffect::INPUT_OUTPUT // IO is fine while cleanup, as it doesn't pollute the main process
+                $sideEffect === SideEffect::INPUT_OUTPUT // IO is fine, as it doesn't pollute the main process
             ) {
                 continue;
             }

--- a/tests/end-to-end/_files/phpt-skipif-io.phpt
+++ b/tests/end-to-end/_files/phpt-skipif-io.phpt
@@ -1,0 +1,11 @@
+--TEST--
+PHPT skip condition with IO operations run in main process
+--SKIPIF--
+<?php declare(strict_types=1);
+file_put_contents(__DIR__ . '/skipif-io.log', 'some content');
+unlink(__DIR__ . '/skipif-io.log');
+--FILE--
+<?php declare(strict_types=1);
+echo "Hello, World!\n";
+--EXPECT--
+Hello, World!

--- a/tests/end-to-end/_files/phpt-skipif-require.phpt
+++ b/tests/end-to-end/_files/phpt-skipif-require.phpt
@@ -1,0 +1,10 @@
+--TEST--
+PHPT skip condition with IO operations run in main process
+--SKIPIF--
+<?php declare(strict_types=1);
+require (__DIR__ . '/phpt-skipif-required-file.php');
+--FILE--
+<?php declare(strict_types=1);
+echo "Hello, World!\n";
+--EXPECT--
+Hello, World!

--- a/tests/end-to-end/_files/phpt-skipif-require.phpt
+++ b/tests/end-to-end/_files/phpt-skipif-require.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PHPT skip condition with IO operations run in main process
+PHPT skip condition with require() runs in subprocess
 --SKIPIF--
 <?php declare(strict_types=1);
 require (__DIR__ . '/phpt-skipif-required-file.php');

--- a/tests/end-to-end/_files/phpt-skipif-required-file.php
+++ b/tests/end-to-end/_files/phpt-skipif-required-file.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace PhpTSkipIfRequiredFile;
+
+class SomeClass {}

--- a/tests/end-to-end/_files/phpt-skipif-required-file.php
+++ b/tests/end-to-end/_files/phpt-skipif-required-file.php
@@ -1,5 +1,14 @@
-<?php
-
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace PhpTSkipIfRequiredFile;
 
-class SomeClass {}
+class SomeClass
+{
+}

--- a/tests/end-to-end/event/phpt-skipif-io.phpt
+++ b/tests/end-to-end/event/phpt-skipif-io.phpt
@@ -1,0 +1,31 @@
+--TEST--
+The right events are emitted in the right order for PHPT test using IO in skipif
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-skipif-io.phpt';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%s%ephpt-skipif-io.phpt, 1 test)
+Test Preparation Started (%s%ephpt-skipif-io.phpt)
+Test Prepared (%s%ephpt-skipif-io.phpt)
+Child Process Started
+Child Process Finished
+Test Passed (%s%ephpt-skipif-io.phpt)
+Test Finished (%s%ephpt-skipif-io.phpt)
+Test Suite Finished (%s%ephpt-skipif-io.phpt, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/event/phpt-skipif-require.phpt
+++ b/tests/end-to-end/event/phpt-skipif-require.phpt
@@ -1,0 +1,33 @@
+--TEST--
+The right events are emitted in the right order for PHPT test using require() in skipif
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/../_files/phpt-skipif-require.phpt';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%s%ephpt-skipif-require.phpt, 1 test)
+Test Preparation Started (%s%ephpt-skipif-require.phpt)
+Test Prepared (%s%ephpt-skipif-require.phpt)
+Child Process Started
+Child Process Finished
+Child Process Started
+Child Process Finished
+Test Passed (%s%ephpt-skipif-require.phpt)
+Test Finished (%s%ephpt-skipif-require.phpt)
+Test Suite Finished (%s%ephpt-skipif-require.phpt, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)


### PR DESCRIPTION
I realized that since we already separate include/require from other IO functions, we can run tests which only do IO (like for filesystem cleanup stuff) in the main process (like we already do for `--CLEAN--`).

followup to https://github.com/sebastianbergmann/phpunit/pull/5998, https://github.com/sebastianbergmann/phpunit/pull/5999