### PR TITLE
Print previous exception in Testdox

### DIFF
--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -209,8 +209,6 @@ final readonly class ResultPrinter
 
     private function printThrowable(TestStatus $status, Throwable $throwable): void
     {
-        assert($throwable instanceof Throwable);
-
         $message    = trim($throwable->description());
         $stackTrace = $this->formatStackTrace($throwable->stackTrace());
         $diff       = '';

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -11,7 +11,6 @@ namespace PHPUnit\TextUI\Output\TestDox;
 
 use const PHP_EOL;
 use function array_map;
-use function assert;
 use function explode;
 use function implode;
 use function preg_match;
@@ -248,9 +247,7 @@ final readonly class ResultPrinter
             } else {
                 $tracePrefix = $this->prefixFor('trace', $status);
             }
-        }
 
-        if ($stackTrace !== '') {
             $this->printer->print(
                 $this->prefixLines($tracePrefix, PHP_EOL . $stackTrace),
             );
@@ -261,7 +258,7 @@ final readonly class ResultPrinter
 
             $this->printer->print(
                 $this->prefixLines(
-                    $tracePrefix,
+                    $this->prefixFor('default', $status),
                     ' ',
                 ),
             );
@@ -270,7 +267,7 @@ final readonly class ResultPrinter
 
             $this->printer->print(
                 $this->prefixLines(
-                    $tracePrefix,
+                    $this->prefixFor('default', $status),
                     'Caused by:',
                 ),
             );

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -177,7 +177,7 @@ final readonly class ResultPrinter
         }
 
         $this->printTestResultBodyStart($test);
-        $this->printThrowable($test);
+        $this->printThrowable($test->status(), $test->throwable());
         $this->printTestResultBodyEnd($test);
     }
 
@@ -207,10 +207,8 @@ final readonly class ResultPrinter
         $this->printer->print(PHP_EOL);
     }
 
-    private function printThrowable(TestDoxTestResult $test): void
+    private function printThrowable(TestStatus $status, Throwable $throwable): void
     {
-        $throwable = $test->throwable();
-
         assert($throwable instanceof Throwable);
 
         $message    = trim($throwable->description());
@@ -220,14 +218,14 @@ final readonly class ResultPrinter
         if (!empty($message) && $this->colors) {
             ['message' => $message, 'diff' => $diff] = $this->colorizeMessageAndDiff(
                 $message,
-                $this->messageColorFor($test->status()),
+                $this->messageColorFor($status),
             );
         }
 
         if (!empty($message)) {
             $this->printer->print(
                 $this->prefixLines(
-                    $this->prefixFor('message', $test->status()),
+                    $this->prefixFor('message', $status),
                     $message,
                 ),
             );
@@ -238,7 +236,7 @@ final readonly class ResultPrinter
         if (!empty($diff)) {
             $this->printer->print(
                 $this->prefixLines(
-                    $this->prefixFor('diff', $test->status()),
+                    $this->prefixFor('diff', $status),
                     $diff,
                 ),
             );
@@ -248,13 +246,13 @@ final readonly class ResultPrinter
 
         if (!empty($stackTrace)) {
             if (!empty($message) || !empty($diff)) {
-                $prefix = $this->prefixFor('default', $test->status());
+                $tracePrefix = $this->prefixFor('default', $status);
             } else {
-                $prefix = $this->prefixFor('trace', $test->status());
+                $tracePrefix = $this->prefixFor('trace', $status);
             }
 
             $this->printer->print(
-                $this->prefixLines($prefix, PHP_EOL . $stackTrace),
+                $this->prefixLines($tracePrefix, PHP_EOL . $stackTrace),
             );
         }
     }

--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -250,10 +250,36 @@ final readonly class ResultPrinter
             } else {
                 $tracePrefix = $this->prefixFor('trace', $status);
             }
+        }
 
+        if ($stackTrace !== '') {
             $this->printer->print(
                 $this->prefixLines($tracePrefix, PHP_EOL . $stackTrace),
             );
+        }
+
+        if ($throwable->hasPrevious()) {
+            $this->printer->print(PHP_EOL);
+
+            $this->printer->print(
+                $this->prefixLines(
+                    $tracePrefix,
+                    ' ',
+                ),
+            );
+
+            $this->printer->print(PHP_EOL);
+
+            $this->printer->print(
+                $this->prefixLines(
+                    $tracePrefix,
+                    'Caused by:',
+                ),
+            );
+
+            $this->printer->print(PHP_EOL);
+
+            $this->printThrowable($status, $throwable->previous());
         }
     }
 

--- a/tests/end-to-end/logging/_files/ThrowsWithPreviousExceptionTest.php
+++ b/tests/end-to-end/logging/_files/ThrowsWithPreviousExceptionTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class ThrowsWithPreviousExceptionTest extends TestCase
+{
+    public function testFoo(): void
+    {
+        throw new Exception(
+            'Outer',
+            previous: new Exception('Inner'),
+        );
+    }
+}

--- a/tests/end-to-end/logging/testdox/testdox-print-previous-exception-colorized.phpt
+++ b/tests/end-to-end/logging/testdox/testdox-print-previous-exception-colorized.phpt
@@ -1,5 +1,10 @@
 --TEST--
 https://github.com/sebastianbergmann/phpunit/issues/5863
+--SKIPIF--
+<?php declare(strict_types=1);
+if (stripos(\PHP_OS, 'WIN') === 0) {
+    print 'skip: Colorized diff is different on Windows.';
+}
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--display-errors';

--- a/tests/end-to-end/logging/testdox/testdox-print-previous-exception-colorized.phpt
+++ b/tests/end-to-end/logging/testdox/testdox-print-previous-exception-colorized.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Testdox: print error message
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--display-errors';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-progress';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--colors=always';
+$_SERVER['argv'][] =  __DIR__ . '/../_files/ThrowsWithPreviousExceptionTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+
+Time: %s, Memory: %s
+
+[4mThrows With Previous Exception (PHPUnit\TestFixture\ThrowsWithPreviousException)[0m
+[33m ✘ [0mFoo
+   [33m┐[0m
+   [33m├[0m [43;30mException: Outer[0m
+   [33m│[0m
+   [33m│[0m [2m%sThrowsWithPreviousExceptionTest.php[2m:[22m[34m%d[0m%A
+   [33m│[0m Caused by:
+   [33m├[0m [43;30mException: Inner[0m
+   [33m│[0m
+   [33m│[0m [2m%sThrowsWithPreviousExceptionTest.php[2m:[22m[34m%d[0m%A
+   [33m┴[0m
+
+[37;41mERRORS![0m
+[37;41mTests: 1[0m[37;41m, Assertions: 0[0m[37;41m, Errors: 1[0m[37;41m.[0m

--- a/tests/end-to-end/logging/testdox/testdox-print-previous-exception-colorized.phpt
+++ b/tests/end-to-end/logging/testdox/testdox-print-previous-exception-colorized.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Testdox: print error message
+https://github.com/sebastianbergmann/phpunit/issues/5863
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--display-errors';

--- a/tests/end-to-end/logging/testdox/testdox-print-previous-exception.phpt
+++ b/tests/end-to-end/logging/testdox/testdox-print-previous-exception.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Testdox: print error message
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--display-errors';
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] =  __DIR__ . '/../_files/ThrowsWithPreviousExceptionTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+
+E                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+Throws With Previous Exception (PHPUnit\TestFixture\ThrowsWithPreviousException)
+ ✘ Foo
+   │
+   │ Exception: Outer
+   │
+   │ %sThrowsWithPreviousExceptionTest.php:%d
+   │  
+   │ Caused by:
+   │ Exception: Inner
+   │
+   │ %sThrowsWithPreviousExceptionTest.php:%d
+   │
+
+ERRORS!
+Tests: 1, Assertions: 0, Errors: 1.

--- a/tests/end-to-end/logging/testdox/testdox-print-previous-exception.phpt
+++ b/tests/end-to-end/logging/testdox/testdox-print-previous-exception.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Testdox: print error message
+https://github.com/sebastianbergmann/phpunit/issues/5863
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--display-errors';


### PR DESCRIPTION
closes https://github.com/sebastianbergmann/phpunit/issues/5863

color rendered result:

<img width="1078" height="708" alt="grafik" src="https://github.com/user-attachments/assets/72c54037-872c-444d-bc7e-0033cf382bc5" />
