### PR TITLE
Improve the error message when `createStubForIntersectionOfInterfaces()` is called with a class 

### DIFF
--- a/src/Framework/MockObject/Generator/Exception/UnknownInterfaceException.php
+++ b/src/Framework/MockObject/Generator/Exception/UnknownInterfaceException.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Generator;
+
+use function sprintf;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class UnknownInterfaceException extends \PHPUnit\Framework\Exception implements Exception
+{
+    public function __construct(string $interfaceName)
+    {
+        parent::__construct(
+            sprintf(
+                'Interface "%s" does not exist',
+                $interfaceName,
+            ),
+        );
+    }
+}

--- a/src/Framework/MockObject/Generator/Generator.php
+++ b/src/Framework/MockObject/Generator/Generator.php
@@ -176,7 +176,7 @@ final class Generator
      * @param list<class-string> $interfaces
      *
      * @throws RuntimeException
-     * @throws UnknownTypeException
+     * @throws UnknownInterfaceException
      */
     public function testDoubleForInterfaceIntersection(array $interfaces, bool $mockObject, bool $callAutoload = true, bool $returnValueGeneration = true): MockObject|Stub
     {
@@ -186,7 +186,7 @@ final class Generator
 
         foreach ($interfaces as $interface) {
             if (!interface_exists($interface, $callAutoload)) {
-                throw new UnknownTypeException($interface);
+                throw new UnknownInterfaceException($interface);
             }
         }
 

--- a/tests/unit/Framework/MockObject/Creation/CreateMockForIntersectionOfInterfacesTest.php
+++ b/tests/unit/Framework/MockObject/Creation/CreateMockForIntersectionOfInterfacesTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Generator\RuntimeException as GeneratorRuntimeException;
-use PHPUnit\Framework\MockObject\Generator\UnknownTypeException;
+use PHPUnit\Framework\MockObject\Generator\UnknownInterfaceException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\AnInterface;
 use PHPUnit\TestFixture\MockObject\AnotherInterface;
@@ -59,7 +59,7 @@ final class CreateMockForIntersectionOfInterfacesTest extends TestCase
 
     public function testCannotCreateMockObjectForIntersectionOfUnknownInterfaces(): void
     {
-        $this->expectException(UnknownTypeException::class);
+        $this->expectException(UnknownInterfaceException::class);
 
         $this->createMockForIntersectionOfInterfaces(['DoesNotExist', 'DoesNotExist']);
     }

--- a/tests/unit/Framework/MockObject/Creation/CreateStubForIntersectionOfInterfacesTest.php
+++ b/tests/unit/Framework/MockObject/Creation/CreateStubForIntersectionOfInterfacesTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Generator\RuntimeException as GeneratorRuntimeException;
-use PHPUnit\Framework\MockObject\Generator\UnknownTypeException;
+use PHPUnit\Framework\MockObject\Generator\UnknownInterfaceException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\AnInterface;
 use PHPUnit\TestFixture\MockObject\AnotherInterface;
@@ -60,7 +60,7 @@ final class CreateStubForIntersectionOfInterfacesTest extends TestCase
 
     public function testCannotCreateTestStubForIntersectionOfUnknownInterfaces(): void
     {
-        $this->expectException(UnknownTypeException::class);
+        $this->expectException(UnknownInterfaceException::class);
 
         $this->createStubForIntersectionOfInterfaces(['DoesNotExist', 'DoesNotExist']);
     }
@@ -75,8 +75,8 @@ final class CreateStubForIntersectionOfInterfacesTest extends TestCase
 
     public function testCannotCreateTestStubForIntersectionOfInterfacesWhenClassIsUsed(): void
     {
-        $this->expectException(UnknownTypeException::class);
-        $this->expectExceptionMessage('Class or interface "PHPUnit\TestFixture\MockObject\ExtendableClass" does not exist');
+        $this->expectException(UnknownInterfaceException::class);
+        $this->expectExceptionMessage('Interface "PHPUnit\TestFixture\MockObject\ExtendableClass" does not exist');
 
         $this->createStubForIntersectionOfInterfaces([AnInterface::class, ExtendableClass::class]);
     }

--- a/tests/unit/Framework/MockObject/Creation/CreateStubForIntersectionOfInterfacesTest.php
+++ b/tests/unit/Framework/MockObject/Creation/CreateStubForIntersectionOfInterfacesTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\AnInterface;
 use PHPUnit\TestFixture\MockObject\AnotherInterface;
 use PHPUnit\TestFixture\MockObject\AnotherInterfaceThatDoesSomething;
+use PHPUnit\TestFixture\MockObject\ExtendableClass;
 
 #[Group('test-doubles')]
 #[Group('test-doubles/creation')]
@@ -70,5 +71,13 @@ final class CreateStubForIntersectionOfInterfacesTest extends TestCase
         $this->expectExceptionMessage('Interfaces must not declare the same method');
 
         $this->createStubForIntersectionOfInterfaces([AnInterface::class, AnotherInterfaceThatDoesSomething::class]);
+    }
+
+    public function testCannotCreateTestStubForIntersectionOfInterfacesWhenClassIsUsed(): void
+    {
+        $this->expectException(UnknownTypeException::class);
+        $this->expectExceptionMessage('Class or interface "PHPUnit\TestFixture\MockObject\ExtendableClass" does not exist');
+
+        $this->createStubForIntersectionOfInterfaces([AnInterface::class, ExtendableClass::class]);
     }
 }


### PR DESCRIPTION
Closes https://github.com/sebastianbergmann/phpunit/issues/6216