### PR TITLE
Added more detailed assertions in Issue5592Test

### DIFF
--- a/tests/end-to-end/regression/5592-process-isolation.phpt
+++ b/tests/end-to-end/regression/5592-process-isolation.phpt
@@ -52,4 +52,4 @@ Test code or tested code removed error handlers other than its own
 %sIssue5592Test.php:%i
 
 FAILURES!
-Tests: 6, Assertions: 6, Failures: 4, Risky: 1.
+Tests: 6, Assertions: 10, Failures: 4, Risky: 1.

--- a/tests/end-to-end/regression/5592-process-isolation.phpt
+++ b/tests/end-to-end/regression/5592-process-isolation.phpt
@@ -7,7 +7,11 @@ $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--process-isolation';
 $_SERVER['argv'][] = __DIR__ . '/5592/Issue5592TestIsolation.php';
 
-set_exception_handler(static fn () => null);
+function global5592IsolationExceptionHandler(Throwable $exception): void
+{
+}
+
+set_exception_handler('global5592IsolationExceptionHandler');
 
 require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);

--- a/tests/end-to-end/regression/5592-process-isolation.phpt
+++ b/tests/end-to-end/regression/5592-process-isolation.phpt
@@ -5,7 +5,7 @@ https://github.com/sebastianbergmann/phpunit/pull/5592
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--process-isolation';
-$_SERVER['argv'][] = __DIR__ . '/5592/Issue5592Test.php';
+$_SERVER['argv'][] = __DIR__ . '/5592/Issue5592TestIsolation.php';
 
 set_exception_handler(static fn () => null);
 
@@ -22,34 +22,34 @@ Time: %s, Memory: %s
 
 There were 4 failures:
 
-1) PHPUnit\TestFixture\Issue5592Test::testAddedErrorHandler
+1) PHPUnit\TestFixture\Issue5592TestIsolation::testAddedErrorHandler
 Failed asserting that false is true.
 
-%sIssue5592Test.php:%i
+%sIssue5592TestIsolation.php:%i
 
-2) PHPUnit\TestFixture\Issue5592Test::testRemovedErrorHandler
+2) PHPUnit\TestFixture\Issue5592TestIsolation::testRemovedErrorHandler
 Failed asserting that false is true.
 
-%sIssue5592Test.php:%i
+%sIssue5592TestIsolation.php:%i
 
-3) PHPUnit\TestFixture\Issue5592Test::testAddedExceptionHandler
+3) PHPUnit\TestFixture\Issue5592TestIsolation::testAddedExceptionHandler
 Failed asserting that false is true.
 
-%sIssue5592Test.php:%i
+%sIssue5592TestIsolation.php:%i
 
-4) PHPUnit\TestFixture\Issue5592Test::testRemovedExceptionHandler
+4) PHPUnit\TestFixture\Issue5592TestIsolation::testRemovedExceptionHandler
 Failed asserting that false is true.
 
-%sIssue5592Test.php:%i
+%sIssue5592TestIsolation.php:%i
 
 --
 
 There was 1 risky test:
 
-1) PHPUnit\TestFixture\Issue5592Test::testRemovedErrorHandler
+1) PHPUnit\TestFixture\Issue5592TestIsolation::testRemovedErrorHandler
 Test code or tested code removed error handlers other than its own
 
-%sIssue5592Test.php:%i
+%sIssue5592TestIsolation.php:%i
 
 FAILURES!
 Tests: 6, Assertions: 10, Failures: 4, Risky: 1.

--- a/tests/end-to-end/regression/5592.phpt
+++ b/tests/end-to-end/regression/5592.phpt
@@ -6,7 +6,11 @@ $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = __DIR__ . '/5592/Issue5592Test.php';
 
-set_exception_handler(static fn () => null);
+function global5592ExceptionHandler(Throwable $exception): void
+{
+}
+
+set_exception_handler('global5592ExceptionHandler');
 
 require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);

--- a/tests/end-to-end/regression/5592.phpt
+++ b/tests/end-to-end/regression/5592.phpt
@@ -66,4 +66,4 @@ Test code or tested code removed exception handlers other than its own
 %sIssue5592Test.php:%i
 
 FAILURES!
-Tests: 6, Assertions: 6, Failures: 4, Risky: 4.
+Tests: 6, Assertions: 10, Failures: 4, Risky: 4.

--- a/tests/end-to-end/regression/5592/Issue5592Test.php
+++ b/tests/end-to-end/regression/5592/Issue5592Test.php
@@ -14,19 +14,25 @@ use function restore_exception_handler;
 use function set_error_handler;
 use function set_exception_handler;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\ErrorHandler;
+use Throwable;
 
 class Issue5592Test extends TestCase
 {
     public function testAddedAndRemovedErrorHandler(): void
     {
-        set_error_handler(static fn () => false);
+        $previous = set_error_handler([$this, 'addedAndRemovedErrorHandler']);
         restore_error_handler();
+
+        $this->assertInstanceOf(ErrorHandler::class, $previous);
         $this->assertTrue(true);
     }
 
     public function testAddedErrorHandler(): void
     {
-        set_error_handler(static fn () => false);
+        $previous = set_error_handler([$this, 'addedErrorHandler']);
+
+        $this->assertInstanceOf(ErrorHandler::class, $previous);
         $this->assertTrue(false);
     }
 
@@ -38,14 +44,18 @@ class Issue5592Test extends TestCase
 
     public function testAddedAndRemovedExceptionHandler(): void
     {
-        set_exception_handler(static fn () => null);
+        $previous = set_exception_handler([$this, 'addedAndRemovedExceptionHandler']);
         restore_exception_handler();
+
+        $this->assertNull($previous);
         $this->assertTrue(true);
     }
 
     public function testAddedExceptionHandler(): void
     {
-        set_exception_handler(static fn () => null);
+        $previous = set_exception_handler([$this, 'addedExceptionHandler']);
+
+        $this->assertNull($previous);
         $this->assertTrue(false);
     }
 
@@ -53,5 +63,21 @@ class Issue5592Test extends TestCase
     {
         restore_exception_handler();
         $this->assertTrue(false);
+    }
+
+    public function addedAndRemovedErrorHandler($errno, $errstr, $errfile, $errline): void
+    {
+    }
+
+    public function addedErrorHandler($errno, $errstr, $errfile, $errline): void
+    {
+    }
+
+    public function addedAndRemovedExceptionHandler(Throwable $exception): void
+    {
+    }
+
+    public function addedExceptionHandler(Throwable $exception): void
+    {
     }
 }

--- a/tests/end-to-end/regression/5592/Issue5592Test.php
+++ b/tests/end-to-end/regression/5592/Issue5592Test.php
@@ -66,12 +66,14 @@ class Issue5592Test extends TestCase
         $this->assertTrue(false);
     }
 
-    public function addedAndRemovedErrorHandler($errno, $errstr, $errfile, $errline): void
+    public function addedAndRemovedErrorHandler($errno, $errstr, $errfile, $errline): bool
     {
+        return false;
     }
 
-    public function addedErrorHandler($errno, $errstr, $errfile, $errline): void
+    public function addedErrorHandler($errno, $errstr, $errfile, $errline): bool
     {
+        return false;
     }
 
     public function addedAndRemovedExceptionHandler(Throwable $exception): void

--- a/tests/end-to-end/regression/5592/Issue5592Test.php
+++ b/tests/end-to-end/regression/5592/Issue5592Test.php
@@ -13,7 +13,6 @@ use function restore_error_handler;
 use function restore_exception_handler;
 use function set_error_handler;
 use function set_exception_handler;
-use Closure;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\ErrorHandler;
 use Throwable;
@@ -48,7 +47,7 @@ class Issue5592Test extends TestCase
         $previous = set_exception_handler([$this, 'addedAndRemovedExceptionHandler']);
         restore_exception_handler();
 
-        $this->assertInstanceOf(Closure::class, $previous);
+        $this->assertSame('global5592ExceptionHandler', $previous);
         $this->assertTrue(true);
     }
 
@@ -56,7 +55,7 @@ class Issue5592Test extends TestCase
     {
         $previous = set_exception_handler([$this, 'addedExceptionHandler']);
 
-        $this->assertInstanceOf(Closure::class, $previous);
+        $this->assertSame('global5592ExceptionHandler', $previous);
         $this->assertTrue(false);
     }
 

--- a/tests/end-to-end/regression/5592/Issue5592Test.php
+++ b/tests/end-to-end/regression/5592/Issue5592Test.php
@@ -13,6 +13,7 @@ use function restore_error_handler;
 use function restore_exception_handler;
 use function set_error_handler;
 use function set_exception_handler;
+use Closure;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\ErrorHandler;
 use Throwable;
@@ -47,7 +48,7 @@ class Issue5592Test extends TestCase
         $previous = set_exception_handler([$this, 'addedAndRemovedExceptionHandler']);
         restore_exception_handler();
 
-        $this->assertNull($previous);
+        $this->assertInstanceOf(Closure::class, $previous);
         $this->assertTrue(true);
     }
 
@@ -55,7 +56,7 @@ class Issue5592Test extends TestCase
     {
         $previous = set_exception_handler([$this, 'addedExceptionHandler']);
 
-        $this->assertNull($previous);
+        $this->assertInstanceOf(Closure::class, $previous);
         $this->assertTrue(false);
     }
 

--- a/tests/end-to-end/regression/5592/Issue5592TestIsolation.php
+++ b/tests/end-to-end/regression/5592/Issue5592TestIsolation.php
@@ -65,12 +65,14 @@ class Issue5592TestIsolation extends TestCase
         $this->assertTrue(false);
     }
 
-    public function addedAndRemovedErrorHandler($errno, $errstr, $errfile, $errline): void
+    public function addedAndRemovedErrorHandler($errno, $errstr, $errfile, $errline): bool
     {
+        return false;
     }
 
-    public function addedErrorHandler($errno, $errstr, $errfile, $errline): void
+    public function addedErrorHandler($errno, $errstr, $errfile, $errline): bool
     {
+        return false;
     }
 
     public function addedAndRemovedExceptionHandler(Throwable $exception): void

--- a/tests/end-to-end/regression/5592/Issue5592TestIsolation.php
+++ b/tests/end-to-end/regression/5592/Issue5592TestIsolation.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use function restore_error_handler;
+use function restore_exception_handler;
+use function set_error_handler;
+use function set_exception_handler;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\ErrorHandler;
+use Throwable;
+
+class Issue5592TestIsolation extends TestCase
+{
+    public function testAddedAndRemovedErrorHandler(): void
+    {
+        $previous = set_error_handler([$this, 'addedAndRemovedErrorHandler']);
+        restore_error_handler();
+
+        $this->assertInstanceOf(ErrorHandler::class, $previous);
+        $this->assertTrue(true);
+    }
+
+    public function testAddedErrorHandler(): void
+    {
+        $previous = set_error_handler([$this, 'addedErrorHandler']);
+
+        $this->assertInstanceOf(ErrorHandler::class, $previous);
+        $this->assertTrue(false);
+    }
+
+    public function testRemovedErrorHandler(): void
+    {
+        restore_error_handler();
+        $this->assertTrue(false);
+    }
+
+    public function testAddedAndRemovedExceptionHandler(): void
+    {
+        $previous = set_exception_handler([$this, 'addedAndRemovedExceptionHandler']);
+        restore_exception_handler();
+
+        $this->assertNull($previous);
+        $this->assertTrue(true);
+    }
+
+    public function testAddedExceptionHandler(): void
+    {
+        $previous = set_exception_handler([$this, 'addedExceptionHandler']);
+
+        $this->assertNull($previous);
+        $this->assertTrue(false);
+    }
+
+    public function testRemovedExceptionHandler(): void
+    {
+        restore_exception_handler();
+        $this->assertTrue(false);
+    }
+
+    public function addedAndRemovedErrorHandler($errno, $errstr, $errfile, $errline): void
+    {
+    }
+
+    public function addedErrorHandler($errno, $errstr, $errfile, $errline): void
+    {
+    }
+
+    public function addedAndRemovedExceptionHandler(Throwable $exception): void
+    {
+    }
+
+    public function addedExceptionHandler(Throwable $exception): void
+    {
+    }
+}


### PR DESCRIPTION
Adding more assertions arround error and exception handler, so one can more easily see that the result of the test depends on PHPUnit inner workings (and the current state of the inner workings).

PHPUnit itself does only register a error-handler, but not a exception handler.
therefore only the error-handler case is considered risky in https://github.com/sebastianbergmann/phpunit/blob/558dfd63e8e823a26453011e50caaef0f6fa8380/tests/end-to-end/regression/5592-process-isolation.phpt#L47-L50

---

as we get different behaviour when the test runs in isolation or not, I have copied the test and adjusted assertions accordingly.

no functional changes - just reflecting current behaviour in assertions.