### PR TITLE
Also collect `E_DEPRECATED` issues when building the test suite

### DIFF
--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -225,7 +225,7 @@ final class ErrorHandler
 
     public function registerDeprecationHandler(): void
     {
-        set_error_handler([self::$instance, 'deprecationHandler'], E_USER_DEPRECATED);
+        set_error_handler([self::$instance, 'deprecationHandler'], E_USER_DEPRECATED | E_DEPRECATED);
     }
 
     public function restoreDeprecationHandler(): void


### PR DESCRIPTION
This was forgotten in #6165
This makes a difference with today's new "sleep" deprecation, which is not correctly gathered.