### PR TITLE
Collect deprecations triggered by autoloading while loading/building the test suite

### DIFF
--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -100,6 +100,12 @@ final class ErrorHandler
 
         $test = Event\Code\TestMethodBuilder::fromCallStack();
 
+        if ($errorNumber === E_USER_DEPRECATED) {
+            $deprecationFrame = $this->guessDeprecationFrame();
+            $errorFile        = $deprecationFrame['file'] ?? $errorFile;
+            $errorLine        = $deprecationFrame['line'] ?? $errorLine;
+        }
+
         $ignoredByBaseline = $this->ignoredByBaseline($errorFile, $errorLine, $errorString);
         $ignoredByTest     = $test->metadata()->isIgnoreDeprecations()->isNotEmpty();
 
@@ -167,13 +173,11 @@ final class ErrorHandler
                 break;
 
             case E_USER_DEPRECATED:
-                $deprecationFrame = $this->guessDeprecationFrame();
-
                 Event\Facade::emitter()->testTriggeredDeprecation(
                     $test,
                     $errorString,
-                    $deprecationFrame['file'] ?? $errorFile,
-                    $deprecationFrame['line'] ?? $errorLine,
+                    $errorFile,
+                    $errorLine,
                     $suppressed,
                     $ignoredByBaseline,
                     $ignoredByTest,

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -185,7 +185,11 @@ final readonly class Application
 
             EventFacade::instance()->seal();
 
+            ErrorHandler::instance()->registerDeprecationHandler();
+
             $testSuite = $this->buildTestSuite($configuration);
+
+            ErrorHandler::instance()->restoreDeprecationHandler();
 
             $this->executeCommandsThatRequireTheTestSuite($configuration, $cliConfiguration, $testSuite);
 

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/baseline.xml
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<files version="1">
+ <file path="vendor/ThirdPartyClass.php">
+  <line number="4" hash="67f46da0ae62f1f93b33314db1c7a53dd56f4f49">
+   <issue><![CDATA[deprecation in third-party code]]></issue>
+  </line>
+ </file>
+</files>

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/phpunit.xml
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true" ignoreIndirectDeprecations="false" baseline="baseline.xml">
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationTrigger>
+            <function>PHPUnit\TestFixture\BaselineIgnoreDeprecation\trigger_deprecation</function>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/src/FirstPartyClass.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/src/FirstPartyClass.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\BaselineIgnoreDeprecation;
+
+final class FirstPartyClass
+{
+    public function method(): true
+    {
+        (new ThirdPartyClass)->method();
+
+        return true;
+    }
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/tests/FirstPartyClassTest.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/tests/FirstPartyClassTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\BaselineIgnoreDeprecation;
+
+use PHPUnit\Framework\TestCase;
+
+final class FirstPartyClassTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue((new ThirdPartyClass)->anotherMethod());
+    }
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/vendor/ThirdPartyClass.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/vendor/ThirdPartyClass.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+namespace PHPUnit\TestFixture\BaselineIgnoreDeprecation;
+
+trigger_deprecation('deprecation in third-party code');
+
+final class ThirdPartyClass
+{
+    public function anotherMethod(): true
+    {
+        return true;
+    }
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/vendor/autoload.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/vendor/autoload.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+require __DIR__ . '/trigger_deprecation.php';
+
+spl_autoload_register(function ($class) {
+    $parts = explode('\\', $class);
+    $file = end($parts) . '.php';
+
+    match ($file) {
+        'FirstPartyClass.php' => require __DIR__ . '/../src/' . $file,
+        'ThirdPartyClass.php' => require __DIR__ . '/' . $file,
+        default => throw new LogicException
+    };
+});
+

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/vendor/trigger_deprecation.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-baseline-ignore/vendor/trigger_deprecation.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+namespace PHPUnit\TestFixture\BaselineIgnoreDeprecation;
+
+function trigger_deprecation(string $message): void
+{
+    @trigger_error($message, E_USER_DEPRECATED);
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/phpunit.xml
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/src/FirstPartyClass.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/src/FirstPartyClass.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\SelfDirectIndirect;
+
+final class FirstPartyClass
+{
+    public function method(): true
+    {
+        return ThirdPartyClass::A;
+    }
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/tests/FirstPartyClassTest.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/tests/FirstPartyClassTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\SelfDirectIndirect;
+
+use PHPUnit\Framework\TestCase;
+
+final class FirstPartyClassTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue((new FirstPartyClass)->method());
+    }
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/vendor/ThirdPartyClass.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/vendor/ThirdPartyClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+namespace PHPUnit\TestFixture\SelfDirectIndirect;
+
+@trigger_error('This class is deprecated', E_USER_DEPRECATED);
+
+final class ThirdPartyClass
+{
+    const A = true;
+}

--- a/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/vendor/autoload.php
+++ b/tests/end-to-end/deprecation-trigger/_files/deprecation-trigger-class/vendor/autoload.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+spl_autoload_register(function ($class) {
+    $parts = explode('\\', $class);
+    $file = end($parts) . '.php';
+
+    match ($file) {
+        'FirstPartyClass.php' => require __DIR__ . '/../src/' . $file,
+        'ThirdPartyClass.php' => require __DIR__ . '/' . $file,
+        default => throw new LogicException
+    };
+});

--- a/tests/end-to-end/deprecation-trigger/deprecation-trigger-baseline-ignore.phpt
+++ b/tests/end-to-end/deprecation-trigger/deprecation-trigger-baseline-ignore.phpt
@@ -1,0 +1,36 @@
+--TEST--
+The right events are emitted in the right order for a test that runs code which triggers E_USER_DEPRECATED
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/deprecation-trigger-baseline-ignore';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (%s)
+Test Runner Configured
+Bootstrap Finished (%sautoload.php)
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%sphpunit.xml, 1 test)
+Test Suite Started (default, 1 test)
+Test Suite Started (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest::testOne)
+Test Prepared (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest::testOne)
+Test Triggered Deprecation (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest::testOne, issue triggered by third-party code, suppressed using operator, ignored by baseline) in %s:%d
+deprecation in third-party code
+Test Passed (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest::testOne)
+Test Finished (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\BaselineIgnoreDeprecation\FirstPartyClassTest, 1 test)
+Test Suite Finished (default, 1 test)
+Test Suite Finished (%sphpunit.xml, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/deprecation-trigger/deprecation-trigger-class.phpt
+++ b/tests/end-to-end/deprecation-trigger/deprecation-trigger-class.phpt
@@ -1,0 +1,36 @@
+--TEST--
+The right events are emitted in the right order for a test that loads a class that triggers E_USER_DEPRECATED
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/deprecation-trigger-class';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Bootstrap Finished (%sautoload.php)
+Event Facade Sealed
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (%sphpunit.xml, 1 test)
+Test Suite Started (default, 1 test)
+Test Suite Started (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest::testOne)
+Test Prepared (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest::testOne)
+Test Triggered Deprecation (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest::testOne, issue triggered by third-party code, suppressed using operator) in %s:%d
+This class is deprecated
+Test Passed (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest::testOne)
+Test Finished (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\SelfDirectIndirect\FirstPartyClassTest, 1 test)
+Test Suite Finished (default, 1 test)
+Test Suite Finished (%sphpunit.xml, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Runner/ErrorHandlerTest.php
+++ b/tests/unit/Runner/ErrorHandlerTest.php
@@ -31,5 +31,6 @@ final class ErrorHandlerTest extends TestCase
         $registeredDeprecations = $globalDeprecations->getValue($errorHandler);
         $this->assertCount(1, $registeredDeprecations);
         $this->assertSame('deprecation', $registeredDeprecations[0][1]);
+        $globalDeprecations->setValue($errorHandler, []);
     }
 }

--- a/tests/unit/Runner/ErrorHandlerTest.php
+++ b/tests/unit/Runner/ErrorHandlerTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+#[CoversClass(ErrorHandler::class)]
+#[Small]
+final class ErrorHandlerTest extends TestCase
+{
+    public function testThrowsExceptionWhenUsingInvalidOrderOption(): void
+    {
+        $errorHandler = ErrorHandler::instance();
+        $errorHandler->registerDeprecationHandler();
+        trigger_error('deprecation', E_USER_DEPRECATED);
+        $errorHandler->restoreDeprecationHandler();
+        $refl                   = new ReflectionClass($errorHandler);
+        $globalDeprecations     = $refl->getProperty('globalDeprecations');
+        $registeredDeprecations = $globalDeprecations->getValue($errorHandler);
+        $this->assertCount(1, $registeredDeprecations);
+        $this->assertSame('deprecation', $registeredDeprecations[0][1]);
+    }
+}


### PR DESCRIPTION
When one triggers a deprecation in a class directly like this:

```php
<?php
trigger_error('Depreciated interface', E_USER_DEPRECATED);

interface Foo {}
```

This technique is notably used in many Symfony components, for example:

https://github.com/symfony/symfony/blob/82cf90aefb7e9117ebd981fec83d7546e310e52b/src/Symfony/Component/PropertyInfo/Type.php#L12-L15

The deprecation will be triggered when autoloading the class, which happens in:

https://github.com/sebastianbergmann/phpunit/blob/4b6a4ee654e5e0c5e1f17e2f83c0f4c91dee1f9c/src/TextUI/Application.php#L181

At that point, the ErrorHandler is not registered and we loose the deprecation. 

This pull request gives an idea on how it may be fixed, indeed the `ErrorHandler` needs a `TestCase` therefore I'm collecting these deprecations and triggering them once we call `ErrorHandler::enable`. I'm open to suggestions on how to fix this differently. Obviously I'll add tests if/once a solution is found that can be merged.

Thanks!