### PR TITLE
"assert.exception" php.ini is deprecated since PHP 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
 
     env:
       PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, phar, tokenizer, xml, xmlwriter
-      PHP_INI_VALUES: memory_limit=-1, assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
+      PHP_INI_VALUES: memory_limit=-1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
     strategy:
       fail-fast: false
@@ -148,7 +148,7 @@ jobs:
 
     env:
       PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, pdo, phar, tokenizer, xml, xmlwriter
-      PHP_INI_VALUES: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
+      PHP_INI_VALUES: zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
     strategy:
       fail-fast: false
@@ -205,7 +205,7 @@ jobs:
           php-version: 8.4
           coverage: xdebug
           extensions: none, ctype, curl, dom, json, libxml, mbstring, pdo, phar, tokenizer, xml, xmlwriter
-          ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
+          ini-values: zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
           tools: none
 
       - name: Install dependencies with Composer
@@ -238,7 +238,7 @@ jobs:
 
     env:
       PHP_EXTENSIONS: none, ctype, dom, json, fileinfo, iconv, libxml, mbstring, phar, tokenizer, xml, xmlwriter
-      PHP_INI_VALUES: assert.exception=1, phar.readonly=0, zend.assertions=1
+      PHP_INI_VALUES: phar.readonly=0, zend.assertions=1
 
     steps:
       - name: Checkout
@@ -286,7 +286,7 @@ jobs:
 
     env:
       PHP_EXTENSIONS: none, ctype, curl, dom, json, fileinfo, iconv, libxml, mbstring, phar, tokenizer, xml, xmlwriter
-      PHP_INI_VALUES: assert.exception=1, phar.readonly=0, zend.assertions=1
+      PHP_INI_VALUES: phar.readonly=0, zend.assertions=1
 
     strategy:
       fail-fast: false

--- a/tests/end-to-end/event/assert-failure.phpt
+++ b/tests/end-to-end/event/assert-failure.phpt
@@ -5,10 +5,6 @@ The right events are emitted in the right order for a test that fails because of
 if (ini_get('zend.assertions') != 1) {
     print 'skip: zend.assertions=1 is required' . PHP_EOL;
 }
-
-if (ini_get('assert.exception') != 1) {
-    print 'skip: assert.exception=1 is required' . PHP_EOL;
-}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/generic/assertion.phpt
+++ b/tests/end-to-end/generic/assertion.phpt
@@ -5,10 +5,6 @@ phpunit ../../_files/AssertionExampleTest.php
 if (ini_get('zend.assertions') != 1) {
     print 'skip: zend.assertions=1 is required' . PHP_EOL;
 }
-
-if (ini_get('assert.exception') != 1) {
-    print 'skip: assert.exception=1 is required' . PHP_EOL;
-}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';


### PR DESCRIPTION
just cleanup

RFC: https://wiki.php.net/rfc/assert-string-eval-cleanup

docs: https://www.php.net/manual/en/function.assert.php