### PR TITLE
Relate deprecations from DataProvider with corresponding tests

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -23,6 +23,7 @@ use PHPUnit\Metadata\ExcludeGlobalVariableFromBackup;
 use PHPUnit\Metadata\ExcludeStaticPropertyFromBackup;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Metadata\PreserveGlobalState;
+use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 use ReflectionClass;
 
@@ -47,7 +48,12 @@ final readonly class TestBuilder
         $data = null;
 
         if ($this->requirementsSatisfied($className, $methodName)) {
-            $data = (new DataProvider)->providedData($className, $methodName);
+            try {
+                ErrorHandler::instance()->enterTestCaseContext($methodName);
+                $data = (new DataProvider)->providedData($className, $methodName);
+            } finally {
+                ErrorHandler::instance()->leaveTestCaseContext();
+            }
         }
 
         if ($data !== null) {

--- a/src/Framework/TestRunner/TestRunner.php
+++ b/src/Framework/TestRunner/TestRunner.php
@@ -81,7 +81,7 @@ final class TestRunner
         $skipped    = false;
 
         if ($this->shouldErrorHandlerBeUsed($test)) {
-            ErrorHandler::instance()->enable();
+            ErrorHandler::instance()->enable($test);
         }
 
         $collectCodeCoverage = CodeCoverage::instance()->isActive() &&

--- a/tests/end-to-end/regression/6279.phpt
+++ b/tests/end-to-end/regression/6279.phpt
@@ -20,21 +20,21 @@ Time: %s, Memory: %s
 
 3 tests triggered 3 deprecations:
 
-1) %sTriggersDeprecationInDataProviderTest.php:25
+1) %sTriggersDeprecationInDataProviderTest.php:26
 some deprecation
 
 Triggered by:
 
 * PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProviderTest::method2#0
-  %sTriggersDeprecationInDataProviderTest.php:38
+  %sTriggersDeprecationInDataProviderTest.php:48
 
 * PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProviderTest::method4#0
-  %sTriggersDeprecationInDataProviderTest.php:51
+  %sTriggersDeprecationInDataProviderTest.php:61
 
-2) %sTriggersDeprecationInDataProviderTest.php:65
+2) %sTriggersDeprecationInDataProviderTest.php:33
 first
 
-3) %sTriggersDeprecationInDataProviderTest.php:66
+3) %sTriggersDeprecationInDataProviderTest.php:34
 second
 
 OK, but there were issues!

--- a/tests/end-to-end/regression/6279.phpt
+++ b/tests/end-to-end/regression/6279.phpt
@@ -20,7 +20,7 @@ Time: %s, Memory: %s
 
 1 test triggered 1 deprecation:
 
-1) %s/end-to-end/regression/6279/TriggersDeprecationInDataProviderTest.php:24
+1) %sTriggersDeprecationInDataProviderTest.php:24
 some deprecation
 
 OK, but there were issues!

--- a/tests/end-to-end/regression/6279.phpt
+++ b/tests/end-to-end/regression/6279.phpt
@@ -1,0 +1,27 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6279
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = __DIR__ . '/6279/TriggersDeprecationInDataProviderTest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.D.                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 1 deprecation:
+
+1) %s/end-to-end/regression/6279/TriggersDeprecationInDataProviderTest.php:24
+some deprecation
+
+OK, but there were issues!
+Tests: 3, Assertions: 3, Deprecations: 1.

--- a/tests/end-to-end/regression/6279.phpt
+++ b/tests/end-to-end/regression/6279.phpt
@@ -14,14 +14,28 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-.D.                                                                 3 / 3 (100%)
+.D.DD                                                               5 / 5 (100%)
 
 Time: %s, Memory: %s
 
-1 test triggered 1 deprecation:
+3 tests triggered 3 deprecations:
 
-1) %sTriggersDeprecationInDataProviderTest.php:24
+1) %sTriggersDeprecationInDataProviderTest.php:25
 some deprecation
 
+Triggered by:
+
+* PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProviderTest::method2#0
+  %sTriggersDeprecationInDataProviderTest.php:38
+
+* PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProviderTest::method4#0
+  %sTriggersDeprecationInDataProviderTest.php:51
+
+2) %sTriggersDeprecationInDataProviderTest.php:65
+first
+
+3) %sTriggersDeprecationInDataProviderTest.php:66
+second
+
 OK, but there were issues!
-Tests: 3, Assertions: 3, Deprecations: 1.
+Tests: 5, Assertions: 5, Deprecations: 3.

--- a/tests/end-to-end/regression/6279/TriggersDeprecationInDataProviderTest.php
+++ b/tests/end-to-end/regression/6279/TriggersDeprecationInDataProviderTest.php
@@ -12,8 +12,10 @@ declare(strict_types=1);
 namespace PHPUnit\TestFixture\Issue6279;
 
 use const E_USER_DEPRECATED;
+use const E_USER_WARNING;
 use function trigger_error;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +24,15 @@ class TriggersDeprecationInDataProviderTest extends TestCase
     public static function dataProvider(): iterable
     {
         @trigger_error('some deprecation', E_USER_DEPRECATED);
+
+        yield [true];
+    }
+
+    public static function dataWith2Deprecations(): iterable
+    {
+        @trigger_error('first', E_USER_DEPRECATED);
+        @trigger_error('second', E_USER_DEPRECATED);
+        @trigger_error('warning', E_USER_WARNING);
 
         yield [true];
     }
@@ -43,5 +54,19 @@ class TriggersDeprecationInDataProviderTest extends TestCase
     public function method3(): void
     {
         $this->assertTrue(true);
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider')]
+    public function method4(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+
+    #[Test]
+    #[DataProviderExternal(self::class, 'dataWith2Deprecations')]
+    public function method5(bool $value): void
+    {
+        $this->assertTrue($value);
     }
 }

--- a/tests/end-to-end/regression/6279/TriggersDeprecationInDataProviderTest.php
+++ b/tests/end-to-end/regression/6279/TriggersDeprecationInDataProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6279;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TriggersDeprecationInDataProviderTest extends TestCase
+{
+    public static function dataProvider(): iterable
+    {
+        @trigger_error('some deprecation', E_USER_DEPRECATED);
+
+        yield [true];
+    }
+
+    #[Test]
+    public function method1(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider')]
+    public function method2(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+
+    #[Test]
+    public function method3(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
fixes https://github.com/sebastianbergmann/phpunit/issues/6279

idea is, that we relate deprecations when triggered while building a dataprovider to the corresponding test

---

we cannot use `$test = Event\Code\TestMethodBuilder::fromCallStack();` to infer the test-contex, as the dataprovider is built before we enter the actual test