### PR TITLE
Regression test for error_log()

### DIFF
--- a/tests/end-to-end/regression/2155-no-expects-log.phpt
+++ b/tests/end-to-end/regression/2155-no-expects-log.phpt
@@ -1,0 +1,26 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/2155
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = __DIR__ . '/2155/Issue2155Test_NoExpectsLog.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+logged a side effect
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+Issue2155Test_No Expects Log (PHPUnit\TestFixture\Issue2155\Issue2155Test_NoExpectsLog)
+ ✔ One
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/regression/2155/Issue2155Test_NoExpectsLog.php
+++ b/tests/end-to-end/regression/2155/Issue2155Test_NoExpectsLog.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue2155;
+
+use function error_log;
+use PHPUnit\Framework\TestCase;
+
+class Foo
+{
+    public function doFoo()
+    {
+        error_log('logged a side effect');
+
+        return '';
+    }
+}
+
+final class Issue2155Test_NoExpectsLog extends TestCase
+{
+    public function testOne(): void
+    {
+        $foo = new Foo;
+
+        $this->assertSame('', $foo->doFoo());
+    }
+}


### PR DESCRIPTION
test the current behaviour when `error_log` is used in a test