### PR TITLE
Allow negative priorities for hook methods

### DIFF
--- a/src/Framework/Attributes/After.php
+++ b/src/Framework/Attributes/After.php
@@ -19,22 +19,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class After
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public function __construct(int $priority = 0)
     {
         $this->priority = $priority;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Framework/Attributes/AfterClass.php
+++ b/src/Framework/Attributes/AfterClass.php
@@ -19,22 +19,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class AfterClass
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public function __construct(int $priority = 0)
     {
         $this->priority = $priority;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Framework/Attributes/Before.php
+++ b/src/Framework/Attributes/Before.php
@@ -19,22 +19,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class Before
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public function __construct(int $priority = 0)
     {
         $this->priority = $priority;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Framework/Attributes/BeforeClass.php
+++ b/src/Framework/Attributes/BeforeClass.php
@@ -19,22 +19,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class BeforeClass
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public function __construct(int $priority = 0)
     {
         $this->priority = $priority;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Framework/Attributes/PostCondition.php
+++ b/src/Framework/Attributes/PostCondition.php
@@ -19,22 +19,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class PostCondition
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public function __construct(int $priority = 0)
     {
         $this->priority = $priority;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Framework/Attributes/PreCondition.php
+++ b/src/Framework/Attributes/PreCondition.php
@@ -19,22 +19,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class PreCondition
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public function __construct(int $priority = 0)
     {
         $this->priority = $priority;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Metadata/After.php
+++ b/src/Metadata/After.php
@@ -16,14 +16,10 @@ namespace PHPUnit\Metadata;
  */
 final readonly class After extends Metadata
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
-     * @param 0|1              $level
-     * @param non-negative-int $priority
+     * @param 0|1 $level
      */
     protected function __construct(int $level, int $priority)
     {
@@ -37,9 +33,6 @@ final readonly class After extends Metadata
         return true;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Metadata/AfterClass.php
+++ b/src/Metadata/AfterClass.php
@@ -16,14 +16,10 @@ namespace PHPUnit\Metadata;
  */
 final readonly class AfterClass extends Metadata
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
-     * @param 0|1              $level
-     * @param non-negative-int $priority
+     * @param 0|1 $level
      */
     protected function __construct(int $level, int $priority)
     {
@@ -37,9 +33,6 @@ final readonly class AfterClass extends Metadata
         return true;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Metadata/Before.php
+++ b/src/Metadata/Before.php
@@ -16,14 +16,10 @@ namespace PHPUnit\Metadata;
  */
 final readonly class Before extends Metadata
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
-     * @param 0|1              $level
-     * @param non-negative-int $priority
+     * @param 0|1 $level
      */
     protected function __construct(int $level, int $priority)
     {
@@ -37,9 +33,6 @@ final readonly class Before extends Metadata
         return true;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Metadata/BeforeClass.php
+++ b/src/Metadata/BeforeClass.php
@@ -16,14 +16,10 @@ namespace PHPUnit\Metadata;
  */
 final readonly class BeforeClass extends Metadata
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
-     * @param 0|1              $level
-     * @param non-negative-int $priority
+     * @param 0|1 $level
      */
     protected function __construct(int $level, int $priority)
     {
@@ -37,9 +33,6 @@ final readonly class BeforeClass extends Metadata
         return true;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -27,17 +27,11 @@ abstract readonly class Metadata
      */
     private int $level;
 
-    /**
-     * @param non-negative-int $priority
-     */
     public static function after(int $priority): After
     {
         return new After(self::METHOD_LEVEL, $priority);
     }
 
-    /**
-     * @param non-negative-int $priority
-     */
     public static function afterClass(int $priority): AfterClass
     {
         return new AfterClass(self::METHOD_LEVEL, $priority);
@@ -63,17 +57,11 @@ abstract readonly class Metadata
         return new BackupStaticProperties(self::METHOD_LEVEL, $enabled);
     }
 
-    /**
-     * @param non-negative-int $priority
-     */
     public static function before(int $priority): Before
     {
         return new Before(self::METHOD_LEVEL, $priority);
     }
 
-    /**
-     * @param non-negative-int $priority
-     */
     public static function beforeClass(int $priority): BeforeClass
     {
         return new BeforeClass(self::METHOD_LEVEL, $priority);
@@ -263,17 +251,11 @@ abstract readonly class Metadata
         return new IgnorePhpunitDeprecations(self::METHOD_LEVEL);
     }
 
-    /**
-     * @param non-negative-int $priority
-     */
     public static function postCondition(int $priority): PostCondition
     {
         return new PostCondition(self::METHOD_LEVEL, $priority);
     }
 
-    /**
-     * @param non-negative-int $priority
-     */
     public static function preCondition(int $priority): PreCondition
     {
         return new PreCondition(self::METHOD_LEVEL, $priority);

--- a/src/Metadata/PostCondition.php
+++ b/src/Metadata/PostCondition.php
@@ -16,14 +16,10 @@ namespace PHPUnit\Metadata;
  */
 final readonly class PostCondition extends Metadata
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
-     * @param 0|1              $level
-     * @param non-negative-int $priority
+     * @param 0|1 $level
      */
     protected function __construct(int $level, int $priority)
     {
@@ -37,9 +33,6 @@ final readonly class PostCondition extends Metadata
         return true;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Metadata/PreCondition.php
+++ b/src/Metadata/PreCondition.php
@@ -16,14 +16,10 @@ namespace PHPUnit\Metadata;
  */
 final readonly class PreCondition extends Metadata
 {
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
-     * @param 0|1              $level
-     * @param non-negative-int $priority
+     * @param 0|1 $level
      */
     protected function __construct(int $level, int $priority)
     {
@@ -37,9 +33,6 @@ final readonly class PreCondition extends Metadata
         return true;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;

--- a/src/Runner/HookMethod/HookMethod.php
+++ b/src/Runner/HookMethod/HookMethod.php
@@ -21,14 +21,10 @@ final readonly class HookMethod
      */
     private string $methodName;
 
-    /**
-     * @var non-negative-int
-     */
     private int $priority;
 
     /**
      * @param non-empty-string $methodName
-     * @param non-negative-int $priority
      */
     public function __construct(string $methodName, int $priority)
     {
@@ -44,9 +40,6 @@ final readonly class HookMethod
         return $this->methodName;
     }
 
-    /**
-     * @return non-negative-int
-     */
     public function priority(): int
     {
         return $this->priority;


### PR DESCRIPTION
Hello,

I think it is perfectly valid to have negative priorities for hook methods. This allows to chose to occur after another hook method which does not have a priority  