### PR TITLE
fix: generate baseline with relative path

### DIFF
--- a/src/Runner/Baseline/Exception/CannotWriteBaselineException.php
+++ b/src/Runner/Baseline/Exception/CannotWriteBaselineException.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Baseline;
+
+use PHPUnit\Runner\Exception;
+use RuntimeException;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class CannotWriteBaselineException extends RuntimeException implements Exception
+{
+}

--- a/src/Runner/Baseline/Writer.php
+++ b/src/Runner/Baseline/Writer.php
@@ -12,6 +12,9 @@ namespace PHPUnit\Runner\Baseline;
 use function assert;
 use function dirname;
 use function file_put_contents;
+use function is_dir;
+use function realpath;
+use function sprintf;
 use XMLWriter;
 
 /**
@@ -23,10 +26,18 @@ final readonly class Writer
 {
     /**
      * @param non-empty-string $baselineFile
+     *
+     * @throws CannotWriteBaselineException
      */
     public function write(string $baselineFile, Baseline $baseline): void
     {
-        $pathCalculator = new RelativePathCalculator(dirname($baselineFile));
+        $normalizedBaselineFile = realpath(dirname($baselineFile));
+
+        if ($normalizedBaselineFile === false || !is_dir($normalizedBaselineFile)) {
+            throw new CannotWriteBaselineException(sprintf('Cannot write baseline to "%s".', $baselineFile));
+        }
+
+        $pathCalculator = new RelativePathCalculator($normalizedBaselineFile);
 
         $writer = new XMLWriter;
 

--- a/tests/end-to-end/_files/baseline/generate-baseline-with-relative-directory/.gitignore
+++ b/tests/end-to-end/_files/baseline/generate-baseline-with-relative-directory/.gitignore
@@ -1,0 +1,1 @@
+baseline.xml

--- a/tests/end-to-end/_files/baseline/generate-baseline-with-relative-directory/phpunit.xml
+++ b/tests/end-to-end/_files/baseline/generate-baseline-with-relative-directory/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source baseline="tests/baseline.xml">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/_files/baseline/generate-baseline-with-relative-directory/tests/Test.php
+++ b/tests/end-to-end/_files/baseline/generate-baseline-with-relative-directory/tests/Test.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Baseline;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class Test extends TestCase
+{
+    public function testDeprecation(): void
+    {
+        trigger_error('deprecation', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/baseline/use-baseline-in-another-directory/phpunit.xml
+++ b/tests/end-to-end/_files/baseline/use-baseline-in-another-directory/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source baseline="tests/baseline.xml">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/_files/baseline/use-baseline-in-another-directory/tests/Test.php
+++ b/tests/end-to-end/_files/baseline/use-baseline-in-another-directory/tests/Test.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Baseline;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class Test extends TestCase
+{
+    public function testDeprecation(): void
+    {
+        trigger_error('deprecation', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/_files/baseline/use-baseline-in-another-directory/tests/baseline.xml
+++ b/tests/end-to-end/_files/baseline/use-baseline-in-another-directory/tests/baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<files version="1">
+ <file path="Test.php">
+  <line number="21" hash="a1022fb62c4705938dd2c6df5ff35b2621f9e97d">
+   <issue><![CDATA[deprecation]]></issue>
+  </line>
+ </file>
+</files>

--- a/tests/end-to-end/baseline/generate-baseline-with-relative-directory.phpt
+++ b/tests/end-to-end/baseline/generate-baseline-with-relative-directory.phpt
@@ -1,0 +1,43 @@
+--TEST--
+phpunit --configuration ../_files/baseline/generate-baseline-with-relative-directory/phpunit.xml --generate-baseline
+--FILE--
+<?php declare(strict_types=1);
+
+$baselineAbsolutePath = __DIR__ . '/../_files/baseline/generate-baseline-with-relative-directory/baseline.xml';
+$baseline = ltrim(str_replace(getcwd(), '', $baselineAbsolutePath), DIRECTORY_SEPARATOR);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--generate-baseline';
+$_SERVER['argv'][] = $baseline;
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/baseline/generate-baseline-with-relative-directory/phpunit.xml';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+print file_get_contents($baseline);
+
+@unlink($baselineAbsolutePath);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+D                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Deprecations: 1.
+
+Baseline written to %sbaseline.xml.
+<?xml version="1.0"?>
+<files version="1">
+ <file path="tests/Test.php">
+  <line number="21" hash="a1022fb62c4705938dd2c6df5ff35b2621f9e97d">
+   <issue><![CDATA[deprecation]]></issue>
+  </line>
+ </file>
+</files>

--- a/tests/end-to-end/baseline/use-baseline-in-another-directory.phpt
+++ b/tests/end-to-end/baseline/use-baseline-in-another-directory.phpt
@@ -1,0 +1,26 @@
+--TEST--
+phpunit --configuration ../_files/baseline/use-baseline-in-another-directory/phpunit.xml --generate-baseline
+--FILE--
+<?php declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/baseline/use-baseline-in-another-directory/phpunit.xml';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+1 issue was ignored by baseline.


### PR DESCRIPTION
fixes https://github.com/sebastianbergmann/phpunit/issues/6160

the problems actually occurs when a relative path is passed to `--generate-baseline` option

```
$ vendor/bin/phpunit --generate-baseline baseline.xml # actually works
$ vendor/bin/phpunit --generate-baseline tests/baseline.xml # generates absolute paths
$ vendor/bin/phpunit --generate-baseline tests/../baseline.xml # generates absolute paths
```

I also added a test which validates that the baseline generated in another directory than the CWD (eg: in `tests` directory) actually works