### PR TITLE
`DefaultResultCache::mergeWith()` for merging result cache instances

### DIFF
--- a/src/Runner/ResultCache/DefaultResultCache.php
+++ b/src/Runner/ResultCache/DefaultResultCache.php
@@ -87,6 +87,17 @@ final class DefaultResultCache implements ResultCache
         return $this->times[$id] ?? 0.0;
     }
 
+    public function mergeWith(self $other): void
+    {
+        foreach ($other->defects as $id => $defect) {
+            $this->defects[$id] = $defect;
+        }
+
+        foreach ($other->times as $id => $time) {
+            $this->times[$id] = $time;
+        }
+    }
+
     public function load(): void
     {
         if (!is_file($this->cacheFilename)) {


### PR DESCRIPTION
Fix https://github.com/sebastianbergmann/phpunit/issues/6078