### PR TITLE
Remove shortenArraysForExportThreshold="10" from config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,6 @@
          xsi:noNamespaceSchemaLocation="phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
-         shortenArraysForExportThreshold="10"
          beStrictAboutOutputDuringTests="true"
          displayDetailsOnPhpunitDeprecations="true"
          failOnPhpunitDeprecation="true"


### PR DESCRIPTION
its the [default value starting with phpunit 12.x](https://github.com/sebastianbergmann/phpunit/blob/8697be3e2a98f5b3fa2e35a095f43ebfa98d89dc/phpunit.xsd#L228) see https://github.com/sebastianbergmann/phpunit/commit/cc9dfcabb53e16b6c65878731e899d82f7f6c454