### PR TITLE
Narrow type

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -77,7 +77,7 @@ final readonly class TestBuilder
      * @param non-empty-string                                                                                                                                                  $methodName
      * @param class-string<TestCase>                                                                                                                                            $className
      * @param array<list<mixed>>                                                                                                                                                $data
-     * @param array{backupGlobals: ?bool, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?bool, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
+     * @param array{backupGlobals: ?true, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?true, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
      * @param list<non-empty-string>                                                                                                                                            $groups
      */
     private function buildDataProviderTestSuite(string $methodName, string $className, array $data, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, bool $runClassInSeparateProcess, array $backupSettings, array $groups): DataProviderTestSuite
@@ -111,7 +111,7 @@ final readonly class TestBuilder
     }
 
     /**
-     * @param array{backupGlobals: ?bool, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?bool, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
+     * @param array{backupGlobals: ?true, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?true, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
      */
     private function configureTestCase(TestCase $test, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, bool $runClassInSeparateProcess, array $backupSettings): void
     {
@@ -148,7 +148,7 @@ final readonly class TestBuilder
      * @param class-string<TestCase> $className
      * @param non-empty-string       $methodName
      *
-     * @return array{backupGlobals: ?bool, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?bool, backupStaticPropertiesExcludeList: array<string,list<string>>}
+     * @return array{backupGlobals: ?true, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?true, backupStaticPropertiesExcludeList: array<string,list<string>>}
      */
     private function backupSettings(string $className, string $methodName): array
     {


### PR DESCRIPTION
fixes future PHPStan error

```
------ ----------------------------------------------------------------------- 
  Line   Framework/TestBuilder.php                                              
 ------ ----------------------------------------------------------------------- 
  153    Return type array{backupGlobals: bool|null, backupGlobalsExcludeList:  
         list<string>, backupStaticProperties: bool|null, backupStaticProperti  
         esExcludeList: array<string, list<string>>} of method PHPUnit\Framewo  
         rk\TestBuilder::backupSettings() can be narrowed to                    
         array{backupGlobals: true|null, backupGlobalsExcludeList: list<string  
         >, backupStaticProperties: true|null, backupStaticPropertiesExcludeLi  
         st: array<string, list<string>>}.                                      
         🪪  return.nestedUnusedType                                            
         💡  Offset 'backupGlobals' (true|null) does not accept type bool|null.  
         💡  Offset 'backupStaticProperties' (true|null) does not accept type   
         bool|null.                                                             
 ------ ----------------------------------------------------------------------- 
 ```