### PR TITLE
Fix PHPStan errors

### DIFF
--- a/src/TextUI/Output/TestDox/ResultPrinter.php
+++ b/src/TextUI/Output/TestDox/ResultPrinter.php
@@ -241,8 +241,8 @@ final readonly class ResultPrinter
             $this->printer->print(PHP_EOL);
         }
 
-        if (!empty($stackTrace)) {
-            if (!empty($message) || !empty($diff)) {
+        if ($stackTrace !== '') {
+            if ($message !== '' || $diff !== '') {
                 $tracePrefix = $this->prefixFor('default', $status);
             } else {
                 $tracePrefix = $this->prefixFor('trace', $status);


### PR DESCRIPTION
fix errors after recent PR

```
Run ./tools/phpstan analyse --no-progress --error-format=github
Note: Using configuration file /home/runner/work/phpunit/phpunit/phpstan.neon.
Error: Construct empty() is not allowed. Use more strict comparison.
Error: Construct empty() is not allowed. Use more strict comparison.
Error: Construct empty() is not allowed. Use more strict comparison.
```