### PR TITLE
Variadic test methods should not warn about too many arguments from data provider

### DIFF
--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -16,7 +16,6 @@ use function get_debug_type;
 use function is_array;
 use function is_int;
 use function is_string;
-use function method_exists;
 use function sprintf;
 use PHPUnit\Event;
 use PHPUnit\Event\Code\TestMethod;
@@ -64,7 +63,9 @@ final readonly class DataProvider
             );
         }
 
-        $testMethodNumberOfParameters = (new ReflectionMethod($className, $methodName))->getNumberOfParameters();
+        $method                       = new ReflectionMethod($className, $methodName);
+        $testMethodNumberOfParameters = $method->getNumberOfParameters();
+        $testMethodIsNonVariadic      = !$method->isVariadic();
 
         foreach ($data as $key => $value) {
             if (!is_array($value)) {
@@ -77,11 +78,7 @@ final readonly class DataProvider
                 );
             }
 
-            if ($testMethodNumberOfParameters < count($value)) {
-                assert(method_exists($className, $methodName));
-
-                $method = new ReflectionMethod($className, $methodName);
-
+            if ($testMethodIsNonVariadic && $testMethodNumberOfParameters < count($value)) {
                 Event\Facade::emitter()->testTriggeredPhpunitWarning(
                     new TestMethod(
                         $className,

--- a/tests/_files/DataProviderTooManyArgumentsTest.php
+++ b/tests/_files/DataProviderTooManyArgumentsTest.php
@@ -32,6 +32,12 @@ final class DataProviderTooManyArgumentsTest extends TestCase
         $this->assertSame($x1, $x2);
     }
 
+    #[DataProvider('provider')]
+    public function testMethodHavingVariadicParameter(bool $x1, ...$rest): void
+    {
+        $this->assertTrue($x1);
+    }
+
     public function testToNotHaveNoTests(): void
     {
         $this->assertTrue(true);

--- a/tests/end-to-end/data-provider/too-many-arguments.phpt
+++ b/tests/end-to-end/data-provider/too-many-arguments.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit ../../_files/DataProviderTooManyArguments.php
+phpunit ../../_files/DataProviderTooManyArgumentsTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
@@ -13,7 +13,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-W...                                                                4 / 4 (100%)
+W......                                                             7 / 7 (100%)
 
 Time: %s, Memory: %s
 
@@ -25,4 +25,4 @@ Data set #2 has more arguments (3) than the test method accepts (2)
 %s:%d
 
 OK, but there were issues!
-Tests: 4, Assertions: 4, Warnings: 1.
+Tests: 7, Assertions: 7, Warnings: 1.


### PR DESCRIPTION
Ref: https://github.com/sebastianbergmann/phpunit/pull/6213#issuecomment-2948961394