### PR TITLE
Optimize prettifyTestMethodName

### DIFF
--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -36,9 +36,9 @@ use function str_replace;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
-use function strtoupper;
 use function substr;
 use function trim;
+use function ucfirst;
 use PHPUnit\Event\Code\TestMethodBuilder;
 use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Framework\TestCase;
@@ -150,7 +150,7 @@ final class NamePrettifier
             return '';
         }
 
-        $name[0] = strtoupper($name[0]);
+        $name = ucfirst($name);
 
         $noUnderscore = str_replace('_', ' ', $name);
 

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -162,7 +162,7 @@ final class NamePrettifier
         $buffer = preg_replace_callback_array(
             [
                 '/(?!^)([A-Z])/' => static fn (array $matches) => ' ' . strtolower($matches[1]),
-                '/(?!^)(\d+)/'   => static fn (array $matches) => ' ' . $matches[1],
+                '/(\d+)/'        => static fn (array $matches) => ' ' . $matches[1],
             ],
             $name,
         );

--- a/src/Logging/TestDox/NamePrettifier.php
+++ b/src/Logging/TestDox/NamePrettifier.php
@@ -28,6 +28,7 @@ use function is_scalar;
 use function method_exists;
 use function preg_quote;
 use function preg_replace;
+use function preg_replace_callback_array;
 use function rtrim;
 use function sprintf;
 use function str_contains;
@@ -158,30 +159,13 @@ final class NamePrettifier
             return trim($noUnderscore);
         }
 
-        $wasNumeric = false;
-
-        $buffer = '';
-
-        $len = strlen($name);
-
-        for ($i = 0; $i < $len; $i++) {
-            if ($i > 0 && $name[$i] >= 'A' && $name[$i] <= 'Z') {
-                $buffer .= ' ' . strtolower($name[$i]);
-            } else {
-                $isNumeric = $name[$i] >= '0' && $name[$i] <= '9';
-
-                if (!$wasNumeric && $isNumeric) {
-                    $buffer .= ' ';
-                    $wasNumeric = true;
-                }
-
-                if ($wasNumeric && !$isNumeric) {
-                    $wasNumeric = false;
-                }
-
-                $buffer .= $name[$i];
-            }
-        }
+        $buffer = preg_replace_callback_array(
+            [
+                '/(?!^)([A-Z])/' => static fn (array $matches) => ' ' . strtolower($matches[1]),
+                '/(?!^)(\d+)/'   => static fn (array $matches) => ' ' . $matches[1],
+            ],
+            $name,
+        );
 
         return trim($buffer);
     }


### PR DESCRIPTION
This should optimise the performance of this method by 10x. Regex is much more suitable for a task like this than a loop which reconstructs the string character by character. `ucfirst` is twice as fast as `strtoupper` with character substitution. Since this is hot code, the optimisation has a significant impact on the runtime. 

<s>One behavioural change is that the second regex also skips the digits at the start of the string. Since the return value is trimmed, it makes sense not to add a space at the beginning of the string.</s>