### PR TITLE
Fix order of tests which use data from data providers is not affected by test sorting

### DIFF
--- a/src/Runner/ResultCache/DefaultResultCache.php
+++ b/src/Runner/ResultCache/DefaultResultCache.php
@@ -56,28 +56,28 @@ final class DefaultResultCache implements ResultCache
         $this->cacheFilename = $filepath ?? $_ENV['PHPUNIT_RESULT_CACHE'] ?? self::DEFAULT_RESULT_CACHE_FILENAME;
     }
 
-    public function setStatus(string $id, TestStatus $status): void
+    public function setStatus(ResultCacheId $id, TestStatus $status): void
     {
         if ($status->isSuccess()) {
             return;
         }
 
-        $this->defects[$id] = $status;
+        $this->defects[$id->asString()] = $status;
     }
 
-    public function status(string $id): TestStatus
+    public function status(ResultCacheId $id): TestStatus
     {
-        return $this->defects[$id] ?? TestStatus::unknown();
+        return $this->defects[$id->asString()] ?? TestStatus::unknown();
     }
 
-    public function setTime(string $id, float $time): void
+    public function setTime(ResultCacheId $id, float $time): void
     {
-        $this->times[$id] = $time;
+        $this->times[$id->asString()] = $time;
     }
 
-    public function time(string $id): float
+    public function time(ResultCacheId $id): float
     {
-        return $this->times[$id] ?? 0.0;
+        return $this->times[$id->asString()] ?? 0.0;
     }
 
     public function mergeWith(self $other): void

--- a/src/Runner/ResultCache/NullResultCache.php
+++ b/src/Runner/ResultCache/NullResultCache.php
@@ -18,20 +18,20 @@ use PHPUnit\Framework\TestStatus\TestStatus;
  */
 final readonly class NullResultCache implements ResultCache
 {
-    public function setStatus(string $id, TestStatus $status): void
+    public function setStatus(ResultCacheId $id, TestStatus $status): void
     {
     }
 
-    public function status(string $id): TestStatus
+    public function status(ResultCacheId $id): TestStatus
     {
         return TestStatus::unknown();
     }
 
-    public function setTime(string $id, float $time): void
+    public function setTime(ResultCacheId $id, float $time): void
     {
     }
 
-    public function time(string $id): float
+    public function time(ResultCacheId $id): float
     {
         return 0;
     }

--- a/src/Runner/ResultCache/ResultCache.php
+++ b/src/Runner/ResultCache/ResultCache.php
@@ -18,13 +18,13 @@ use PHPUnit\Framework\TestStatus\TestStatus;
  */
 interface ResultCache
 {
-    public function setStatus(string $id, TestStatus $status): void;
+    public function setStatus(ResultCacheId $id, TestStatus $status): void;
 
-    public function status(string $id): TestStatus;
+    public function status(ResultCacheId $id): TestStatus;
 
-    public function setTime(string $id, float $time): void;
+    public function setTime(ResultCacheId $id, float $time): void;
 
-    public function time(string $id): float;
+    public function time(ResultCacheId $id): float;
 
     public function load(): void;
 

--- a/src/Runner/ResultCache/ResultCacheHandler.php
+++ b/src/Runner/ResultCache/ResultCacheHandler.php
@@ -63,7 +63,7 @@ final class ResultCacheHandler
     public function testMarkedIncomplete(MarkedIncomplete $event): void
     {
         $this->cache->setStatus(
-            $event->test()->name(),
+            ResultCacheId::fromTest($event->test()),
             TestStatus::incomplete($event->throwable()->message()),
         );
     }
@@ -71,7 +71,7 @@ final class ResultCacheHandler
     public function testConsideredRisky(ConsideredRisky $event): void
     {
         $this->cache->setStatus(
-            $event->test()->name(),
+            ResultCacheId::fromTest($event->test()),
             TestStatus::risky($event->message()),
         );
     }
@@ -79,7 +79,7 @@ final class ResultCacheHandler
     public function testErrored(Errored $event): void
     {
         $this->cache->setStatus(
-            $event->test()->name(),
+            ResultCacheId::fromTest($event->test()),
             TestStatus::error($event->throwable()->message()),
         );
     }
@@ -87,7 +87,7 @@ final class ResultCacheHandler
     public function testFailed(Failed $event): void
     {
         $this->cache->setStatus(
-            $event->test()->name(),
+            ResultCacheId::fromTest($event->test()),
             TestStatus::failure($event->throwable()->message()),
         );
     }
@@ -99,11 +99,11 @@ final class ResultCacheHandler
     public function testSkipped(Skipped $event): void
     {
         $this->cache->setStatus(
-            $event->test()->name(),
+            ResultCacheId::fromTest($event->test()),
             TestStatus::skipped($event->message()),
         );
 
-        $this->cache->setTime($event->test()->name(), $this->duration($event));
+        $this->cache->setTime(ResultCacheId::fromTest($event->test()), $this->duration($event));
     }
 
     /**
@@ -112,7 +112,7 @@ final class ResultCacheHandler
      */
     public function testFinished(Finished $event): void
     {
-        $this->cache->setTime($event->test()->name(), $this->duration($event));
+        $this->cache->setTime(ResultCacheId::fromTest($event->test()), $this->duration($event));
 
         $this->time = null;
     }

--- a/src/Runner/ResultCache/ResultCacheHandler.php
+++ b/src/Runner/ResultCache/ResultCacheHandler.php
@@ -65,7 +65,7 @@ final class ResultCacheHandler
     public function testMarkedIncomplete(MarkedIncomplete $event): void
     {
         $this->cache->setStatus(
-            $this->getTestSortId($event),
+            $event->test()->name(),
             TestStatus::incomplete($event->throwable()->message()),
         );
     }
@@ -73,7 +73,7 @@ final class ResultCacheHandler
     public function testConsideredRisky(ConsideredRisky $event): void
     {
         $this->cache->setStatus(
-            $this->getTestSortId($event),
+            $event->test()->name(),
             TestStatus::risky($event->message()),
         );
     }
@@ -81,7 +81,7 @@ final class ResultCacheHandler
     public function testErrored(Errored $event): void
     {
         $this->cache->setStatus(
-            $this->getTestSortId($event),
+            $event->test()->name(),
             TestStatus::error($event->throwable()->message()),
         );
     }
@@ -89,7 +89,7 @@ final class ResultCacheHandler
     public function testFailed(Failed $event): void
     {
         $this->cache->setStatus(
-            $this->getTestSortId($event),
+            $event->test()->name(),
             TestStatus::failure($event->throwable()->message()),
         );
     }
@@ -101,11 +101,11 @@ final class ResultCacheHandler
     public function testSkipped(Skipped $event): void
     {
         $this->cache->setStatus(
-            $this->getTestSortId($event),
+            $event->test()->name(),
             TestStatus::skipped($event->message()),
         );
 
-        $this->cache->setTime($this->getTestSortId($event), $this->duration($event));
+        $this->cache->setTime($event->test()->name(), $this->duration($event));
     }
 
     /**
@@ -114,7 +114,7 @@ final class ResultCacheHandler
      */
     public function testFinished(Finished $event): void
     {
-        $this->cache->setTime($this->getTestSortId($event), $this->duration($event));
+        $this->cache->setTime($event->test()->name(), $this->duration($event));
 
         $this->time = null;
     }
@@ -147,14 +147,4 @@ final class ResultCacheHandler
         );
     }
 
-    private function getTestSortId(Event $event): string
-    {
-        $test = $event->test();
-
-        if ($test instanceof TestMethod) {
-            return $test->name();
-        }
-
-        return $test->id();
-    }
 }

--- a/src/Runner/ResultCache/ResultCacheHandler.php
+++ b/src/Runner/ResultCache/ResultCacheHandler.php
@@ -9,8 +9,6 @@
  */
 namespace PHPUnit\Runner\ResultCache;
 
-use PHPUnit\Event\Code\TestMethod;
-use PHPUnit\Framework\Reorderable;
 use function round;
 use PHPUnit\Event\Event;
 use PHPUnit\Event\Facade;
@@ -146,5 +144,4 @@ final class ResultCacheHandler
             new TestFinishedSubscriber($this),
         );
     }
-
 }

--- a/src/Runner/ResultCache/ResultCacheId.php
+++ b/src/Runner/ResultCache/ResultCacheId.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\ResultCache;
+
+use PHPUnit\Event\Code\Test;
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Framework\Reorderable;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class ResultCacheId
+{
+    public static function fromTest(Test $test): self
+    {
+        if ($test instanceof TestMethod) {
+            return new self($test->className() . '::' . $test->name());
+        }
+
+        return new self($test->id());
+    }
+
+    public static function fromReorderable(Reorderable $reorderable): self
+    {
+        return new self($reorderable->sortId());
+    }
+
+    /**
+     * For use in PHPUnit tests only!
+     *
+     * @param class-string<TestCase> $class
+     */
+    public static function fromTestClassAndMethodName(string $class, string $methodName): self
+    {
+        return new self($class . '::' . $methodName);
+    }
+
+    private function __construct(
+        private string $id,
+    ) {
+    }
+
+    public function asString(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\ResultCache\NullResultCache;
 use PHPUnit\Runner\ResultCache\ResultCache;
+use PHPUnit\Runner\ResultCache\ResultCacheId;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -172,9 +173,11 @@ final class TestSuiteSorter
                 continue;
             }
 
-            if (!isset($this->defectSortOrder[$test->sortId()])) {
-                $this->defectSortOrder[$test->sortId()] = $this->cache->status($test->sortId())->asInt();
-                $max                                    = max($max, $this->defectSortOrder[$test->sortId()]);
+            $sortId = $test->sortId();
+
+            if (!isset($this->defectSortOrder[$sortId])) {
+                $this->defectSortOrder[$sortId] = $this->cache->status(ResultCacheId::fromReorderable($test))->asInt();
+                $max                            = max($max, $this->defectSortOrder[$sortId]);
             }
         }
 
@@ -286,7 +289,7 @@ final class TestSuiteSorter
             return 0;
         }
 
-        return $this->cache->time($a->sortId()) <=> $this->cache->time($b->sortId());
+        return $this->cache->time(ResultCacheId::fromReorderable($a)) <=> $this->cache->time(ResultCacheId::fromReorderable($b));
     }
 
     /**

--- a/tests/_files/FaillingDataProviderTest.php
+++ b/tests/_files/FaillingDataProviderTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class FaillingDataProviderTest extends TestCase
+{
+    public static function provideData(): array
+    {
+        return [
+            'good1' => [3, 1, 2],
+            'good2' => [5, 2, 3],
+            'fail1' => [10, 3, 4],
+            'good3' => [10, 5, 5],
+            'fail2' => [20, 3, 4],
+        ];
+    }
+
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('provideData')]
+    public function testWithProvider($sum, $summand, $summmand2): void
+    {
+        $this->assertSame($sum, $summand + $summmand2);
+    }
+}

--- a/tests/unit/Runner/ResultCache/NullTestResultCacheTest.php
+++ b/tests/unit/Runner/ResultCache/NullTestResultCacheTest.php
@@ -23,7 +23,7 @@ final class NullTestResultCacheTest extends TestCase
         $cache->load();
         $cache->persist();
 
-        $this->assertTrue($cache->status('testName')->isUnknown());
-        $this->assertSame(0.0, $cache->time('testName'));
+        $this->assertTrue($cache->status(ResultCacheId::fromTestClassAndMethodName(self::class, 'testName'))->isUnknown());
+        $this->assertSame(0.0, $cache->time(ResultCacheId::fromTestClassAndMethodName(self::class, 'testName')));
     }
 }

--- a/tests/unit/Runner/ResultCache/ResultCacheIdTest.php
+++ b/tests/unit/Runner/ResultCache/ResultCacheIdTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\ResultCache;
+
+use PHPUnit\Event\Code\TestDox;
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\TestData\TestDataCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Metadata\MetadataCollection;
+
+#[CoversClass(DefaultResultCache::class)]
+#[Small]
+final class ResultCacheIdTest extends TestCase
+{
+    public static function provideResultCacheIds(): iterable
+    {
+        yield ['PHPUnit\Runner\ResultCache\ResultCacheIdTest::a method', ResultCacheId::fromTestClassAndMethodName(self::class, 'a method')];
+
+        yield ['PHPUnit\Runner\ResultCache\ResultCacheIdTest::testMethod', ResultCacheId::fromTest(self::testMethod())];
+    }
+
+    #[DataProvider('provideResultCacheIds')]
+    public function testResultCacheId($expectedString, ResultCacheId $cacheId): void
+    {
+        $this->assertSame($expectedString, $cacheId->asString());
+    }
+
+    private static function testMethod(): TestMethod
+    {
+        return new TestMethod(
+            self::class,
+            'testMethod',
+            'TestClass.php',
+            1,
+            new TestDox('', '', ''),
+            MetadataCollection::fromArray([]),
+            TestDataCollection::fromArray([]),
+        );
+    }
+}

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestStatus\TestStatus;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\ResultCache\DefaultResultCache;
+use PHPUnit\Runner\ResultCache\ResultCacheId;
 use PHPUnit\TestFixture\FaillingDataProviderTest;
 use PHPUnit\TestFixture\MultiDependencyTest;
 use ReflectionClass;
@@ -585,8 +586,8 @@ final class TestSuiteSorterTest extends TestCase
         ];
 
         foreach ($runState as $testName => $data) {
-            $cache->setStatus(MultiDependencyTest::class . '::' . $testName, $data['state']);
-            $cache->setTime(MultiDependencyTest::class . '::' . $testName, $data['time']);
+            $cache->setStatus(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $data['state']);
+            $cache->setTime(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $data['time']);
         }
 
         $sorter = new TestSuiteSorter($cache);
@@ -657,7 +658,7 @@ final class TestSuiteSorterTest extends TestCase
         $cache = new DefaultResultCache;
 
         foreach ($testTimes as $testName => $time) {
-            $cache->setTime(MultiDependencyTest::class . '::' . $testName, $time);
+            $cache->setTime(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $time);
         }
 
         $sorter = new TestSuiteSorter($cache);
@@ -681,8 +682,8 @@ final class TestSuiteSorterTest extends TestCase
         $cache = new DefaultResultCache;
 
         foreach ($runState as $testName => $data) {
-            $cache->setStatus(MultiDependencyTest::class . '::' . $testName, $data['state']);
-            $cache->setTime(MultiDependencyTest::class . '::' . $testName, $data['time']);
+            $cache->setStatus(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $data['state']);
+            $cache->setTime(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $data['time']);
         }
 
         $sorter = new TestSuiteSorter($cache);
@@ -700,8 +701,8 @@ final class TestSuiteSorterTest extends TestCase
         $cache = new DefaultResultCache;
 
         foreach ($runState as $testName => $data) {
-            $cache->setStatus(FaillingDataProviderTest::class . '::' . $testName, $data['state']);
-            $cache->setTime(FaillingDataProviderTest::class . '::' . $testName, $data['time']);
+            $cache->setStatus(ResultCacheId::fromTestClassAndMethodName(FaillingDataProviderTest::class, $testName), $data['state']);
+            $cache->setTime(ResultCacheId::fromTestClassAndMethodName(FaillingDataProviderTest::class, $testName), $data['time']);
         }
 
         $sorter = new TestSuiteSorter($cache);


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/6259