### PR TITLE
Avoid reading from `STDOUT` when `rewind()` fails

### DIFF
--- a/src/Framework/TestRunner/templates/class.tpl
+++ b/src/Framework/TestRunner/templates/class.tpl
@@ -87,9 +87,9 @@ function __phpunit_run_isolated_test()
     ini_set('xdebug.scream', '0');
 
     // Not every STDOUT target stream is rewindable
-    @rewind(STDOUT);
+    $hasRewound = @rewind(STDOUT);
 
-    if ($stdout = @stream_get_contents(STDOUT)) {
+    if ($hasRewound && $stdout = @stream_get_contents(STDOUT)) {
         $output         = $stdout . $output;
         $streamMetaData = stream_get_meta_data(STDOUT);
 

--- a/src/Framework/TestRunner/templates/method.tpl
+++ b/src/Framework/TestRunner/templates/method.tpl
@@ -87,9 +87,9 @@ function __phpunit_run_isolated_test()
     ini_set('xdebug.scream', '0');
 
     // Not every STDOUT target stream is rewindable
-    @rewind(STDOUT);
+    $hasRewound = @rewind(STDOUT);
 
-    if ($stdout = @stream_get_contents(STDOUT)) {
+    if ($hasRewound && $stdout = @stream_get_contents(STDOUT)) {
         $output         = $stdout . $output;
         $streamMetaData = stream_get_meta_data(STDOUT);
 


### PR DESCRIPTION
If rewind silently fails and the return is not checked, it's possible `stream_get_contents` will hang forever waiting for new input that will never come.

I have tested this on Linux and Linux on WSL and I couldn't reproduce the error, but it happens in our FreeBSD server.
I'm not sure if it's a FreeBSD quirk or something weird with our configs, but it seems like it's a sensible change to avoid reading the stream if it couldn't be rewound.

This is related to the issue: https://github.com/sebastianbergmann/phpunit/issues/6401