### PR TITLE
test(deprecations): test deprecs in data provider can be ignored

### DIFF
--- a/tests/end-to-end/regression/6279.phpt
+++ b/tests/end-to-end/regression/6279.phpt
@@ -5,7 +5,7 @@ https://github.com/sebastianbergmann/phpunit/issues/6279
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--display-deprecations';
-$_SERVER['argv'][] = __DIR__ . '/6279/TriggersDeprecationInDataProviderTest.php';
+$_SERVER['argv'][] = __DIR__ . '/6279/';
 
 require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
@@ -14,11 +14,11 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-.D.DD                                                               5 / 5 (100%)
+.D.DD..DD.                                                        10 / 10 (100%)
 
 Time: %s, Memory: %s
 
-3 tests triggered 3 deprecations:
+5 tests triggered 5 deprecations:
 
 1) %sTriggersDeprecationInDataProviderTest.php:26
 some deprecation
@@ -37,5 +37,11 @@ first
 3) %sTriggersDeprecationInDataProviderTest.php:34
 second
 
+4) %sTriggersDeprecationInDataProviderUsingIgnoreDeprecationsTest.php:32
+some deprecation 2
+
+5) %sTriggersDeprecationInDataProviderUsingIgnoreDeprecationsTest.php:39
+some deprecation 3
+
 OK, but there were issues!
-Tests: 5, Assertions: 5, Deprecations: 3.
+Tests: 10, Assertions: 10, Deprecations: 5.

--- a/tests/end-to-end/regression/6279/TriggersDeprecationInDataProviderUsingIgnoreDeprecationsTest.php
+++ b/tests/end-to-end/regression/6279/TriggersDeprecationInDataProviderUsingIgnoreDeprecationsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6279;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TriggersDeprecationInDataProviderUsingIgnoreDeprecationsTest extends TestCase
+{
+    public static function dataProvider1(): iterable
+    {
+        @trigger_error('some deprecation', E_USER_DEPRECATED);
+
+        yield [true];
+    }
+
+    public static function dataProvider2(): iterable
+    {
+        @trigger_error('some deprecation 2', E_USER_DEPRECATED);
+
+        yield [true];
+    }
+
+    public static function dataProvider3(): iterable
+    {
+        @trigger_error('some deprecation 3', E_USER_DEPRECATED);
+
+        yield [true];
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider1')]
+    #[IgnoreDeprecations]
+    public function someMethod1(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider2')]
+    #[IgnoreDeprecations]
+    public function method2_1(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider2')]
+    public function method2_2(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider3')]
+    public function method3_1(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+
+    #[Test]
+    #[DataProvider('dataProvider3')]
+    #[IgnoreDeprecations]
+    public function method3_2(bool $value): void
+    {
+        $this->assertTrue($value);
+    }
+}


### PR DESCRIPTION
add tests that validates `#[IgnoreDeprecations]`  can be used to ignore deprecs triggered by a data provider

as [suggested](https://github.com/sebastianbergmann/phpunit/pull/6293#issuecomment-3173495032) by @xabbuh 

ping @staabm 