### PR TITLE
Support for regular expressions with `#[IgnoreDeprecations]` attribute

### DIFF
--- a/src/Framework/Attributes/IgnoreDeprecations.php
+++ b/src/Framework/Attributes/IgnoreDeprecations.php
@@ -19,4 +19,22 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 final readonly class IgnoreDeprecations
 {
+    /** @var null|non-empty-string */
+    private ?string $messagePattern;
+
+    /**
+     * @param null|non-empty-string $messagePattern
+     */
+    public function __construct(null|string $messagePattern = null)
+    {
+        $this->messagePattern = $messagePattern;
+    }
+
+    /**
+     * @return null|non-empty-string
+     */
+    public function messagePattern(): ?string
+    {
+        return $this->messagePattern;
+    }
 }

--- a/src/Metadata/IgnoreDeprecations.php
+++ b/src/Metadata/IgnoreDeprecations.php
@@ -16,8 +16,30 @@ namespace PHPUnit\Metadata;
  */
 final readonly class IgnoreDeprecations extends Metadata
 {
+    /** @var null|non-empty-string */
+    private ?string $messagePattern;
+
+    /**
+     * @param int<0, 1>             $level
+     * @param null|non-empty-string $messagePattern
+     */
+    protected function __construct(int $level, null|string $messagePattern)
+    {
+        parent::__construct($level);
+
+        $this->messagePattern = $messagePattern;
+    }
+
     public function isIgnoreDeprecations(): true
     {
         return true;
+    }
+
+    /**
+     * @return null|non-empty-string
+     */
+    public function messagePattern(): ?string
+    {
+        return $this->messagePattern;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -225,14 +225,20 @@ abstract readonly class Metadata
         return new Group(self::METHOD_LEVEL, $groupName);
     }
 
-    public static function ignoreDeprecationsOnClass(): IgnoreDeprecations
+    /**
+     * @param null|non-empty-string $messagePattern
+     */
+    public static function ignoreDeprecationsOnClass(?string $messagePattern = null): IgnoreDeprecations
     {
-        return new IgnoreDeprecations(self::CLASS_LEVEL);
+        return new IgnoreDeprecations(self::CLASS_LEVEL, $messagePattern);
     }
 
-    public static function ignoreDeprecationsOnMethod(): IgnoreDeprecations
+    /**
+     * @param null|non-empty-string $messagePattern
+     */
+    public static function ignoreDeprecationsOnMethod(?string $messagePattern = null): IgnoreDeprecations
     {
-        return new IgnoreDeprecations(self::METHOD_LEVEL);
+        return new IgnoreDeprecations(self::METHOD_LEVEL, $messagePattern);
     }
 
     /**

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -296,7 +296,7 @@ final readonly class AttributeParser implements Parser
                 case IgnoreDeprecations::class:
                     assert($attributeInstance instanceof IgnoreDeprecations);
 
-                    $result[] = Metadata::ignoreDeprecationsOnClass();
+                    $result[] = Metadata::ignoreDeprecationsOnClass($attributeInstance->messagePattern());
 
                     break;
 
@@ -698,7 +698,7 @@ final readonly class AttributeParser implements Parser
                 case IgnoreDeprecations::class:
                     assert($attributeInstance instanceof IgnoreDeprecations);
 
-                    $result[] = Metadata::ignoreDeprecationsOnMethod();
+                    $result[] = Metadata::ignoreDeprecationsOnMethod($attributeInstance->messagePattern());
 
                     break;
 

--- a/tests/end-to-end/event/_files/IgnoreDeprecationsWithPatternTest.php
+++ b/tests/end-to-end/event/_files/IgnoreDeprecationsWithPatternTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+
+#[IgnoreDeprecations('foo')]
+final class IgnoreDeprecationsWithPatternTest extends TestCase
+{
+    #[IgnoreDeprecations('bar')]
+    public function testOne(): void
+    {
+        trigger_error('foo', E_USER_DEPRECATED);
+        trigger_error('bar', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        trigger_error('foo', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+
+    public function testThree(): void
+    {
+        trigger_error('foo', E_USER_DEPRECATED);
+        trigger_error('baz', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+
+    #[IgnoreDeprecations('bar|baz')]
+    public function testFour(): void
+    {
+        trigger_error('foo', E_USER_DEPRECATED);
+        trigger_error('bar', E_USER_DEPRECATED);
+        trigger_error('baz', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute-and-pattern.phpt
+++ b/tests/end-to-end/event/deprecations-can-be-ignored-using-attribute-and-pattern.phpt
@@ -1,0 +1,28 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/5532
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = __DIR__ . '/_files/IgnoreDeprecationsWithPatternTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+
+..D.                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s MB
+
+1 test triggered 1 deprecation:
+
+1) %sIgnoreDeprecationsWithPatternTest.php:%d
+baz
+
+OK, but there were issues!
+Tests: 4, Assertions: 4, Deprecations: 1.


### PR DESCRIPTION
This will allow to only ignore specific deprecations, instead of all of them