### PR TITLE
Fix saving information about passed tests

### DIFF
--- a/tests/end-to-end/regression/6222.phpt
+++ b/tests/end-to-end/regression/6222.phpt
@@ -1,0 +1,58 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6222
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--display-skipped';
+$_SERVER['argv'][] = __DIR__ . '/6222/Issue6222Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+F..S.FSFFS                                                        10 / 10 (100%)
+
+Time: %s, Memory: %s
+
+There were 4 failures:
+
+1) PHPUnit\TestFixture\Issue6222\Issue6222Test::testOne
+Failed asserting that false is true.
+
+%sIssue6222Test.php:%d
+
+2) PHPUnit\TestFixture\Issue6222\Issue6222Test::testOneCasePassing with data set #1 (2)
+Failed asserting that 2 is identical to 1.
+
+%sIssue6222Test.php:%d
+
+3) PHPUnit\TestFixture\Issue6222\Issue6222Test::testZeroCasesPassing with data set #0 (1)
+Failed asserting that 1 is identical to 3.
+
+%sIssue6222Test.php:%d
+
+4) PHPUnit\TestFixture\Issue6222\Issue6222Test::testZeroCasesPassing with data set #1 (2)
+Failed asserting that 2 is identical to 3.
+
+%sIssue6222Test.php:%d
+
+--
+
+There were 3 skipped tests:
+
+1) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnTwoCasesPassing
+This test depends on "PHPUnit\TestFixture\Issue6222\Issue6222Test::testTwoCasesPassing" to pass
+
+2) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnOneCasePassing
+This test depends on "PHPUnit\TestFixture\Issue6222\Issue6222Test::testOneCasePassing" to pass
+
+3) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnZeroCasesPassing
+This test depends on "PHPUnit\TestFixture\Issue6222\Issue6222Test::testZeroCasesPassing" to pass
+
+FAILURES!
+Tests: 10, Assertions: 7, Failures: 4, Skipped: 3.

--- a/tests/end-to-end/regression/6222.phpt
+++ b/tests/end-to-end/regression/6222.phpt
@@ -15,7 +15,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-F..S.FSFFS                                                        10 / 10 (100%)
+F....FSFFS                                                        10 / 10 (100%)
 
 Time: %s, Memory: %s
 
@@ -43,16 +43,13 @@ Failed asserting that 2 is identical to 3.
 
 --
 
-There were 3 skipped tests:
+There were 2 skipped tests:
 
-1) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnTwoCasesPassing
-This test depends on "PHPUnit\TestFixture\Issue6222\Issue6222Test::testTwoCasesPassing" to pass
-
-2) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnOneCasePassing
+1) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnOneCasePassing
 This test depends on "PHPUnit\TestFixture\Issue6222\Issue6222Test::testOneCasePassing" to pass
 
-3) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnZeroCasesPassing
+2) PHPUnit\TestFixture\Issue6222\Issue6222Test::testDependingOnZeroCasesPassing
 This test depends on "PHPUnit\TestFixture\Issue6222\Issue6222Test::testZeroCasesPassing" to pass
 
 FAILURES!
-Tests: 10, Assertions: 7, Failures: 4, Skipped: 3.
+Tests: 10, Assertions: 8, Failures: 4, Skipped: 2.

--- a/tests/end-to-end/regression/6222/Issue6222Test.php
+++ b/tests/end-to-end/regression/6222/Issue6222Test.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6222;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+
+class Issue6222Test extends TestCase
+{
+    public static function provider(): iterable
+    {
+        yield [1];
+
+        yield [2];
+    }
+
+    public function testOne(): void
+    {
+        $this->assertTrue(false);
+    }
+
+    #[DataProvider('provider')]
+    public function testTwoCasesPassing(int $x): void
+    {
+        $this->assertGreaterThan(0, $x);
+    }
+
+    #[Depends('testTwoCasesPassing')]
+    public function testDependingOnTwoCasesPassing(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('provider')]
+    public function testOneCasePassing(int $x): void
+    {
+        $this->assertSame(1, $x);
+    }
+
+    #[Depends('testOneCasePassing')]
+    public function testDependingOnOneCasePassing(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('provider')]
+    public function testZeroCasesPassing(int $x): void
+    {
+        $this->assertSame(3, $x);
+    }
+
+    #[Depends('testZeroCasesPassing')]
+    public function testDependingOnZeroCasesPassing(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/6222

Current behaviour:
- when the test - let's call it `Foo` - with the data provider finishes, it calls [`testSuiteFinished`](https://github.com/sebastianbergmann/phpunit/blob/12.2.1/src/Runner/TestResult/Collector.php#L265) method
- [if](https://github.com/sebastianbergmann/phpunit/blob/12.2.1/src/Runner/TestResult/Collector.php#L267) there is a failed test case in the class (might be completely unrelated to the test `Foo`, like in https://github.com/sebastianbergmann/phpunit/issues/6222) the information that the `Foo` passed will not [be saved](https://github.com/sebastianbergmann/phpunit/blob/12.2.1/src/Runner/TestResult/Collector.php#L285).
- the information that `Foo` passed is not saved, so the test using `Depends` on `Foo` will be skipped because [`hasTestMethodPassed`](https://github.com/sebastianbergmann/phpunit/blob/12.2.1/src/Runner/TestResult/PassedTests.php#L92) will return `false`.

Proposed behaviour:
 - after the test suite, i.e. test with data provider finishes, we check if we have an event for the failed case of that test - if there is none, that means the test (all of its cases) passed.