### PR TITLE
Fix type errors in PhptTestCase

### DIFF
--- a/src/Runner/PHPT/PhptTestCase.php
+++ b/src/Runner/PHPT/PhptTestCase.php
@@ -561,7 +561,9 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
                     );
                 }
 
-                $sections[$section] = file_get_contents($testDirectory . $externalFilename);
+                $contents = file_get_contents($testDirectory . $externalFilename);
+                assert($contents !== false && $contents !== '');
+                $sections[$section] = $contents;
             }
         }
     }
@@ -694,9 +696,9 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
 
         file_put_contents($files['job'], $job);
 
-        $job = $template->render();
-
-        assert($job !== '');
+        $rendered = $template->render();
+        assert($rendered !== '');
+        $job = $rendered;
     }
 
     private function cleanupForCoverage(): RawCodeCoverageData

--- a/src/TextUI/Command/Commands/VersionCheckCommand.php
+++ b/src/TextUI/Command/Commands/VersionCheckCommand.php
@@ -41,8 +41,6 @@ final readonly class VersionCheckCommand implements Command
 
         $latestCompatibleVersion = $this->downloader->download('https://phar.phpunit.de/latest-version-of/phpunit-' . $this->majorVersionNumber);
 
-        assert($latestCompatibleVersion !== false);
-
         $notLatest           = version_compare($latestVersion, $this->versionId, '>');
         $notLatestCompatible = false;
 


### PR DESCRIPTION
fixes
```
------ -------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Runner/PHPT/PhptTestCase.php                                                                                                                
 ------ -------------------------------------------------------------------------------------------------------------------------------------------- 
  634    Parameter &$sections by-ref type of method PHPUnit\Runner\PhptTestCase::parseExternal() expects array<non-empty-string, non-empty-string>,  
         non-empty-array<non-empty-string, string|false> given.                                                                                      
         💡 You can change the parameter out type with @param-out PHPDoc tag.                                                                        
  767    Parameter &$job @param-out type of method PHPUnit\Runner\PhptTestCase::renderForCoverage() expects non-empty-string, string given.          
 ------ -------------------------------------------------------------------------------------------------------------------------------------------- 
```

on my way to ease the PHPStan 2.0 update