### PR TITLE
fix(deprecations): testCaseContext should be computed with class name

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -47,7 +47,7 @@ final readonly class TestBuilder
 
         if ($this->requirementsSatisfied($className, $methodName)) {
             try {
-                ErrorHandler::instance()->enterTestCaseContext($methodName);
+                ErrorHandler::instance()->enterTestCaseContext($className, $methodName);
 
                 $data = (new DataProvider)->providedData($className, $methodName);
             } finally {

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -282,9 +282,9 @@ final class ErrorHandler
         $this->deprecationTriggers = $deprecationTriggers;
     }
 
-    public function enterTestCaseContext(string $methodName): void
+    public function enterTestCaseContext(string $className, string $methodName): void
     {
-        $this->testCaseContext = $methodName;
+        $this->testCaseContext = $this->testCaseContext($className, $methodName);
     }
 
     public function leaveTestCaseContext(): void
@@ -477,8 +477,15 @@ final class ErrorHandler
             $this->__invoke(...$d);
         }
 
-        foreach ($this->testCaseContextDeprecations[$test->name()] ?? [] as $d) {
+        $testCaseContext = $this->testCaseContext($test::class, $test->name());
+
+        foreach ($this->testCaseContextDeprecations[$testCaseContext] ?? [] as $d) {
             $this->__invoke(...$d);
         }
+    }
+
+    private function testCaseContext(string $className, string $methodName): string
+    {
+        return "{$className}::{$methodName}";
     }
 }

--- a/tests/end-to-end/regression/6279.phpt
+++ b/tests/end-to-end/regression/6279.phpt
@@ -5,7 +5,7 @@ https://github.com/sebastianbergmann/phpunit/issues/6279
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--display-deprecations';
-$_SERVER['argv'][] = __DIR__ . '/6279/';
+$_SERVER['argv'][] = __DIR__ . '/6279';
 
 require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
@@ -14,27 +14,27 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-.D.DD..DD.                                                        10 / 10 (100%)
+.D.DD....DD.                                                      12 / 12 (100%)
 
 Time: %s, Memory: %s
 
 5 tests triggered 5 deprecations:
 
-1) %sTriggersDeprecationInDataProviderTest.php:26
+1) %sTriggersDeprecationInDataProvider1Test.php:26
 some deprecation
 
 Triggered by:
 
-* PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProviderTest::method2#0
-  %sTriggersDeprecationInDataProviderTest.php:48
+* PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProvider1Test::method2#0
+  %sTriggersDeprecationInDataProvider1Test.php:48
 
-* PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProviderTest::method4#0
-  %sTriggersDeprecationInDataProviderTest.php:61
+* PHPUnit\TestFixture\Issue6279\TriggersDeprecationInDataProvider1Test::method4#0
+  %sTriggersDeprecationInDataProvider1Test.php:61
 
-2) %sTriggersDeprecationInDataProviderTest.php:33
+2) %sTriggersDeprecationInDataProvider1Test.php:33
 first
 
-3) %sTriggersDeprecationInDataProviderTest.php:34
+3) %sTriggersDeprecationInDataProvider1Test.php:34
 second
 
 4) %sTriggersDeprecationInDataProviderUsingIgnoreDeprecationsTest.php:32
@@ -44,4 +44,4 @@ some deprecation 2
 some deprecation 3
 
 OK, but there were issues!
-Tests: 10, Assertions: 10, Deprecations: 5.
+Tests: 12, Assertions: 12, Deprecations: 5.

--- a/tests/end-to-end/regression/6279/TriggersDeprecationInDataProvider1Test.php
+++ b/tests/end-to-end/regression/6279/TriggersDeprecationInDataProvider1Test.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-class TriggersDeprecationInDataProviderTest extends TestCase
+class TriggersDeprecationInDataProvider1Test extends TestCase
 {
     public static function dataProvider(): iterable
     {
@@ -68,5 +68,11 @@ class TriggersDeprecationInDataProviderTest extends TestCase
     public function method5(bool $value): void
     {
         $this->assertTrue($value);
+    }
+
+    #[Test]
+    public function methodWithSameNameThanInAnotherTest(): void
+    {
+        $this->assertTrue(true);
     }
 }

--- a/tests/end-to-end/regression/6279/TriggersDeprecationInDataProvider2Test.php
+++ b/tests/end-to-end/regression/6279/TriggersDeprecationInDataProvider2Test.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6279;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TriggersDeprecationInDataProvider2Test extends TestCase
+{
+    public static function dataProvider(): iterable
+    {
+        @trigger_error('some deprecation 1', E_USER_DEPRECATED);
+
+        yield [true];
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider')]
+    #[IgnoreDeprecations]
+    public function methodWithSameNameThanInAnotherTest(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+}


### PR DESCRIPTION
This fixes a small bug in https://github.com/sebastianbergmann/phpunit/pull/6293

the so-called "test case context" in `ErrorHandler` was only relying on the test method's name, so two methods with the same name in different test classes would be related to the same deprecation from the data provider, although if one of them does not trigger a deprec

ping @staabm 