### PR TITLE
DX: Faster feedback loop when running regression tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,7 @@
          failOnPhpunitDeprecation="true"
          failOnRisky="true"
          failOnWarning="true"
+         executionOrder="defects"
          colors="true">
     <testsuites>
         <testsuite name="unit">


### PR DESCRIPTION
when working in PHPUnit itself it is helpful to run previously errors first to shorten the feedback loop.

I also tried `random` order, but it seems to trigger a warning when running tests, therefore I just went with `defects` for now.