### PR TITLE
Fixes #6470: Mocking a class with a covariant property hook setter leads to an unexpected fatal error

### DIFF
--- a/src/Framework/MockObject/Generator/Generator.php
+++ b/src/Framework/MockObject/Generator/Generator.php
@@ -1255,8 +1255,9 @@ final class Generator
                 continue;
             }
 
-            $hasGetHook = false;
-            $hasSetHook = false;
+            $hasGetHook                 = false;
+            $hasSetHook                 = false;
+            $setHookMethodParameterType = null;
 
             if ($property->hasHook(PropertyHookType::Get) &&
                 !$property->getHook(PropertyHookType::Get)->isFinal()) {
@@ -1265,7 +1266,8 @@ final class Generator
 
             if ($property->hasHook(PropertyHookType::Set) &&
                 !$property->getHook(PropertyHookType::Set)->isFinal()) {
-                $hasSetHook = true;
+                $hasSetHook                 = true;
+                $setHookMethodParameterType = $mapper->fromParameterTypes($property->getHook(PropertyHookType::Set))[0]->type();
             }
 
             if (!$hasGetHook && !$hasSetHook) {
@@ -1277,6 +1279,7 @@ final class Generator
                 $mapper->fromPropertyType($property),
                 $hasGetHook,
                 $hasSetHook,
+                $setHookMethodParameterType,
             );
         }
 

--- a/src/Framework/MockObject/Generator/HookedProperty.php
+++ b/src/Framework/MockObject/Generator/HookedProperty.php
@@ -25,12 +25,12 @@ final readonly class HookedProperty
     private Type $type;
     private bool $getHook;
     private bool $setHook;
-    private Type $setterType;
+    private ?Type $setterType;
 
     /**
      * @param non-empty-string $name
      */
-    public function __construct(string $name, Type $type, bool $getHook, bool $setHook, Type $setterType)
+    public function __construct(string $name, Type $type, bool $getHook, bool $setHook, ?Type $setterType)
     {
         $this->name       = $name;
         $this->type       = $type;

--- a/src/Framework/MockObject/Generator/HookedProperty.php
+++ b/src/Framework/MockObject/Generator/HookedProperty.php
@@ -25,16 +25,18 @@ final readonly class HookedProperty
     private Type $type;
     private bool $getHook;
     private bool $setHook;
+    private Type $setterType;
 
     /**
      * @param non-empty-string $name
      */
-    public function __construct(string $name, Type $type, bool $getHook, bool $setHook)
+    public function __construct(string $name, Type $type, bool $getHook, bool $setHook, Type $setterType)
     {
-        $this->name    = $name;
-        $this->type    = $type;
-        $this->getHook = $getHook;
-        $this->setHook = $setHook;
+        $this->name       = $name;
+        $this->type       = $type;
+        $this->getHook    = $getHook;
+        $this->setHook    = $setHook;
+        $this->setterType = $setterType;
     }
 
     public function name(): string
@@ -55,5 +57,10 @@ final readonly class HookedProperty
     public function hasSetHook(): bool
     {
         return $this->setHook;
+    }
+
+    public function setterType(): Type
+    {
+        return $this->setterType;
     }
 }

--- a/src/Framework/MockObject/Generator/HookedPropertyGenerator.php
+++ b/src/Framework/MockObject/Generator/HookedPropertyGenerator.php
@@ -70,7 +70,7 @@ EOT,
         }
 
 EOT,
-                    $property->type()->asString(),
+                    $property->setterType()->asString(),
                     $className,
                     $property->name(),
                 );

--- a/tests/_files/mock-object/ExtendableClassWithPropertyWithCovariantSetHook.php
+++ b/tests/_files/mock-object/ExtendableClassWithPropertyWithCovariantSetHook.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\MockObject;
+
+class ExtendableClassWithPropertyWithCovariantSetHook
+{
+    public string $property {
+        set(string|int|float|bool $value) {
+            $this->property = (int) $value;
+        }
+    }
+}

--- a/tests/unit/Framework/MockObject/Generator/PropertyTest.php
+++ b/tests/unit/Framework/MockObject/Generator/PropertyTest.php
@@ -24,7 +24,7 @@ final class PropertyTest extends TestCase
     {
         $name = 'property-name';
 
-        $property = new HookedProperty($name, Type::fromName('string', false), false, false);
+        $property = new HookedProperty($name, Type::fromName('string', false), false, false, Type::fromName('string', false));
 
         $this->assertSame($name, $property->name());
     }
@@ -33,36 +33,46 @@ final class PropertyTest extends TestCase
     {
         $type = Type::fromName('string', false);
 
-        $property = new HookedProperty('property-name', $type, false, false);
+        $property = new HookedProperty('property-name', $type, false, false, $type);
 
         $this->assertSame($type, $property->type());
     }
 
     public function testMayHaveGetHook(): void
     {
-        $property = new HookedProperty('property-name', Type::fromName('string', false), true, false);
+        $property = new HookedProperty('property-name', Type::fromName('string', false), true, false, Type::fromName('string', false));
 
         $this->assertTrue($property->hasGetHook());
     }
 
     public function testMayNotHaveGetHook(): void
     {
-        $property = new HookedProperty('property-name', Type::fromName('string', false), false, false);
+        $property = new HookedProperty('property-name', Type::fromName('string', false), false, false, Type::fromName('string', false));
 
         $this->assertFalse($property->hasGetHook());
     }
 
     public function testMayHaveSetHook(): void
     {
-        $property = new HookedProperty('property-name', Type::fromName('string', false), false, true);
+        $property = new HookedProperty('property-name', Type::fromName('string', false), false, true, Type::fromName('string', false));
 
         $this->assertTrue($property->hasSetHook());
     }
 
     public function testMayNotHaveSetHook(): void
     {
-        $property = new HookedProperty('property-name', Type::fromName('string', false), false, false);
+        $property = new HookedProperty('property-name', Type::fromName('string', false), false, false, Type::fromName('string', false));
 
         $this->assertFalse($property->hasSetHook());
+    }
+
+    public function testHasSetterType(): void
+    {
+        $type       = Type::fromName('string', false);
+        $setterType = Type::fromName('string', true);
+
+        $property = new HookedProperty('property-name', $type, false, false, $setterType);
+
+        $this->assertSame($setterType, $property->setterType());
     }
 }

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -494,8 +494,6 @@ EOT,
     #[RequiresMethod(ReflectionProperty::class, 'isFinal')]
     public function testExpectationCanBeConfiguredForCovariantSetHookForPropertyOfExtendableClass(): void
     {
-        require_once './tests/_files/mock-object/ExtendableClassWithPropertyWithCovariantSetHook.php';
-
         $double = $this->createTestDouble(ExtendableClassWithPropertyWithCovariantSetHook::class);
 
         $double->expects($this->once())->method(PropertyHook::set('property'))->with('0');

--- a/tests/unit/Framework/MockObject/MockObjectTest.php
+++ b/tests/unit/Framework/MockObject/MockObjectTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\AnInterface;
 use PHPUnit\TestFixture\MockObject\ExtendableClassWithCloneMethod;
+use PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertyWithCovariantSetHook;
 use PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertyWithSetHook;
 use PHPUnit\TestFixture\MockObject\ExtendableReadonlyClassWithCloneMethod;
 use PHPUnit\TestFixture\MockObject\InterfaceWithImplicitProtocol;
@@ -488,6 +489,18 @@ EOT,
         $double->expects($this->once())->method(PropertyHook::set('property'))->with('value');
 
         $double->property = 'value';
+    }
+
+    #[RequiresMethod(ReflectionProperty::class, 'isFinal')]
+    public function testExpectationCanBeConfiguredForCovariantSetHookForPropertyOfExtendableClass(): void
+    {
+        require_once './tests/_files/mock-object/ExtendableClassWithPropertyWithCovariantSetHook.php';
+
+        $double = $this->createTestDouble(ExtendableClassWithPropertyWithCovariantSetHook::class);
+
+        $double->expects($this->once())->method(PropertyHook::set('property'))->with('0');
+
+        $double->property = '0';
     }
 
     #[TestDox('__toString() method returns empty string when return value generation is disabled and no return value is configured')]


### PR DESCRIPTION
Set hooks allow covariant setters to expand the scope of a parameter (eg, converting strings into Datetimes). PHPUnit uses wrongly the type for the property for the setter instead of the setters type. 

Closes #6470 