### PR TITLE
Improve performance of `SourceMapper`

### DIFF
--- a/src/TextUI/Configuration/SourceMapper.php
+++ b/src/TextUI/Configuration/SourceMapper.php
@@ -40,8 +40,10 @@ final class SourceMapper
 
         $files = [];
 
-        foreach ($source->includeDirectories() as $directory) {
-            foreach ((new FileIteratorFacade)->getFilesAsArray($directory->path(), $directory->suffix(), $directory->prefix()) as $file) {
+        $directories = $this->aggregateDirectories($source->includeDirectories());
+
+        foreach ($directories as $path => [$prefixes, $suffixes]) {
+            foreach ((new FileIteratorFacade)->getFilesAsArray($path, $suffixes, $prefixes) as $file) {
                 $file = realpath($file);
 
                 if (!$file) {
@@ -62,8 +64,10 @@ final class SourceMapper
             $files[$file] = true;
         }
 
-        foreach ($source->excludeDirectories() as $directory) {
-            foreach ((new FileIteratorFacade)->getFilesAsArray($directory->path(), $directory->suffix(), $directory->prefix()) as $file) {
+        $directories = $this->aggregateDirectories($source->excludeDirectories());
+
+        foreach ($directories as $path => [$prefixes, $suffixes]) {
+            foreach ((new FileIteratorFacade)->getFilesAsArray($path, $suffixes, $prefixes) as $file) {
                 $file = realpath($file);
 
                 if (!$file) {
@@ -95,5 +99,34 @@ final class SourceMapper
         self::$files[$source] = $files;
 
         return $files;
+    }
+
+    /**
+     * @return array<string,array{list<string>,list<string>}>
+     */
+    private function aggregateDirectories(FilterDirectoryCollection $directories): array
+    {
+        $aggregated = [];
+
+        foreach ($directories as $directory) {
+            if (!isset($aggregated[$directory->path()])) {
+                $aggregated[$directory->path()] = [
+                    0 => [],
+                    1 => [],
+                ];
+            }
+            $prefix = $directory->prefix();
+
+            if ($prefix !== '') {
+                $aggregated[$directory->path()][0][] = $prefix;
+            }
+            $suffix = $directory->suffix();
+
+            if ($suffix !== '') {
+                $aggregated[$directory->path()][1][] = $suffix;
+            }
+        }
+
+        return $aggregated;
     }
 }

--- a/tests/unit/TextUI/SourceMapperTest.php
+++ b/tests/unit/TextUI/SourceMapperTest.php
@@ -270,6 +270,82 @@ final class SourceMapperTest extends TestCase
                 ),
             ),
         ];
+
+        yield 'files included using same directory and different suffixes' => [
+            [
+                self::fixturePath('a/c/Prefix.php')              => true,
+                self::fixturePath('a/c/d/Prefix.php')            => true,
+                self::fixturePath('b/e/PrefixExampleSuffix.php') => true,
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(
+                            self::fixturePath(),
+                            '',
+                            'ExampleSuffix.php',
+                        ),
+                        new FilterDirectory(
+                            self::fixturePath(),
+                            '',
+                            'Prefix.php',
+                        ),
+                    ],
+                ),
+            ),
+        ];
+
+        yield 'files included using same directory and different prefixes' => [
+            [
+                self::fixturePath('a/c/Suffix.php')              => true,
+                self::fixturePath('a/c/d/Suffix.php')            => true,
+                self::fixturePath('b/e/PrefixExampleSuffix.php') => true,
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(
+                            self::fixturePath(),
+                            'Suffix',
+                            '.php',
+                        ),
+                        new FilterDirectory(
+                            self::fixturePath(),
+                            'PrefixExample',
+                            '.php',
+                        ),
+                    ],
+                ),
+            ),
+        ];
+
+        yield 'files excluded using same directory and different prefixes' => [
+            [
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray([
+                    new FilterDirectory(
+                        self::fixturePath(),
+                        '',
+                        '.php',
+                    ),
+                ]),
+                excludeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(
+                            self::fixturePath(),
+                            'Prefix',
+                            '.php',
+                        ),
+                        new FilterDirectory(
+                            self::fixturePath(),
+                            'Suffix',
+                            '.php',
+                        ),
+                    ],
+                ),
+            ),
+        ];
     }
 
     public static function fixturePath(?string $subPath = null): string


### PR DESCRIPTION
Improve source map performance for directories with same path

This PR aggregates the directories to a map of paths to tuples containing prefixes and suffixes.

This will reduce the overhead of scanning paths when multiple directory elements are defined with the same path but differnet prefixes or suffixes.

For example:

```xml
<exclude>
    <directory suffix="Controller.php">src/</directory>
    <directory suffix="Factory.php">src/</directory>
    <directory suffix="Bus.php">src/</directory>
    <directory suffix="Car.php">src/</directory>
</exclude>
```

Would be resolved as:

```php
[
   'src/' => [
       [], // no prefixes
       ['Controller.php', 'Factory.php', 'Bus.php', 'Car.php'],
   ],
],
```

The File Iterator already accepts an array of suffixes or prefixes.

---

Imroves perforamance in the [example repository](https://github.com/dantleech/phpunit-6111) from 3.5 to 1.8 seconds.