### PR TITLE
--list-tests-xml is broken if a numeric @group annotation is specified

### DIFF
--- a/src/TextUI/Command/Commands/ListGroupsCommand.php
+++ b/src/TextUI/Command/Commands/ListGroupsCommand.php
@@ -70,13 +70,13 @@ final readonly class ListGroupsCommand implements Command
         );
 
         foreach ($groups as $group => $numberOfTests) {
-            if (str_starts_with($group, '__phpunit_')) {
+            if (str_starts_with((string) $group, '__phpunit_')) {
                 continue;
             }
 
             $buffer .= sprintf(
                 ' - %s (%d test%s)' . PHP_EOL,
-                $group,
+                (string) $group,
                 $numberOfTests,
                 $numberOfTests > 1 ? 's' : '',
             );

--- a/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
@@ -108,7 +108,7 @@ final readonly class ListTestsAsXmlCommand implements Command
 
         foreach ($groups as $groupName => $testIds) {
             $writer->startElement('group');
-            $writer->writeAttribute('name', $groupName);
+            $writer->writeAttribute('name', (string) $groupName);
 
             foreach ($testIds as $testId) {
                 $writer->startElement('test');

--- a/tests/end-to-end/_files/listing-tests-and-groups/ExampleTest.php
+++ b/tests/end-to-end/_files/listing-tests-and-groups/ExampleTest.php
@@ -25,4 +25,10 @@ final class ExampleTest extends TestCase
     {
         $this->assertTrue(true);
     }
+
+    #[Group('3')]
+    public function testThree(): void
+    {
+        $this->assertTrue(true);
+    }
 }

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-groups-exclude-filter.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-groups-exclude-filter.phpt
@@ -15,5 +15,6 @@ require_once __DIR__ . '/../../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-Available test group:
+Available test groups:
+ - 3 (1 test)
  - two (1 test)

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-groups-exclude-group.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-groups-exclude-group.phpt
@@ -16,5 +16,6 @@ require_once __DIR__ . '/../../../bootstrap.php';
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Available test groups:
+ - 3 (1 test)
  - default (1 test)
  - two (1 test)

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-groups-include-filter.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-groups-include-filter.phpt
@@ -15,5 +15,6 @@ require_once __DIR__ . '/../../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-Available test group:
+Available test groups:
+ - 3 (1 test)
  - two (1 test)

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-groups.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-groups.phpt
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../../../bootstrap.php';
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Available test groups:
+ - 3 (1 test)
  - default (1 test)
  - one (1 test)
  - two (1 test)

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests-exclude-filter.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests-exclude-filter.phpt
@@ -17,3 +17,4 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Available test:
  - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo
+ - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests-exclude-filter.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests-exclude-filter.phpt
@@ -15,6 +15,6 @@ require_once __DIR__ . '/../../../bootstrap.php';
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
-Available test:
+Available tests:
  - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo
  - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests-exclude-group.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests-exclude-group.phpt
@@ -17,4 +17,5 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Available tests:
  - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo
+ - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree
  - %sexample.phpt

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests-xml-exclude-filter.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests-xml-exclude-filter.phpt
@@ -21,9 +21,13 @@ PHPUnit %s by Sebastian Bergmann and contributors.
  <tests>
   <testClass name="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest" file="%sExampleTest.php">
    <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo" name="testTwo"/>
+   <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree" name="testThree"/>
   </testClass>
  </tests>
  <groups>
+  <group name="3">
+   <test id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree"/>
+  </group>
   <group name="two">
    <test id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo"/>
   </group>

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests-xml-exclude-group.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests-xml-exclude-group.phpt
@@ -21,10 +21,14 @@ PHPUnit %s by Sebastian Bergmann and contributors.
  <tests>
   <testClass name="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest" file="%sExampleTest.php">
    <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo" name="testTwo"/>
+   <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree" name="testThree"/>
   </testClass>
   <phpt file="%sexample.phpt"/>
  </tests>
  <groups>
+  <group name="3">
+   <test id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree"/>
+  </group>
   <group name="two">
    <test id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo"/>
   </group>

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests-xml.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests-xml.phpt
@@ -21,10 +21,14 @@ PHPUnit %s by Sebastian Bergmann and contributors.
   <testClass name="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest" file="%sExampleTest.php">
    <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testOne" name="testOne"/>
    <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo" name="testTwo"/>
+   <testMethod id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree" name="testThree"/>
   </testClass>
   <phpt file="%sexample.phpt"/>
  </tests>
  <groups>
+  <group name="3">
+   <test id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree"/>
+  </group>
   <group name="one">
    <test id="PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testOne"/>
   </group>

--- a/tests/end-to-end/cli/listing-tests-and-groups/list-tests.phpt
+++ b/tests/end-to-end/cli/listing-tests-and-groups/list-tests.phpt
@@ -16,4 +16,5 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Available tests:
  - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testOne
  - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testTwo
+ - PHPUnit\TestFixture\ListingTestsAndGroups\ExampleTest::testThree
  - %sexample.phpt


### PR DESCRIPTION
Fixes #6096.