### PR TITLE
error_log output not displayed in failed test cases

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1268,6 +1268,13 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 print preg_replace('/\[.+\] /', '', $errorLogOutput);
             }
         } catch (Throwable $exception) {
+            if (!$this->expectErrorLog) {
+                $errorLogOutput = stream_get_contents($capture);
+
+                // strip date from logged error, see https://github.com/php/php-src/blob/c696087e323263e941774ebbf902ac249774ec9f/main/main.c#L905
+                print preg_replace('/\[.+\] /', '', $errorLogOutput);
+            }
+
             if (!$this->shouldExceptionExpectationsBeVerified($exception)) {
                 throw $exception;
             }


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/6173

----

it might make sense to separate the regression test and also merge it into 11.x