### PR TITLE
Introduce attribute `#[RequiresPackageVersion]`

### DIFF
--- a/src/Framework/Attributes/RequiresPackageVersion.php
+++ b/src/Framework/Attributes/RequiresPackageVersion.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Attributes;
+
+use Attribute;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final readonly class RequiresPackageVersion
+{
+    /**
+     * @var non-empty-string
+     */
+    private string $packageName;
+
+    /**
+     * @var non-empty-string
+     */
+    private string $versionConstraint;
+
+    /**
+     * @param non-empty-string $packageName
+     * @param non-empty-string $versionConstraint
+     */
+    public function __construct(string $packageName, string $versionConstraint)
+    {
+        $this->packageName       = $packageName;
+        $this->versionConstraint = $versionConstraint;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function packageName(): string
+    {
+        return $this->packageName;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function versionConstraint(): string
+    {
+        return $this->versionConstraint;
+    }
+}

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -390,6 +390,24 @@ abstract readonly class Metadata
     }
 
     /**
+     * @param non-empty-string $packageName
+     * @param non-empty-string $versionConstraint
+     */
+    public static function requiresPackageVersionOnClass(string $packageName, string $versionConstraint): RequiresPackageVersion
+    {
+        return new RequiresPackageVersion(self::CLASS_LEVEL, $packageName, $versionConstraint);
+    }
+
+    /**
+     * @param non-empty-string $packageName
+     * @param non-empty-string $versionConstraint
+     */
+    public static function requiresPackageVersionOnMethod(string $packageName, string $versionConstraint): RequiresPackageVersion
+    {
+        return new RequiresPackageVersion(self::METHOD_LEVEL, $packageName, $versionConstraint);
+    }
+
+    /**
      * @param class-string<Extension> $extensionClass
      */
     public static function requiresPhpunitExtensionOnClass(string $extensionClass): RequiresPhpunitExtension
@@ -881,6 +899,14 @@ abstract readonly class Metadata
      * @phpstan-assert-if-true RequiresPhpunit $this
      */
     public function isRequiresPhpunit(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @phpstan-assert-if-true RequiresPackageVersion $this
+     */
+    public function isRequiresPackageVersion(): bool
     {
         return false;
     }

--- a/src/Metadata/MetadataCollection.php
+++ b/src/Metadata/MetadataCollection.php
@@ -511,6 +511,16 @@ final readonly class MetadataCollection implements Countable, IteratorAggregate
         );
     }
 
+    public function isRequiresPackageVersion(): self
+    {
+        return new self(
+            ...array_filter(
+                $this->metadata,
+                static fn (Metadata $metadata): bool => $metadata->isRequiresPackageVersion(),
+            ),
+        );
+    }
+
     public function isRequiresPhpunitExtension(): self
     {
         return new self(

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -65,6 +65,7 @@ use PHPUnit\Framework\Attributes\RequiresFunction;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
+use PHPUnit\Framework\Attributes\RequiresPackageVersion;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
@@ -398,6 +399,16 @@ final readonly class AttributeParser implements Parser
                     if ($requirement !== null) {
                         $result[] = Metadata::requiresPhpunitOnClass($requirement);
                     }
+
+                    break;
+
+                case RequiresPackageVersion::class:
+                    assert($attributeInstance instanceof RequiresPackageVersion);
+
+                    $result[] = Metadata::requiresPackageVersionOnClass(
+                        $attributeInstance->packageName(),
+                        $attributeInstance->versionConstraint(),
+                    );
 
                     break;
 
@@ -828,6 +839,16 @@ final readonly class AttributeParser implements Parser
                     if ($requirement !== null) {
                         $result[] = Metadata::requiresPhpunitOnMethod($requirement);
                     }
+
+                    break;
+
+                case RequiresPackageVersion::class:
+                    assert($attributeInstance instanceof RequiresPackageVersion);
+
+                    $result[] = Metadata::requiresPackageVersionOnMethod(
+                        $attributeInstance->packageName(),
+                        $attributeInstance->versionConstraint(),
+                    );
 
                     break;
 

--- a/src/Metadata/RequiresPackageVersion.php
+++ b/src/Metadata/RequiresPackageVersion.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class RequiresPackageVersion extends Metadata
+{
+    /**
+     * @var non-empty-string
+     */
+    private string $packageName;
+
+    /**
+     * @var non-empty-string
+     */
+    private string $versionConstraint;
+
+    /**
+     * @param int<0, 1>        $level
+     * @param non-empty-string $packageName
+     * @param non-empty-string $versionConstraint
+     */
+    protected function __construct(int $level, string $packageName, string $versionConstraint)
+    {
+        parent::__construct($level);
+
+        $this->packageName       = $packageName;
+        $this->versionConstraint = $versionConstraint;
+    }
+
+    public function isRequiresPackageVersion(): true
+    {
+        return true;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function packageName(): string
+    {
+        return $this->packageName;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function versionConstraint(): string
+    {
+        return $this->versionConstraint;
+    }
+}

--- a/tests/_files/Metadata/Attribute/tests/RequiresPackageVersionTest.php
+++ b/tests/_files/Metadata/Attribute/tests/RequiresPackageVersionTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Metadata\Attribute;
+
+use PHPUnit\Framework\Attributes\RequiresPackageVersion;
+use PHPUnit\Framework\TestCase;
+
+#[RequiresPackageVersion('phpunit/php-invoker', '^6.0')]
+final class RequiresPackageVersionTest extends TestCase
+{
+    #[RequiresPackageVersion('phpunit/php-invoker', '^5.0')]
+    public function testOne(): void
+    {
+    }
+
+    #[RequiresPackageVersion('phpunit/php-invoker', '^6.0')]
+    public function testTwo(): void
+    {
+    }
+}

--- a/tests/_files/RequiresPackageVersionTest.php
+++ b/tests/_files/RequiresPackageVersionTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\RequiresPackageVersion;
+use PHPUnit\Framework\TestCase;
+
+final class RequiresPackageVersionTest extends TestCase
+{
+    #[RequiresPackageVersion('phpunit/php-invoker', '^6.0')]
+    public function testPackageVersionSatisfied(): void
+    {
+    }
+
+    #[RequiresPackageVersion('phpunit/php-invoker', '^5.0')]
+    public function testPackageVersionNotSatisfied(): void
+    {
+    }
+
+    #[RequiresPackageVersion('some/non-existent-package', '^1.0')]
+    public function testPackageNotInstalled(): void
+    {
+    }
+
+    #[RequiresPackageVersion('phpunit/php-invoker', '^')]
+    public function testVersionNotValid(): void
+    {
+    }
+}

--- a/tests/unit/Metadata/Api/RequirementsTest.php
+++ b/tests/unit/Metadata/Api/RequirementsTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\RequirementsEnvironmentVariableTest;
+use PHPUnit\TestFixture\RequiresPackageVersionTest;
 
 #[CoversClass(Requirements::class)]
 #[Small]
@@ -157,6 +158,48 @@ final class RequirementsTest extends TestCase
                 'Environment variable "BAZ" is required.',
             ],
             (new Requirements)->requirementsNotSatisfiedFor(RequirementsEnvironmentVariableTest::class, 'testRequiresEnvironmentVariable'),
+        );
+    }
+
+    public function testPackageVersionSatisfied(): void
+    {
+        $this->assertEquals(
+            [],
+            (new Requirements)->requirementsNotSatisfiedFor(RequiresPackageVersionTest::class, 'testPackageVersionSatisfied'),
+        );
+    }
+
+    public function testPackageVersionNotSatisfied(): void
+    {
+        $this->assertEquals(
+            [
+                'Package "phpunit/php-invoker" ^5.0 is required.',
+            ],
+            (new Requirements)->requirementsNotSatisfiedFor(RequiresPackageVersionTest::class, 'testPackageVersionNotSatisfied'),
+        );
+    }
+
+    public function testPackageNotInstalled(): void
+    {
+        $result = (new Requirements)->requirementsNotSatisfiedFor(RequiresPackageVersionTest::class, 'testPackageNotInstalled');
+
+        $this->assertEquals(
+            [
+                'Package "some/non-existent-package" is not installed.',
+            ],
+            $result,
+        );
+    }
+
+    public function testVersionNotValid(): void
+    {
+        $result = (new Requirements)->requirementsNotSatisfiedFor(RequiresPackageVersionTest::class, 'testVersionNotValid');
+
+        $this->assertEquals(
+            [
+                'Invalid version constraint "^" for package "phpunit/php-invoker".',
+            ],
+            $result,
         );
     }
 }

--- a/tests/unit/Metadata/MetadataCollectionTest.php
+++ b/tests/unit/Metadata/MetadataCollectionTest.php
@@ -47,6 +47,7 @@ use stdClass;
 #[UsesClass(RequiresPhp::class)]
 #[UsesClass(RequiresPhpExtension::class)]
 #[UsesClass(RequiresPhpunit::class)]
+#[UsesClass(RequiresPackageVersion::class)]
 #[UsesClass(RequiresPhpunitExtension::class)]
 #[UsesClass(RequiresEnvironmentVariable::class)]
 #[UsesClass(RequiresSetting::class)]
@@ -426,6 +427,14 @@ final class MetadataCollectionTest extends TestCase
         $this->assertTrue($collection->asArray()[0]->isRequiresPhpunit());
     }
 
+    public function test_Can_be_filtered_for_RequiresPackageVersion(): void
+    {
+        $collection = $this->collectionWithOneOfEach()->isRequiresPackageVersion();
+
+        $this->assertCount(1, $collection);
+        $this->assertTrue($collection->asArray()[0]->isRequiresPackageVersion());
+    }
+
     public function test_Can_be_filtered_for_RequiresPhpunitExtension(): void
     {
         $collection = $this->collectionWithOneOfEach()->isRequiresPhpunitExtension();
@@ -619,6 +628,10 @@ final class MetadataCollectionTest extends TestCase
                         '10.0.0',
                         new VersionComparisonOperator('>='),
                     ),
+                ),
+                Metadata::requiresPackageVersionOnClass(
+                    'phpunit/php-invoker',
+                    '^6.0',
                 ),
                 Metadata::requiresPhpunitExtensionOnClass(stdClass::class),
                 Metadata::requiresEnvironmentVariableOnClass('foo', 'bar'),

--- a/tests/unit/Metadata/MetadataTest.php
+++ b/tests/unit/Metadata/MetadataTest.php
@@ -69,6 +69,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -135,6 +136,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -199,6 +201,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -262,6 +265,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -326,6 +330,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -390,6 +395,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -454,6 +460,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -520,6 +527,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -585,6 +593,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -649,6 +658,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -716,6 +726,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -781,6 +792,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -846,6 +858,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -911,6 +924,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -976,6 +990,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1042,6 +1057,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1105,6 +1121,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1168,6 +1185,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1233,6 +1251,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1300,6 +1319,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1367,6 +1387,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1435,6 +1456,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1498,6 +1520,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1561,6 +1584,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1624,6 +1648,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1688,6 +1713,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1752,6 +1778,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1818,6 +1845,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1884,6 +1912,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -1951,6 +1980,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2015,6 +2045,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2078,6 +2109,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2141,6 +2173,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2206,6 +2239,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2270,6 +2304,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2335,6 +2370,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2398,6 +2434,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2461,6 +2498,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2526,6 +2564,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2592,6 +2631,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2652,6 +2692,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2713,6 +2754,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2778,6 +2820,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2844,6 +2887,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2910,6 +2954,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -2975,6 +3020,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3040,6 +3086,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3105,6 +3152,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3170,6 +3218,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3235,6 +3284,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3305,6 +3355,7 @@ final class MetadataTest extends TestCase
         $this->assertTrue($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3375,6 +3426,7 @@ final class MetadataTest extends TestCase
         $this->assertTrue($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3440,6 +3492,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertTrue($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3515,6 +3568,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertTrue($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3582,6 +3636,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertTrue($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3657,6 +3712,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertTrue($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3729,6 +3785,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertTrue($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3794,6 +3851,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertTrue($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3864,6 +3922,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertTrue($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3881,6 +3940,146 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('>= 10.0.0', $metadata->versionRequirement()->asString());
+
+        $this->assertTrue($metadata->isMethodLevel());
+        $this->assertFalse($metadata->isClassLevel());
+    }
+
+    public function testCanBeRequiresPackageVersionOnClass(): void
+    {
+        $metadata = Metadata::requiresPackageVersionOnClass(
+            'phpunit/php-invoker',
+            '^6.0',
+        );
+
+        $this->assertFalse($metadata->isAfter());
+        $this->assertFalse($metadata->isAfterClass());
+        $this->assertFalse($metadata->isAllowMockObjectsWithoutExpectations());
+        $this->assertFalse($metadata->isBackupGlobals());
+        $this->assertFalse($metadata->isBackupStaticProperties());
+        $this->assertFalse($metadata->isBeforeClass());
+        $this->assertFalse($metadata->isBefore());
+        $this->assertFalse($metadata->isCoversNamespace());
+        $this->assertFalse($metadata->isCoversClass());
+        $this->assertFalse($metadata->isCoversClassesThatExtendClass());
+        $this->assertFalse($metadata->isCoversClassesThatImplementInterface());
+        $this->assertFalse($metadata->isCoversFunction());
+        $this->assertFalse($metadata->isCoversMethod());
+        $this->assertFalse($metadata->isCoversNothing());
+        $this->assertFalse($metadata->isCoversTrait());
+        $this->assertFalse($metadata->isDataProvider());
+        $this->assertFalse($metadata->isDependsOnClass());
+        $this->assertFalse($metadata->isDependsOnMethod());
+        $this->assertFalse($metadata->isDisableReturnValueGenerationForTestDoubles());
+        $this->assertFalse($metadata->isDoesNotPerformAssertions());
+        $this->assertFalse($metadata->isExcludeGlobalVariableFromBackup());
+        $this->assertFalse($metadata->isExcludeStaticPropertyFromBackup());
+        $this->assertFalse($metadata->isGroup());
+        $this->assertFalse($metadata->isIgnoreDeprecations());
+        $this->assertFalse($metadata->isIgnorePhpunitDeprecations());
+        $this->assertFalse($metadata->isIgnorePHPUnitWarnings());
+        $this->assertFalse($metadata->isRunInSeparateProcess());
+        $this->assertFalse($metadata->isRunTestsInSeparateProcesses());
+        $this->assertFalse($metadata->isTest());
+        $this->assertFalse($metadata->isPreCondition());
+        $this->assertFalse($metadata->isPostCondition());
+        $this->assertFalse($metadata->isPreserveGlobalState());
+        $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresFunction());
+        $this->assertFalse($metadata->isRequiresOperatingSystem());
+        $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
+        $this->assertFalse($metadata->isRequiresPhp());
+        $this->assertFalse($metadata->isRequiresPhpExtension());
+        $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertTrue($metadata->isRequiresPackageVersion());
+        $this->assertFalse($metadata->isRequiresPhpunitExtension());
+        $this->assertFalse($metadata->isRequiresEnvironmentVariable());
+        $this->assertFalse($metadata->isWithEnvironmentVariable());
+        $this->assertFalse($metadata->isRequiresSetting());
+        $this->assertFalse($metadata->isTestDox());
+        $this->assertFalse($metadata->isTestDoxFormatter());
+        $this->assertFalse($metadata->isTestWith());
+        $this->assertFalse($metadata->isUsesNamespace());
+        $this->assertFalse($metadata->isUsesClass());
+        $this->assertFalse($metadata->isUsesClassesThatExtendClass());
+        $this->assertFalse($metadata->isUsesClassesThatImplementInterface());
+        $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isUsesMethod());
+        $this->assertFalse($metadata->isUsesTrait());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
+
+        $this->assertSame('phpunit/php-invoker', $metadata->packageName());
+        $this->assertSame('^6.0', $metadata->versionConstraint());
+
+        $this->assertTrue($metadata->isClassLevel());
+        $this->assertFalse($metadata->isMethodLevel());
+    }
+
+    public function testCanBeRequiresPackageVersionOnMethod(): void
+    {
+        $metadata = Metadata::requiresPackageVersionOnMethod(
+            'phpunit/php-invoker',
+            '^6.0',
+        );
+
+        $this->assertFalse($metadata->isAfter());
+        $this->assertFalse($metadata->isAfterClass());
+        $this->assertFalse($metadata->isAllowMockObjectsWithoutExpectations());
+        $this->assertFalse($metadata->isBackupGlobals());
+        $this->assertFalse($metadata->isBackupStaticProperties());
+        $this->assertFalse($metadata->isBeforeClass());
+        $this->assertFalse($metadata->isBefore());
+        $this->assertFalse($metadata->isCoversNamespace());
+        $this->assertFalse($metadata->isCoversClass());
+        $this->assertFalse($metadata->isCoversClassesThatExtendClass());
+        $this->assertFalse($metadata->isCoversClassesThatImplementInterface());
+        $this->assertFalse($metadata->isCoversFunction());
+        $this->assertFalse($metadata->isCoversMethod());
+        $this->assertFalse($metadata->isCoversNothing());
+        $this->assertFalse($metadata->isCoversTrait());
+        $this->assertFalse($metadata->isDataProvider());
+        $this->assertFalse($metadata->isDependsOnClass());
+        $this->assertFalse($metadata->isDependsOnMethod());
+        $this->assertFalse($metadata->isDisableReturnValueGenerationForTestDoubles());
+        $this->assertFalse($metadata->isDoesNotPerformAssertions());
+        $this->assertFalse($metadata->isExcludeGlobalVariableFromBackup());
+        $this->assertFalse($metadata->isExcludeStaticPropertyFromBackup());
+        $this->assertFalse($metadata->isGroup());
+        $this->assertFalse($metadata->isIgnoreDeprecations());
+        $this->assertFalse($metadata->isIgnorePhpunitDeprecations());
+        $this->assertFalse($metadata->isIgnorePHPUnitWarnings());
+        $this->assertFalse($metadata->isRunInSeparateProcess());
+        $this->assertFalse($metadata->isRunTestsInSeparateProcesses());
+        $this->assertFalse($metadata->isTest());
+        $this->assertFalse($metadata->isPreCondition());
+        $this->assertFalse($metadata->isPostCondition());
+        $this->assertFalse($metadata->isPreserveGlobalState());
+        $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresFunction());
+        $this->assertFalse($metadata->isRequiresOperatingSystem());
+        $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
+        $this->assertFalse($metadata->isRequiresPhp());
+        $this->assertFalse($metadata->isRequiresPhpExtension());
+        $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertTrue($metadata->isRequiresPackageVersion());
+        $this->assertFalse($metadata->isRequiresPhpunitExtension());
+        $this->assertFalse($metadata->isRequiresEnvironmentVariable());
+        $this->assertFalse($metadata->isWithEnvironmentVariable());
+        $this->assertFalse($metadata->isRequiresSetting());
+        $this->assertFalse($metadata->isTestDox());
+        $this->assertFalse($metadata->isTestDoxFormatter());
+        $this->assertFalse($metadata->isTestWith());
+        $this->assertFalse($metadata->isUsesNamespace());
+        $this->assertFalse($metadata->isUsesClass());
+        $this->assertFalse($metadata->isUsesClassesThatExtendClass());
+        $this->assertFalse($metadata->isUsesClassesThatImplementInterface());
+        $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isUsesMethod());
+        $this->assertFalse($metadata->isUsesTrait());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
+
+        $this->assertSame('phpunit/php-invoker', $metadata->packageName());
+        $this->assertSame('^6.0', $metadata->versionConstraint());
 
         $this->assertTrue($metadata->isMethodLevel());
         $this->assertFalse($metadata->isClassLevel());
@@ -3929,6 +4128,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertTrue($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -3994,6 +4194,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertTrue($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4060,6 +4261,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertTrue($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4126,6 +4328,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertTrue($metadata->isWithEnvironmentVariable());
@@ -4192,6 +4395,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertTrue($metadata->isWithEnvironmentVariable());
@@ -4258,6 +4462,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4324,6 +4529,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4390,6 +4596,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4455,6 +4662,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4520,6 +4728,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4586,6 +4795,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4654,6 +4864,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4719,6 +4930,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4784,6 +4996,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4849,6 +5062,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4914,6 +5128,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -4978,6 +5193,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -5044,6 +5260,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());
@@ -5109,6 +5326,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isRequiresPhp());
         $this->assertFalse($metadata->isRequiresPhpExtension());
         $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPackageVersion());
         $this->assertFalse($metadata->isRequiresPhpunitExtension());
         $this->assertFalse($metadata->isRequiresEnvironmentVariable());
         $this->assertFalse($metadata->isWithEnvironmentVariable());

--- a/tests/unit/Metadata/Parser/AttributeParserTestCase.php
+++ b/tests/unit/Metadata/Parser/AttributeParserTestCase.php
@@ -16,6 +16,7 @@ use PHPUnit\Metadata\DependsOnClass;
 use PHPUnit\Metadata\DependsOnMethod;
 use PHPUnit\Metadata\InvalidAttributeException;
 use PHPUnit\Metadata\RequiresEnvironmentVariable;
+use PHPUnit\Metadata\RequiresPackageVersion;
 use PHPUnit\Metadata\RequiresPhp;
 use PHPUnit\Metadata\RequiresPhpExtension;
 use PHPUnit\Metadata\RequiresPhpunit;
@@ -55,6 +56,7 @@ use PHPUnit\TestFixture\Metadata\Attribute\RequiresFunctionTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresMethodTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresOperatingSystemFamilyTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresOperatingSystemTest;
+use PHPUnit\TestFixture\Metadata\Attribute\RequiresPackageVersionTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresPhpExtensionTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresPhpTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresPhpunitExtensionTest;
@@ -366,6 +368,23 @@ abstract class AttributeParserTestCase extends TestCase
         assert($versionRequirement instanceof ComparisonRequirement);
 
         $this->assertSame('>= 10.0.0', $versionRequirement->asString());
+    }
+
+    #[TestDox('Parses #[RequiresPackageVersion] attribute on class')]
+    public function test_parses_RequiresPackageVersion_attribute_on_class(): void
+    {
+        $metadata = $this->parser()->forClass(RequiresPackageVersionTest::class)->isRequiresPackageVersion();
+
+        $this->assertCount(1, $metadata);
+
+        $requirement = $metadata->asArray()[0];
+
+        $this->assertTrue($requirement->isRequiresPackageVersion());
+
+        assert($requirement instanceof RequiresPackageVersion);
+
+        $this->assertSame('phpunit/php-invoker', $requirement->packageName());
+        $this->assertSame('^6.0', $requirement->versionConstraint());
     }
 
     #[TestDox('Parses #[RequiresPhpunitExtension] attribute on class')]
@@ -1004,6 +1023,23 @@ abstract class AttributeParserTestCase extends TestCase
         assert($versionRequirement instanceof ConstraintRequirement);
 
         $this->assertSame('^10.0', $versionRequirement->asString());
+    }
+
+    #[TestDox('Parses #[RequiresPackageVersion] attribute on method')]
+    public function test_parses_RequiresPackageVersion_attribute_on_method(): void
+    {
+        $metadata = $this->parser()->forMethod(RequiresPackageVersionTest::class, 'testOne')->isRequiresPackageVersion();
+
+        $this->assertCount(1, $metadata);
+
+        $requirement = $metadata->asArray()[0];
+
+        $this->assertTrue($requirement->isRequiresPackageVersion());
+
+        assert($requirement instanceof RequiresPackageVersion);
+
+        $this->assertSame('phpunit/php-invoker', $requirement->packageName());
+        $this->assertSame('^5.0', $requirement->versionConstraint());
     }
 
     #[TestDox('Parses #[RequiresPhpunitExtension] attribute on method')]


### PR DESCRIPTION
Hello :wave: 

this new attribute is the missing piece along with other `RequiresXXX` attributes.

It can be helpful to adapt the test towards the version of the dependencies, in a test matrix for example.

The CI is failing because now `Requirements` triggers PHUnit warnings, but I did not found a way to mute them. Any idea?

thanks.