### PR TITLE
Exceptions raised in after-test method are not reported for skipped tests

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -620,7 +620,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
                 Event\Code\ComparisonFailureBuilder::from($e),
             );
         } catch (Throwable $exceptionRaisedDuringTearDown) {
-            if (!isset($e)) {
+            if (!isset($e) || $e instanceof SkippedWithMessageException) {
                 $this->status = TestStatus::error($exceptionRaisedDuringTearDown->getMessage());
                 $e            = $exceptionRaisedDuringTearDown;
 


### PR DESCRIPTION
Currently, if a test calls markTestSkipped() (throwing a SkippedWithMessageException) and tearDown() then throws its own exception (e.g. due to uninitialized state), PHPUnit swallows the tearDown() exception and only reports the skip and any resulting risky‑test warnings.

This change treats SkippedWithMessageException differently so that exceptions raised in tearDown() are still surfaced, making it easier to diagnose teardown issues even in skipped tests.

Related: https://github.com/laravel/framework/issues/49502

## Issue Fixed:
If a test is marked as skipped and your `tearDown()` throws an exception before Laravel’s cleanup runs, PHPUnit will swallow that teardown exception and instead show the vague “Test code or tested code did not remove its own exception handlers” message.

### Why:
`markTestSkipped()` throws a `SkippedWithMessageException`.
PHPUnit’s `runBare()` always calls `tearDown()` afterward, but if `tearDown()` throws, the exception is ignored because PHPUnit assumes the earlier skip exception is the “real” outcome.
Since Laravel’s cleanup never ran, global handlers remain, triggering the risky-test warning.

### Example:

```php
public function setUp(): void
{
    parent::setUp();

    if (!File::exists(base_path('node_modules'))) {
        $this->markTestSkipped('This test requires node_modules to be installed');
    }

    // Never reached if skipped:
    $this->fixturePath = base_path('modules/system/tests');
}

public function tearDown(): void
{
    // Uses $this->fixturePath but it’s null if skipped early
    if (File::isDirectory($this->fixturePath . '/node_modules')) {
        File::deleteDirectory($this->fixturePath . '/node_modules');
    }

    parent::tearDown();
}
```

### Result:
Instead of the teardown exception, PHPUnit only reports:

> Test code or tested code did not remove its own exception handlers.