### PR TITLE
Remove duplicate `is_file()` check

### DIFF
--- a/src/Runner/PhptTestCase.php
+++ b/src/Runner/PhptTestCase.php
@@ -89,10 +89,6 @@ final class PhptTestCase implements Reorderable, SelfDescribing, Test
      */
     public function __construct(string $filename, ?AbstractPhpProcess $phpUtil = null)
     {
-        if (!is_file($filename)) {
-            throw new FileDoesNotExistException($filename);
-        }
-
         $this->filename = $filename;
         $this->phpUtil  = $phpUtil ?: AbstractPhpProcess::factory();
     }


### PR DESCRIPTION
there is only a single place where [`new PhptTestCase` is used](https://github.com/sebastianbergmann/phpunit/blob/5960490e8fef8ba47bb234d453562e4de608abd3/src/Framework/TestSuite.php#L227).
at this call-site we already check with `is_file` for the file existance, so there is no value in doing the same IO check a second time