### PR TITLE
Add test for Assert::markTestSkipped static helper

### DIFF
--- a/tests/unit/Framework/Assert/markTestSkippedTest.php
+++ b/tests/unit/Framework/Assert/markTestSkippedTest.php
@@ -27,4 +27,14 @@ final class markTestSkippedTest extends TestCase
 
         $this->markTestSkipped($message);
     }
+
+    public function testStaticMarksTestAsSkipped(): void
+    {
+        $message = 'static message';
+
+        $this->expectException(SkippedWithMessageException::class);
+        $this->expectExceptionMessage($message);
+
+        Assert::markTestSkipped($message);
+    }
 }


### PR DESCRIPTION
Adds `testStaticMarksTestAsSkipped` to `tests/unit/Framework/Assert/markTestSkippedTest.php.`
The test calls `Assert::markTestSkipped('static message')` and asserts a SkippedWithMessageException with the expected message. 