### PR TITLE
Enhancement: Enable and configure `attribute_empty_parentheses` fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -26,6 +26,9 @@ $config->setFinder($finder)
         'array_indentation' => true,
         'array_push' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'attribute_empty_parentheses' => [
+            'use_parentheses' => false,
+        ],
         'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'operators' => [


### PR DESCRIPTION
This pull request

- [x] enables and configures the `attribute_empty_parentheses` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.75.0/doc/rules/attribute_notation/attribute_empty_parentheses.rst.