### PR TITLE
Fix incorrect docblocks for assertArrayHasKey and assertArrayNotHasKey

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -163,8 +163,10 @@ abstract class Assert
 
     /**
      * Asserts that an array has a specified key.
-     *
+     * 
+     * @param mixed $key
      * @param array<mixed>|ArrayAccess<array-key, mixed> $array
+     * @param string $message
      *
      * @throws Exception
      * @throws ExpectationFailedException
@@ -179,7 +181,9 @@ abstract class Assert
     /**
      * Asserts that an array does not have a specified key.
      *
+     * @param mixed $key
      * @param array<mixed>|ArrayAccess<array-key, mixed> $array
+     * @param string $message
      *
      * @throws Exception
      * @throws ExpectationFailedException


### PR DESCRIPTION
This PR updates the docblocks for `assertArrayHasKey()` and `assertArrayNotHasKey()` to accurately reflect their actual behavior and parameter requirements.

This makes the documentation clearer, more precise, and aligned with PHPUnit’s actual behavior.