### PR TITLE
fix: PHPStan detecting type correctly after usage of Assert::assertIsList

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -194,6 +194,8 @@ abstract class Assert
     }
 
     /**
+     * @phpstan-assert list $array
+     *
      * @throws ExpectationFailedException
      */
     final public static function assertIsList(mixed $array, string $message = ''): void


### PR DESCRIPTION
Hey there,

recently I found that the `assertIsList` method does not tell PHPStan correctly that the variable is of type `list` afterwards. This PR is fixing that. 

I wanted to add this to 10.5 branch first, but I saw, that there are no `phpstan-assert` annotations at all, so I was not sure, if that was reasonable. 

This is my first contribution here, so I hope, I did everything correct. Not sure, if I need a test for this

See https://github.com/phpstan/phpstan-phpunit/issues/212 for reference