### PR TITLE
Allow different trait error message

### DIFF
--- a/tests/end-to-end/generic/phar-extension-suppressed.phpt
+++ b/tests/end-to-end/generic/phar-extension-suppressed.phpt
@@ -10,4 +10,4 @@ $_SERVER['argv'][] = '--no-extensions';
 require_once __DIR__ . '/../../bootstrap.php';
 PHPUnit\TextUI\Command::main();
 --EXPECTF--
-Fatal error: Trait %sPHPUnit\ExampleExtension\TestCaseTrait%s not found in %A
+Fatal error:%sTrait %sPHPUnit\ExampleExtension\TestCaseTrait%s not found in %A


### PR DESCRIPTION
Since https://github.com/php/php-src/commit/8731c95b35f6838bacd12a07c50886e020aad5a6 the trait error message is different.

I've had failures vs master in the 8.5 and 9.6 branch. I haven't investigated why the other branches didn't fail though. I'm a bit in a rush and I also wasn't able to test the fix myself, but I'm fairly confident it should work ;-)

```
1) /home/runner/work/php-latest-builds/php-latest-builds/tests/end-to-end/generic/phar-extension-suppressed.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
-Fatal error: Trait %sPHPUnit\ExampleExtension\TestCaseTrait%s not found in %A
+Fatal error: Uncaught Error: Trait "PHPUnit\ExampleExtension\TestCaseTrait" not found in /home/runner/work/php-latest-builds/php-latest-builds/tests/_files/phpunit-example-extension/tests/OneTest.php:13
+Stack trace:
```