### PR TITLE
Allow `Throwable` in `expectExceptionObject()`

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1083,7 +1083,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      * Information for expected exception class, expected exception message, and
      * expected exception code are retrieved from a given Exception object.
      */
-    final protected function expectExceptionObject(\Throwable $exception): void
+    final protected function expectExceptionObject(Throwable $exception): void
     {
         $this->expectException($exception::class);
         $this->expectExceptionMessage($exception->getMessage());

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1083,7 +1083,7 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
      * Information for expected exception class, expected exception message, and
      * expected exception code are retrieved from a given Exception object.
      */
-    final protected function expectExceptionObject(\Exception $exception): void
+    final protected function expectExceptionObject(\Throwable $exception): void
     {
         $this->expectException($exception::class);
         $this->expectExceptionMessage($exception->getMessage());


### PR DESCRIPTION
- expectException works with a Throwable class and is typed `class-string<Throwable>`
- Throwable has both Message and Code

So this method could works on Throwable.