### PR TITLE
Changed separated process runner templates to return object instead of array allowing class template to return array of objects when refactored.

### DIFF
--- a/src/Framework/TestRunner/SeparateProcessTestRunner.php
+++ b/src/Framework/TestRunner/SeparateProcessTestRunner.php
@@ -14,6 +14,7 @@ use function defined;
 use function file_get_contents;
 use function get_include_path;
 use function hrtime;
+use function is_array;
 use function is_file;
 use function restore_error_handler;
 use function serialize;
@@ -252,22 +253,28 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         }
 
         if ($childResult !== false) {
-            if (!empty($childResult['output'])) {
-                $output = $childResult['output'];
+            if (!is_array($childResult)) {
+                $childResult = [$childResult];
             }
 
-            Facade::instance()->forward($childResult['events']);
-            PassedTests::instance()->import($childResult['passedTests']);
+            foreach ($childResult as $result) {
+                if (!empty($result->output)) {
+                    $output = $result->output;
+                }
 
-            assert($test instanceof TestCase);
+                Facade::instance()->forward($result->events);
+                PassedTests::instance()->import($result->passedTests);
 
-            $test->setResult($childResult['testResult']);
-            $test->addToAssertionCount($childResult['numAssertions']);
+                assert($test instanceof TestCase);
 
-            if (CodeCoverage::instance()->isActive() && $childResult['codeCoverage'] instanceof \SebastianBergmann\CodeCoverage\CodeCoverage) {
-                CodeCoverage::instance()->codeCoverage()->merge(
-                    $childResult['codeCoverage'],
-                );
+                $test->setResult($result->testResult);
+                $test->addToAssertionCount($result->numAssertions);
+
+                if (CodeCoverage::instance()->isActive() && $result->codeCoverage instanceof \SebastianBergmann\CodeCoverage\CodeCoverage) {
+                    CodeCoverage::instance()->codeCoverage()->merge(
+                        $result->codeCoverage,
+                    );
+                }
             }
         }
 

--- a/src/Framework/TestRunner/templates/class.tpl
+++ b/src/Framework/TestRunner/templates/class.tpl
@@ -105,7 +105,7 @@ function __phpunit_run_isolated_test()
     file_put_contents(
         '{processResultFile}',
         serialize(
-            [
+            (object)[
                 'testResult'    => $test->result(),
                 'codeCoverage'  => {collectCodeCoverageInformation} ? CodeCoverage::instance()->codeCoverage() : null,
                 'numAssertions' => $test->numberOfAssertionsPerformed(),

--- a/src/Framework/TestRunner/templates/method.tpl
+++ b/src/Framework/TestRunner/templates/method.tpl
@@ -105,7 +105,7 @@ function __phpunit_run_isolated_test()
     file_put_contents(
         '{processResultFile}',
         serialize(
-            [
+            (object)[
                 'testResult'    => $test->result(),
                 'codeCoverage'  => {collectCodeCoverageInformation} ? CodeCoverage::instance()->codeCoverage() : null,
                 'numAssertions' => $test->numberOfAssertionsPerformed(),

--- a/tests/end-to-end/regression/5884/tests/FooTest.php
+++ b/tests/end-to-end/regression/5884/tests/FooTest.php
@@ -61,10 +61,11 @@ final class FooTest extends TestCase
 
         // Now verify the original file is unchanged.
         $contents = file_get_contents($filename);
-        $this->assertSame('foo', $contents);
 
         chmod($filename, 0o755);
         unlink($filename);
+
+        $this->assertSame('foo', $contents);
     }
 
     #[WithoutErrorHandler]
@@ -85,10 +86,11 @@ final class FooTest extends TestCase
 
         // Now verify the original file is unchanged.
         $contents = file_get_contents($filename);
-        $this->assertSame('foo', $contents);
 
         chmod($filename, 0o755);
         unlink($filename);
+
+        $this->assertSame('foo', $contents);
     }
 
     public function testStreamToInvalidFile(): void


### PR DESCRIPTION
Here is first pass for the separated process improvement/fix for the class template. I've changed the return type from array to object and corrected the 5884 regression test to remove temp file. It throws error when executed inside WSL.