### PR TITLE
Fix TestCase::expectErrorLog() with open_basedir php.ini

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1328,6 +1328,8 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                         print $this->stripDateFromErrorLog($errorLogOutput);
                     }
                 }
+            } elseif ($this->expectErrorLog) {
+                $this->markTestIncomplete('Could not create writable error_log file.');
             }
         } catch (Throwable $exception) {
             if ($capture !== false) {

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1325,8 +1325,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                     $this->assertNotEmpty($errorLogOutput, 'Test did not call error_log().');
                 } else {
                     if ($errorLogOutput !== false) {
-                        // strip date from logged error, see https://github.com/php/php-src/blob/c696087e323263e941774ebbf902ac249774ec9f/main/main.c#L905
-                        print preg_replace('/\[.+\] /', '', $errorLogOutput);
+                        print $this->stripDateFromErrorLog($errorLogOutput);
                     }
                 }
             }
@@ -1336,8 +1335,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                     $errorLogOutput = stream_get_contents($capture);
 
                     if ($errorLogOutput !== false) {
-                        // strip date from logged error, see https://github.com/php/php-src/blob/c696087e323263e941774ebbf902ac249774ec9f/main/main.c#L905
-                        print preg_replace('/\[.+\] /', '', $errorLogOutput);
+                        print $this->stripDateFromErrorLog($errorLogOutput);
                     }
                 }
             }
@@ -1362,6 +1360,12 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         $this->expectedExceptionWasNotRaised();
 
         return $testResult;
+    }
+
+    private function stripDateFromErrorLog(string $log): string
+    {
+        // https://github.com/php/php-src/blob/c696087e323263e941774ebbf902ac249774ec9f/main/main.c#L905
+        return preg_replace('/\[\d+-\w+-\d+ \d+:\d+:\d+ [^\r\n[\]]+?\] /', '', $log);
     }
 
     /**

--- a/tests/end-to-end/generic/expect-error-log-fail-with-open_basedir.phpt
+++ b/tests/end-to-end/generic/expect-error-log-fail-with-open_basedir.phpt
@@ -13,7 +13,8 @@ $_SERVER['argv'][] = __DIR__ . '/_files/ExpectErrorLogFailTest.php';
  * - https://github.com/php/php-src/issues/17817
  * - https://github.com/php/php-src/issues/18530
  *
- * Until then, ignore TestCase::expectErrorLog() if open_basedir php.ini is in effect.
+ * Until then, mark the test result as incomplete when TestCase::expectErrorLog() was called and an error_log file
+ * could not be created (because of open_basedir php.ini in effect, readonly filesystem...).
  */
 
 ini_set('open_basedir', (ini_get('open_basedir') ? ini_get('open_basedir') . PATH_SEPARATOR : '') . dirname(__DIR__, 3));
@@ -26,11 +27,16 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-.                                                                   1 / 1 (100%)
+I                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %s
 
 Expect Error Log Fail (PHPUnit\TestFixture\ExpectNoErrorLog\ExpectErrorLogFail)
- ✔ One
+ ∅ One
+   │
+   │ Could not create writable error_log file.
 
-OK (1 test, 1 assertion)
+   │
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Incomplete: 1.

--- a/tests/end-to-end/generic/expect-error-log-fail-with-open_basedir.phpt
+++ b/tests/end-to-end/generic/expect-error-log-fail-with-open_basedir.phpt
@@ -1,0 +1,36 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6197
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = __DIR__ . '/_files/ExpectErrorLogFailTest.php';
+
+/*
+ * Expected result should match the result of expect-error-log-fail-with-open_basedir.phpt test,
+ * but at least one of these feature requests needs to be implemented in php-src:
+ * - https://github.com/php/php-src/issues/17817
+ * - https://github.com/php/php-src/issues/18530
+ *
+ * Until then, ignore TestCase::expectErrorLog() if open_basedir php.ini is in effect.
+ */
+
+ini_set('open_basedir', (ini_get('open_basedir') ? ini_get('open_basedir') . PATH_SEPARATOR : '') . dirname(__DIR__, 3));
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+Expect Error Log Fail (PHPUnit\TestFixture\ExpectNoErrorLog\ExpectErrorLogFail)
+ ✔ One
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/generic/expect-error-log-with-open_basedir.phpt
+++ b/tests/end-to-end/generic/expect-error-log-with-open_basedir.phpt
@@ -1,0 +1,28 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6197
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = __DIR__ . '/_files/ExpectErrorLogTest.php';
+
+ini_set('open_basedir', (ini_get('open_basedir') ? ini_get('open_basedir') . PATH_SEPARATOR : '') . dirname(__DIR__, 3));
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+logged a side effect
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+Expect Error Log (PHPUnit\TestFixture\ExpectErrorLog\ExpectErrorLog)
+ ✔ One
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/generic/expect-error-log-with-open_basedir.phpt
+++ b/tests/end-to-end/generic/expect-error-log-with-open_basedir.phpt
@@ -18,11 +18,16 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 Runtime: %s
 
 logged a side effect
-.                                                                   1 / 1 (100%)
+I                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %s
 
 Expect Error Log (PHPUnit\TestFixture\ExpectErrorLog\ExpectErrorLog)
- ✔ One
+ ∅ One
+   │
+   │ Could not create writable error_log file.
 
-OK (1 test, 1 assertion)
+   │
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Incomplete: 1.


### PR DESCRIPTION
fix #6197

rebased version of #6208 (because of https://github.com/sebastianbergmann/phpunit/pull/6208#issuecomment-2948567868)