### PR TITLE
Remove wrong assertion phpdocs on assertEmpty(), assertNotEmpty()

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -1073,8 +1073,6 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      * @throws GeneratorNotSupportedException
-     *
-     * @phpstan-assert empty $actual
      */
     final public static function assertEmpty(mixed $actual, string $message = ''): void
     {
@@ -1090,8 +1088,6 @@ abstract class Assert
      *
      * @throws ExpectationFailedException
      * @throws GeneratorNotSupportedException
-     *
-     * @phpstan-assert !empty $actual
      */
     final public static function assertNotEmpty(mixed $actual, string $message = ''): void
     {

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -1062,8 +1062,6 @@ if (!function_exists('PHPUnit\Framework\assertEmpty')) {
      * @throws ExpectationFailedException
      * @throws GeneratorNotSupportedException
      *
-     * @phpstan-assert empty $actual
-     *
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertEmpty
@@ -1080,8 +1078,6 @@ if (!function_exists('PHPUnit\Framework\assertNotEmpty')) {
      *
      * @throws ExpectationFailedException
      * @throws GeneratorNotSupportedException
-     *
-     * @phpstan-assert !empty $actual
      *
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/6199

I though about how we can/should unit test such change, but it seems atm there is no static analysis covering tests