### PR TITLE
Fix order of tests which use data from data providers is not affected by test sorting

### DIFF
--- a/src/Runner/ResultCache/ResultCacheId.php
+++ b/src/Runner/ResultCache/ResultCacheId.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Runner\ResultCache;
 
 use PHPUnit\Event\Code\Test;
+use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Framework\Reorderable;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,10 @@ final readonly class ResultCacheId
 {
     public static function fromTest(Test $test): self
     {
+        if ($test instanceof TestMethod) {
+            return new self($test->className() . '::' . $test->name());
+        }
+
         return new self($test->id());
     }
 

--- a/tests/_files/FaillingDataProviderTest.php
+++ b/tests/_files/FaillingDataProviderTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class FaillingDataProviderTest extends TestCase
+{
+    public static function provideData(): array
+    {
+        return [
+            'good1' => [3, 1, 2],
+            'good2' => [5, 2, 3],
+            'fail1' => [10, 3, 4],
+            'good3' => [10, 5, 5],
+            'fail2' => [20, 3, 4],
+        ];
+    }
+
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('provideData')]
+    public function testWithProvider($sum, $summand, $summmand2): void
+    {
+        $this->assertSame($sum, $summand + $summmand2);
+    }
+}

--- a/tests/unit/Runner/ResultCache/ResultCacheIdTest.php
+++ b/tests/unit/Runner/ResultCache/ResultCacheIdTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Runner\ResultCache;
 
+use PHPUnit\Event\Code\Phpt;
 use PHPUnit\Event\Code\TestDox;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\TestData\TestDataCollection;
@@ -42,6 +43,14 @@ final class ResultCacheIdTest extends TestCase
         $this->assertInstanceOf(Reorderable::class, $reorderable);
 
         $this->assertSame('PHPUnit\Runner\ResultCache\ResultCacheIdTest::testReorderableResultCacheId', ResultCacheId::fromReorderable($reorderable)->asString());
+    }
+
+    public function testPhptResultCacheId(): void
+    {
+        $file     = 'test.phpt';
+        $phptTest = new Phpt($file);
+
+        $this->assertSame('test.phpt', ResultCacheId::fromTest($phptTest)->asString());
     }
 
     private static function testMethod(): TestMethod

--- a/tests/unit/Runner/TestSuiteSorterTest.php
+++ b/tests/unit/Runner/TestSuiteSorterTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestStatus\TestStatus;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\ResultCache\DefaultResultCache;
 use PHPUnit\Runner\ResultCache\ResultCacheId;
+use PHPUnit\TestFixture\FaillingDataProviderTest;
 use PHPUnit\TestFixture\MultiDependencyTest;
 use ReflectionClass;
 
@@ -436,6 +437,74 @@ final class TestSuiteSorterTest extends TestCase
         return $data;
     }
 
+    /**
+     * A data provider for testing defects execution reordering options based on FaillingDataProviderTest.
+     */
+    public static function defectsSorterWithDataProviderProvider(): array
+    {
+        return [
+            // The most simple situation should work as normal
+            'default, no defects' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'                                => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "good1"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "good2"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "good3"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "fail1"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "fail2"' => ['state' => TestStatus::success(), 'time' => 1],
+                ],
+                [
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good1"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good2"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "fail1"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good3"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "fail2"',
+                    FaillingDataProviderTest::class . '::testOne',
+                ],
+            ],
+
+            // Running with an empty cache should not spook the TestSuiteSorter
+            'default, empty result cache' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    // empty result cache
+                ],
+                [
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good1"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good2"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "fail1"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good3"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "fail2"',
+                    FaillingDataProviderTest::class . '::testOne',
+                ],
+            ],
+
+            'default, defects' => [
+                TestSuiteSorter::ORDER_DEFAULT,
+                self::IGNORE_DEPENDENCIES,
+                [
+                    'testOne'                                => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "good1"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "good2"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "good3"' => ['state' => TestStatus::success(), 'time' => 1],
+                    'testWithProvider with data set "fail1"' => ['state' => TestStatus::error(), 'time' => 1],
+                    'testWithProvider with data set "fail2"' => ['state' => TestStatus::error(), 'time' => 1],
+                ],
+                [
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "fail1"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "fail2"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good1"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good2"',
+                    FaillingDataProviderTest::class . '::testWithProvider with data set "good3"',
+                    FaillingDataProviderTest::class . '::testOne',
+                ],
+            ],
+        ];
+    }
+
     public function testThrowsExceptionWhenUsingInvalidOrderOption(): void
     {
         $suite = TestSuite::empty('test suite name');
@@ -615,6 +684,25 @@ final class TestSuiteSorterTest extends TestCase
         foreach ($runState as $testName => $data) {
             $cache->setStatus(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $data['state']);
             $cache->setTime(ResultCacheId::fromTestClassAndMethodName(MultiDependencyTest::class, $testName), $data['time']);
+        }
+
+        $sorter = new TestSuiteSorter($cache);
+        $sorter->reorderTestsInSuite($suite, $order, $resolveDependencies, TestSuiteSorter::ORDER_DEFECTS_FIRST);
+
+        $this->assertSame($expected, $sorter->getExecutionOrder());
+    }
+
+    #[DataProvider('defectsSorterWithDataProviderProvider')]
+    public function testSuiteSorterDefectsWithDataProviderTest(int $order, bool $resolveDependencies, array $runState, array $expected): void
+    {
+        $suite = TestSuite::empty('test suite name');
+        $suite->addTestSuite(new ReflectionClass(FaillingDataProviderTest::class));
+
+        $cache = new DefaultResultCache;
+
+        foreach ($runState as $testName => $data) {
+            $cache->setStatus(ResultCacheId::fromTestClassAndMethodName(FaillingDataProviderTest::class, $testName), $data['state']);
+            $cache->setTime(ResultCacheId::fromTestClassAndMethodName(FaillingDataProviderTest::class, $testName), $data['time']);
         }
 
         $sorter = new TestSuiteSorter($cache);


### PR DESCRIPTION
the root cause of the problem is, that `DefaultResultCache` is persisting the test-status with keys like
`PHPUnit\TestFixture\FaillingDataProviderTest::testWithProvider#good1` in `DefaultResultCache::setStatus()`.

but looks them up later on in the format:
`PHPUnit\TestFixture\FaillingDataProviderTest::testWithProvider with data set "good1"` in `DefaultResultCache::status()`.

closes https://github.com/sebastianbergmann/phpunit/issues/6259

extracted from https://github.com/sebastianbergmann/phpunit/pull/6261