### PR TITLE
fix: PHPStan detecting type correctly after usage of Assert::assertContainsOnly*

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -294,6 +294,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type array.
      *
+     * @phpstan-assert iterable<array<mixed>> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -311,6 +313,8 @@ abstract class Assert
 
     /**
      * Asserts that a haystack contains only values of type bool.
+     *
+     * @phpstan-assert iterable<bool> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -330,6 +334,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type callable.
      *
+     * @phpstan-assert iterable<callable> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -347,6 +353,8 @@ abstract class Assert
 
     /**
      * Asserts that a haystack contains only values of type float.
+     *
+     * @phpstan-assert iterable<float> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -366,6 +374,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type int.
      *
+     * @phpstan-assert iterable<int> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -383,6 +393,8 @@ abstract class Assert
 
     /**
      * Asserts that a haystack contains only values of type iterable.
+     *
+     * @phpstan-assert iterable<iterable<mixed>> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -402,6 +414,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type null.
      *
+     * @phpstan-assert iterable<null> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -419,6 +433,8 @@ abstract class Assert
 
     /**
      * Asserts that a haystack contains only values of type numeric.
+     *
+     * @phpstan-assert iterable<numeric> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -438,6 +454,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type object.
      *
+     * @phpstan-assert iterable<object> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -455,6 +473,8 @@ abstract class Assert
 
     /**
      * Asserts that a haystack contains only values of type resource.
+     *
+     * @phpstan-assert iterable<resource> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -474,6 +494,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type closed resource.
      *
+     * @phpstan-assert iterable<resource> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -492,6 +514,8 @@ abstract class Assert
     /**
      * Asserts that a haystack contains only values of type scalar.
      *
+     * @phpstan-assert iterable<scalar> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -509,6 +533,8 @@ abstract class Assert
 
     /**
      * Asserts that a haystack contains only values of type string.
+     *
+     * @phpstan-assert iterable<string> $haystack
      *
      * @param iterable<mixed> $haystack
      *

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -303,6 +303,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyArray')) {
     /**
      * Asserts that a haystack contains only values of type array.
      *
+     * @phpstan-assert iterable<array<mixed>> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -320,6 +322,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyArray')) {
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyBool')) {
     /**
      * Asserts that a haystack contains only values of type bool.
+     *
+     * @phpstan-assert iterable<bool> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -339,6 +343,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyCallable')) {
     /**
      * Asserts that a haystack contains only values of type callable.
      *
+     * @phpstan-assert iterable<callable> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -356,6 +362,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyCallable')) {
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyFloat')) {
     /**
      * Asserts that a haystack contains only values of type float.
+     *
+     * @phpstan-assert iterable<float> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -375,6 +383,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyInt')) {
     /**
      * Asserts that a haystack contains only values of type int.
      *
+     * @phpstan-assert iterable<int> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -392,6 +402,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyInt')) {
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyIterable')) {
     /**
      * Asserts that a haystack contains only values of type iterable.
+     *
+     * @phpstan-assert iterable<iterable<mixed>> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -411,6 +423,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyNull')) {
     /**
      * Asserts that a haystack contains only values of type null.
      *
+     * @phpstan-assert iterable<null> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -428,6 +442,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyNull')) {
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyNumeric')) {
     /**
      * Asserts that a haystack contains only values of type numeric.
+     *
+     * @phpstan-assert iterable<numeric> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -447,6 +463,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyObject')) {
     /**
      * Asserts that a haystack contains only values of type object.
      *
+     * @phpstan-assert iterable<object> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -464,6 +482,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyObject')) {
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyResource')) {
     /**
      * Asserts that a haystack contains only values of type resource.
+     *
+     * @phpstan-assert iterable<resource> $haystack
      *
      * @param iterable<mixed> $haystack
      *
@@ -483,6 +503,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyClosedResource')) {
     /**
      * Asserts that a haystack contains only values of type closed resource.
      *
+     * @phpstan-assert iterable<resource> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -501,6 +523,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyScalar')) {
     /**
      * Asserts that a haystack contains only values of type scalar.
      *
+     * @phpstan-assert iterable<scalar> $haystack
+     *
      * @param iterable<mixed> $haystack
      *
      * @throws ExpectationFailedException
@@ -518,6 +542,8 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyScalar')) {
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyString')) {
     /**
      * Asserts that a haystack contains only values of type string.
+     *
+     * @phpstan-assert iterable<string> $haystack
      *
      * @param iterable<mixed> $haystack
      *


### PR DESCRIPTION
Hey there :wave: 

I added more `phpstan-assert` annotation to the `Assert` class and to the standalone functions. Those cover the `assertContainsOnly**` methods.