### PR TITLE
Fix migration of configuration without schema location

### DIFF
--- a/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php
+++ b/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php
@@ -31,7 +31,7 @@ final readonly class UpdateSchemaLocation implements Migration
 
         assert($root instanceof DOMElement);
 
-        $existingSchemaLocation = $root->getAttributeNodeNS(self::NAMESPACE_URI, self::LOCAL_NAME_SCHEMA_LOCATION)->value;
+        $existingSchemaLocation = $root->getAttributeNS(self::NAMESPACE_URI, self::LOCAL_NAME_SCHEMA_LOCATION);
 
         if (str_contains($existingSchemaLocation, '://') === false) { // If the current schema location is a relative path, don't update it
             return;

--- a/tests/_files/XmlConfigurationMigration/input-no-schema-location.xml
+++ b/tests/_files/XmlConfigurationMigration/input-no-schema-location.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <coverage cacheDirectory="var/.coverage-cache"/>
+</phpunit>

--- a/tests/_files/XmlConfigurationMigration/output-no-schema-location.xml
+++ b/tests/_files/XmlConfigurationMigration/output-no-schema-location.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <coverage/>
+</phpunit>

--- a/tests/unit/TextUI/Configuration/Xml/MigratorTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/MigratorTest.php
@@ -30,6 +30,10 @@ final class MigratorTest extends TestCase
                 __DIR__ . '/../../../../_files/XmlConfigurationMigration/output-relative-schema-path.xml',
                 __DIR__ . '/../../../../_files/XmlConfigurationMigration/input-relative-schema-path.xml',
             ],
+            'No Schema Location' => [
+                __DIR__ . '/../../../../_files/XmlConfigurationMigration/output-no-schema-location.xml',
+                __DIR__ . '/../../../../_files/XmlConfigurationMigration/input-no-schema-location.xml',
+            ],
             'Issue 5859' => [
                 __DIR__ . '/../../../../_files/XmlConfigurationMigration/output-issue-5859.xml',
                 __DIR__ . '/../../../../_files/XmlConfigurationMigration/input-issue-5859.xml',


### PR DESCRIPTION
When `phpunit.xml` contains `<phpunit>` element without `xsi:noNamespaceSchemaLocation` attribute, configuration migration will throw an error:

```
$ ./phpunit --migrate-configuration
PHPUnit 11.5.44-32-gfc5369646 by Sebastian Bergmann and contributors.

PHP Warning:  Attempt to read property "value" on null in /home/takaram/oss/phpunit/src/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.php on line 34
PHP Stack trace:
PHP   1. {main}() /home/takaram/oss/phpunit/phpunit:0
PHP   2. PHPUnit\TextUI\Application->run($argv = [0 => './phpunit', 1 => '--migrate-configuration', 2 => '-c', 3 => 'tests/_files/XmlConfigurationMigration/input-no-schema-path.xml']) /home/takaram/oss/phpunit/phpunit:104
PHP   3. PHPUnit\TextUI\Application->executeCommandsThatOnlyRequireCliConfiguration($cliConfiguration = class PHPUnit\TextUI\CliArguments\Configuration { private readonly array $arguments = []; private readonly ?string $atLeastVersion = NULL; private readonly ?bool $backupGlobals = NULL; private readonly ?bool $backupStaticProperties = NULL; private readonly ?bool $beStrictAboutChangesToGlobalState = NULL; private readonly ?string $bootstrap = NULL; private readonly ?string $cacheDirectory = NULL; private readonly ?bool $cacheResult = NULL; private readonly bool $checkPhpConfiguration = FALSE; private readonly bool $checkVersion = FALSE; private readonly ?string $colors = NULL; private readonly string|int|null $columns = NULL; private readonly ?string $configurationFile = 'tests/_files/XmlConfigurationMigration/input-no-schema-path.xml'; private readonly ?array $coverageFilter = NULL; private readonly ?string $coverageClover = NULL; private readonly ?string $coverageCobertura = NULL; private readonly ?string $coverageCrap4J = NULL; private readonly ?string $coverageHtml = NULL; private readonly ?string $coveragePhp = NULL; private readonly ?string $coverageText = NULL; private readonly ?bool $coverageTextShowUncoveredFiles = NULL; private readonly ?bool $coverageTextShowOnlySummary = NULL; private readonly ?string $coverageXml = NULL; private readonly ?bool $pathCoverage = NULL; private readonly bool $warmCoverageCache = FALSE; private readonly ?int $defaultTimeLimit = NULL; private readonly ?bool $disableCodeCoverageIgnore = NULL; private readonly ?bool $disallowTestOutput = NULL; private readonly ?bool $enforceTimeLimit = NULL; private readonly ?array $excludeGroups = NULL; private readonly ?int $executionOrder = NULL; private readonly ?int $executionOrderDefects = NULL; private readonly ?bool $failOnAllIssues = NULL; private readonly ?bool $failOnDeprecation = NULL; private readonly ?bool $failOnPhpunitDeprecation = NULL; private readonly ?bool $failOnPhpunitWarning = NULL; private readonly ?bool $failOnEmptyTestSuite = NULL; private readonly ?bool $failOnIncomplete = NULL; private readonly ?bool $failOnNotice = NULL; private readonly ?bool $failOnRisky = NULL; private readonly ?bool $failOnSkipped = NULL; private readonly ?bool $failOnWarning = NULL; private readonly ?bool $doNotFailOnDeprecation = NULL; private readonly ?bool $doNotFailOnPhpunitDeprecation = NULL; private readonly ?bool $doNotFailOnPhpunitWarning = NULL; private readonly ?bool $doNotFailOnEmptyTestSuite = NULL; private readonly ?bool $doNotFailOnIncomplete = NULL; private readonly ?bool $doNotFailOnNotice = NULL; private readonly ?bool $doNotFailOnRisky = NULL; private readonly ?bool $doNotFailOnSkipped = NULL; private readonly ?bool $doNotFailOnWarning = NULL; private readonly ?bool $stopOnDefect = NULL; private readonly ?bool $stopOnDeprecation = NULL; private readonly ?string $specificDeprecationToStopOn = NULL; private readonly ?bool $stopOnError = NULL; private readonly ?bool $stopOnFailure = NULL; private readonly ?bool $stopOnIncomplete = NULL; private readonly ?bool $stopOnNotice = NULL; private readonly ?bool $stopOnRisky = NULL; private readonly ?bool $stopOnSkipped = NULL; private readonly ?bool $stopOnWarning = NULL; private readonly ?string $filter = NULL; private readonly ?string $excludeFilter = NULL; private readonly ?string $generateBaseline = NULL; private readonly ?string $useBaseline = NULL; private readonly bool $ignoreBaseline = FALSE; private readonly bool $generateConfiguration = FALSE; private readonly bool $migrateConfiguration = TRUE; private readonly ?array $groups = NULL; private readonly ?array $testsCovering = NULL; private readonly ?array $testsUsing = NULL; private readonly ?array $testsRequiringPhpExtension = NULL; private readonly bool $help = FALSE; private readonly ?string $includePath = NULL; private readonly ?array $iniSettings = NULL; private readonly ?string $junitLogfile = NULL; private readonly bool $listGroups = FALSE; private readonly bool $listSuites = FALSE; private readonly bool $listTestFiles = FALSE; private readonly bool $listTests = FALSE; private readonly ?string $listTestsXml = NULL; private readonly ?bool $noCoverage = NULL; private readonly ?bool $noExtensions = NULL; private readonly ?bool $noOutput = NULL; private readonly ?bool $noProgress = NULL; private readonly ?bool $noResults = NULL; private readonly ?bool $noLogging = NULL; private readonly ?bool $processIsolation = NULL; private readonly ?int $randomOrderSeed = NULL; private readonly ?bool $reportUselessTests = NULL; private readonly ?bool $resolveDependencies = NULL; private readonly ?bool $reverseList = NULL; private readonly ?bool $stderr = NULL; private readonly ?bool $strictCoverage = NULL; private readonly ?string $teamcityLogfile = NULL; private readonly ?bool $teamCityPrinter = NULL; private readonly ?string $testdoxHtmlFile = NULL; private readonly ?string $testdoxTextFile = NULL; private readonly ?bool $testdoxPrinter = NULL; private readonly ?bool $testdoxPrinterSummary = NULL; private readonly ?array $testSuffixes = NULL; private readonly ?string $testSuite = NULL; private readonly ?string $excludeTestSuite = NULL; private readonly bool $useDefaultConfiguration = TRUE; private readonly ?bool $displayDetailsOnAllIssues = NULL; private readonly ?bool $displayDetailsOnIncompleteTests = NULL; private readonly ?bool $displayDetailsOnSkippedTests = NULL; private readonly ?bool $displayDetailsOnTestsThatTriggerDeprecations = NULL; private readonly ?bool $displayDetailsOnPhpunitDeprecations = NULL; private readonly ?bool $displayDetailsOnTestsThatTriggerErrors = NULL; private readonly ?bool $displayDetailsOnTestsThatTriggerNotices = NULL; private readonly ?bool $displayDetailsOnTestsThatTriggerWarnings = NULL; private readonly bool $version = FALSE; private readonly ?string $logEventsText = NULL; private readonly ?string $logEventsVerboseText = NULL; private readonly bool $debug = FALSE; private readonly ?array $extensions = NULL }, $configurationFile = 'tests/_files/XmlConfigurationMigration/input-no-schema-path.xml') /home/takaram/oss/phpunit/src/TextUI/Application.php:110
PHP   4. PHPUnit\TextUI\Application->execute($command = class PHPUnit\TextUI\Command\MigrateConfigurationCommand { private readonly string $filename = '/home/takaram/oss/phpunit/tests/_files/XmlConfigurationMigration/input-no-schema-path.xml' }, $requiresResultCollectedFromEvents = *uninitialized*) /home/takaram/oss/phpunit/src/TextUI/Application.php:456
PHP   5. PHPUnit\TextUI\Command\MigrateConfigurationCommand->execute() /home/takaram/oss/phpunit/src/TextUI/Application.php:320
PHP   6. PHPUnit\TextUI\XmlConfiguration\Migrator->migrate($filename = '/home/takaram/oss/phpunit/tests/_files/XmlConfigurationMigration/input-no-schema-path.xml') /home/takaram/oss/phpunit/src/TextUI/Command/Commands/MigrateConfigurationCommand.php:36
PHP   7. PHPUnit\TextUI\XmlConfiguration\UpdateSchemaLocation->migrate($document = class DOMDocument { public $doctype = NULL; public $implementation = '(object value omitted)'; public $documentElement = '(object value omitted)'; public $actualEncoding = 'UTF-8'; public $encoding = 'UTF-8'; public $xmlEncoding = 'UTF-8'; public $standalone = FALSE; public $xmlStandalone = FALSE; public $version = '1.0'; public $xmlVersion = '1.0'; public $strictErrorChecking = TRUE; public $documentURI = '/home/takaram/oss/phpunit/'; public $config = NULL; public $formatOutput = FALSE; public $validateOnParse = FALSE; public $resolveExternals = FALSE; public $preserveWhiteSpace = FALSE; public $recover = FALSE; public $substituteEntities = FALSE; public $firstElementChild = '(object value omitted)'; public $lastElementChild = '(object value omitted)'; public $childElementCount = 1; public $nodeName = '#document'; public $nodeValue = NULL; public $nodeType = 9; public $parentNode = NULL; public $parentElement = NULL; public $childNodes = '(object value omitted)'; public $firstChild = '(object value omitted)'; public $lastChild = '(object value omitted)'; public $previousSibling = NULL; public $nextSibling = NULL; public $attributes = NULL; public $isConnected = TRUE; public $ownerDocument = NULL; public $namespaceURI = NULL; public $prefix = ''; public $localName = NULL; public $baseURI = '/home/takaram/oss/phpunit/'; public $textContent = '' }) /home/takaram/oss/phpunit/src/TextUI/Configuration/Xml/Migration/Migrator.php:44
Migration of /home/takaram/oss/phpunit/tests/_files/XmlConfigurationMigration/input-no-schema-path.xml failed:
str_contains(): Argument #1 ($haystack) must be of type string, null given
```

This PR fixes the problem.