### PR TITLE
Manual trigger the release workflow via GitHub UI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,20 @@ on:
   push:
     tags:
       - "**"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to Release'
+        required: true
 
 name: Release
 
 jobs:
   release:
     name: Release
+
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -28,9 +36,6 @@ jobs:
           coverage: none
           extensions: none
           tools: none
-
-      - name: Determine tag
-        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Parse ChangeLog
         run: build/scripts/extract-release-notes.php ${{ env.RELEASE_TAG }} > release-notes.md


### PR DESCRIPTION
## Patch Summary

Partially resolves [#6327](https://github.com/sebastianbergmann/phpunit/issues/6327) by updating `.github/workflows/release.yaml`.

**Workflow Trigger Improvements:**

* Added a `workflow_dispatch` trigger with an input field for specifying the release tag, enabling manual releases from the GitHub UI.

**Environment and Tag Handling:**

* Set the `RELEASE_TAG` environment variable to use either the manually entered tag or the current Git reference name, streamlining tag selection for both manual and automatic releases.
* Removed the separate step that previously determined the release tag from the Git reference, as it is now handled via the environment variable.

## How to Trigger the Release Workflow (once merged)

1. **Go to the workflow:**  
   Visit: [Release Workflow Actions](https://github.com/sebastianbergmann/phpunit/actions/workflows/release.yaml)

2. **Locate the workflow_dispatch banner:**  
   <details>
   <summary>Screenshot: Banner location</summary>
   <p>
   <img width="2148" height="900" alt="Workflow Dispatch Banner" src="https://github.com/user-attachments/assets/532e4b8e-673d-4015-9134-f38854002118" />
   </p>
   </details>

3. **Click "Run workflow":**  
   <details>
   <summary>Screenshot: Run workflow button</summary>
   <p>
   <img width="2168" height="900" alt="Run Workflow Button" src="https://github.com/user-attachments/assets/182e7210-2c0b-44f9-acdf-8e9fdca82cea" />
   </p>
   </details>

4. **Fill out the workflow form:**  
   - Select the branch containing the workflow configuration.
   - Enter the tag to release.
   - Click the green **"Run workflow"** button to start the release.

---
**Note:**  

* The workflow will use the configuration from the selected branch/tag. Always verify branch/tag selection before triggering a release.

* You have multiple branches with customized workflow files, you may need to apply this patch to each branch.