### PR TITLE
Add a trailing \n in ShutdownHandler message

### DIFF
--- a/src/Runner/ShutdownHandler.php
+++ b/src/Runner/ShutdownHandler.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Runner;
 
 use function register_shutdown_function;
+use function rtrim;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -44,7 +45,7 @@ final class ShutdownHandler
         register_shutdown_function(
             static function (): void
             {
-                print self::$message;
+                print rtrim(self::$message) . "\n";
             },
         );
     }


### PR DESCRIPTION
The first execution is without my patch
The second one is with my patch.

As you can see, the output is cleaner with it

<img width="1591" height="352" alt="image" src="https://github.com/user-attachments/assets/b0bd9b78-8b34-4f98-b58d-4e7735a7c7f3" />
