### PR TITLE
GH-6114: Static path matching

### DIFF
--- a/src/TextUI/Configuration/SourceFilter.php
+++ b/src/TextUI/Configuration/SourceFilter.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use PHPUnit\Util\FileMatcherPattern;
 use function array_map;
 use PHPUnit\Util\FileMatcher;
 use PHPUnit\Util\FileMatcherRegex;
@@ -52,11 +53,11 @@ final class SourceFilter
         $this->source                  = $source;
         $this->includeDirectoryRegexes = array_map(static function (FilterDirectory $directory)
         {
-            return FileMatcher::toRegEx($directory->path());
+            return FileMatcher::toRegEx(new FileMatcherPattern($directory->path()));
         }, $source->includeDirectories()->asArray());
         $this->excludeDirectoryRegexes = array_map(static function (FilterDirectory $directory)
         {
-            return FileMatcher::toRegEx($directory->path());
+            return FileMatcher::toRegEx(new FileMatcherPattern($directory->path()));
         }, $source->excludeDirectories()->asArray());
     }
 

--- a/src/TextUI/Configuration/SourceFilter.php
+++ b/src/TextUI/Configuration/SourceFilter.php
@@ -9,6 +9,10 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use PHPUnit\Util\FileMatcher;
+use PHPUnit\Util\FileMatcherRegex;
+
+
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -18,19 +22,23 @@ final class SourceFilter
 {
     private static ?self $instance = null;
 
+    private Source $source;
+
     /**
-     * @var array<non-empty-string, true>
+     * @var list<FileMatcherRegex>
      */
-    private readonly array $map;
+    private array $includeDirectoryRegexes;
+
+    /**
+     * @var list<FileMatcherRegex>
+     */
+    private array $excludeDirectoryRegexes;
 
     public static function instance(): self
     {
         if (self::$instance === null) {
-            self::$instance = new self(
-                (new SourceMapper)->map(
-                    Registry::get()->source(),
-                ),
-            );
+            $source = Registry::get()->source();
+            return new self($source);
         }
 
         return self::$instance;
@@ -39,13 +47,21 @@ final class SourceFilter
     /**
      * @param array<non-empty-string, true> $map
      */
-    public function __construct(array $map)
+    public function __construct(Source $source)
     {
-        $this->map = $map;
+        $this->source = $source;
+        $this->includeDirectoryRegexes = array_map(function (FilterDirectory $directory) {
+            return FileMatcher::toRegEx($directory->path());
+        }, $source->includeDirectories()->asArray());
+        $this->excludeDirectoryRegexes = array_map(function (FilterDirectory $directory) {
+            return FileMatcher::toRegEx($directory->path());
+        }, $source->excludeDirectories()->asArray());
     }
 
     public function includes(string $path): bool
     {
+        foreach ($this->source->includeDirectories() as $directory) {
+        }
         return isset($this->map[$path]);
     }
 }

--- a/src/TextUI/Configuration/SourceFilter.php
+++ b/src/TextUI/Configuration/SourceFilter.php
@@ -38,9 +38,10 @@ final class SourceFilter
     public static function instance(): self
     {
         if (self::$instance === null) {
-            $source = Registry::get()->source();
+            $source         = Registry::get()->source();
+            self::$instance = new self($source);
 
-            return new self($source);
+            return self::$instance;
         }
 
         return self::$instance;

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -55,9 +55,9 @@ final readonly class FileMatcher
     /**
      * Compile a regex for the given glob.
      */
-    public static function toRegEx(string $glob): FileMatcherRegex
+    public static function toRegEx(FileMatcherPattern $pattern): FileMatcherRegex
     {
-        $tokens = self::tokenize($glob);
+        $tokens = self::tokenize($pattern->path);
         $tokens = self::processTokens($tokens);
 
         return self::mapToRegex($tokens);

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use RuntimeException;
+use const DIRECTORY_SEPARATOR;
+use function basename;
+use function dirname;
+use function is_dir;
+use function mkdir;
+use function realpath;
+use function str_starts_with;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class FileMatcher
+{
+    public static function match(string $path, FileMatcherPattern $pattern): bool
+    {
+        if (substr($path, 0, 1) !== '/') {
+            throw new RuntimeException(sprintf(
+                'Path "%s" must be absolute',
+                $path
+            ));
+        }
+        return false;
+    }
+}
+

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -19,8 +19,9 @@ use function strlen;
 use RuntimeException;
 
 /**
- * FileMatcher attempts to emulate the behavior of PHP's glob function on file
- * paths based on POSIX.2.
+ * FileMatcher ultimately attempts to emulate the behavior `php-file-iterator`
+ * which *mostly* comes down to emulating PHP's glob function on file paths
+ * based on POSIX.2:
  *
  * - https://en.wikipedia.org/wiki/Glob_(programming)
  * - https://man7.org/linux/man-pages/man7/glob.7.html
@@ -189,6 +190,8 @@ final readonly class FileMatcher
                 continue;
             }
 
+            // two consecutive ** which are not surrounded by `/` are invalid and
+            // we interpret them as literals.
             if ($type === self::T_ASTERIX && ($tokens[$offset + 1][0] ?? null) === self::T_ASTERIX) {
                 $resolved[] = [self::T_CHAR, $char];
                 $resolved[] = [self::T_CHAR, $char];
@@ -249,7 +252,6 @@ final readonly class FileMatcher
                 $resolved[] = [self::T_CHAR, ':' . $class];
             }
 
-
             // if bracket is already open and we have another open bracket
             // interpret it as a literal
             if ($bracketOpen === true && $type === self::T_BRACKET_OPEN) {
@@ -273,7 +275,6 @@ final readonly class FileMatcher
             //
             // TODO: $bracketOpen === true below is not tested
             if ($bracketOpen === true && $type === self::T_BRACKET_CLOSE) {
-
                 // TODO: this is not tested
                 $bracketOpen = false;
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -25,6 +25,12 @@ use RuntimeException;
  * - https://en.wikipedia.org/wiki/Glob_(programming)
  * - https://man7.org/linux/man-pages/man7/glob.7.html
  *
+ * The file matcher compiles the regex in three passes:
+ *
+ * - Tokenise interesting chars in the glob grammar.
+ * - Process the tokens and reorient them to produce regex.
+ * - Map the processed tokens to regular expression segments.
+ *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
@@ -53,7 +59,17 @@ final readonly class FileMatcher
     public static function toRegEx(string $glob): FileMatcherRegex
     {
         $tokens = self::tokenize($glob);
-        $regex  = '';
+        $tokens = self::processTokens($tokens);
+
+        return self::mapToRegex($tokens);
+    }
+
+    /**
+     * @param list<token> $tokens
+     */
+    public static function mapToRegex(array $tokens): FileMatcherRegex
+    {
+        $regex = '';
 
         foreach ($tokens as $token) {
             $type = $token[0];
@@ -111,7 +127,7 @@ final readonly class FileMatcher
             };
         }
 
-        return self::processTokens($tokens);
+        return $tokens;
     }
 
     /**

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -176,8 +176,13 @@ final readonly class FileMatcher
             }
 
             // complementation - only parse BANG if it is at the start of a character group
-            if ($type === self::T_BANG && isset($resolved[array_key_last($resolved) - 1]) && $resolved[array_key_last($resolved) - 1][0] === self::T_BRACKET_OPEN) {
+            if ($type === self::T_BANG && isset($resolved[array_key_last($resolved)]) && $resolved[array_key_last($resolved)][0] === self::T_BRACKET_OPEN) {
                 $resolved[] = [self::T_BANG, '!'];
+                continue;
+            }
+
+            if ($type === self::T_BANG) {
+                $resolved[] = [self::T_CHAR, $char];
                 continue;
             }
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -68,7 +68,7 @@ final readonly class FileMatcher
     /**
      * @param list<token> $tokens
      */
-    public static function mapToRegex(array $tokens): FileMatcherRegex
+    private static function mapToRegex(array $tokens): FileMatcherRegex
     {
         $regex = '';
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -128,6 +128,7 @@ final readonly class FileMatcher
     {
         $resolved = [];
         $escaped = false;
+        $brackets = [];
         for ($offset = 0; $offset < count($tokens); $offset++) {
             [$type, $char] = $tokens[$offset];
 
@@ -171,7 +172,17 @@ final readonly class FileMatcher
                 continue;
             }
 
+            if ($type === self::T_BRACKET_OPEN) {
+                $brackets[] = $offset;
+            }
+            if ($type === self::T_BRACKET_CLOSE) {
+                array_pop($brackets);
+            }
+
             $resolved[] = [$type, $char];
+        }
+        foreach ($brackets as $unterminatedBracket) {
+            $resolved[$unterminatedBracket] = [self::T_CHAR, '['];
         }
         return $resolved;
     }

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -137,6 +137,7 @@ final readonly class FileMatcher
     {
         $resolved = [];
         $escaped  = false;
+        $bracketOpen = false;
         $brackets = [];
 
         for ($offset = 0; $offset < count($tokens); $offset++) {
@@ -205,14 +206,24 @@ final readonly class FileMatcher
             }
 
             if ($type === self::T_BRACKET_OPEN && $tokens[$offset + 1][0] === self::T_BRACKET_CLOSE) {
-                $resolved[] = [self::T_BRACKET_OPEN, $char];
+                $bracketOpen = true;
+                $resolved[] = [self::T_BRACKET_OPEN, '['];
                 $brackets[] = array_key_last($resolved);
-                $resolved[] = [self::T_CHAR, $char];
+                $resolved[] = [self::T_CHAR, ']'];
+                $offset += 1;
 
                 continue;
             }
 
-            if ($type === self::T_BRACKET_OPEN) {
+            if ($bracketOpen === true && $type === self::T_BRACKET_OPEN) {
+                // if bracket is already open, interpret everything as a
+                // literal char
+                $resolved[] = [self::T_CHAR, $char];
+                continue;
+            }
+
+            if ($bracketOpen === false && $type === self::T_BRACKET_OPEN) {
+                $bracketOpen = true;
                 $resolved[] = [$type, $char];
                 $brackets[] = array_key_last($resolved);
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -14,9 +14,7 @@ use function array_pop;
 use function count;
 use function ctype_alpha;
 use function preg_quote;
-use function sprintf;
 use function strlen;
-use RuntimeException;
 
 /**
  * FileMatcher ultimately attempts to emulate the behavior `php-file-iterator`
@@ -90,11 +88,9 @@ final readonly class FileMatcher
                 self::T_BRACKET_OPEN    => '[',
                 self::T_BRACKET_CLOSE   => ']',
                 self::T_HYPHEN          => '-',
+                self::T_COLON           => ':',
+                self::T_BACKSLASH       => '\\',
                 self::T_CHAR_CLASS      => '[:' . $token[1] . ':]',
-                default                 => throw new RuntimeException(sprintf(
-                    'Unhandled token type: %s - this should not happen',
-                    $type,
-                )),
             };
         }
         $regex .= '(/|$)';

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -38,19 +38,19 @@ use function strlen;
  */
 final readonly class FileMatcher
 {
-    private const T_BRACKET_OPEN    = 'bracket_open';
-    private const T_BRACKET_CLOSE   = 'bracket_close';
-    private const T_BANG            = 'bang';
-    private const T_HYPHEN          = 'hyphen';
-    private const T_ASTERIX         = 'asterix';
-    private const T_SLASH           = 'slash';
-    private const T_BACKSLASH       = 'backslash';
-    private const T_CHAR            = 'char';
-    private const T_GREEDY_GLOBSTAR = 'greedy_globstar';
-    private const T_QUERY           = 'query';
-    private const T_GLOBSTAR        = 'globstar';
-    private const T_COLON           = 'colon';
-    private const T_CHAR_CLASS      = 'char_class';
+    private const string T_BRACKET_OPEN    = 'bracket_open';
+    private const string T_BRACKET_CLOSE   = 'bracket_close';
+    private const string T_BANG            = 'bang';
+    private const string T_HYPHEN          = 'hyphen';
+    private const string T_ASTERIX         = 'asterix';
+    private const string T_SLASH           = 'slash';
+    private const string T_BACKSLASH       = 'backslash';
+    private const string T_CHAR            = 'char';
+    private const string T_GREEDY_GLOBSTAR = 'greedy_globstar';
+    private const string T_QUERY           = 'query';
+    private const string T_GLOBSTAR        = 'globstar';
+    private const string T_COLON           = 'colon';
+    private const string T_CHAR_CLASS      = 'char_class';
 
     /**
      * Compile a regex for the given glob.

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -69,6 +69,9 @@ final readonly class FileMatcher
                 self::T_ASTERIX => '[^/]*',
                 self::T_GREEDY_GLOBSTAR => '.*',
                 self::T_GLOBSTAR => '/([^/]+/)*',
+                self::T_BRACKET_OPEN => '[',
+                self::T_BRACKET_CLOSE => ']',
+                self::T_HYPHEN => '-',
                 default => '',
             };
         }

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -39,7 +39,8 @@ final readonly class FileMatcher
 
         $regex = self::toRegEx($pattern->path);
 
-        return preg_match($regex, $path) !== 0;
+        $result = preg_match($regex, $path) !== 0;
+        return $result;
     }
 
     /**
@@ -181,14 +182,22 @@ final readonly class FileMatcher
                 continue;
             }
 
+            // if this was _not_ a bang preceded by a `[` token then convert it
+            // to a literal char
             if ($type === self::T_BANG) {
                 $resolved[] = [self::T_CHAR, $char];
                 continue;
             }
 
+            if ($type === self::T_BRACKET_OPEN && $tokens[$offset + 1][0] === self::T_BRACKET_CLOSE) {
+                $resolved[] = [self::T_BRACKET_OPEN, $char];
+                $brackets[] = array_key_last($resolved);
+                $resolved[] = [self::T_CHAR, $char];
+                continue;
+            }
             if ($type === self::T_BRACKET_OPEN) {
-                $brackets[] = $offset;
                 $resolved[] = [$type, $char];
+                $brackets[] = array_key_last($resolved);
                 continue;
             }
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -140,6 +140,7 @@ final readonly class FileMatcher
 
             if ($escaped === true) {
                 $resolved[] = [self::T_CHAR, $char];
+                $escaped = false;
                 continue;
             }
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -131,6 +131,7 @@ final readonly class FileMatcher
         $resolved = [];
         $escaped = false;
         $brackets = [];
+
         for ($offset = 0; $offset < count($tokens); $offset++) {
             [$type, $char] = $tokens[$offset];
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -61,8 +61,8 @@ final readonly class FileMatcher
                     $regex .= '-';
                     break;
                 case '!':
-                    // complementation/negation
-                    if ($glob[$i - 1] === '[') {
+                    // complementation/negation: taking into account escaped square brackets
+                    if ($glob[$i - 1] === '[' && ($glob[$i - 2] !== '\\' || ($glob[$i -2] === '\\' && $glob[$i - 3] === '\\'))) {
                         $regex .= '^';
                         break;
                     }
@@ -131,6 +131,7 @@ final readonly class FileMatcher
 
         $regex .= '(/|$)';
 
+        dump($regex);
         return '{^'.$regex.'}';
     }
 

--- a/src/Util/FileMatcher.php
+++ b/src/Util/FileMatcher.php
@@ -9,14 +9,8 @@
  */
 namespace PHPUnit\Util;
 
+use InvalidArgumentException;
 use RuntimeException;
-use const DIRECTORY_SEPARATOR;
-use function basename;
-use function dirname;
-use function is_dir;
-use function mkdir;
-use function realpath;
-use function str_starts_with;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -27,13 +21,87 @@ final readonly class FileMatcher
 {
     public static function match(string $path, FileMatcherPattern $pattern): bool
     {
+        self::assertIsAbsolute($path);
+
+        $regex = self::toRegEx($pattern->path);
+        dump($pattern->path, $regex, $path);
+
+        return preg_match($regex, $path) !== 0;
+    }
+
+    /**
+     * Based on webmozart/glob
+     *
+     * @return string The regular expression for matching the glob.
+     */
+    public static function toRegEx($glob, $flags = 0): string
+    {
+        self::assertIsAbsolute($glob);
+
+        $inSquare = false;
+        $regex = '';
+        $length = strlen($glob);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $c = $glob[$i];
+
+            switch ($c) {
+                case '?':
+                    $regex .= '.';
+                    break;
+
+                // the PHPUnit file iterator will match all
+                // files within a wildcard, not just until the
+                // next directory separator
+                case '*':
+                    // if this is a ** but it is NOT preceded with `/` then
+                    // it is not a globstar and just interpret it as a literal
+                    if (($glob[$i + 1] ?? null) === '*') {
+                        $regex .= '\*\*';
+                        $i++;
+                        break;
+                    }
+                    $regex .= '.*';
+                    break;
+                case '/':
+                    if (isset($glob[$i + 3]) && '**/' === $glob[$i + 1].$glob[$i + 2].$glob[$i + 3]) {
+                        $regex .= '/([^/]+/)*';
+                        $i += 3;
+                        break;
+                    }
+                    if ((!isset($glob[$i + 3])) && isset($glob[$i + 2]) && '**' === $glob[$i + 1].$glob[$i + 2]) {
+                        $regex .= '.*';
+                        $i += 2;
+                        break;
+                    }
+                    $regex .= '/';
+                    break;
+                default:
+                    $regex .= $c;
+                    break;
+            }
+        }
+
+        if ($inSquare) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid glob: missing ] in %s',
+                $glob
+            ));
+        }
+
+        $regex .= '(/|$)';
+
+        return '{^'.$regex.'}';
+    }
+
+    private static function assertIsAbsolute(string $path): void
+    {
         if (substr($path, 0, 1) !== '/') {
             throw new RuntimeException(sprintf(
                 'Path "%s" must be absolute',
                 $path
             ));
         }
-        return false;
     }
 }
 

--- a/src/Util/FileMatcherPattern.php
+++ b/src/Util/FileMatcherPattern.php
@@ -9,7 +9,7 @@
  */
 namespace PHPUnit\Util;
 
-class FileMatcherPattern
+final class FileMatcherPattern
 {
     public function __construct(public string $path)
     {

--- a/src/Util/FileMatcherPattern.php
+++ b/src/Util/FileMatcherPattern.php
@@ -1,5 +1,12 @@
-<?php
-
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace PHPUnit\Util;
 
 class FileMatcherPattern
@@ -7,5 +14,4 @@ class FileMatcherPattern
     public function __construct(public string $path)
     {
     }
-
 }

--- a/src/Util/FileMatcherPattern.php
+++ b/src/Util/FileMatcherPattern.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PHPUnit\Util;
+
+class FileMatcherPattern
+{
+    public function __construct(public string $path)
+    {
+    }
+
+}

--- a/src/Util/FileMatcherRegex.php
+++ b/src/Util/FileMatcherRegex.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Util;
+
+use function preg_match;
+use function sprintf;
+use function substr;
+use RuntimeException;
+
+final class FileMatcherRegex
+{
+    public function __construct(private string $regex)
+    {
+    }
+
+    public function matches(string $path): bool
+    {
+        self::assertIsAbsolute($path);
+
+        return preg_match($this->regex, $path) !== 0;
+    }
+
+    private static function assertIsAbsolute(string $path): void
+    {
+        if (substr($path, 0, 1) !== '/') {
+            throw new RuntimeException(sprintf(
+                'Path "%s" must be absolute',
+                $path,
+            ));
+        }
+    }
+}

--- a/tests/unit/TextUI/SourceFilterTest.php
+++ b/tests/unit/TextUI/SourceFilterTest.php
@@ -422,7 +422,7 @@ final class SourceFilterTest extends AbstractSouceFilterTestCase
             $this->assertFileExists($file);
             $this->assertSame(
                 $shouldInclude,
-                (new SourceFilter((new SourceMapper)->map($source)))->includes($file),
+                (new SourceFilter($source))->includes($file),
                 sprintf('expected match to return %s for: %s', json_encode($shouldInclude), $file),
             );
         }

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -612,7 +612,7 @@ class FileMatcherTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Path "foo/bar" must be absolute');
-        FileMatcher::match('foo/bar', new FileMatcherPattern(''));
+        FileMatcher::toRegEx('/a')->matches('foo/bar');
     }
 
     /**
@@ -621,7 +621,7 @@ class FileMatcherTest extends TestCase
     private static function assertMap(FileMatcherPattern $pattern, array $matchMap): void
     {
         foreach ($matchMap as $candidate => $shouldMatch) {
-            $matches = FileMatcher::match($candidate, $pattern);
+            $matches = FileMatcher::toRegEx($pattern->path)->matches($candidate);
 
             if ($matches === $shouldMatch) {
                 self::assertTrue(true);

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -613,7 +613,7 @@ class FileMatcherTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Path "foo/bar" must be absolute');
-        FileMatcher::toRegEx('/a')->matches('foo/bar');
+        FileMatcher::toRegEx(new FileMatcherPattern('/a'))->matches('foo/bar');
     }
 
     /**
@@ -622,7 +622,7 @@ class FileMatcherTest extends TestCase
     private static function assertMap(FileMatcherPattern $pattern, array $matchMap): void
     {
         foreach ($matchMap as $candidate => $shouldMatch) {
-            $matches = FileMatcher::toRegEx($pattern->path)->matches($candidate);
+            $matches = FileMatcher::toRegEx($pattern)->matches($candidate);
 
             if ($matches === $shouldMatch) {
                 self::assertTrue(true);

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -371,6 +371,7 @@ class FileMatcherTest extends TestCase
                 '/a' => false,
                 '/' => false,
             ],
+            'This test fails because `[` should be interpreted a literal',
         ];
 
         yield 'match ranges' => [

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -1,7 +1,15 @@
-<?php
-
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace PHPUnit\Util;
 
+use function sprintf;
 use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -13,31 +21,6 @@ use RuntimeException;
 #[Small]
 class FileMatcherTest extends TestCase
 {
-    public function testExceptionIfPathIsNotAbsolute(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Path "foo/bar" must be absolute');
-        FileMatcher::match('foo/bar', new FileMatcherPattern(''));
-    }
-
-    /**
-     * @param array<FileMatcherPattern,bool> $matchMap
-     */
-    #[DataProvider('provideMatch')]
-    #[DataProvider('provideWildcard')]
-    #[DataProvider('provideGlobstar')]
-    #[DataProvider('provideQuestionMark')]
-    #[DataProvider('provideCharacterGroup')]
-    #[DataProvider('provideRelativePathSegments')]
-    public function testMatch(FileMatcherPattern $pattern, array $matchMap, ?string $skip = null): void
-    {
-        if ($skip) {
-            self::markTestSkipped($skip);
-        }
-
-        self::assertMap($pattern, $matchMap);
-    }
-
     /**
      * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
      */
@@ -54,9 +37,9 @@ class FileMatcherTest extends TestCase
         yield 'directory' => [
             new FileMatcherPattern('/path/to'),
             [
-                '/path/to' => true,
+                '/path/to'                 => true,
                 '/path/to/example/Foo.php' => true,
-                '/path/foo/Bar.php' => false,
+                '/path/foo/Bar.php'        => false,
             ],
         ];
     }
@@ -69,65 +52,66 @@ class FileMatcherTest extends TestCase
         yield 'leaf wildcard' => [
             new FileMatcherPattern('/path/*'),
             [
-                '/path/foo/bar' => true,
-                '/path/foo/baz' => true,
-                '/path/baz.php' => true,
-                '/path/foo/baz/boo.php' => true,
+                '/path/foo/bar'          => true,
+                '/path/foo/baz'          => true,
+                '/path/baz.php'          => true,
+                '/path/foo/baz/boo.php'  => true,
                 '/path/example/file.php' => true,
-                '/' => false,
+                '/'                      => false,
             ],
         ];
 
         yield 'leaf directory wildcard' => [
             new FileMatcherPattern('/path/*'),
             [
-                '/path/foo/bar' => true,
-                '/path/foo/baz' => true,
-                '/path/foo/baz/boo.php' => true,
+                '/path/foo/bar'          => true,
+                '/path/foo/baz'          => true,
+                '/path/foo/baz/boo.php'  => true,
                 '/path/example/file.php' => true,
-                '/' => false,
+                '/'                      => false,
             ],
-       ];
+        ];
+
         yield 'segment directory wildcard' => [
             new FileMatcherPattern('/path/*/bar'),
             [
-                '/path/foo/bar' => true,
-                '/path/foo/baz' => false,
+                '/path/foo/bar'         => true,
+                '/path/foo/baz'         => false,
                 '/path/foo/bar/boo.php' => true,
-                '/foo/bar/file.php' => false,
+                '/foo/bar/file.php'     => false,
             ],
-       ];
+        ];
 
         yield 'multiple segment directory wildcards' => [
             new FileMatcherPattern('/path/*/example/*/bar'),
             [
-                '/path/zz/example/aa/bar' => true,
+                '/path/zz/example/aa/bar'     => true,
                 '/path/zz/example/aa/bar/foo' => true,
-                '/path/example/aa/bar/foo' => false,
-                '/path/zz/example/bb/foo' => false,
+                '/path/example/aa/bar/foo'    => false,
+                '/path/zz/example/bb/foo'     => false,
             ],
         ];
 
         yield 'partial wildcard' => [
             new FileMatcherPattern('/path/f*'),
             [
-                '/path/foo/bar' => true,
-                '/path/foo/baz' => true,
-                '/path/boo' => false,
+                '/path/foo/bar'              => true,
+                '/path/foo/baz'              => true,
+                '/path/boo'                  => false,
                 '/path/boo/example/file.php' => false,
             ],
-       ];
+        ];
 
         yield 'partial segment wildcard' => [
             new FileMatcherPattern('/path/f*/bar'),
             [
-                '/path/foo/bar' => true,
-                '/path/faa/bar' => true,
-                '/path/foo/baz' => false,
-                '/path/boo' => false,
+                '/path/foo/bar'              => true,
+                '/path/faa/bar'              => true,
+                '/path/foo/baz'              => false,
+                '/path/boo'                  => false,
                 '/path/boo/example/file.php' => false,
             ],
-       ];
+        ];
     }
 
     /**
@@ -138,20 +122,20 @@ class FileMatcherTest extends TestCase
         yield 'leaf globstar at root' => [
             new FileMatcherPattern('/**'),
             [
-                '/foo' => true,
+                '/foo'     => true,
                 '/foo/bar' => true,
-                '/' => true, // matches zero or more
+                '/'        => true, // matches zero or more
             ],
         ];
 
         yield 'leaf globstar' => [
             new FileMatcherPattern('/foo/**'),
             [
-                '/foo' => true,
-                '/foo/foo' => true,
+                '/foo'             => true,
+                '/foo/foo'         => true,
                 '/foo/foo/baz.php' => true,
-                '/bar/foo' => false,
-                '/bar/foo/baz' => false,
+                '/bar/foo'         => false,
+                '/bar/foo/baz'     => false,
             ],
         ];
 
@@ -159,23 +143,23 @@ class FileMatcherTest extends TestCase
         yield 'partial leaf globstar' => [
             new FileMatcherPattern('/foo/emm**'),
             [
-                '/foo/emmer' => false,
-                '/foo/emm' => false,
+                '/foo/emmer'   => false,
+                '/foo/emm'     => false,
                 '/foo/emm/bar' => false,
-                '/' => false,
+                '/'            => false,
             ],
         ];
 
         yield 'segment globstar' => [
             new FileMatcherPattern('/foo/emm/**/bar'),
             [
-                '/foo/emm/bar' => true,
-                '/foo/emm/foo/bar' => true,
+                '/foo/emm/bar'         => true,
+                '/foo/emm/foo/bar'     => true,
                 '/baz/emm/foo/bar/boo' => false,
-                '/baz/emm/foo/bar' => false,
-                '/foo/emm/barfoo' => false,
-                '/foo/emm/' => false,
-                '/foo/emm' => false,
+                '/baz/emm/foo/bar'     => false,
+                '/foo/emm/barfoo'      => false,
+                '/foo/emm/'            => false,
+                '/foo/emm'             => false,
             ],
         ];
 
@@ -186,13 +170,13 @@ class FileMatcherTest extends TestCase
         yield 'EDGE: segment globstar with wildcard' => [
             new FileMatcherPattern('/foo/emm/**/*ar'),
             [
-                '/foo/emm/bar' => true,
-                '/foo/emm/far' => true,
-                '/foo/emm/foo/far' => true,
-                '/foo/emm/foo/far' => true,
+                '/foo/emm/bar'         => true,
+                '/foo/emm/far'         => true,
+                '/foo/emm/foo/far'     => true,
+                '/foo/emm/foo/far'     => true,
                 '/foo/emm/foo/bar/far' => true,
                 '/baz/emm/foo/bar/boo' => true,
-                '/baz/emm/foo/bad' => false,
+                '/baz/emm/foo/bad'     => false,
                 '/baz/emm/foo/bad/boo' => false,
             ],
             'PHPUnit edge case',
@@ -207,58 +191,63 @@ class FileMatcherTest extends TestCase
         yield 'question mark at root' => [
             new FileMatcherPattern('/?'),
             [
-                '/' => false,
-                '/f' => true,
-                '/foo' => false,
-                '/f/emm/foo/bar' => true,
+                '/'                => false,
+                '/f'               => true,
+                '/foo'             => false,
+                '/f/emm/foo/bar'   => true,
                 '/foo/emm/foo/bar' => false,
             ],
         ];
+
         yield 'question mark at leaf' => [
             new FileMatcherPattern('/foo/?'),
             [
-                '/foo' => false,
-                '/foo/' => false,
-                '/foo/a' => true,
-                '/foo/ab' => false,
+                '/foo'     => false,
+                '/foo/'    => false,
+                '/foo/a'   => true,
+                '/foo/ab'  => false,
                 '/foo/a/c' => true,
             ],
         ];
+
         yield 'question mark at segment start' => [
             new FileMatcherPattern('/foo/?ar'),
             [
-                '/' => false,
-                '/foo' => false,
-                '/foo/' => false,
-                '/foo/aa' => false,
-                '/foo/aar' => true,
-                '/foo/aarg' => false,
+                '/'             => false,
+                '/foo'          => false,
+                '/foo/'         => false,
+                '/foo/aa'       => false,
+                '/foo/aar'      => true,
+                '/foo/aarg'     => false,
                 '/foo/aar/barg' => true,
-                '/foo/bar' => true,
-                '/foo/ab/c' => false,
+                '/foo/bar'      => true,
+                '/foo/ab/c'     => false,
             ],
         ];
+
         yield 'question mark in segment' => [
             new FileMatcherPattern('/foo/f?o'),
             [
-                '/foo' => false,
-                '/foo/' => false,
-                '/foo/foo' => true,
-                '/foo/boo' => false,
+                '/foo'          => false,
+                '/foo/'         => false,
+                '/foo/foo'      => true,
+                '/foo/boo'      => false,
                 '/foo/foo/true' => true,
             ],
         ];
+
         yield 'consecutive question marks' => [
             new FileMatcherPattern('/foo/???'),
             [
-                '/foo' => false,
-                '/foo/' => false,
-                '/foo/bar' => true,
-                '/foo/car' => true,
-                '/foo/the/test/will/pass' => true,
+                '/foo'                        => false,
+                '/foo/'                       => false,
+                '/foo/bar'                    => true,
+                '/foo/car'                    => true,
+                '/foo/the/test/will/pass'     => true,
                 '/bar/the/test/will/not/pass' => false,
             ],
         ];
+
         yield 'multiple question marks in segment' => [
             new FileMatcherPattern('/foo/?a?'),
             [
@@ -266,24 +255,26 @@ class FileMatcherTest extends TestCase
                 '/foo/ccr' => false,
             ],
         ];
+
         yield 'multiple question marks in segments' => [
             new FileMatcherPattern('/foo/?a?/bar/f?a'),
             [
-                '/foo' => false,
-                '/foo/aaa' => false,
-                '/foo/aaa/bar' => false,
-                '/foo/aaa/bar/' => false,
-                '/foo/bar/zaa' => false,
+                '/foo'             => false,
+                '/foo/aaa'         => false,
+                '/foo/aaa/bar'     => false,
+                '/foo/aaa/bar/'    => false,
+                '/foo/bar/zaa'     => false,
                 '/foo/car/bar/faa' => true,
             ],
         ];
+
         yield 'tailing question mark' => [
             new FileMatcherPattern('/foo/?a?/bar/fa?'),
             [
-                '/foo/car' => false,
+                '/foo/car'         => false,
                 '/foo/car/bar/faa' => true,
-                '/foo/ccr' => false,
-                '/foo/bar/zaa' => false,
+                '/foo/ccr'         => false,
+                '/foo/bar/zaa'     => false,
             ],
         ];
     }
@@ -296,32 +287,35 @@ class FileMatcherTest extends TestCase
         yield 'unterminated char group' => [
             new FileMatcherPattern('/[AB'),
             [
-                '/[' => false,
-                '/[A' => false,
-                '/[AB' => true,
+                '/['       => false,
+                '/[A'      => false,
+                '/[AB'     => true,
                 '/[AB/foo' => true,
             ],
         ];
+
         yield 'unterminated char group followed by char group' => [
             new FileMatcherPattern('/[AB[a-z]'),
             [
-                '/[' => false,
-                '/[Ac' => false,
-                '/[ABc' => true,
+                '/['        => false,
+                '/[Ac'      => false,
+                '/[ABc'     => true,
                 '/[ABc/foo' => true,
             ],
         ];
+
         yield 'multiple unterminated char groups followed by char group' => [
             new FileMatcherPattern('/[AB[CD[a-z]EF'),
             [
-                '/[' => false,
-                '/[Ac' => false,
-                '/[AB[C' => false,
-                '/[AB[CD' => false,
-                '/[AB[CDz' => false,
+                '/['         => false,
+                '/[Ac'       => false,
+                '/[AB[C'     => false,
+                '/[AB[CD'    => false,
+                '/[AB[CDz'   => false,
                 '/[AB[CDzEF' => true,
             ],
         ];
+
         yield 'single char leaf' => [
             new FileMatcherPattern('/[A]'),
             [
@@ -329,24 +323,26 @@ class FileMatcherTest extends TestCase
                 '/B' => false,
             ],
         ];
+
         yield 'single char segment' => [
             new FileMatcherPattern('/a/[B]/c'),
             [
-                '/a' => false,
-                '/a/B' => false,
+                '/a'     => false,
+                '/a/B'   => false,
                 '/a/B/c' => true,
                 '/a/Z/c' => false,
             ],
         ];
+
         yield 'multichar' => [
             new FileMatcherPattern('/a/[ABC]/c'),
             [
-                '/a' => false,
-                '/a/A' => false,
-                '/a/B/c' => true,
-                '/a/C/c' => true,
-                '/a/Z/c' => false,
-                '/a/Za/c' => false,
+                '/a'       => false,
+                '/a/A'     => false,
+                '/a/B/c'   => true,
+                '/a/C/c'   => true,
+                '/a/Z/c'   => false,
+                '/a/Za/c'  => false,
                 '/a/Aaa/c' => false,
             ],
         ];
@@ -354,7 +350,7 @@ class FileMatcherTest extends TestCase
         yield 'matching is case sensitive' => [
             new FileMatcherPattern('/a/[ABC]/c'),
             [
-                '/a/a' => false,
+                '/a/a'   => false,
                 '/a/b/c' => false,
                 '/a/c/c' => false,
             ],
@@ -365,11 +361,11 @@ class FileMatcherTest extends TestCase
             new FileMatcherPattern('/[][!]'),
             [
                 '/[hello' => true,
-                '/[' => true,
-                '/!' => true,
-                '/!bang' => true,
-                '/a' => false,
-                '/' => false,
+                '/['      => true,
+                '/!'      => true,
+                '/!bang'  => true,
+                '/a'      => false,
+                '/'       => false,
             ],
             'This test fails because `[` should be interpreted a literal',
         ];
@@ -377,7 +373,7 @@ class FileMatcherTest extends TestCase
         yield 'match ranges' => [
             new FileMatcherPattern('/a/[a-c]/c'),
             [
-                '/a/a' => false,
+                '/a/a'   => false,
                 '/a/z/c' => false,
                 '/a/b/c' => true,
                 '/a/c/c' => true,
@@ -389,7 +385,7 @@ class FileMatcherTest extends TestCase
         yield 'multiple match ranges' => [
             new FileMatcherPattern('/a/[a-c0-8]/c'),
             [
-                '/a/a' => false,
+                '/a/a'   => false,
                 '/a/0/c' => true,
                 '/a/2/c' => true,
                 '/a/8/c' => true,
@@ -403,32 +399,32 @@ class FileMatcherTest extends TestCase
         yield 'dash in group' => [
             new FileMatcherPattern('/a/[-]/c'),
             [
-                '/a/-' => false,
-                '/a/-/c' => true,
+                '/a/-'      => false,
+                '/a/-/c'    => true,
                 '/a/-/ca/d' => false,
                 '/a/-/c/da' => true,
-                '/a/a/fo' => false,
+                '/a/a/fo'   => false,
             ],
         ];
 
         yield 'range prefix dash' => [
             new FileMatcherPattern('/a/[-a-c]/c'),
             [
-                '/a/a' => false,
-                '/a/-' => false,
-                '/a/-/c' => true,
-                '/a/d' => false,
-                '/a/-b/c' => false,
+                '/a/a'      => false,
+                '/a/-'      => false,
+                '/a/-/c'    => true,
+                '/a/d'      => false,
+                '/a/-b/c'   => false,
                 '/a/a/c/fo' => true,
-                '/a/c/fo' => false,
-                '/a/d/c' => false,
+                '/a/c/fo'   => false,
+                '/a/d/c'    => false,
             ],
         ];
 
         yield 'range infix dash' => [
             new FileMatcherPattern('/a/[a-c-e-f]/c'),
             [
-                '/a/a' => false,
+                '/a/a'   => false,
                 '/a/-/c' => true,
                 '/a/-/a' => false,
                 '/a/c/c' => true,
@@ -443,7 +439,7 @@ class FileMatcherTest extends TestCase
         yield 'range suffix dash' => [
             new FileMatcherPattern('/a/[a-ce-f-]/c'),
             [
-                '/a/a' => false,
+                '/a/a'   => false,
                 '/a/-/c' => true,
                 '/a/-/c' => true,
                 '/a/c/c' => true,
@@ -458,12 +454,12 @@ class FileMatcherTest extends TestCase
         yield 'complementation single char' => [
             new FileMatcherPattern('/a/[!a]/c'),
             [
-                '/a/a' => false,
-                '/a/a/c' => false,
-                '/a/b/c' => true,
-                '/a/0/c' => true,
+                '/a/a'    => false,
+                '/a/a/c'  => false,
+                '/a/b/c'  => true,
+                '/a/0/c'  => true,
                 '/a/0a/c' => false,
-            ]
+            ],
         ];
 
         yield 'complementation multi char' => [
@@ -473,7 +469,7 @@ class FileMatcherTest extends TestCase
                 '/a/b/c' => false,
                 '/a/c/c' => false,
                 '/a/d/c' => true,
-            ]
+            ],
         ];
 
         yield 'complementation range' => [
@@ -483,17 +479,18 @@ class FileMatcherTest extends TestCase
                 '/a/b/c' => false,
                 '/a/c/c' => false,
                 '/a/d/c' => true,
-            ]
+            ],
         ];
 
         yield 'escape range' => [
             new FileMatcherPattern('/a/\[!a-c]/c'),
             [
-                '/a/[!a-c]/c' => true,
+                '/a/[!a-c]/c'   => true,
                 '/a/[!a-c]/c/d' => true,
                 '/b/[!a-c]/c/d' => false,
             ],
         ];
+
         yield 'literal backslash negated group' => [
             new FileMatcherPattern('/a/\\\[!a-c]/c'),
             [
@@ -546,7 +543,8 @@ class FileMatcherTest extends TestCase
     }
 
     /**
-     * TODO: expand this
+     * TODO: expand this.
+     *
      * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
      */
     public static function provideRelativePathSegments(): Generator
@@ -560,6 +558,32 @@ class FileMatcherTest extends TestCase
             'Relative path segments',
         ];
     }
+
+    public function testExceptionIfPathIsNotAbsolute(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Path "foo/bar" must be absolute');
+        FileMatcher::match('foo/bar', new FileMatcherPattern(''));
+    }
+
+    /**
+     * @param array<FileMatcherPattern,bool> $matchMap
+     */
+    #[DataProvider('provideMatch')]
+    #[DataProvider('provideWildcard')]
+    #[DataProvider('provideGlobstar')]
+    #[DataProvider('provideQuestionMark')]
+    #[DataProvider('provideCharacterGroup')]
+    #[DataProvider('provideRelativePathSegments')]
+    public function testMatch(FileMatcherPattern $pattern, array $matchMap, ?string $skip = null): void
+    {
+        if ($skip) {
+            $this->markTestSkipped($skip);
+        }
+
+        self::assertMap($pattern, $matchMap);
+    }
+
     /**
      * @param array<FileMatcherPattern,bool> $matchMap
      */
@@ -567,15 +591,17 @@ class FileMatcherTest extends TestCase
     {
         foreach ($matchMap as $candidate => $shouldMatch) {
             $matches = FileMatcher::match($candidate, $pattern);
+
             if ($matches === $shouldMatch) {
                 self::assertTrue(true);
+
                 continue;
             }
             self::fail(sprintf(
                 'Expected the pattern "%s" %s match path "%s"',
                 $pattern->path,
                 $shouldMatch ? 'to' : 'to not',
-                $candidate
+                $candidate,
             ));
         }
     }

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -297,22 +297,24 @@ class FileMatcherTest extends TestCase
         yield 'unterminated char group followed by char group' => [
             new FileMatcherPattern('/[AB[a-z]'),
             [
-                '/['        => false,
-                '/[Ac'      => false,
-                '/[ABc'     => true,
-                '/[ABc/foo' => true,
+                '/[' => true, // nested [ is literal
+                '/f' => true, // within a-z
+                '/A' => true,
+                '/B' => true,
+
+                '/Z' => false,
+                '/[c' => false,
             ],
         ];
 
         yield 'multiple unterminated char groups followed by char group' => [
             new FileMatcherPattern('/[AB[CD[a-z]EF'),
             [
-                '/['         => false,
-                '/[Ac'       => false,
-                '/[AB[C'     => false,
-                '/[AB[CD'    => false,
-                '/[AB[CDz'   => false,
-                '/[AB[CDzEF' => true,
+                '/[EF' => true,
+                '/AEF' => true,
+                '/[EF' => true,
+                '/DEF' => true,
+                '/EEF' => false,
             ],
         ];
 
@@ -358,7 +360,7 @@ class FileMatcherTest extends TestCase
 
         // https://man7.org/linux/man-pages/man7/glob.7.html
         yield 'square bracket in char group' => [
-            new FileMatcherPattern('/[][!]'),
+            new FileMatcherPattern('/[][!]*'),
             [
                 '/[hello' => true,
                 '/['      => true,
@@ -367,7 +369,6 @@ class FileMatcherTest extends TestCase
                 '/a'      => false,
                 '/'       => false,
             ],
-            'This test fails because `[` should be interpreted a literal',
         ];
 
         yield 'match ranges' => [

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -493,7 +493,12 @@ class FileMatcherTest extends TestCase
                 '/a/[!a-c]/c/d' => true,
                 '/b/[!a-c]/c/d' => false,
             ],
-            'Regex escaping',
+        ];
+        yield 'literal backslash neagted group' => [
+            new FileMatcherPattern('/a/\\\[!a-c]/c'),
+            [
+                '/a/\\d/c' => true,
+            ],
         ];
 
         // TODO: test all the character clases

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -3,10 +3,14 @@
 namespace PHPUnit\Util;
 
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+#[CoversClass(FileMatcher::class)]
+#[Small]
 class FileMatcherTest extends TestCase
 {
     public function testExceptionIfPathIsNotAbsolute(): void
@@ -20,16 +24,12 @@ class FileMatcherTest extends TestCase
      * @param array<FileMatcherPattern,bool> $matchMap
      */
     #[DataProvider('provideMatch')]
-    public function testMatch(FileMatcherPattern $pattern, array $matchMap): void
-    {
-        self::assertMap($pattern, $matchMap);
-    }
-
-    /**
-     * @param array<FileMatcherPattern,bool> $matchMap
-     */
     #[DataProvider('provideWildcard')]
-    public function testWildcard(FileMatcherPattern $pattern, array $matchMap): void
+    #[DataProvider('provideGlobstar')]
+    #[DataProvider('provideQuestionMark')]
+    #[DataProvider('provideCharacterGroup')]
+    #[DataProvider('provideRelativePathSegments')]
+    public function testMatch(FileMatcherPattern $pattern, array $matchMap): void
     {
         self::assertMap($pattern, $matchMap);
     }
@@ -62,7 +62,6 @@ class FileMatcherTest extends TestCase
      */
     public static function provideWildcard(): Generator
     {
-
         yield 'leaf wildcard' => [
             new FileMatcherPattern('/path/*'),
             [
@@ -130,12 +129,410 @@ class FileMatcherTest extends TestCase
     }
 
     /**
+     * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
+     */
+    public static function provideGlobstar(): Generator
+    {
+        yield 'leaf globstar at root' => [
+            new FileMatcherPattern('/**'),
+            [
+                '/foo' => true,
+                '/foo/bar' => true,
+                '/' => false,
+            ],
+        ];
+
+        yield 'leaf globstar' => [
+            new FileMatcherPattern('/foo/**'),
+            [
+                '/foo' => true,
+                '/foo/foo' => true,
+                '/foo/foo/baz.php' => true,
+                '/bar/foo' => false,
+                '/bar/foo/baz' => false,
+            ],
+        ];
+
+        // partial match does not work with globstar
+        yield 'partial leaf globstar' => [
+            new FileMatcherPattern('/foo/emm**'),
+            [
+                '/foo/emmer' => false,
+                '/foo/emm' => false,
+                '/foo/emm/bar' => false,
+                '/' => false,
+            ],
+        ];
+
+        yield 'segment globstar' => [
+            new FileMatcherPattern('/foo/emm/**/bar'),
+            [
+                '/foo/emm/bar' => true,
+                '/foo/emm/foo/bar' => true,
+                '/baz/emm/foo/bar/boo' => true,
+                '/baz/emm/foo/bar' => false,
+                '/foo/emm/barfoo' => false,
+                '/foo/emm/' => false,
+                '/foo/emm' => false,
+            ],
+        ];
+
+        yield 'segment globstar with wildcard' => [
+            new FileMatcherPattern('/foo/emm/**/*ar'),
+            [
+                '/foo/emm/bar' => true,
+                '/foo/emm/far' => true,
+                '/foo/emm/foo/far' => true,
+                '/foo/emm/foo/far' => true,
+                '/foo/emm/foo/bar/far' => true,
+                '/baz/emm/foo/bar/boo' => true,
+                '/baz/emm/foo/bad' => false,
+                '/baz/emm/foo/bad/boo' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
+     */
+    public static function provideQuestionMark(): Generator
+    {
+        yield 'question mark at root' => [
+            new FileMatcherPattern('/?'),
+            [
+                '/' => false,
+                '/f' => true,
+                '/foo' => true,
+                '/foo/emm/foo/bar' => true,
+            ],
+        ];
+        yield 'question mark at leaf' => [
+            new FileMatcherPattern('/foo/?'),
+            [
+                '/foo' => false,
+                '/foo/' => false,
+                '/foo/a' => true,
+                '/foo/ab' => true,
+                '/foo/ab/c' => true,
+            ],
+        ];
+        yield 'question mark at segment start' => [
+            new FileMatcherPattern('/foo/?ar'),
+            [
+                '/' => false,
+                '/foo' => false,
+                '/foo/' => false,
+                '/foo/aa' => false,
+                '/foo/aar' => true,
+                '/foo/aarg' => true,
+                '/foo/aarg/barg' => true,
+                '/foo/bar' => true,
+                '/foo/ab/c' => true,
+            ],
+        ];
+        yield 'question mark in segment' => [
+            new FileMatcherPattern('/foo/f?o'),
+            [
+                '/foo' => false,
+                '/foo/' => false,
+                '/foo/foo' => true,
+                '/foo/boo' => false,
+                '/foo/foo/true' => true,
+            ],
+        ];
+        yield 'consecutive question marks' => [
+            new FileMatcherPattern('/foo/???'),
+            [
+                '/foo' => false,
+                '/foo/' => false,
+                '/foo/bar' => true,
+                '/foo/car' => true,
+                '/foo/the/test/will/pass' => true,
+                '/bar/the/test/will/not/pass' => false,
+            ],
+        ];
+        yield 'multiple question marks in segment' => [
+            new FileMatcherPattern('/foo/?a?'),
+            [
+                '/foo/car' => true,
+                '/foo/ccr' => false,
+            ],
+        ];
+        yield 'multiple question marks in segments' => [
+            new FileMatcherPattern('/foo/?a?/bar/f?a'),
+            [
+                '/foo' => false,
+                '/foo/aaa' => false,
+                '/foo/aaa/bar' => false,
+                '/foo/aaa/bar/' => false,
+                '/foo/bar/zaa' => false,
+                '/foo/car/faa' => true,
+            ],
+        ];
+        yield 'tailing question mark' => [
+            new FileMatcherPattern('/foo/?a?/bar/fa?'),
+            [
+                '/foo/car' => true,
+                '/foo/car/faa' => true,
+                '/foo/ccr' => false,
+                '/foo/bar/zaa' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
+     */
+    public static function provideCharacterGroup(): Generator
+    {
+        yield 'unterminated char group' => [
+            new FileMatcherPattern('/[AB'),
+            [
+                '/[' => false,
+                '/[A' => false,
+                '/[AB' => true,
+                '/[AB/foo' => true,
+            ],
+        ];
+        yield 'single char leaf' => [
+            new FileMatcherPattern('/[A]'),
+            [
+                '/A' => true,
+                '/B' => false,
+            ],
+        ];
+        yield 'single char segment' => [
+            new FileMatcherPattern('/a/[B]/c'),
+            [
+                '/a' => false,
+                '/a/B' => true,
+                '/a/B/c' => true,
+                '/a/Z/c' => false,
+            ],
+        ];
+        yield 'multichar' => [
+            new FileMatcherPattern('/a/[ABC]/c'),
+            [
+                '/a' => false,
+                '/a/A' => true,
+                '/a/B/c' => true,
+                '/a/C/c' => true,
+                '/a/Z/c' => false,
+                '/a/Za/c' => false,
+                '/a/Aaa/c' => false,
+            ],
+        ];
+
+        yield 'matching is case sensitive' => [
+            new FileMatcherPattern('/a/[ABC]/c'),
+            [
+                '/a/a' => false,
+                '/a/b/c' => false,
+                '/a/c/c' => false,
+            ],
+        ];
+
+        // https://man7.org/linux/man-pages/man7/glob.7.html
+        // example from glob manpage
+        yield 'square bracket in char group' => [
+            new FileMatcherPattern('/[][!]'),
+            [
+                '/[hello' => true,
+                '/[' => true,
+                '/!' => true,
+                '/!bang' => true,
+                '/a' => false,
+                '/' => false,
+            ],
+        ];
+
+        yield 'match ranges' => [
+            new FileMatcherPattern('/a/[a-c]/c'),
+            [
+                '/a/a' => false,
+                '/a/z/c' => false,
+                '/a/b/c' => true,
+                '/a/c/c' => true,
+                '/a/d/c' => false,
+                '/a/c/d' => false,
+            ],
+        ];
+
+        yield 'multiple match ranges' => [
+            new FileMatcherPattern('/a/[a-c0-8]/c'),
+            [
+                '/a/a' => false,
+                '/a/0/c' => true,
+                '/a/2/c' => true,
+                '/a/8/c' => true,
+                '/a/9/c' => false,
+                '/a/c/c' => true,
+                '/a/a/c' => true,
+                '/a/d/c' => false,
+            ],
+        ];
+
+        yield 'dash in group' => [
+            new FileMatcherPattern('/a/[-]/c'),
+            [
+                '/a/-' => true,
+                '/a/-/fo' => true,
+                '/a/a/fo' => false,
+            ],
+        ];
+
+        yield 'range prefix dash' => [
+            new FileMatcherPattern('/a/[-a-c]/c'),
+            [
+                '/a/a' => false,
+                '/a/-' => true,
+                '/a/d' => false,
+                '/a/-b/c' => false,
+                '/a/a/fo' => true,
+                '/a/c/fo' => true,
+                '/a/d/fo' => false,
+            ],
+        ];
+
+        yield 'range infix dash' => [
+            new FileMatcherPattern('/a/[a-c-e-f]/c'),
+            [
+                '/a/a' => false,
+                '/a/-' => true,
+                '/a/-/a' => true,
+                '/a/c/a' => true,
+                '/a/a/a' => true,
+                '/a/d/a' => false,
+                '/a/e/a' => true,
+                '/a/g/a' => false,
+                '/a/-/c' => true,
+            ],
+        ];
+
+        yield 'range suffix dash' => [
+            new FileMatcherPattern('/a/[a-ce-f-]/c'),
+            [
+                '/a/a' => false,
+                '/a/-' => true,
+                '/a/-/a' => true,
+                '/a/c/a' => true,
+                '/a/a/a' => true,
+                '/a/d/a' => false,
+                '/a/e/a' => true,
+                '/a/g/a' => false,
+                '/a/-/c' => true,
+            ],
+        ];
+
+        yield 'complementation single char' => [
+            new FileMatcherPattern('/a/[!a]/c'),
+            [
+                '/a/a' => false,
+                '/a/a/b' => false,
+                '/a/b/b' => true,
+                '/a/0/b' => true,
+                '/a/0a/b' => false,
+            ]
+        ];
+
+        yield 'complementation multi char' => [
+            new FileMatcherPattern('/a/[!abc]/c'),
+            [
+                '/a/a/b' => false,
+                '/a/b/b' => false,
+                '/a/c/b' => false,
+                '/a/d/b' => true,
+            ]
+        ];
+
+        yield 'complementation range' => [
+            new FileMatcherPattern('/a/[!a-c]/c'),
+            [
+                '/a/a/b' => false,
+                '/a/b/b' => false,
+                '/a/c/b' => false,
+                '/a/d/b' => true,
+            ]
+        ];
+
+        yield 'escape range' => [
+            new FileMatcherPattern('/a/\[!a-c]/c'),
+            [
+                '/a/[!a-c]/c' => true,
+                '/a/[!a-c]/c/d' => true,
+                '/b/[!a-c]/c/d' => false,
+            ]
+        ];
+
+        // TODO: test all the character clases
+        // [:alnum:]  [:alpha:]  [:blank:]  [:cntrl:]
+        // [:digit:]  [:graph:]  [:lower:]  [:print:]
+        // [:punct:]  [:space:]  [:upper:]  [:xdigit:]
+        yield 'character class...' => [
+            new FileMatcherPattern('/a/[:alnum:]/c'),
+            [
+                '/a/1/c' => true,
+                '/a/2/c' => true,
+                '/b/!/c' => false,
+            ]
+        ];
+
+        // TODO: all of these?
+        // Collating symbols, like "[.ch.]" or "[.a-acute.]", where the
+        // string between "[." and ".]" is a collating element defined for
+        // the current locale.  Note that this may be a multicharacter
+        // element
+        yield 'collating symbols' => [
+            new FileMatcherPattern('/a/[.a-acute.]/c'),
+            [
+                '/a/á/c' => true,
+                '/a/a/c' => false,
+            ]
+        ];
+
+        // TODO: all of these?
+        // Equivalence class expressions, like "[=a=]", where the string
+        //        between "[=" and "=]" is any collating element from its
+        //        equivalence class, as defined for the current locale.  For
+        //        example, "[[=a=]]" might be equivalent to "[aáàäâ]", that is, to
+        //        "[a[.a-acute.][.a-grave.][.a-umlaut.][.a-circumflex.]]".
+        yield 'equivalence class expressions' => [
+            new FileMatcherPattern('/a/[=a=]/c'),
+            [
+                '/a/á/c' => true,
+                '/a/a/c' => true,
+            ]
+
+        ];
+    }
+
+    /**
+     * TODO: expand this
+     * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
+     */
+    public static function provideRelativePathSegments(): Generator
+    {
+        yield 'equivalence class expressions' => [
+            new FileMatcherPattern('/a/../a/c'),
+            [
+                '/a/a/c' => true,
+                '/a/b/c' => true,
+            ]
+
+        ];
+    }
+    /**
      * @param array<FileMatcherPattern,bool> $matchMap
      */
     private static function assertMap(FileMatcherPattern $pattern, array $matchMap): void
     {
         foreach ($matchMap as $candidate => $shouldMatch) {
-            self::assertSame($shouldMatch, FileMatcher::match($candidate, $pattern));
+            $matches = FileMatcher::match($candidate, $pattern);
+            if ($matches === $shouldMatch) {
+                $this->addToAssertionCount(1);
+                continue;
+            }
+            self::fail(sprintf('Expected the pattern "%s" to match path "%s"', $pattern->path, $candidate));
         }
     }
 }

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -371,7 +371,6 @@ class FileMatcherTest extends TestCase
                 '/a' => false,
                 '/' => false,
             ],
-            'Unterminated square bracket 2',
         ];
 
         yield 'match ranges' => [

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace PHPUnit\Util;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class FileMatcherTest extends TestCase
+{
+    public function testExceptionIfPathIsNotAbsolute(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Path "foo/bar" must be absolute');
+        FileMatcher::match('foo/bar', new FileMatcherPattern(''));
+    }
+
+    /**
+     * @param array<FileMatcherPattern,bool> $matchMap
+     */
+    #[DataProvider('provideMatch')]
+    public function testMatch(FileMatcherPattern $pattern, array $matchMap): void
+    {
+        self::assertMap($pattern, $matchMap);
+    }
+
+    /**
+     * @param array<FileMatcherPattern,bool> $matchMap
+     */
+    #[DataProvider('provideWildcard')]
+    public function testWildcard(FileMatcherPattern $pattern, array $matchMap): void
+    {
+        self::assertMap($pattern, $matchMap);
+    }
+
+    /**
+     * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
+     */
+    public static function provideMatch(): Generator
+    {
+        yield 'exact path' => [
+            new FileMatcherPattern('/path/to/example/Foo.php'),
+            [
+                '/path/to/example/Foo.php' => true,
+                '/path/to/example/Bar.php' => false,
+            ],
+        ];
+
+        yield 'directory' => [
+            new FileMatcherPattern('/path/to'),
+            [
+                '/path/to' => true,
+                '/path/to/example/Foo.php' => true,
+                '/path/foo/Bar.php' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return Generator<string,array{FileMatcherPattern,array<string,bool>}>
+     */
+    public static function provideWildcard(): Generator
+    {
+
+        yield 'leaf wildcard' => [
+            new FileMatcherPattern('/path/*'),
+            [
+                '/path/foo/bar' => true,
+                '/path/foo/baz' => true,
+                '/path/baz.php' => true,
+                '/path/foo/baz/boo.php' => true,
+                '/path/example/file.php' => false,
+                '/' => false,
+                '' => false,
+            ],
+        ];
+
+        yield 'leaf directory wildcard' => [
+            new FileMatcherPattern('/path/*'),
+            [
+                '/path/foo/bar' => true,
+                '/path/foo/baz' => true,
+                '/path/foo/baz/boo.php' => true,
+                '/path/example/file.php' => false,
+                '/' => false,
+                '' => false,
+            ],
+       ];
+        yield 'segment directory wildcard' => [
+            new FileMatcherPattern('/path/*/bar'),
+            [
+                '/path/foo/bar' => true,
+                '/path/foo/baz' => false,
+                '/path/foo/bar/boo.php' => true,
+                '/foo/bar/file.php' => false,
+            ],
+       ];
+
+        yield 'multiple segment directory wildcards' => [
+            new FileMatcherPattern('/path/*/example/*/bar'),
+            [
+                '/path/zz/example/aa/bar' => true,
+                '/path/zz/example/aa/bar/foo' => true,
+                '/path/example/aa/bar/foo' => false,
+                '/path/zz/example/bb/foo' => false,
+            ],
+        ];
+
+        yield 'partial wildcard' => [
+            new FileMatcherPattern('/path/f*'),
+            [
+                '/path/foo/bar' => true,
+                '/path/foo/baz' => true,
+                '/path/boo' => false,
+                '/path/boo/example/file.php' => false,
+            ],
+       ];
+
+        yield 'partial segment wildcard' => [
+            new FileMatcherPattern('/path/f*/bar'),
+            [
+                '/path/foo/bar' => true,
+                '/path/faa/bar' => true,
+                '/path/foo/baz' => false,
+                '/path/boo' => false,
+                '/path/boo/example/file.php' => false,
+            ],
+       ];
+    }
+
+    /**
+     * @param array<FileMatcherPattern,bool> $matchMap
+     */
+    private static function assertMap(FileMatcherPattern $pattern, array $matchMap): void
+    {
+        foreach ($matchMap as $candidate => $shouldMatch) {
+            self::assertSame($shouldMatch, FileMatcher::match($candidate, $pattern));
+        }
+    }
+}

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -293,10 +293,6 @@ class FileMatcherTest extends TestCase
      */
     public static function provideCharacterGroup(): Generator
     {
-        // TODO: POSIX will interpret an unterminated [ group as a literal while
-        //       Regex will crash -- we'd need to look ahead to see if the [ is
-        //       terminated if we continue using Regex.
-        //
         yield 'unterminated char group' => [
             new FileMatcherPattern('/[AB'),
             [
@@ -305,7 +301,26 @@ class FileMatcherTest extends TestCase
                 '/[AB' => true,
                 '/[AB/foo' => true,
             ],
-            'Unterminated square bracket',
+        ];
+        yield 'unterminated char group followed by char group' => [
+            new FileMatcherPattern('/[AB[a-z]'),
+            [
+                '/[' => false,
+                '/[Ac' => false,
+                '/[ABc' => true,
+                '/[ABc/foo' => true,
+            ],
+        ];
+        yield 'multiple unterminated char groups followed by char group' => [
+            new FileMatcherPattern('/[AB[CD[a-z]EF'),
+            [
+                '/[' => false,
+                '/[Ac' => false,
+                '/[AB[C' => false,
+                '/[AB[CD' => false,
+                '/[AB[CDz' => false,
+                '/[AB[CDzEF' => true,
+            ],
         ];
         yield 'single char leaf' => [
             new FileMatcherPattern('/[A]'),

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -143,6 +143,7 @@ class FileMatcherTest extends TestCase
         yield 'partial leaf globstar' => [
             new FileMatcherPattern('/foo/emm**'),
             [
+                '/foo/emm**'   => true,
                 '/foo/emmer'   => false,
                 '/foo/emm'     => false,
                 '/foo/emm/bar' => false,

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -167,7 +167,7 @@ class FileMatcherTest extends TestCase
             [
                 '/foo/emm/bar' => true,
                 '/foo/emm/foo/bar' => true,
-                '/baz/emm/foo/bar/boo' => true,
+                '/baz/emm/foo/bar/boo' => false,
                 '/baz/emm/foo/bar' => false,
                 '/foo/emm/barfoo' => false,
                 '/foo/emm/' => false,
@@ -175,6 +175,8 @@ class FileMatcherTest extends TestCase
             ],
         ];
 
+        // TODO: this edge case
+        return;
         // PHPUnit will match ALL directories within `/foo` with `/foo/A**`
         // however it will NOT match anything with `/foo/Aa**`
         //
@@ -204,8 +206,9 @@ class FileMatcherTest extends TestCase
             [
                 '/' => false,
                 '/f' => true,
-                '/foo' => true,
-                '/foo/emm/foo/bar' => true,
+                '/foo' => false,
+                '/f/emm/foo/bar' => true,
+                '/foo/emm/foo/bar' => false,
             ],
         ];
         yield 'question mark at leaf' => [
@@ -214,8 +217,8 @@ class FileMatcherTest extends TestCase
                 '/foo' => false,
                 '/foo/' => false,
                 '/foo/a' => true,
-                '/foo/ab' => true,
-                '/foo/ab/c' => true,
+                '/foo/ab' => false,
+                '/foo/a/c' => true,
             ],
         ];
         yield 'question mark at segment start' => [
@@ -226,10 +229,10 @@ class FileMatcherTest extends TestCase
                 '/foo/' => false,
                 '/foo/aa' => false,
                 '/foo/aar' => true,
-                '/foo/aarg' => true,
-                '/foo/aarg/barg' => true,
+                '/foo/aarg' => false,
+                '/foo/aar/barg' => true,
                 '/foo/bar' => true,
-                '/foo/ab/c' => true,
+                '/foo/ab/c' => false,
             ],
         ];
         yield 'question mark in segment' => [
@@ -268,14 +271,14 @@ class FileMatcherTest extends TestCase
                 '/foo/aaa/bar' => false,
                 '/foo/aaa/bar/' => false,
                 '/foo/bar/zaa' => false,
-                '/foo/car/faa' => true,
+                '/foo/car/bar/faa' => true,
             ],
         ];
         yield 'tailing question mark' => [
             new FileMatcherPattern('/foo/?a?/bar/fa?'),
             [
-                '/foo/car' => true,
-                '/foo/car/faa' => true,
+                '/foo/car' => false,
+                '/foo/car/bar/faa' => true,
                 '/foo/ccr' => false,
                 '/foo/bar/zaa' => false,
             ],

--- a/tests/unit/Util/FileMatcherTest.php
+++ b/tests/unit/Util/FileMatcherTest.php
@@ -494,7 +494,7 @@ class FileMatcherTest extends TestCase
                 '/b/[!a-c]/c/d' => false,
             ],
         ];
-        yield 'literal backslash neagted group' => [
+        yield 'literal backslash negated group' => [
             new FileMatcherPattern('/a/\\\[!a-c]/c'),
             [
                 '/a/\\d/c' => true,

--- a/tools/map
+++ b/tools/map
@@ -1,0 +1,38 @@
+#!/usr/bin/env php
+<?php
+
+use PHPUnit\TextUI\Configuration\FileCollection;
+use PHPUnit\TextUI\Configuration\FilterDirectory;
+use PHPUnit\TextUI\Configuration\FilterDirectoryCollection;
+use PHPUnit\TextUI\Configuration\Source;
+use PHPUnit\TextUI\Configuration\SourceMapper;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$dirs = $argv[1];
+
+$map = (new SourceMapper())->map(new Source(
+    baseline: null,
+    ignoreBaseline: false,
+    includeDirectories: FilterDirectoryCollection::fromArray([new FilterDirectory($dirs, '', '')]),
+    includeFiles: FileCollection::fromArray([]),
+    excludeDirectories: FilterDirectoryCollection::fromArray([]),
+    excludeFiles: FileCollection::fromArray([]),
+    restrictDeprecations: false,
+    restrictNotices: false,
+    restrictWarnings: false,
+    ignoreSuppressionOfDeprecations: false,
+    ignoreSuppressionOfPhpDeprecations: false,
+    ignoreSuppressionOfErrors: false,
+    ignoreSuppressionOfNotices: false,
+    ignoreSuppressionOfPhpNotices: false,
+    ignoreSuppressionOfWarnings: false,
+    ignoreSuppressionOfPhpWarnings: false,
+    deprecationTriggers: [],
+    ignoreSelfDeprecations: false,
+    ignoreDirectDeprecations: false,
+    ignoreIndirectDeprecations: false
+));
+
+
+var_dump($map);

--- a/tools/map
+++ b/tools/map
@@ -1,6 +1,9 @@
 #!/usr/bin/env php
 <?php
 
+// This file is temporary to this pull request and it here to provide
+// a convenient way to explore the existing behavior.
+
 use PHPUnit\TextUI\Configuration\FileCollection;
 use PHPUnit\TextUI\Configuration\FilterDirectory;
 use PHPUnit\TextUI\Configuration\FilterDirectoryCollection;
@@ -10,6 +13,7 @@ use PHPUnit\TextUI\Configuration\SourceMapper;
 require __DIR__ . '/../vendor/autoload.php';
 
 $dirs = $argv[1];
+var_dump($dirs);
 
 $map = (new SourceMapper())->map(new Source(
     baseline: null,


### PR DESCRIPTION
This (early stage) WIP PR introduces a static path matcher which intends to emulate the behavior of the PHPUnit `FileIterator` in order to prevent PHPUnit traversing the filesystem when a [deprecation is triggered](https://github.com/sebastianbergmann/phpunit/issues/6114).

The PHPUnit FileIterator uses `glob` to find directories and we therefore need to support the glob patterns - which can [vary](https://www.php.net/manual/en/function.glob.php) according to the platform. This PR uses https://man7.org/linux/man-pages/man7/glob.7.html as a reference in addition to testing the behavior locally to confirm assumptions.

The [webmozart/glob](https://github.com/webmozarts/glob/blob/4.8.x/src/Glob.php#L313) provides a similar feature however it's behavior is different as it supports curly braces, and `*` is restricted to a single directory level, while `*` in PHPUnit will return all descendants and I'm sure there are other differences - however I've used that as a starting point.

TODO:

- [x] Escaping unhandled regex characters, or escaping the regex before parsing the pattern.
- [x] Character classes `[:alnum:]` etc.
- [ ] Collating symbols
- [ ] Equivalence class expressions
- [x] Emulating `glob` behavior of unterminated `[` character groups.
- [ ] Seems to be a PHPUnit globstar bug whereby `/a**` will match `/b` and all other directories, where as `/ab*` will not match anything. We can either copy that behavior or "fix" it.

~and maybe writing the implementation from scratch if regex turns out to be a bad fit.~

Usages on Github:

- wildcard: 1.8k https://github.com/search?q=directory+%22*%22+path%3A*.xml+path%3A**%2Fphpunit.xml+language%3AXML&type=code
- globstar: 378: https://github.com/search?q=directory+%22**%22+path%3A*.xml+path%3A**%2Fphpunit.xml+language%3AXML&type=code
- Character range/class (`directory.*\[`): 0: https://github.com/search?q=%2Fdirectory.*%5C%5B%2F+path%3A*.xml+path%3A**%2Fphpunit.xml+language%3AXML&type=code
- `?` any char: 0 https://github.com/search?q=%2Fdirectory.*%5C%5B%2F+path%3A*.xml+path%3A**%2Fphpunit.xml+language%3AXML&type=code