### PR TITLE
Fix test with data provider and dependency which does not return value

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1800,6 +1800,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 return true;
             }
 
+            if (!$passedTests->hasReturnValue($dependencyTarget)) {
+                return true;
+            }
+
             $returnValue = $passedTests->returnValue($dependencyTarget);
 
             if ($dependency->deepClone()) {

--- a/src/Runner/TestResult/PassedTests.php
+++ b/src/Runner/TestResult/PassedTests.php
@@ -11,11 +11,14 @@ namespace PHPUnit\TestRunner\TestResult;
 
 use function array_merge;
 use function assert;
+use function explode;
 use function in_array;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Framework\TestSize\Known;
 use PHPUnit\Framework\TestSize\TestSize;
 use PHPUnit\Metadata\Api\Groups;
+use ReflectionMethod;
+use ReflectionNamedType;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -111,6 +114,13 @@ final class PassedTests
         assert($size instanceof Known);
 
         return $size->isGreaterThan($other);
+    }
+
+    public function hasReturnValue(string $method): mixed
+    {
+        $returnType = (new ReflectionMethod(...explode('::', $method)))->getReturnType();
+
+        return !$returnType instanceof ReflectionNamedType || !in_array($returnType->getName(), ['never', 'void'], true);
     }
 
     public function returnValue(string $method): mixed

--- a/tests/_files/DataProviderDependencyVoidTest.php
+++ b/tests/_files/DataProviderDependencyVoidTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
+
+final class DataProviderDependencyVoidTest extends TestCase
+{
+    public static function provider(): iterable
+    {
+        return [
+            [0, 0],
+            [1, 'b' => 1],
+            ['a' => 2, 'b' => 2],
+            ['b' => 3, 'a' => 3],
+        ];
+    }
+
+    #[DataProvider('provider')]
+    #[Depends('testDependency')]
+    public function testEquality($a, $b): void
+    {
+        $this->assertSame($a, $b);
+    }
+
+    public function testDependency(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/data-provider/dependency-void.phpt
+++ b/tests/end-to-end/data-provider/dependency-void.phpt
@@ -13,20 +13,8 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-..EEE                                                               5 / 5 (100%)
+.....                                                               5 / 5 (100%)
 
 Time: %s, Memory: %s
 
-There were 3 errors:
-
-1) PHPUnit\TestFixture\DataProviderDependencyVoidTest::testEquality with data set #1 (1, 1)
-Error: Cannot use positional argument after named argument during unpacking
-
-2) PHPUnit\TestFixture\DataProviderDependencyVoidTest::testEquality with data set #2 (2, 2)
-Error: Cannot use positional argument after named argument during unpacking
-
-3) PHPUnit\TestFixture\DataProviderDependencyVoidTest::testEquality with data set #3 (3, 3)
-Error: Cannot use positional argument after named argument during unpacking
-
-ERRORS!
-Tests: 5, Assertions: 2, Errors: 3.
+OK (5 tests, 5 assertions)

--- a/tests/end-to-end/data-provider/dependency-void.phpt
+++ b/tests/end-to-end/data-provider/dependency-void.phpt
@@ -1,0 +1,32 @@
+--TEST--
+phpunit ../../_files/DataProviderDependencyVoidTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderDependencyVoidTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+..EEE                                                               5 / 5 (100%)
+
+Time: %s, Memory: %s
+
+There were 3 errors:
+
+1) PHPUnit\TestFixture\DataProviderDependencyVoidTest::testEquality with data set #1 (1, 1)
+Error: Cannot use positional argument after named argument during unpacking
+
+2) PHPUnit\TestFixture\DataProviderDependencyVoidTest::testEquality with data set #2 (2, 2)
+Error: Cannot use positional argument after named argument during unpacking
+
+3) PHPUnit\TestFixture\DataProviderDependencyVoidTest::testEquality with data set #3 (3, 3)
+Error: Cannot use positional argument after named argument during unpacking
+
+ERRORS!
+Tests: 5, Assertions: 2, Errors: 3.


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/6104

The problem is that currently in `PHPUnit\Framework\TestCase` both - test dependency returning `null` and test dependency not returning value - are treated the same, as technically they both "return" `null`.

As always, I've split the PR into multiple commits if you prefer a different fix, Sebastian.