### PR TITLE
Detect premature end of PHPUnit's main PHP process

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -353,7 +353,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
         if (!$this->shouldRunInSeparateProcess() || $this->requirementsNotSatisfied()) {
             try {
-                ShutdownHandler::setMessage('Fatal error: Premature end of PHP process.');
+                ShutdownHandler::setMessage(sprintf('Fatal error: Premature end of PHP process in %s.', $this->toString()));
                 (new TestRunner)->run($this);
             } finally {
                 ShutdownHandler::resetMessage();

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -353,7 +353,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
         if (!$this->shouldRunInSeparateProcess() || $this->requirementsNotSatisfied()) {
             try {
-                ShutdownHandler::setMessage(sprintf('Fatal error: Premature end of PHP process in %s.', $this->toString()));
+                ShutdownHandler::setMessage(sprintf('Fatal error: Premature end of PHP process when running %s.', $this->toString()));
                 (new TestRunner)->run($this);
             } finally {
                 ShutdownHandler::resetMessage();

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -352,7 +352,12 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         }
 
         if (!$this->shouldRunInSeparateProcess() || $this->requirementsNotSatisfied()) {
-            (new TestRunner)->run($this);
+            try {
+                ShutdownHandler::setMessage('Fatal error: Premature end of PHP process.');
+                (new TestRunner)->run($this);
+            } finally {
+                ShutdownHandler::resetMessage();
+            }
 
             return;
         }

--- a/src/Runner/ShutdownHandler.php
+++ b/src/Runner/ShutdownHandler.php
@@ -39,6 +39,7 @@ final class ShutdownHandler
             return;
         }
 
+        self::$registered = true;
         register_shutdown_function(static function (): void
         {
             print self::$message;

--- a/tests/end-to-end/regression/6234.phpt
+++ b/tests/end-to-end/regression/6234.phpt
@@ -14,4 +14,4 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-Fatal error: Premature end of PHP process.
+Fatal error: Premature end of PHP process in PHPUnit\TestFixture\Issue6234Test::testExitWithoutProcessIsolation.

--- a/tests/end-to-end/regression/6234.phpt
+++ b/tests/end-to-end/regression/6234.phpt
@@ -14,4 +14,4 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-Fatal error: Premature end of PHP process in PHPUnit\TestFixture\Issue6234Test::testExitWithoutProcessIsolation.
+Fatal error: Premature end of PHP process when running PHPUnit\TestFixture\Issue6234Test::testExitWithoutProcessIsolation.

--- a/tests/end-to-end/regression/6234.phpt
+++ b/tests/end-to-end/regression/6234.phpt
@@ -1,0 +1,17 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6234
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/6234/Issue6234Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+Fatal error: Premature end of PHP process.

--- a/tests/end-to-end/regression/6234/Issue6234Test.php
+++ b/tests/end-to-end/regression/6234/Issue6234Test.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Issue6234Test extends TestCase
+{
+    public function testExitWithoutProcessIsolation(): void
+    {
+        $this->assertTrue(true);
+        $this->assertTrue(true);
+
+        exit(1);
+    }
+}


### PR DESCRIPTION
when a test calls `exit()` phpunit main process halted and printed nothing.
since [PHPUnit 12.3 we have a `ShutdownHandler`](https://github.com/sebastianbergmann/phpunit/pull/6296) which we utilize with this PR to handle this situation and print a more usefull error message.

before this PR:
```
➜  phpunit git:(11.5) ✗ php phpunit Test.php
PHPUnit 11.5.32-19-g48f14e340 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.24
Configuration: /Users/staabm/workspace/phpunit/phpunit.xml
```

after this PR:
```
➜  phpunit git:(11.5) ✗ php phpunit Test.php
PHPUnit 11.5.32-19-g48f14e340 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.24
Configuration: /Users/staabm/workspace/phpunit/phpunit.xml

Fatal error: Premature end of PHP process when running PHPUnit\TestFixture\Issue6234Test::testExitWithoutProcessIsolation.
```

similar to https://github.com/sebastianbergmann/phpunit/issues/6234
-> [in a separate PR I will add expectation handling for subprocesses](https://github.com/sebastianbergmann/phpunit/pull/6275).