### PR TITLE
Fix test turning warnings into ErrorExceptions

### DIFF
--- a/tests/end-to-end/regression/5764/error-handler.php
+++ b/tests/end-to-end/regression/5764/error-handler.php
@@ -9,5 +9,10 @@
  */
 \set_error_handler(static function (int $err_lvl, string $err_msg, string $err_file, int $err_line): bool
 {
+    // silenced errors (via "@" operator)
+    if (!(\error_reporting() & $errno)) {
+        return false;
+    }
+
     throw new ErrorException($err_msg, 0, $err_lvl, $err_file, $err_line);
 });


### PR DESCRIPTION
Fixes

```diff
1) /home/runner/work/phpunit/phpunit/tests/end-to-end/regression/5764/5764.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 1) No tests found in class "PHPUnit\TestFixture\Issue5764\Issue5764Test".
 
-No tests executed!
+No tests executed!
+
+Fatal error: Uncaught ErrorException: file(Standard input code): Failed to open stream: No such file or directory in /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Data/RawCodeCoverageData.php:270
+Stack trace:
+#0 [internal function]: PHPUnit\TextUI\Application::{closure:/home/runner/work/phpunit/phpunit/tests/end-to-end/regression/5764/error-handler.php:10}()
+#1 /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Data/RawCodeCoverageData.php(270): file()
+#2 /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Data/RawCodeCoverageData.php(256): SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData->getEmptyLinesForFile()
+#3 /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Data/RawCodeCoverageData.php(106): SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData->skipEmptyLines()
+#4 /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Data/RawCodeCoverageData.php(59): SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData->__construct()
+#5 /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Driver/XdebugDriver.php(117): SebastianBergmann\CodeCoverage\Data\RawCodeCoverageData::fromXdebugWithoutPathCoverage()
+#6 /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/CodeCoverage.php(169): SebastianBergmann\CodeCoverage\Driver\XdebugDriver->stop()
+#7 Standard input code(47): SebastianBergmann\CodeCoverage\CodeCoverage->stop()
+#8 [internal function]: {closure:Standard input code:43}()
+#9 {main}
+  thrown in /home/runner/work/phpunit/phpunit/vendor/phpunit/php-code-coverage/src/Data/RawCodeCoverageData.php on line 270

/home/runner/work/phpunit/phpunit/tests/end-to-end/regression/5764/5764.phpt:21
/home/runner/work/phpunit/phpunit/src/Framework/TestSuite.php:369
/home/runner/work/phpunit/phpunit/src/Framework/TestSuite.php:369
/home/runner/work/phpunit/phpunit/src/TextUI/TestRunner.php:64
/home/runner/work/phpunit/phpunit/src/TextUI/Application.php:210
```

refs https://github.com/sebastianbergmann/php-code-coverage/commit/c41f7301aeb5b4ecdf073ed3809086781734237a#commitcomment-150604845
