### PR TITLE
deps: remove ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require": {
         "php": ">=8.4.1",
         "ext-dom": "*",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-xml": "*",


### PR DESCRIPTION
This extension is always active since PHP 8.0: https://www.php.net/manual/en/json.installation.php

I _stole_ the idea from: 

- https://github.com/VincentLanglet/Twig-CS-Fixer/issues/416