### PR TITLE
Set default Clover coverage project name

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -287,7 +287,7 @@ final class CodeCoverage
 
             try {
                 $writer = new CloverReport;
-                $writer->process($this->codeCoverage(), $configuration->coverageClover());
+                $writer->process($this->codeCoverage(), $configuration->coverageClover(), 'Clover Coverage');
 
                 $this->codeCoverageGenerationSucceeded($printer);
 


### PR DESCRIPTION
Some Clover XML report processing tools require the project name to be set.

e.g. https://issues.jenkins.io/browse/JENKINS-75648

Could this be backported to phpunit 8.5?