### PR TITLE
Use pcov as coverage driver again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,7 +211,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.4
-          coverage: xdebug
+          coverage: pcov
           extensions: none, ctype, curl, dom, json, libxml, mbstring, pdo, phar, soap, tokenizer, xml, xmlwriter
           ini-values: assert.exception=1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
           tools: none


### PR DESCRIPTION
reverts https://github.com/sebastianbergmann/phpunit/commit/6eb1bc9dec8f982a2bd014f1cd54b9814ecd1b96

as https://github.com/krakjoe/pcov/issues/59 was fixed in pcov and many [more improvements are currently in the making](https://github.com/krakjoe/pcov/commits/develop/), lets try to switch back to pcov (or at least uncover issues, which might get fixed as pcov is currently beeing worked on)

---

[support for property hooks](https://github.com/krakjoe/pcov/pull/121) was also recently implemented. the changes are not yet released though.