### PR TITLE
Remove unnecessary ext-json requirement

### DIFF
--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -30,7 +30,7 @@ if (version_compare('8.3.0', PHP_VERSION, '>')) {
     die(1);
 }
 
-$requiredExtensions = ['ctype', 'dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
+$requiredExtensions = ['ctype', 'dom', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
 
 $unavailableExtensions = array_filter(
     $requiredExtensions,

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require": {
         "php": ">=8.3",
         "ext-dom": "*",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-xml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -1600,7 +1600,6 @@
     "platform": {
         "php": ">=8.3",
         "ext-dom": "*",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-xml": "*",

--- a/phpunit
+++ b/phpunit
@@ -71,7 +71,7 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
 
 require PHPUNIT_COMPOSER_INSTALL;
 
-$requiredExtensions = ['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
+$requiredExtensions = ['dom', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
 
 $unavailableExtensions = array_filter(
     $requiredExtensions,


### PR DESCRIPTION
JSON extension is always available as of PHP 8.0+.