### PR TITLE
Warn when `#[DataProvider*]` attributes are mixed with `#[TestWith*]` attributes

### DIFF
--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -52,6 +52,25 @@ final readonly class DataProvider
         }
 
         if ($dataProvider->isNotEmpty()) {
+            if ($testWith->isNotEmpty()) {
+                $method = new ReflectionMethod($className, $methodName);
+
+                Event\Facade::emitter()->testTriggeredPhpunitWarning(
+                    new TestMethod(
+                        $className,
+                        $methodName,
+                        $method->getFileName(),
+                        $method->getStartLine(),
+                        Event\Code\TestDoxBuilder::fromClassNameAndMethodName(
+                            $className,
+                            $methodName,
+                        ),
+                        MetadataCollection::fromArray([]),
+                        Event\TestData\TestDataCollection::fromArray([]),
+                    ),
+                    'Mixing #[DataProvider] and #[TestWith] attributes is not supported, only the data provided by #[DataProvider] will be used',
+                );
+            }
             $data = $this->dataProvidedByMethods($className, $methodName, $dataProvider);
         } else {
             $data = $this->dataProvidedByMetadata($testWith);

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -68,7 +68,7 @@ final readonly class DataProvider
                         MetadataCollection::fromArray([]),
                         Event\TestData\TestDataCollection::fromArray([]),
                     ),
-                    'Mixing #[DataProvider] and #[TestWith] attributes is not supported, only the data provided by #[DataProvider] will be used',
+                    'Mixing #[DataProvider*] and #[TestWith*] attributes is not supported, only the data provided by #[DataProvider*] will be used',
                 );
             }
             $data = $this->dataProvidedByMethods($className, $methodName, $dataProvider);

--- a/tests/end-to-end/_files/TestDataProviderExternalAndDataProviderTest.php
+++ b/tests/end-to-end/_files/TestDataProviderExternalAndDataProviderTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\TestCase;
+
+final class TestDataProviderExternalAndDataProviderTest extends TestCase
+{
+    public static function externalProvider(): iterable
+    {
+        yield 'foo' => ['bar', 'baz'];
+    }
+
+    public static function provider(): iterable
+    {
+        yield 'foo2' => ['bar', 'baz'];
+    }
+
+    #[DataProvider('provider')]
+    #[DataProviderExternal(self::class, 'externalProvider')]
+    public function testWithDifferentProviderTypes($one, $two): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/TestWithAndTestWithJsonDataProviderTest.php
+++ b/tests/end-to-end/_files/TestWithAndTestWithJsonDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\Attributes\TestWithJson;
+use PHPUnit\Framework\TestCase;
+
+final class TestWithAndTestWithJsonDataProviderTest extends TestCase
+{
+    public static function provider(): iterable
+    {
+        yield 'foo' => ['bar', 'baz'];
+    }
+
+    #[TestWith(['a', 'b'], 'foo')]
+    #[TestWithJson('[1, 2]')]
+    public function testWithDifferentProviderTypes($one, $two): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/TestWithAttributeAndDataProviderTest.php
+++ b/tests/end-to-end/_files/TestWithAttributeAndDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+final class TestWithAttributeAndDataProviderTest extends TestCase
+{
+    public static function provider(): iterable
+    {
+        yield 'foo' => ['bar', 'baz'];
+    }
+
+    #[TestWith(['a', 'b'], 'foo')]
+    #[DataProvider('provider')]
+    public function testWithDifferentProviderTypes($one, $two): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/TestWithAttributeAndExternalDataProviderTest.php
+++ b/tests/end-to-end/_files/TestWithAttributeAndExternalDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+final class TestWithAttributeAndExternalDataProviderTest extends TestCase
+{
+    public static function provider(): iterable
+    {
+        yield 'foo' => ['bar', 'baz'];
+    }
+
+    #[TestWith(['a', 'b'], 'foo')]
+    #[DataProviderExternal(self::class, 'provider')]
+    public function testWithDifferentProviderTypes($one, $two): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/TestWithJsonAttributeAndDataProviderTest.php
+++ b/tests/end-to-end/_files/TestWithJsonAttributeAndDataProviderTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWithJson;
+use PHPUnit\Framework\TestCase;
+
+final class TestWithJsonAttributeAndDataProviderTest extends TestCase
+{
+    public static function provider(): iterable
+    {
+        yield 'foo' => ['bar', 'baz'];
+    }
+
+    #[TestWithJson('[1, 2, 3]')]
+    #[DataProvider('provider')]
+    public function testWithDifferentProviderTypes($one, $two): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/metadata/mix-attribute-dataproviders.phpt
+++ b/tests/end-to-end/metadata/mix-attribute-dataproviders.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit ../_files/TestDataProviderExternalAndDataProviderTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/TestDataProviderExternalAndDataProviderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)

--- a/tests/end-to-end/metadata/mix-test-with-dataproviders.phpt
+++ b/tests/end-to-end/metadata/mix-test-with-dataproviders.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit ../_files/TestWithAndTestWithJsonDataProviderTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/TestWithAndTestWithJsonDataProviderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+OK (2 tests, 2 assertions)

--- a/tests/end-to-end/metadata/warning-mix-dataprovider-test-with-json-types.phpt
+++ b/tests/end-to-end/metadata/warning-mix-dataprovider-test-with-json-types.phpt
@@ -4,7 +4,7 @@ phpunit ../_files/TestWithAttributeAndDataProviderTest.php
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
-$_SERVER['argv'][] = __DIR__ . '/../_files/TestWithAttributeAndDataProviderTest.php';
+$_SERVER['argv'][] = __DIR__ . '/../_files/TestWithJsonAttributeAndDataProviderTest.php';
 
 require __DIR__ . '/../../bootstrap.php';
 
@@ -20,10 +20,10 @@ Time: %s, Memory: %s
 
 1 test triggered 1 PHPUnit warning:
 
-1) PHPUnit\TestFixture\TestWithAttributeAndDataProviderTest::testWithDifferentProviderTypes
-Mixing #[DataProvider] and #[TestWith] attributes is not supported, only the data provided by #[DataProvider] will be used
+1) PHPUnit\TestFixture\TestWithJsonAttributeAndDataProviderTest::testWithDifferentProviderTypes
+Mixing #[DataProvider*] and #[TestWith*] attributes is not supported, only the data provided by #[DataProvider*] will be used
 
-%sTestWithAttributeAndDataProviderTest.php:%d
+%sTestWithJsonAttributeAndDataProviderTest.php:%d
 
 OK, but there were issues!
 Tests: 1, Assertions: 1, PHPUnit Warnings: 1.

--- a/tests/end-to-end/metadata/warning-mix-dataprovider-test-with-json-types.phpt
+++ b/tests/end-to-end/metadata/warning-mix-dataprovider-test-with-json-types.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit ../_files/TestWithAttributeAndDataProviderTest.php
+phpunit ../_files/TestWithJsonAttributeAndDataProviderTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/metadata/warning-mix-dataprovider-test-with-types.phpt
+++ b/tests/end-to-end/metadata/warning-mix-dataprovider-test-with-types.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit ../_files/TestWithAttributeAndDataProviderTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/TestWithAttributeAndDataProviderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+W                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 1 PHPUnit warning:
+
+1) PHPUnit\TestFixture\TestWithAttributeAndDataProviderTest::testWithDifferentProviderTypes
+Mixing #[DataProvider*] and #[TestWith*] attributes is not supported, only the data provided by #[DataProvider*] will be used
+
+%sTestWithAttributeAndDataProviderTest.php:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, PHPUnit Warnings: 1.

--- a/tests/end-to-end/metadata/warning-mix-dataprovider-types.phpt
+++ b/tests/end-to-end/metadata/warning-mix-dataprovider-types.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit ../_files/TestWithAttributeAndDataProviderTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/TestWithAttributeAndDataProviderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+W                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 1 PHPUnit warning:
+
+1) PHPUnit\TestFixture\TestWithAttributeAndDataProviderTest::testWithDifferentProviderTypes
+Mixing #[DataProvider] and #[TestWith] attributes is not supported, only the data provided by #[DataProvider] will be used
+
+%sTestWithAttributeAndDataProviderTest.php:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, PHPUnit Warnings: 1.

--- a/tests/end-to-end/metadata/warning-mix-external-dataprovider-with-types.phpt
+++ b/tests/end-to-end/metadata/warning-mix-external-dataprovider-with-types.phpt
@@ -1,5 +1,5 @@
 --TEST--
-phpunit ../_files/TestWithAttributeAndDataProviderTest.php
+phpunit ../_files/TestWithAttributeAndExternalDataProviderTest.php
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';

--- a/tests/end-to-end/metadata/warning-mix-external-dataprovider-with-types.phpt
+++ b/tests/end-to-end/metadata/warning-mix-external-dataprovider-with-types.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit ../_files/TestWithAttributeAndDataProviderTest.php
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/TestWithAttributeAndExternalDataProviderTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+W                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 1 PHPUnit warning:
+
+1) PHPUnit\TestFixture\TestWithAttributeAndExternalDataProviderTest::testWithDifferentProviderTypes
+Mixing #[DataProvider*] and #[TestWith*] attributes is not supported, only the data provided by #[DataProvider*] will be used
+
+%sTestWithAttributeAndExternalDataProviderTest.php:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, PHPUnit Warnings: 1.


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/6265