### PR TITLE
Remove redundant data from data providers

### DIFF
--- a/tests/unit/Framework/Assert/assertEqualsTest.php
+++ b/tests/unit/Framework/Assert/assertEqualsTest.php
@@ -177,11 +177,11 @@ final class assertEqualsTest extends TestCase
             [2, 1],
             // floats
             [2.3, 4.2],
-            [2.3, 4.2, 0.5],
-            [[2.3], [4.2], 0.5],
-            [[[2.3]], [[4.2]], 0.5],
-            [new Struct(2.3), new Struct(4.2), 0.5],
-            [[new Struct(2.3)], [new Struct(4.2)], 0.5],
+            [2.3, 4.2],
+            [[2.3], [4.2]],
+            [[[2.3]], [[4.2]]],
+            [new Struct(2.3), new Struct(4.2)],
+            [[new Struct(2.3)], [new Struct(4.2)]],
             [1 / 3, 1 - 2 / 3],
             [1 / 3, '0.33333333333333337'],
             [1 - 2 / 3, '3333333333333333'],
@@ -233,12 +233,10 @@ final class assertEqualsTest extends TestCase
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-29 03:13:35', new DateTimeZone('America/New_York')),
-                3500,
             ],
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-29 05:13:35', new DateTimeZone('America/New_York')),
-                3500,
             ],
             [
                 new DateTimeImmutable('2013-03-29', new DateTimeZone('America/New_York')),
@@ -247,7 +245,6 @@ final class assertEqualsTest extends TestCase
             [
                 new DateTimeImmutable('2013-03-29', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-30', new DateTimeZone('America/New_York')),
-                43200,
             ],
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
@@ -256,7 +253,6 @@ final class assertEqualsTest extends TestCase
             [
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
                 new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/Chicago')),
-                3500,
             ],
             [
                 new DateTimeImmutable('2013-03-30', new DateTimeZone('America/New_York')),


### PR DESCRIPTION
Extracted from https://github.com/sebastianbergmann/phpunit/pull/6213, targeting `11.5` branch.

Does it make sense / is it worth the burden, to have this one and the others (adding params to test methods) in the lowest branches where they exist?