### PR TITLE
Reference dataprovider label in more error messages

### DIFF
--- a/src/Framework/Exception/InvalidDataProviderException.php
+++ b/src/Framework/Exception/InvalidDataProviderException.php
@@ -9,6 +9,8 @@
  */
 namespace PHPUnit\Framework;
 
+use Throwable;
+
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -16,4 +18,30 @@ namespace PHPUnit\Framework;
  */
 final class InvalidDataProviderException extends Exception
 {
+    private ?string $providerLabel = null;
+
+    public static function forException(Throwable $e, string $providerLabel): self
+    {
+        $exception = new self(
+            $e->getMessage(),
+            $e->getCode(),
+            $e,
+        );
+        $exception->providerLabel = $providerLabel;
+
+        return $exception;
+    }
+
+    public static function forProvider(string $message, string $providerLabel): self
+    {
+        $exception                = new self($message);
+        $exception->providerLabel = $providerLabel;
+
+        return $exception;
+    }
+
+    public function getProviderLabel(): ?string
+    {
+        return $this->providerLabel;
+    }
 }

--- a/src/Framework/Exception/InvalidDataProviderException.php
+++ b/src/Framework/Exception/InvalidDataProviderException.php
@@ -32,14 +32,6 @@ final class InvalidDataProviderException extends Exception
         return $exception;
     }
 
-    public static function forProvider(string $message, string $providerLabel): self
-    {
-        $exception                = new self($message);
-        $exception->providerLabel = $providerLabel;
-
-        return $exception;
-    }
-
     public function getProviderLabel(): ?string
     {
         return $this->providerLabel;

--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -13,6 +13,7 @@ use function array_merge;
 use function assert;
 use PHPUnit\Metadata\Api\DataProvider;
 use PHPUnit\Metadata\Api\Groups;
+use PHPUnit\Metadata\Api\ProvidedData;
 use PHPUnit\Metadata\Api\Requirements;
 use PHPUnit\Metadata\BackupGlobals;
 use PHPUnit\Metadata\BackupStaticProperties;
@@ -76,7 +77,7 @@ final readonly class TestBuilder
     /**
      * @param non-empty-string                                                                                                                                                  $methodName
      * @param class-string<TestCase>                                                                                                                                            $className
-     * @param array<array<mixed>>                                                                                                                                               $data
+     * @param array<ProvidedData>                                                                                                                                               $data
      * @param array{backupGlobals: ?bool, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?bool, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
      * @param list<non-empty-string>                                                                                                                                            $groups
      */
@@ -94,7 +95,7 @@ final readonly class TestBuilder
         foreach ($data as $_dataName => $_data) {
             $_test = new $className($methodName);
 
-            $_test->setData($_dataName, $_data);
+            $_test->setData($_dataName, $_data->getData());
 
             $this->configureTestCase(
                 $_test,

--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -514,6 +514,23 @@ class TestSuite implements IteratorAggregate, Reorderable, Test
         try {
             $test = (new TestBuilder)->build($class, $methodName, $groups);
         } catch (InvalidDataProviderException $e) {
+            if ($e->getProviderLabel() === null) {
+                $message = sprintf(
+                    "The data provider specified for %s::%s is invalid\n%s",
+                    $className,
+                    $methodName,
+                    $this->exceptionToString($e),
+                );
+            } else {
+                $message = sprintf(
+                    "The data provider %s specified for %s::%s is invalid\n%s",
+                    $e->getProviderLabel(),
+                    $className,
+                    $methodName,
+                    $this->exceptionToString($e),
+                );
+            }
+
             Event\Facade::emitter()->testTriggeredPhpunitError(
                 new TestMethod(
                     $className,
@@ -527,12 +544,7 @@ class TestSuite implements IteratorAggregate, Reorderable, Test
                     MetadataCollection::fromArray([]),
                     Event\TestData\TestDataCollection::fromArray([]),
                 ),
-                sprintf(
-                    "The data provider specified for %s::%s is invalid\n%s",
-                    $className,
-                    $methodName,
-                    $this->exceptionToString($e),
-                ),
+                $message,
             );
 
             return;

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -73,8 +73,9 @@ final readonly class DataProvider
             if (!is_array($value)) {
                 throw InvalidDataProviderException::forProvider(
                     sprintf(
-                        'Data set %s is invalid, expected array but got %s',
+                        'Data set %s provided by %s is invalid, expected array but got %s',
                         $this->formatKey($key),
+                        $providedData->getProviderLabel(),
                         get_debug_type($value),
                     ),
                     $providedData->getProviderLabel(),
@@ -96,8 +97,9 @@ final readonly class DataProvider
                         Event\TestData\TestDataCollection::fromArray([]),
                     ),
                     sprintf(
-                        'Data set %s has more arguments (%d) than the test method accepts (%d)',
+                        'Data set %s provided by %s has more arguments (%d) than the test method accepts (%d)',
                         $this->formatKey($key),
+                        $providedData->getProviderLabel(),
                         count($value),
                         $testMethodNumberOfParameters,
                     ),

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -197,8 +197,9 @@ final readonly class DataProvider
 
                         throw InvalidDataProviderException::forProvider(
                             sprintf(
-                                'The key "%s" has already been defined by a previous data provider',
+                                'The key "%s" has already been defined by provider %s',
                                 $key,
+                                $result[$key]->getProviderLabel(),
                             ),
                             $providerLabel,
                         );

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -71,14 +71,13 @@ final readonly class DataProvider
             $value = $providedData->getData();
 
             if (!is_array($value)) {
-                throw InvalidDataProviderException::forProvider(
+                throw new InvalidDataProviderException(
                     sprintf(
                         'Data set %s provided by %s is invalid, expected array but got %s',
                         $this->formatKey($key),
                         $providedData->getProviderLabel(),
                         get_debug_type($value),
                     ),
-                    $providedData->getProviderLabel(),
                 );
             }
 
@@ -141,35 +140,32 @@ final readonly class DataProvider
                 $method = new ReflectionMethod($_dataProvider->className(), $_dataProvider->methodName());
 
                 if (!$method->isPublic()) {
-                    throw InvalidDataProviderException::forProvider(
+                    throw new InvalidDataProviderException(
                         sprintf(
                             'Data Provider method %s::%s() is not public',
                             $_dataProvider->className(),
                             $_dataProvider->methodName(),
                         ),
-                        $providerLabel,
                     );
                 }
 
                 if (!$method->isStatic()) {
-                    throw InvalidDataProviderException::forProvider(
+                    throw new InvalidDataProviderException(
                         sprintf(
                             'Data Provider method %s::%s() is not static',
                             $_dataProvider->className(),
                             $_dataProvider->methodName(),
                         ),
-                        $providerLabel,
                     );
                 }
 
                 if ($method->getNumberOfParameters() > 0) {
-                    throw InvalidDataProviderException::forProvider(
+                    throw new InvalidDataProviderException(
                         sprintf(
                             'Data Provider method %s::%s() expects an argument',
                             $_dataProvider->className(),
                             $_dataProvider->methodName(),
                         ),
-                        $providerLabel,
                     );
                 }
 
@@ -197,25 +193,23 @@ final readonly class DataProvider
                             ...$methodsCalled,
                         );
 
-                        throw InvalidDataProviderException::forProvider(
+                        throw new InvalidDataProviderException(
                             sprintf(
                                 'The key "%s" has already been defined by provider %s',
                                 $key,
                                 $result[$key]->getProviderLabel(),
                             ),
-                            $providerLabel,
                         );
                     }
 
                     $result[$key] = new ProvidedData($providerLabel, $value);
                 } else {
                     // @codeCoverageIgnoreStart
-                    throw InvalidDataProviderException::forProvider(
+                    throw new InvalidDataProviderException(
                         sprintf(
                             'The key must be an integer or a string, %s given',
                             get_debug_type($key),
                         ),
-                        $providerLabel,
                     );
                     // @codeCoverageIgnoreEnd
                 }
@@ -246,12 +240,11 @@ final readonly class DataProvider
                 $key = $_testWith->name();
 
                 if (array_key_exists($key, $result)) {
-                    throw InvalidDataProviderException::forProvider(
+                    throw new InvalidDataProviderException(
                         sprintf(
                             'The key "%s" has already been defined by a previous TestWith attribute',
                             $key,
                         ),
-                        $providerLabel,
                     );
                 }
 

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -231,10 +231,9 @@ final readonly class DataProvider
     {
         $result = [];
 
-        $providerLabel = 'TestWith attribute';
-
-        foreach ($testWith as $_testWith) {
+        foreach ($testWith as $i => $_testWith) {
             assert($_testWith instanceof TestWith);
+            $providerLabel = sprintf('TestWith#%s attribute', $i);
 
             if ($_testWith->hasName()) {
                 $key = $_testWith->name();
@@ -242,8 +241,9 @@ final readonly class DataProvider
                 if (array_key_exists($key, $result)) {
                     throw new InvalidDataProviderException(
                         sprintf(
-                            'The key "%s" has already been defined by a previous TestWith attribute',
+                            'The key "%s" has already been defined by %s',
                             $key,
+                            $result[$key]->getProviderLabel(),
                         ),
                     );
                 }

--- a/src/Metadata/Api/ProvidedData.php
+++ b/src/Metadata/Api/ProvidedData.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata\Api;
+
+final readonly class ProvidedData
+{
+    public function __construct(
+        private string $providerLabel,
+        private mixed $data
+    ) {
+    }
+
+    public function getData(): mixed
+    {
+        return $this->data;
+    }
+
+    public function getProviderLabel(): string
+    {
+        return $this->providerLabel;
+    }
+}

--- a/tests/end-to-end/data-provider/too-many-arguments.phpt
+++ b/tests/end-to-end/data-provider/too-many-arguments.phpt
@@ -20,7 +20,7 @@ Time: %s, Memory: %s
 1 test triggered 1 PHPUnit warning:
 
 1) PHPUnit\TestFixture\DataProviderTooManyArgumentsTest::testMethodHavingTwoParameters
-Data set #2 has more arguments (3) than the test method accepts (2)
+Data set #2 provided by PHPUnit\TestFixture\DataProviderTooManyArgumentsTest::provider has more arguments (3) than the test method accepts (2)
 
 %s:%d
 

--- a/tests/end-to-end/event/data-provider-duplicate-key.phpt
+++ b/tests/end-to-end/event/data-provider-duplicate-key.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\DataProviderDuplicateKeyT
 Data Provider Method Finished for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething:
 - PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething)
-The data provider PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider specified for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething is invalid
+The data provider specified for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething is invalid
 The key "key" has already been defined by provider PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/data-provider-duplicate-key.phpt
+++ b/tests/end-to-end/event/data-provider-duplicate-key.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\DataProviderDuplicateKeyT
 Data Provider Method Finished for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething:
 - PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething)
-The data provider specified for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething is invalid
+The data provider PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider specified for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething is invalid
 The key "key" has already been defined by a previous data provider
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/data-provider-duplicate-key.phpt
+++ b/tests/end-to-end/event/data-provider-duplicate-key.phpt
@@ -19,7 +19,7 @@ Data Provider Method Finished for PHPUnit\TestFixture\Event\DataProviderDuplicat
 - PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething)
 The data provider PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider specified for PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::testSomething is invalid
-The key "key" has already been defined by a previous data provider
+The key "key" has already been defined by provider PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest::provider
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\DataProviderDuplicateKeyTest".)
 Test Suite Loaded (0 tests)
 Test Runner Started

--- a/tests/end-to-end/event/data-provider-exception.phpt
+++ b/tests/end-to-end/event/data-provider-exception.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\ExceptionInDataProviderTe
 Data Provider Method Finished for PHPUnit\TestFixture\Event\ExceptionInDataProviderTest::testOne:
 - PHPUnit\TestFixture\Event\ExceptionInDataProviderTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\ExceptionInDataProviderTest::testOne)
-The data provider specified for PHPUnit\TestFixture\Event\ExceptionInDataProviderTest::testOne is invalid
+The data provider PHPUnit\TestFixture\Event\ExceptionInDataProviderTest::provider specified for PHPUnit\TestFixture\Event\ExceptionInDataProviderTest::testOne is invalid
 message
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\ExceptionInDataProviderTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/data-provider-expects-argument.phpt
+++ b/tests/end-to-end/event/data-provider-expects-argument.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\ArgumentDataProviderTest:
 Data Provider Method Finished for PHPUnit\TestFixture\Event\ArgumentDataProviderTest::testSuccess:
 - PHPUnit\TestFixture\Event\ArgumentDataProviderTest::values
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\ArgumentDataProviderTest::testSuccess)
-The data provider specified for PHPUnit\TestFixture\Event\ArgumentDataProviderTest::testSuccess is invalid
+The data provider PHPUnit\TestFixture\Event\ArgumentDataProviderTest::values specified for PHPUnit\TestFixture\Event\ArgumentDataProviderTest::testSuccess is invalid
 Data Provider method PHPUnit\TestFixture\Event\ArgumentDataProviderTest::values() expects an argument
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\ArgumentDataProviderTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/data-provider-not-public.phpt
+++ b/tests/end-to-end/event/data-provider-not-public.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\PrivateDataProviderTest::
 Data Provider Method Finished for PHPUnit\TestFixture\Event\PrivateDataProviderTest::testSuccess:
 - PHPUnit\TestFixture\Event\PrivateDataProviderTest::values
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\PrivateDataProviderTest::testSuccess)
-The data provider specified for PHPUnit\TestFixture\Event\PrivateDataProviderTest::testSuccess is invalid
+The data provider PHPUnit\TestFixture\Event\PrivateDataProviderTest::values specified for PHPUnit\TestFixture\Event\PrivateDataProviderTest::testSuccess is invalid
 Data Provider method PHPUnit\TestFixture\Event\PrivateDataProviderTest::values() is not public
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\PrivateDataProviderTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/data-provider-not-static.phpt
+++ b/tests/end-to-end/event/data-provider-not-static.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\DynamicDataProviderTest::
 Data Provider Method Finished for PHPUnit\TestFixture\Event\DynamicDataProviderTest::testSuccess:
 - PHPUnit\TestFixture\Event\DynamicDataProviderTest::values
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\DynamicDataProviderTest::testSuccess)
-The data provider specified for PHPUnit\TestFixture\Event\DynamicDataProviderTest::testSuccess is invalid
+The data provider PHPUnit\TestFixture\Event\DynamicDataProviderTest::values specified for PHPUnit\TestFixture\Event\DynamicDataProviderTest::testSuccess is invalid
 Data Provider method PHPUnit\TestFixture\Event\DynamicDataProviderTest::values() is not static
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\DynamicDataProviderTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
+++ b/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\InvalidDataProviderWithOn
 Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne:
 - PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne)
-The data provider PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
+The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
 Data set #0 provided by PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider is invalid, expected array but got int
 Test Suite Loaded (1 test)
 Test Runner Started

--- a/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
+++ b/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\InvalidDataProviderWithOn
 Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne:
 - PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne)
-The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
+The data provider PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
 Data set #0 is invalid, expected array but got int
 Test Suite Loaded (1 test)
 Test Runner Started

--- a/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
+++ b/tests/end-to-end/event/invalid-data-provider-with-passing-test.phpt
@@ -19,7 +19,7 @@ Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderW
 - PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne)
 The data provider PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::testOne is invalid
-Data set #0 is invalid, expected array but got int
+Data set #0 provided by PHPUnit\TestFixture\Event\InvalidDataProviderWithOneTestPassingTest::provider is invalid, expected array but got int
 Test Suite Loaded (1 test)
 Test Runner Started
 Test Suite Sorted

--- a/tests/end-to-end/event/invalid-data-provider.phpt
+++ b/tests/end-to-end/event/invalid-data-provider.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\InvalidDataProviderTest::
 Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne:
 - PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne)
-The data provider PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne is invalid
+The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne is invalid
 Data set #0 provided by PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider is invalid, expected array but got int
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\InvalidDataProviderTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/event/invalid-data-provider.phpt
+++ b/tests/end-to-end/event/invalid-data-provider.phpt
@@ -19,7 +19,7 @@ Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderT
 - PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne)
 The data provider PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne is invalid
-Data set #0 is invalid, expected array but got int
+Data set #0 provided by PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider is invalid, expected array but got int
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\InvalidDataProviderTest".)
 Test Suite Loaded (0 tests)
 Test Runner Started

--- a/tests/end-to-end/event/invalid-data-provider.phpt
+++ b/tests/end-to-end/event/invalid-data-provider.phpt
@@ -18,7 +18,7 @@ Data Provider Method Called (PHPUnit\TestFixture\Event\InvalidDataProviderTest::
 Data Provider Method Finished for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne:
 - PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider
 Test Triggered PHPUnit Error (PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne)
-The data provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne is invalid
+The data provider PHPUnit\TestFixture\Event\InvalidDataProviderTest::provider specified for PHPUnit\TestFixture\Event\InvalidDataProviderTest::testOne is invalid
 Data set #0 is invalid, expected array but got int
 Test Runner Triggered Warning (No tests found in class "PHPUnit\TestFixture\Event\InvalidDataProviderTest".)
 Test Suite Loaded (0 tests)

--- a/tests/end-to-end/regression/2137-filter.phpt
+++ b/tests/end-to-end/regression/2137-filter.phpt
@@ -18,13 +18,13 @@ Runtime: %s
 There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
-The data provider specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
+The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
 Data set #0 is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
-The data provider specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
+The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
 Data set #0 is invalid, expected array but got stdClass
 
 %s:%d

--- a/tests/end-to-end/regression/2137-filter.phpt
+++ b/tests/end-to-end/regression/2137-filter.phpt
@@ -19,13 +19,13 @@ There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
 The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
-Data set #0 is invalid, expected array but got stdClass
+Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
 The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
-Data set #0 is invalid, expected array but got stdClass
+Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d
 

--- a/tests/end-to-end/regression/2137-filter.phpt
+++ b/tests/end-to-end/regression/2137-filter.phpt
@@ -18,13 +18,13 @@ Runtime: %s
 There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
-The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
+The data provider specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
 Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
-The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
+The data provider specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
 Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d

--- a/tests/end-to-end/regression/2137-no_filter.phpt
+++ b/tests/end-to-end/regression/2137-no_filter.phpt
@@ -17,13 +17,13 @@ There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
 The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
-Data set #0 is invalid, expected array but got stdClass
+Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
 The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
-Data set #0 is invalid, expected array but got stdClass
+Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d
 

--- a/tests/end-to-end/regression/2137-no_filter.phpt
+++ b/tests/end-to-end/regression/2137-no_filter.phpt
@@ -16,13 +16,13 @@ Runtime: %s
 There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
-The data provider specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
+The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
 Data set #0 is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
-The data provider specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
+The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
 Data set #0 is invalid, expected array but got stdClass
 
 %s:%d

--- a/tests/end-to-end/regression/2137-no_filter.phpt
+++ b/tests/end-to-end/regression/2137-no_filter.phpt
@@ -16,13 +16,13 @@ Runtime: %s
 There were 2 PHPUnit errors:
 
 1) PHPUnit\TestFixture\Issue2137Test::testBrandService
-The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
+The data provider specified for PHPUnit\TestFixture\Issue2137Test::testBrandService is invalid
 Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d
 
 2) PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid
-The data provider PHPUnit\TestFixture\Issue2137Test::provideBrandService specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
+The data provider specified for PHPUnit\TestFixture\Issue2137Test::testSomethingElseInvalid is invalid
 Data set #0 provided by PHPUnit\TestFixture\Issue2137Test::provideBrandService is invalid, expected array but got stdClass
 
 %s:%d

--- a/tests/end-to-end/regression/498.phpt
+++ b/tests/end-to-end/regression/498.phpt
@@ -18,7 +18,7 @@ Runtime: %s
 There was 1 PHPUnit error:
 
 1) PHPUnit\TestFixture\Issue498Test::shouldBeFalse
-The data provider specified for PHPUnit\TestFixture\Issue498Test::shouldBeFalse is invalid
+The data provider PHPUnit\TestFixture\Issue498Test::shouldBeFalseDataProvider specified for PHPUnit\TestFixture\Issue498Test::shouldBeFalse is invalid
 Can't create the data
 
 %s:%d

--- a/tests/end-to-end/regression/5138.phpt
+++ b/tests/end-to-end/regression/5138.phpt
@@ -17,7 +17,7 @@ Configuration: %s
 There was 1 PHPUnit error:
 
 1) PHPUnit\TestFixture\Issue5138Test::testOne
-The data provider specified for PHPUnit\TestFixture\Issue5138Test::testOne is invalid
+The data provider PHPUnit\TestFixture\Issue5138Test::provideData specified for PHPUnit\TestFixture\Issue5138Test::testOne is invalid
 message
 
 %s:%d

--- a/tests/end-to-end/regression/5451.phpt
+++ b/tests/end-to-end/regression/5451.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
 There was 1 PHPUnit error:
 
 1) PHPUnit\TestFixture\Issue5451\Issue5451Test::testWithErrorInDataProvider
-The data provider specified for PHPUnit\TestFixture\Issue5451\Issue5451Test::testWithErrorInDataProvider is invalid
+The data provider PHPUnit\TestFixture\Issue5451\Issue5451Test::dataProviderThatTriggersPhpError specified for PHPUnit\TestFixture\Issue5451\Issue5451Test::testWithErrorInDataProvider is invalid
 Call to a member function bar() on array
 
 %s%eIssue5451Test.php:26

--- a/tests/end-to-end/regression/5908-list-tests-xml.phpt
+++ b/tests/end-to-end/regression/5908-list-tests-xml.phpt
@@ -20,5 +20,5 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 There were errors:
 
-The data provider specified for PHPUnit\TestFixture\Issue5908\Issue5908Test::testOne is invalid
+The data provider PHPUnit\TestFixture\Issue5908\Issue5908Test::provider specified for PHPUnit\TestFixture\Issue5908\Issue5908Test::testOne is invalid
 message

--- a/tests/end-to-end/regression/5908-list-tests.phpt
+++ b/tests/end-to-end/regression/5908-list-tests.phpt
@@ -15,5 +15,5 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 There were errors:
 
-The data provider specified for PHPUnit\TestFixture\Issue5908\Issue5908Test::testOne is invalid
+The data provider PHPUnit\TestFixture\Issue5908\Issue5908Test::provider specified for PHPUnit\TestFixture\Issue5908\Issue5908Test::testOne is invalid
 message

--- a/tests/end-to-end/regression/765.phpt
+++ b/tests/end-to-end/regression/765.phpt
@@ -25,7 +25,7 @@ Time: %s, Memory: %s
 There was 1 PHPUnit error:
 
 1) PHPUnit\TestFixture\Issue765Test::testDependent
-The data provider specified for PHPUnit\TestFixture\Issue765Test::testDependent is invalid
+The data provider PHPUnit\TestFixture\Issue765Test::dependentProvider specified for PHPUnit\TestFixture\Issue765Test::testDependent is invalid
 <no message>
 
 %s:%d

--- a/tests/unit/Metadata/Api/DataProviderTest.php
+++ b/tests/unit/Metadata/Api/DataProviderTest.php
@@ -172,7 +172,7 @@ final class DataProviderTest extends TestCase
     public function testWithDuplicateKeyDataProvider(): void
     {
         $this->expectException(InvalidDataProviderException::class);
-        $this->expectExceptionMessage('The key "foo" has already been defined by a previous data provider');
+        $this->expectExceptionMessage('The key "foo" has already been defined by provider PHPUnit\TestFixture\DuplicateKeyDataProviderTest::dataProvider');
 
         /* @noinspection UnusedFunctionResultInspection */
         (new DataProvider)->providedData(DuplicateKeyDataProviderTest::class, 'test');
@@ -204,7 +204,7 @@ final class DataProviderTest extends TestCase
     public function testWithDuplicateKeyDataProviders(): void
     {
         $this->expectException(InvalidDataProviderException::class);
-        $this->expectExceptionMessage('The key "bar" has already been defined by a previous data provider');
+        $this->expectExceptionMessage('The key "bar" has already been defined by provider PHPUnit\TestFixture\DuplicateKeyDataProvidersTest::dataProvider1');
 
         /* @noinspection UnusedFunctionResultInspection */
         (new DataProvider)->providedData(DuplicateKeyDataProvidersTest::class, 'test');

--- a/tests/unit/Metadata/Api/DataProviderTest.php
+++ b/tests/unit/Metadata/Api/DataProviderTest.php
@@ -30,7 +30,9 @@ final class DataProviderTest extends TestCase
      */
     public function testMultipleDataProviders(): void
     {
-        $dataSets = (new DataProvider)->providedData(MultipleDataProviderTest::class, 'testOne');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(MultipleDataProviderTest::class, 'testOne'),
+        );
 
         $this->assertCount(9, $dataSets);
 
@@ -51,7 +53,9 @@ final class DataProviderTest extends TestCase
 
     public function testMultipleYieldIteratorDataProviders(): void
     {
-        $dataSets = (new DataProvider)->providedData(MultipleDataProviderTest::class, 'testTwo');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(MultipleDataProviderTest::class, 'testTwo'),
+        );
 
         $this->assertCount(9, $dataSets);
 
@@ -72,7 +76,9 @@ final class DataProviderTest extends TestCase
 
     public function testWithVariousIterableDataProvidersFromParent(): void
     {
-        $dataSets = (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testFromParent');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testFromParent'),
+        );
 
         $this->assertEquals([
             ['J'],
@@ -89,7 +95,9 @@ final class DataProviderTest extends TestCase
 
     public function testWithVariousIterableDataProvidersInParent(): void
     {
-        $dataSets = (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testInParent');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testInParent'),
+        );
 
         $this->assertEquals([
             ['J'],
@@ -106,7 +114,9 @@ final class DataProviderTest extends TestCase
 
     public function testWithVariousIterableAbstractDataProviders(): void
     {
-        $dataSets = (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testAbstract');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testAbstract'),
+        );
 
         $this->assertEquals([
             ['S'],
@@ -123,7 +133,9 @@ final class DataProviderTest extends TestCase
 
     public function testWithVariousIterableStaticDataProviders(): void
     {
-        $dataSets = (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testStatic');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testStatic'),
+        );
 
         $this->assertEquals([
             ['A'],
@@ -140,7 +152,9 @@ final class DataProviderTest extends TestCase
 
     public function testWithVariousIterableNonStaticDataProviders(): void
     {
-        $dataSets = (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testNonStatic');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(VariousIterableDataProviderTest::class, 'testNonStatic'),
+        );
 
         $this->assertEquals([
             ['S'],
@@ -166,7 +180,9 @@ final class DataProviderTest extends TestCase
 
     public function testTestWithAttribute(): void
     {
-        $dataSets = (new DataProvider)->providedData(TestWithAttributeDataProviderTest::class, 'testWithAttribute');
+        $dataSets = $this->getRawDataFromProvidedData(
+            (new DataProvider)->providedData(TestWithAttributeDataProviderTest::class, 'testWithAttribute'),
+        );
 
         $this->assertSame([
             'foo' => ['a', 'b'],
@@ -192,5 +208,21 @@ final class DataProviderTest extends TestCase
 
         /* @noinspection UnusedFunctionResultInspection */
         (new DataProvider)->providedData(DuplicateKeyDataProvidersTest::class, 'test');
+    }
+
+    /**
+     * @param array<ProvidedData> $providedData
+     *
+     * @return array<mixed>
+     */
+    private function getRawDataFromProvidedData(array $providedData): array
+    {
+        $raw = [];
+
+        foreach ($providedData as $key => $data) {
+            $raw[$key] = $data->getData();
+        }
+
+        return $raw;
     }
 }

--- a/tests/unit/Metadata/Api/DataProviderTest.php
+++ b/tests/unit/Metadata/Api/DataProviderTest.php
@@ -195,7 +195,7 @@ final class DataProviderTest extends TestCase
     public function testTestWithAttributeWithDuplicateKey(): void
     {
         $this->expectException(InvalidDataProviderException::class);
-        $this->expectExceptionMessage('The key "foo" has already been defined by a previous TestWith attribute');
+        $this->expectExceptionMessage('The key "foo" has already been defined by TestWith#0 attribute');
 
         /* @noinspection UnusedFunctionResultInspection */
         (new DataProvider)->providedData(TestWithAttributeDataProviderTest::class, 'testWithDuplicateName');


### PR DESCRIPTION
Introduces `ProvidedData`, a container class which holds the raw dataprovider data.
As we no longer pass arround raw arrays but a `array<ProvidedData>` we can now stick the dataprovider label onto the `ProvidedData`-objects, which means we can later on build more precise error messages which note the dataproviders name.

closes https://github.com/sebastianbergmann/phpunit/pull/5992