### PR TITLE
Do not run tests when code coverage analysis is requested but code coverage data cannot be collected

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -72,18 +72,18 @@ final class CodeCoverage
         return self::$instance;
     }
 
-    public function init(Configuration $configuration, CodeCoverageFilterRegistry $codeCoverageFilterRegistry, bool $extensionRequiresCodeCoverageCollection): void
+    public function init(Configuration $configuration, CodeCoverageFilterRegistry $codeCoverageFilterRegistry, bool $extensionRequiresCodeCoverageCollection): CodeCoverageInitializationStatus
     {
         $codeCoverageFilterRegistry->init($configuration);
 
         if (!$configuration->hasCoverageReport() && !$extensionRequiresCodeCoverageCollection) {
-            return;
+            return CodeCoverageInitializationStatus::NOT_REQUESTED;
         }
 
         $this->activate($codeCoverageFilterRegistry->get(), $configuration->pathCoverage());
 
         if (!$this->isActive()) {
-            return;
+            return CodeCoverageInitializationStatus::FAILED;
         }
 
         if ($configuration->hasCoverageCacheDirectory()) {
@@ -154,6 +154,8 @@ final class CodeCoverage
                 $statistics['cacheMisses'],
             );
         }
+
+        return CodeCoverageInitializationStatus::SUCCESSFULLY;
     }
 
     /**

--- a/src/Runner/CodeCoverageInitializationStatus.php
+++ b/src/Runner/CodeCoverageInitializationStatus.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner;
+
+enum CodeCoverageInitializationStatus
+{
+    case NOT_REQUESTED;
+    case SUCCESSFULLY;
+    case FAILED;
+}

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -44,6 +44,7 @@ use PHPUnit\Runner\Baseline\Generator as BaselineGenerator;
 use PHPUnit\Runner\Baseline\Reader;
 use PHPUnit\Runner\Baseline\Writer;
 use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\Runner\CodeCoverageInitializationStatus;
 use PHPUnit\Runner\DeprecationCollector\Facade as DeprecationCollector;
 use PHPUnit\Runner\DirectoryDoesNotExistException;
 use PHPUnit\Runner\ErrorHandler;
@@ -201,7 +202,7 @@ final readonly class Application
                 $this->execute(new ShowHelpCommand(Result::FAILURE));
             }
 
-            CodeCoverage::instance()->init(
+            $coverageInitializationStatus = CodeCoverage::instance()->init(
                 $configuration,
                 CodeCoverageFilterRegistry::instance(),
                 $extensionRequiresCodeCoverageCollection,
@@ -220,13 +221,18 @@ final readonly class Application
             $timer = new Timer;
             $timer->start();
 
-            $runner = new TestRunner;
+            if (
+                $coverageInitializationStatus === CodeCoverageInitializationStatus::NOT_REQUESTED ||
+                $coverageInitializationStatus === CodeCoverageInitializationStatus::SUCCESSFULLY
+            ) {
+                $runner = new TestRunner;
 
-            $runner->run(
-                $configuration,
-                $resultCache,
-                $testSuite,
-            );
+                $runner->run(
+                    $configuration,
+                    $resultCache,
+                    $testSuite,
+                );
+            }
 
             $duration = $timer->stop();
 

--- a/tests/end-to-end/_files/coverage/coverage-no-tests-when-missing-coverage-driver.phpt
+++ b/tests/end-to-end/_files/coverage/coverage-no-tests-when-missing-coverage-driver.phpt
@@ -5,8 +5,6 @@ Don't run tests when coverage driver is not loaded
 if (extension_loaded('xdebug') || extension_loaded('pcov')) {
     print 'skip: No debug driver should be loaded.';
 }
---ENV--
-XDEBUG_MODE=debug
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/_files/coverage/coverage-no-tests-when-missing-coverage-driver.phpt
+++ b/tests/end-to-end/_files/coverage/coverage-no-tests-when-missing-coverage-driver.phpt
@@ -5,23 +5,26 @@ Don't run tests when coverage driver is not loaded
 if (extension_loaded('xdebug') || extension_loaded('pcov')) {
     print 'skip: No debug driver should be loaded.';
 }
+--ENV--
+XDEBUG_MODE=debug
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
-$_SERVER['argv'][] = '--no-configuration';
-$_SERVER['argv'][] = \realpath(__DIR__ . '/../../_files/coverage/coverage-no-tests-when-missing-coverage-driver.phpt');
+$_SERVER['argv'][] = '--coverage-html';
+$_SERVER['argv'][] = 'my_coverage_folder';
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
 --EXPECTF--
---EXPECTF--
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
+Configuration: %s
 
-.                                                                   1 / 1 (100%)
+There was 1 PHPUnit test runner warning:
 
-Time: %s, Memory: %s
+1) No code coverage driver available
 
-OK (1 test, 1 assertion)
+No tests executed!
+

--- a/tests/end-to-end/_files/coverage/coverage-no-tests-when-wrong-xdebug-mode.phpt
+++ b/tests/end-to-end/_files/coverage/coverage-no-tests-when-wrong-xdebug-mode.phpt
@@ -5,11 +5,13 @@ Don't run tests when wrong xdebug mode is set
 if (!extension_loaded('xdebug')) {
     print 'skip: Extension xdebug must be loaded.';
 }
+--ENV--
+XDEBUG_MODE=debug
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
-$_SERVER['argv'][] = '--no-configuration';
-$_SERVER['argv'][] = \realpath(__DIR__ . '/../../_files/coverage/coverage-no-tests-when-wrong-xdebug-mode.phpt');
+$_SERVER['argv'][] = '--coverage-html';
+$_SERVER['argv'][] = 'my_coverage_folder';
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
@@ -18,9 +20,11 @@ require_once __DIR__ . '/../../../bootstrap.php';
 PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
+Configuration: %s
 
-.                                                                   1 / 1 (100%)
+There was 1 PHPUnit test runner warning:
 
-Time: %s, Memory: %s
+1) XDEBUG_MODE=coverage (environment variable) or xdebug.mode=coverage (PHP configuration setting) has to be set
 
-OK (1 test, 1 assertion)
+No tests executed!
+

--- a/tests/end-to-end/cli/coverage/coverage-no-tests-when-missing-coverage-driver.phpt
+++ b/tests/end-to-end/cli/coverage/coverage-no-tests-when-missing-coverage-driver.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Don't run tests when coverage driver is not loaded
+--SKIPIF--
+<?php declare(strict_types=1);
+if (extension_loaded('xdebug') || extension_loaded('pcov')) {
+    print 'skip: No debug driver should be loaded.';
+}
+--ENV--
+XDEBUG_MODE=debug
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--coverage-html';
+$_SERVER['argv'][] = 'my_coverage_folder';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) No code coverage driver available
+
+No tests executed!
+

--- a/tests/end-to-end/cli/coverage/coverage-no-tests-when-wrong-xdebug-mode.phpt
+++ b/tests/end-to-end/cli/coverage/coverage-no-tests-when-wrong-xdebug-mode.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Don't run tests when wrong xdebug mode is set
+--SKIPIF--
+<?php declare(strict_types=1);
+if (!extension_loaded('xdebug')) {
+    print 'skip: Extension xdebug must be loaded.';
+}
+--ENV--
+XDEBUG_MODE=debug
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--coverage-html';
+$_SERVER['argv'][] = 'my_coverage_folder';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) XDEBUG_MODE=coverage (environment variable) or xdebug.mode=coverage (PHP configuration setting) has to be set
+
+No tests executed!
+


### PR DESCRIPTION
doing a process restart and persisting all possible cli args etc, while not just re-using composer/xdebug-handler and re-implementing everything is not a useful way and requires lots of code we would need to maintain.

therefore I figured I would just make sure that phpunit exits early instead of running all tests, when the coverage driver cannot be activated

closes https://github.com/sebastianbergmann/phpunit/issues/6233