### PR TITLE
fix: RequiresEnvironmentVariable should only allow strings

### DIFF
--- a/src/Framework/Attributes/RequiresEnvironmentVariable.php
+++ b/src/Framework/Attributes/RequiresEnvironmentVariable.php
@@ -20,9 +20,9 @@ use Attribute;
 final readonly class RequiresEnvironmentVariable
 {
     private string $environmentVariableName;
-    private null|bool|int|string $value;
+    private null|string $value;
 
-    public function __construct(string $environmentVariableName, null|bool|int|string $value = null)
+    public function __construct(string $environmentVariableName, null|string $value = null)
     {
         $this->environmentVariableName = $environmentVariableName;
         $this->value                   = $value;
@@ -33,7 +33,7 @@ final readonly class RequiresEnvironmentVariable
         return $this->environmentVariableName;
     }
 
-    public function value(): null|bool|int|string
+    public function value(): null|string
     {
         return $this->value;
     }

--- a/src/Metadata/Api/Requirements.php
+++ b/src/Metadata/Api/Requirements.php
@@ -110,7 +110,8 @@ final readonly class Requirements
             if ($metadata->isRequiresEnvironmentVariable()) {
                 assert($metadata instanceof RequiresEnvironmentVariable);
 
-                if (!array_key_exists($metadata->environmentVariableName(), $_ENV)) {
+                if (!array_key_exists($metadata->environmentVariableName(), $_ENV) ||
+                    $metadata->value() === null && $_ENV[$metadata->environmentVariableName()] === '') {
                     $notSatisfied[] = sprintf('Environment variable "%s" is required.', $metadata->environmentVariableName());
 
                     continue;

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -391,12 +391,12 @@ abstract readonly class Metadata
         return new RequiresPhpunitExtension(self::METHOD_LEVEL, $extensionClass);
     }
 
-    public static function requiresEnvironmentVariableOnClass(string $environmentVariableName, null|int|string $value): RequiresEnvironmentVariable
+    public static function requiresEnvironmentVariableOnClass(string $environmentVariableName, null|string $value): RequiresEnvironmentVariable
     {
         return new RequiresEnvironmentVariable(self::CLASS_LEVEL, $environmentVariableName, $value);
     }
 
-    public static function requiresEnvironmentVariableOnMethod(string $environmentVariableName, null|int|string $value): RequiresEnvironmentVariable
+    public static function requiresEnvironmentVariableOnMethod(string $environmentVariableName, null|string $value): RequiresEnvironmentVariable
     {
         return new RequiresEnvironmentVariable(self::METHOD_LEVEL, $environmentVariableName, $value);
     }

--- a/src/Metadata/RequiresEnvironmentVariable.php
+++ b/src/Metadata/RequiresEnvironmentVariable.php
@@ -17,9 +17,9 @@ namespace PHPUnit\Metadata;
 final readonly class RequiresEnvironmentVariable extends Metadata
 {
     private string $environmentVariableName;
-    private null|bool|int|string $value;
+    private null|string $value;
 
-    public function __construct(int $level, string $environmentVariableName, null|bool|int|string $value)
+    public function __construct(int $level, string $environmentVariableName, null|string $value)
     {
         parent::__construct($level);
 
@@ -37,7 +37,7 @@ final readonly class RequiresEnvironmentVariable extends Metadata
         return $this->environmentVariableName;
     }
 
-    public function value(): null|bool|int|string
+    public function value(): null|string
     {
         return $this->value;
     }

--- a/tests/_files/RequirementsEnvironmentVariableTest.php
+++ b/tests/_files/RequirementsEnvironmentVariableTest.php
@@ -15,8 +15,9 @@ use PHPUnit\Framework\TestCase;
 
 final class RequirementsEnvironmentVariableTest extends TestCase
 {
-    #[RequiresEnvironmentVariable('foo', 'bar')]
-    #[RequiresEnvironmentVariable('baz')]
+    #[RequiresEnvironmentVariable('FOO', 'bar')]
+    #[RequiresEnvironmentVariable('BAR')]
+    #[RequiresEnvironmentVariable('BAZ')]
     public function testRequiresEnvironmentVariable(): void
     {
     }

--- a/tests/end-to-end/_files/requires_environment_variable/SomeTest.php
+++ b/tests/end-to-end/_files/requires_environment_variable/SomeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\requires_environment_variable;
+
+use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    #[RequiresEnvironmentVariable('FOO', 'bar')]
+    public function testShouldNotRunFOOHasWrongValue(): void
+    {
+        $this->fail();
+    }
+
+    #[RequiresEnvironmentVariable('BAR')]
+    public function testShouldNotRunBARIsEmpty(): void
+    {
+        $this->fail();
+    }
+
+    #[RequiresEnvironmentVariable('BAZ')]
+    public function testShouldNotRunBAZDoesNotExist(): void
+    {
+        $this->fail();
+    }
+
+    #[RequiresEnvironmentVariable('FOO')]
+    public function testOneShouldRun(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[RequiresEnvironmentVariable('FOO', '1')]
+    public function testTwoShouldRun(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[RequiresEnvironmentVariable('BAR', '')]
+    public function testThreeShouldRun(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[RunInSeparateProcess]
+    #[RequiresEnvironmentVariable('FOO', '1')]
+    public function testMustRunInSeparateProcess(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/requires_environment_variable/phpunit.xml
+++ b/tests/end-to-end/_files/requires_environment_variable/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+         colors="false"
+         cacheResult="false">
+    <testsuites>
+        <testsuite name="requires_environment_variable">
+            <file>SomeTest.php</file>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <env name="FOO" value="1"/>
+        <env name="BAR" value=""/>
+    </php>
+</phpunit>

--- a/tests/end-to-end/metadata/requires-environment-variable.phpt
+++ b/tests/end-to-end/metadata/requires-environment-variable.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Tests are correctly ran based on environment variables requirements
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/requires_environment_variable/phpunit.xml';
+$_SERVER['argv'][] = '--display-skipped';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+SSS....                                                             7 / 7 (100%)
+
+Time: %s, Memory: %s
+
+There were 3 skipped tests:
+
+1) PHPUnit\TestFixture\requires_environment_variable\SomeTest::testShouldNotRunFOOHasWrongValue
+Environment variable "FOO" is required to be "bar".
+
+2) PHPUnit\TestFixture\requires_environment_variable\SomeTest::testShouldNotRunBARIsEmpty
+Environment variable "BAR" is required.
+
+3) PHPUnit\TestFixture\requires_environment_variable\SomeTest::testShouldNotRunBAZDoesNotExist
+Environment variable "BAZ" is required.
+
+OK, but some tests were skipped!
+Tests: 7, Assertions: 4, Skipped: 3.
+

--- a/tests/unit/Metadata/Api/RequirementsTest.php
+++ b/tests/unit/Metadata/Api/RequirementsTest.php
@@ -133,7 +133,7 @@ final class RequirementsTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($_ENV['foo']);
+        unset($_ENV['FOO'], $_ENV['BAR']);
     }
 
     #[DataProvider('missingRequirementsProvider')]
@@ -147,12 +147,14 @@ final class RequirementsTest extends TestCase
 
     public function testGetMissingEnvironmentVariableRequirements(): void
     {
-        $_ENV['foo'] = '';
+        $_ENV['FOO'] = 'foo';
+        $_ENV['BAR'] = '';
 
         $this->assertEquals(
             [
-                'Environment variable "foo" is required to be "bar".',
-                'Environment variable "baz" is required.',
+                'Environment variable "FOO" is required to be "bar".',
+                'Environment variable "BAR" is required.',
+                'Environment variable "BAZ" is required.',
             ],
             (new Requirements)->requirementsNotSatisfiedFor(RequirementsEnvironmentVariableTest::class, 'testRequiresEnvironmentVariable'),
         );


### PR DESCRIPTION
see https://github.com/sebastianbergmann/phpunit/pull/6074#pullrequestreview-2488488457

some questions towards the behavior of the feature:
- should I only test `$_ENV` or maybe `$_ENV ?? getenv()`?
- when no value is provided, should I at least test the value of the env var is okish?
- not sure what @mvorisek meant [here](https://github.com/sebastianbergmann/phpunit/pull/6074#discussion_r1875896248) by "in separate process"? 