### PR TITLE
Added missing dependency to randomly failing test

### DIFF
--- a/tests/unit/Framework/MockObject/MockClassTest.php
+++ b/tests/unit/Framework/MockObject/MockClassTest.php
@@ -29,6 +29,9 @@ final class MockClassTest extends TestCase
         $this->assertTrue(class_exists($mockName));
     }
 
+    /**
+     * @depends testGenerateClassFromSource
+     */
     public function testGenerateReturnsNameOfGeneratedClass(): void
     {
         $mockName = 'PHPUnit\TestFixture\MockObject\MockClassGenerated';


### PR DESCRIPTION
The test randomly fails on the nightly build: https://github.com/mbeccati/phpunit-tmp/actions/runs/17169819499/job/48717189409 due to `--order-by depends,random` and a missing dependency.

Only applies to 8.5 and 9.6 as far as I can tell.

Refs #6305 