### PR TITLE
feat(baseline): can ignore deprecations with regex

### DIFF
--- a/src/Runner/Baseline/Issue.php
+++ b/src/Runner/Baseline/Issue.php
@@ -13,6 +13,7 @@ use const FILE_IGNORE_NEW_LINES;
 use function assert;
 use function file;
 use function is_file;
+use function preg_match;
 use function sha1;
 use PHPUnit\Runner\FileDoesNotExistException;
 
@@ -112,7 +113,7 @@ final readonly class Issue
         return $this->file() === $other->file() &&
                $this->line() === $other->line() &&
                $this->hash() === $other->hash() &&
-               $this->description() === $other->description();
+               ($this->description() === $other->description() || preg_match('{' . $this->description() . '}', $other->description()) > 0);
     }
 
     /**

--- a/tests/end-to-end/_files/baseline/use-baseline-with-regex/baseline.xml
+++ b/tests/end-to-end/_files/baseline/use-baseline-with-regex/baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<files version="1">
+ <file path="tests/UseBaselineTest.php">
+  <line number="20" hash="bee8cf8f19af95867fd8c6092e6813ae06cc12a9">
+   <issue><![CDATA[deprecation \d{3}]]></issue>
+  </line>
+ </file>
+</files>

--- a/tests/end-to-end/_files/baseline/use-baseline-with-regex/phpunit.xml
+++ b/tests/end-to-end/_files/baseline/use-baseline-with-regex/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source baseline="baseline.xml">
+    </source>
+</phpunit>

--- a/tests/end-to-end/_files/baseline/use-baseline-with-regex/tests/UseBaselineTest.php
+++ b/tests/end-to-end/_files/baseline/use-baseline-with-regex/tests/UseBaselineTest.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Baseline;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class UseBaselineTest extends TestCase
+{
+    public function testOne(): void
+    {
+        trigger_error('deprecation 123', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/baseline/use-baseline-with-regex.phpt
+++ b/tests/end-to-end/baseline/use-baseline-with-regex.phpt
@@ -1,0 +1,24 @@
+--TEST--
+phpunit --configuration ../_files/baseline/use-baseline-with-regex/phpunit.xml
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/baseline/use-baseline-with-regex/phpunit.xml';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK (1 test, 1 assertion)
+
+1 issue was ignored by baseline.

--- a/tests/unit/Runner/Baseline/IssueTest.php
+++ b/tests/unit/Runner/Baseline/IssueTest.php
@@ -50,6 +50,11 @@ final class IssueTest extends TestCase
         $this->assertFalse($this->issue()->equals($this->anotherIssue()));
     }
 
+    public function testIsComparableWithRegex(): void
+    {
+        $this->assertTrue($this->issueWithRegex()->equals($this->issue()));
+    }
+
     public function testCannotBeCreatedForFileThatDoesNotExist(): void
     {
         $this->expectException(FileDoesNotExistException::class);
@@ -81,6 +86,16 @@ final class IssueTest extends TestCase
             10,
             null,
             'Undefined variable $b',
+        );
+    }
+
+    private function issueWithRegex(): Issue
+    {
+        return Issue::from(
+            realpath(__DIR__ . '/../../../_files/baseline/FileWithIssues.php'),
+            10,
+            null,
+            '(.)*',
         );
     }
 


### PR DESCRIPTION
I think it could be nice to be able to ignore deprecations using regex: see for instance [doctrine/deprecations](https://github.com/doctrine/deprecations/blob/1.1.x/src/Deprecation.php#L198-L206): they do insert the line number in their deprecation messages. Meaning that if they change some code in the file, if PHPUnit is not able to ignore deprecations based on regex, the code would break 