### PR TITLE
Be strict about data providers having redundant data

### DIFF
--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Metadata\Api;
 
 use function array_key_exists;
 use function assert;
+use function count;
 use function get_debug_type;
 use function is_array;
 use function is_int;
@@ -23,6 +24,7 @@ use PHPUnit\Metadata\MetadataCollection;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Metadata\TestWith;
 use ReflectionClass;
+use ReflectionMethod;
 use Throwable;
 
 /**
@@ -61,6 +63,8 @@ final readonly class DataProvider
             );
         }
 
+        $testMethodNumberOfParameters = (new ReflectionMethod($className, $methodName))->getNumberOfParameters();
+
         foreach ($data as $key => $value) {
             if (!is_array($value)) {
                 throw new InvalidDataProviderException(
@@ -68,6 +72,17 @@ final readonly class DataProvider
                         'Data set %s is invalid, expected array but got %s',
                         is_int($key) ? '#' . $key : '"' . $key . '"',
                         get_debug_type($value),
+                    ),
+                );
+            }
+
+            if ($testMethodNumberOfParameters < count($value)) {
+                throw new InvalidDataProviderException(
+                    sprintf(
+                        'The key "%s" has more arguments (%d) than the test method accepts (%d).',
+                        $key,
+                        count($value),
+                        $testMethodNumberOfParameters,
                     ),
                 );
             }

--- a/tests/_files/AbstractVariousIterableDataProviderTest.php
+++ b/tests/_files/AbstractVariousIterableDataProviderTest.php
@@ -49,14 +49,14 @@ abstract class AbstractVariousIterableDataProviderTest
     #[DataProvider('asArrayProvider')]
     #[DataProvider('asIteratorProvider')]
     #[DataProvider('asTraversableProvider')]
-    public function testAbstract(): void
+    public function testAbstract(string $x): void
     {
     }
 
     #[DataProvider('asArrayProviderInParent')]
     #[DataProvider('asIteratorProviderInParent')]
     #[DataProvider('asTraversableProviderInParent')]
-    public function testInParent(): void
+    public function testInParent(string $x): void
     {
     }
 }

--- a/tests/_files/DataProviderTooManyArguments.php
+++ b/tests/_files/DataProviderTooManyArguments.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DataProviderTooManyArguments extends TestCase
+{
+    public static function provider(): iterable
+    {
+        // correct case, 2nd parameter is not required
+        yield [true];
+
+        // correct case
+        yield [true, true];
+
+        // incorrect case
+        yield [true, true, 'Third argument, but test method only has two.'];
+    }
+
+    #[DataProvider('provider')]
+    public function testMethodHavingTwoParameters(bool $x1, bool $x2 = false): void
+    {
+        $this->assertSame($x1, $x2);
+    }
+
+    public function testToNotHaveNoTests(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/_files/Metadata/Attribute/tests/TestWithTest.php
+++ b/tests/_files/Metadata/Attribute/tests/TestWithTest.php
@@ -16,25 +16,25 @@ use PHPUnit\Framework\TestCase;
 final class TestWithTest extends TestCase
 {
     #[TestWith([1, 2, 3])]
-    public function testOne(): void
+    public function testOne($one, $two, $three): void
     {
         $this->assertTrue(true);
     }
 
     #[TestWith([1, 2, 3], 'Name1')]
-    public function testOneWithName(): void
+    public function testOneWithName($one, $two = null, $three = null): void
     {
         $this->assertTrue(true);
     }
 
     #[TestWithJson('[1, 2, 3]')]
-    public function testTwo(): void
+    public function testTwo($one, $two, $three): void
     {
         $this->assertTrue(true);
     }
 
     #[TestWithJson('[1, 2, 3]', 'Name2')]
-    public function testTwoWithName(): void
+    public function testTwoWithName($one, $two, $three): void
     {
         $this->assertTrue(true);
     }

--- a/tests/_files/MultipleDataProviderTest.php
+++ b/tests/_files/MultipleDataProviderTest.php
@@ -79,14 +79,14 @@ final class MultipleDataProviderTest extends TestCase
     #[DataProvider('providerA')]
     #[DataProvider('providerB')]
     #[DataProvider('providerC')]
-    public function testOne(): void
+    public function testOne($one, $two, $three): void
     {
     }
 
     #[DataProvider('providerD')]
     #[DataProvider('providerE')]
     #[DataProvider('providerF')]
-    public function testTwo(): void
+    public function testTwo($one, $two, $three): void
     {
     }
 }

--- a/tests/_files/TestWithDataProvider.php
+++ b/tests/_files/TestWithDataProvider.php
@@ -20,7 +20,7 @@ final class TestWithDataProvider extends TestCase
     }
 
     #[DataProvider('provider')]
-    public function testOne(): void
+    public function testOne(int $zero): void
     {
     }
 }

--- a/tests/_files/VariousIterableDataProviderTest.php
+++ b/tests/_files/VariousIterableDataProviderTest.php
@@ -71,21 +71,21 @@ final class VariousIterableDataProviderTest extends AbstractVariousIterableDataP
     #[DataProvider('asArrayStaticProvider')]
     #[DataProvider('asIteratorStaticProvider')]
     #[DataProvider('asTraversableStaticProvider')]
-    public function testStatic(): void
+    public function testStatic(string $x): void
     {
     }
 
     #[DataProvider('asArrayProvider')]
     #[DataProvider('asIteratorProvider')]
     #[DataProvider('asTraversableProvider')]
-    public function testNonStatic(): void
+    public function testNonStatic(string $x): void
     {
     }
 
     #[DataProvider('asArrayProviderInParent')]
     #[DataProvider('asIteratorProviderInParent')]
     #[DataProvider('asTraversableProviderInParent')]
-    public function testFromParent(): void
+    public function testFromParent(string $x): void
     {
     }
 }

--- a/tests/end-to-end/data-provider/too-many-arguments.phpt
+++ b/tests/end-to-end/data-provider/too-many-arguments.phpt
@@ -1,0 +1,31 @@
+--TEST--
+phpunit ../../_files/DataProviderTooManyArguments.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderTooManyArguments.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit error:
+
+1) PHPUnit\TestFixture\DataProviderTooManyArguments::testMethodHavingTwoParameters
+The data provider specified for PHPUnit\TestFixture\DataProviderTooManyArguments::testMethodHavingTwoParameters is invalid
+The key "2" has more arguments (3) than the test method accepts (2).
+
+%A
+
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.
+

--- a/tests/end-to-end/regression/2830/Issue2830Test.php
+++ b/tests/end-to-end/regression/2830/Issue2830Test.php
@@ -22,7 +22,7 @@ class Issue2830Test extends TestCase
     }
 
     #[DataProvider('simpleDataProvider')]
-    public function testMethodUsesDataProvider(): void
+    public function testMethodUsesDataProvider(string $foo): void
     {
         $this->assertTrue(true);
     }

--- a/tests/unit/Framework/Assert/assertEqualsTest.php
+++ b/tests/unit/Framework/Assert/assertEqualsTest.php
@@ -177,11 +177,11 @@ final class assertEqualsTest extends TestCase
             [2, 1],
             // floats
             [2.3, 4.2],
-            [2.3, 4.2, 0.5],
-            [[2.3], [4.2], 0.5],
-            [[[2.3]], [[4.2]], 0.5],
-            [new Struct(2.3), new Struct(4.2), 0.5],
-            [[new Struct(2.3)], [new Struct(4.2)], 0.5],
+            [2.3, 4.2],
+            [[2.3], [4.2]],
+            [[[2.3]], [[4.2]]],
+            [new Struct(2.3), new Struct(4.2)],
+            [[new Struct(2.3)], [new Struct(4.2)]],
             [1 / 3, 1 - 2 / 3],
             [1 / 3, '0.33333333333333337'],
             [1 - 2 / 3, '3333333333333333'],
@@ -233,12 +233,10 @@ final class assertEqualsTest extends TestCase
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-29 03:13:35', new DateTimeZone('America/New_York')),
-                3500,
             ],
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-29 05:13:35', new DateTimeZone('America/New_York')),
-                3500,
             ],
             [
                 new DateTimeImmutable('2013-03-29', new DateTimeZone('America/New_York')),
@@ -247,7 +245,6 @@ final class assertEqualsTest extends TestCase
             [
                 new DateTimeImmutable('2013-03-29', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-30', new DateTimeZone('America/New_York')),
-                43200,
             ],
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
@@ -256,7 +253,6 @@ final class assertEqualsTest extends TestCase
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/Chicago')),
-                3500,
             ],
             [
                 new DateTimeImmutable('2013-03-30', new DateTimeZone('America/New_York')),


### PR DESCRIPTION
Closes https://github.com/sebastianbergmann/phpunit/issues/6211

- 1st commit is the feature itself
- 2nd commit is the changes to align the codebase to follow the new rule

Should this be hidden behind a config option?
Should it make the test risky/with a warning rather than producing error?