### PR TITLE
Fix file attribute in ListTestsAsXml for abstract class inheritance

### DIFF
--- a/ChangeLog-10.5.md
+++ b/ChangeLog-10.5.md
@@ -2,6 +2,12 @@
 
 All notable changes of the PHPUnit 10.5 release series are documented in this file using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
+## [Unreleased]
+
+### Fixed
+
+* [#6097](https://github.com/sebastianbergmann/phpunit/issues/6097): `--list-tests-xml` file attribute shows incorrect path for tests inheriting from abstract classes
+
 ## [10.5.48] - 2025-07-11
 
 ### Fixed

--- a/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
+++ b/src/TextUI/Command/Commands/ListTestsAsXmlCommand.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\TextUI\Command;
 
 use const PHP_EOL;
+use function assert;
 use function file_put_contents;
 use function implode;
 use function sprintf;
@@ -19,6 +20,7 @@ use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\PhptTestCase;
 use PHPUnit\TextUI\Configuration\Registry;
 use RecursiveIteratorIterator;
+use ReflectionClass;
 use XMLWriter;
 
 /**
@@ -58,6 +60,10 @@ final class ListTestsAsXmlCommand implements Command
 
                     $writer->startElement('testCaseClass');
                     $writer->writeAttribute('name', $test::class);
+
+                    $classFile = (new ReflectionClass($test))->getFileName();
+                    assert($classFile !== false);
+                    $writer->writeAttribute('file', $classFile);
 
                     $currentTestCase = $test::class;
                 }

--- a/tests/end-to-end/cli/list-tests/list-tests-xml-abstract-inheritance.phpt
+++ b/tests/end-to-end/cli/list-tests/list-tests-xml-abstract-inheritance.phpt
@@ -1,0 +1,22 @@
+--TEST--
+phpunit --list-tests-xml abstract inheritance
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--list-tests-xml';
+$_SERVER['argv'][] = 'php://stdout';
+$_SERVER['argv'][] = __DIR__ . '/../../../_files/abstract/without-test-suffix';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+<?xml version="1.0"?>
+<tests>
+ <testCaseClass name="PHPUnit\TestFixture\ConcreteTestClassExtendingAbstractTestClassWithoutTestSuffixTest" file="%sConcreteTestClassExtendingAbstractTestClassWithoutTestSuffixTest.php">
+  <testCaseMethod id="PHPUnit\TestFixture\ConcreteTestClassExtendingAbstractTestClassWithoutTestSuffixTest::testOne" name="testOne" groups="default"/>
+ </testCaseClass>
+</tests>%A 

--- a/tests/end-to-end/cli/list-tests/list-tests-xml-dataprovider.phpt
+++ b/tests/end-to-end/cli/list-tests/list-tests-xml-dataprovider.phpt
@@ -16,7 +16,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 <?xml version="1.0"?>
 <tests>
- <testCaseClass name="PHPUnit\TestFixture\DataProviderTest">
+ <testCaseClass name="PHPUnit\TestFixture\DataProviderTest" file="%sDataProviderTest.php">
   <testCaseMethod id="PHPUnit\TestFixture\DataProviderTest::testAdd#0" name="testAdd" groups="default" dataSet="#0"/>
   <testCaseMethod id="PHPUnit\TestFixture\DataProviderTest::testAdd#1" name="testAdd" groups="default" dataSet="#1"/>
   <testCaseMethod id="PHPUnit\TestFixture\DataProviderTest::testAdd#2" name="testAdd" groups="default" dataSet="#2"/>


### PR DESCRIPTION
The `file` attribute of `<testCaseClass>` nodes in `--list-tests-xml` output was incorrect when test methods were inherited from abstract base classes. The file path pointed to the abstract class file instead of the concrete test class file.

This fix uses `ReflectionClass` to get the actual class file path instead of the method file path.

Fixes #6097