### PR TITLE
Fix MockObject::method() return type

### DIFF
--- a/src/Framework/MockObject/Runtime/Interface/MockObject.php
+++ b/src/Framework/MockObject/Runtime/Interface/MockObject.php
@@ -9,8 +9,10 @@
  */
 namespace PHPUnit\Framework\MockObject;
 
+use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -18,4 +20,6 @@ use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 interface MockObject extends Stub
 {
     public function expects(InvocationOrder $invocationRule): InvocationMocker;
+
+    public function method(Constraint|PropertyHook|string $constraint): InvocationMocker;
 }


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/issues/5416 / https://github.com/sebastianbergmann/phpunit/commit/98cc1116a3ddc8ca2bd9d3e503a2795dfb06009b removed the `MockObject::method()` pseudo method but didn't add an actual implemention on `MockObject`. A call to `MockObject::method()` thus only guarantees an `InvocationStubber` return as declared on `Stub::method()`.

With that, method mocking like this is technically not correct anymore:
```php
$this->createMock('SomeClass')
    ->method('call') // returns InvocationStubber
    ->with('foo') // only available on InvocationMocker, not InvocationStubber
    ->willReturn('bar');
```

and instead a `->expects($this->any())` is technically required in the chain to keep the existing behavior:
```php
$this->createMock('SomeClass')
    ->expects($this->any()) // returns InvocationMocker
    ->method('call') // InvocationMocker::method() returns InvocationMocker
    ->with('foo')
    ->willReturn('bar');
```

This seems like an unintended requirement(?), hence the PR.

(relates to the closed issue https://github.com/sebastianbergmann/phpunit/issues/6132)