### PR TITLE
build: stop on error while phar-build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -337,6 +337,7 @@
             <arg value="add-prefix" />
             <arg value="--no-ansi" />
             <arg value="--force" />
+            <arg value="--stop-on-failure" />
             <arg value="--config" />
             <arg path="${basedir}/build/config/php-scoper.php" />
             <arg value="--no-interaction" />


### PR DESCRIPTION
when building PHPUnit 10.5.x on PHP 8.5.0 without this flag we don't get any error, but a non-scoped phar build.

with this option added, we see the actual error:

```
[php-scoper]  [INFO] Using the option "stop-on-failure" is now deprecated. Any non PHP-Parser
[php-scoper]         parsing error will now halt the process. To continue upon non-PHP-Parser
[php-scoper]         parsing errors, use the option "continue-on-failure".                   
[php-scoper] 
[php-scoper] 
[php-scoper]     ____  __  ______     _____
[php-scoper]    / __ \/ / / / __ \   / ___/_________  ____  ___  _____
[php-scoper]   / /_/ / /_/ / /_/ /   \__ \/ ___/ __ \/ __ \/ _ \/ ___/
[php-scoper]  / ____/ __  / ____/   ___/ / /__/ /_/ / /_/ /  __/ /
[php-scoper] /_/   /_/ /_/_/       /____/\___/\____/ .___/\___/_/
[php-scoper]                                      /_/
[php-scoper] 
[php-scoper] PhpScoper version 0.18.18 2025-10-15 15:31:10 UTC
[php-scoper] 
[php-scoper] 
[php-scoper] 
[php-scoper]  // Memory usage: 21.82MB (peak: 21.92MB), time: 0.01s                          
[php-scoper] 
[php-scoper]     0/1545 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
[php-scoper]  1545/1545 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
[php-scoper] In ParsingException.php line 11:
[php-scoper]                                                                                
[php-scoper]   Could not parse the file "/Users/staabm/workspace/phpunit/build/tmp/phar/my  
[php-scoper]   clabs-deep-copy/DeepCopy/DeepCopy.php".                                      
[php-scoper]                                                                                
[php-scoper] 
[php-scoper] In Php8.php line 1123:
[php-scoper]                                                                                
[php-scoper]   Method SplObjectStorage::attach() is deprecated since 8.5, use method SplOb  
[php-scoper]   jectStorage::offsetSet() instead                                             
[php-scoper]                                                                                
[php-scoper] 
[php-scoper] add-prefix [-d|--working-dir WORKING-DIR] [-p|--prefix PREFIX] [-o|--output-dir OUTPUT-DIR] [-f|--force] [-s|--stop-on-failure] [--continue-on-failure] [-c|--config CONFIG] [--no-config] [--php-version PHP-VERSION] [--] [<paths>...]
[php-scoper] 
[php-scoper] Result: 1

BUILD FAILED
/Users/staabm/workspace/phpunit/build.xml:112: The following error occurred while executing this line:
/Users/staabm/workspace/phpunit/build.xml:349: Replace: source file /Users/staabm/workspace/phpunit/build/tmp/phar-scoped/phpunit/Util/PHP/Template/PhptTestCase.tpl doesn't exist
```

---

this option seems to be deprecated, but at least it makes the error show up instead of silently building the wrong PHAR.
see also https://github.com/humbug/php-scoper/issues/1138