### PR TITLE
New array assertions

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -20,6 +20,8 @@ use ArrayAccess;
 use Countable;
 use Generator;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
+use PHPUnit\Framework\Constraint\ArraysAreEqual;
+use PHPUnit\Framework\Constraint\ArraysAreIdentical;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\Count;
@@ -203,6 +205,154 @@ abstract class Assert
         self::assertThat(
             $array,
             new IsList,
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays are identical.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysAreIdentical(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreIdentical($expected, true, true),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays are identical while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysAreIdenticalIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreIdentical($expected, true, false),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays have identical values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysHaveIdenticalValues(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreIdentical($expected, false, true),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays have identical values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysHaveIdenticalValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreIdentical($expected, false, false),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays are equal.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     */
+    final public static function assertArraysAreEqual(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreEqual($expected, true, true),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays are equal while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysAreEqualIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreEqual($expected, true, false),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays have equal values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     */
+    final public static function assertArraysHaveEqualValues(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreEqual($expected, false, true),
+            $message,
+        );
+    }
+
+    /**
+     * Assert that two arrays have equal values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysHaveEqualValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new ArraysAreEqual($expected, false, false),
             $message,
         );
     }

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -201,6 +201,176 @@ if (!function_exists('PHPUnit\Framework\assertIsList')) {
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertArraysAreIdentical')) {
+    /**
+     * Assert that two arrays are identical.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared strictly.
+     * This is essentially an alias for assertSame().
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreIdentical
+     */
+    function assertArraysAreIdentical(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysAreIdentical(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysAreEqual')) {
+    /**
+     * Assert that two arrays are equal.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreEqual
+     */
+    function assertArraysAreEqual(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysAreEqual(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysAreIdenticalIgnoringOrder')) {
+    /**
+     * Assert that two arrays are identical while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreIdenticalIgnoringOrder
+     */
+    function assertArraysAreIdenticalIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysAreIdenticalIgnoringOrder(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysAreEqualIgnoringOrder')) {
+    /**
+     * Assert that two arrays are equal while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared loosely.
+     * This is essentially an alias for assertEquals().
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreEqualIgnoringOrder
+     */
+    function assertArraysAreEqualIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysAreEqualIgnoringOrder(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysHaveIdenticalValues')) {
+    /**
+     * Assert that two arrays have identical values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveIdenticalValues
+     */
+    function assertArraysHaveIdenticalValues(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysHaveIdenticalValues(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysHaveEqualValues')) {
+    /**
+     * Assert that two arrays have equal values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveEqualValues
+     */
+    function assertArraysHaveEqualValues(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysHaveEqualValues(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysHaveIdenticalValuesIgnoringOrder')) {
+    /**
+     * Assert that two arrays have identical values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveIdenticalValuesIgnoringOrder
+     */
+    function assertArraysHaveIdenticalValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysHaveIdenticalValuesIgnoringOrder(...func_get_args());
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertArraysHaveEqualValuesIgnoringOrder')) {
+    /**
+     * Assert that two arrays have equal values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveEqualValuesIgnoringOrder
+     */
+    function assertArraysHaveEqualValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        Assert::assertArraysHaveEqualValuesIgnoringOrder(...func_get_args());
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertContains')) {
     /**
      * Asserts that a haystack contains a needle.

--- a/src/Framework/Constraint/Array/ArrayComparison.php
+++ b/src/Framework/Constraint/Array/ArrayComparison.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use function array_values;
+use function is_array;
+use function ksort;
+use function sort;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\Exporter;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+abstract class ArrayComparison extends Constraint
+{
+    /**
+     * @var array<mixed>
+     */
+    protected readonly array $expected;
+    protected readonly bool $keysMatter;
+    protected readonly bool $orderMatters;
+
+    /**
+     * @param array<mixed> $expected
+     */
+    public function __construct(array $expected, bool $keysMatter, bool $orderMatters)
+    {
+        $this->expected     = $expected;
+        $this->keysMatter   = $keysMatter;
+        $this->orderMatters = $orderMatters;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other.
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @throws ExpectationFailedException
+     */
+    public function evaluate(mixed $other, string $description = '', bool $returnResult = false): ?bool
+    {
+        if (!is_array($other)) {
+            return false;
+        }
+
+        $expected = $this->expected;
+        $actual   = $other;
+
+        if ($this->keysMatter && !$this->orderMatters) {
+            ksort($expected);
+            ksort($actual);
+        }
+
+        if (!$this->keysMatter) {
+            $expected = array_values($expected);
+            $actual   = array_values($actual);
+
+            if (!$this->orderMatters) {
+                sort($expected);
+                sort($actual);
+            }
+        }
+
+        $success = $this->compareArrays($expected, $actual);
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail(
+                $other,
+                $description,
+                new ComparisonFailure(
+                    $this->expected,
+                    $other,
+                    Exporter::export($this->expected),
+                    Exporter::export($other),
+                ),
+            );
+        }
+
+        // @codeCoverageIgnoreStart
+        return null;
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     */
+    public function toString(): string
+    {
+        if ($this->keysMatter && $this->orderMatters) {
+            return 'two arrays are ' . $this->comparisonType();
+        }
+
+        if (!$this->keysMatter && !$this->orderMatters) {
+            return 'two arrays are ' . $this->comparisonType() . ' while ignoring keys and order';
+        }
+
+        if (!$this->keysMatter) {
+            return 'two arrays are ' . $this->comparisonType() . ' while ignoring keys';
+        }
+
+        return 'two arrays are ' . $this->comparisonType() . ' while ignoring order';
+    }
+
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     */
+    protected function failureDescription(mixed $other): string
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Compares two arrays using the appropriate comparison method.
+     */
+    abstract protected function compareArrays(mixed $expected, mixed $actual): bool;
+
+    /**
+     * @return 'equal'|'identical'
+     */
+    abstract protected function comparisonType(): string;
+}

--- a/src/Framework/Constraint/Array/ArrayComparison.php
+++ b/src/Framework/Constraint/Array/ArrayComparison.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
+use function array_keys;
 use function array_values;
 use function is_array;
 use function ksort;
@@ -61,8 +62,18 @@ abstract class ArrayComparison extends Constraint
         $actual   = $other;
 
         if ($this->keysMatter && !$this->orderMatters) {
-            ksort($expected);
-            ksort($actual);
+            $expectedKeys = array_keys($expected);
+            $actualKeys   = array_keys($actual);
+            sort($expectedKeys);
+            sort($actualKeys);
+
+            if ($expectedKeys === $actualKeys) {
+                sort($expected);
+                sort($actual);
+            } else {
+                ksort($expected);
+                ksort($actual);
+            }
         }
 
         if (!$this->keysMatter) {

--- a/src/Framework/Constraint/Array/ArraysAreEqual.php
+++ b/src/Framework/Constraint/Array/ArraysAreEqual.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class ArraysAreEqual extends ArrayComparison
+{
+    protected function compareArrays(mixed $expected, mixed $actual): bool
+    {
+        /** @phpstan-ignore equal.notAllowed */
+        return $expected == $actual;
+    }
+
+    /**
+     * @return 'equal'
+     */
+    protected function comparisonType(): string
+    {
+        return 'equal';
+    }
+}

--- a/src/Framework/Constraint/Array/ArraysAreIdentical.php
+++ b/src/Framework/Constraint/Array/ArraysAreIdentical.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class ArraysAreIdentical extends ArrayComparison
+{
+    protected function compareArrays(mixed $expected, mixed $actual): bool
+    {
+        return $expected === $actual;
+    }
+
+    /**
+     * @return 'identical'
+     */
+    protected function comparisonType(): string
+    {
+        return 'identical';
+    }
+}

--- a/tests/_files/ObjectComparison/ChildOfValueObjectA.php
+++ b/tests/_files/ObjectComparison/ChildOfValueObjectA.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ObjectComparison;
+
+final class ChildOfValueObjectA extends ValueObjectA
+{
+}

--- a/tests/_files/ObjectComparison/SameStructAsValueObjectA.php
+++ b/tests/_files/ObjectComparison/SameStructAsValueObjectA.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ObjectComparison;
+
+final class SameStructAsValueObjectA
+{
+    public function __construct(public mixed $value)
+    {
+    }
+}

--- a/tests/_files/ObjectComparison/ValueObjectA.php
+++ b/tests/_files/ObjectComparison/ValueObjectA.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ObjectComparison;
+
+class ValueObjectA
+{
+    public function __construct(public mixed $value)
+    {
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
@@ -56,6 +56,11 @@ final class assertArraysAreEqualIgnoringOrderTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
@@ -327,9 +327,9 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => stdClass Object #1991 (
+-    0 => stdClass Object #%d (
 -        'a' => 'a',
-+    0 => stdClass Object #1995 (
++    0 => stdClass Object #%d (
 +        'a' => 'A',
      ),
  ]
@@ -346,8 +346,8 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #1994 (
-+    0 => PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA Object #1993 (
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
++    0 => PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA Object #%d (
          'value' => 'a',
      ),
  ]
@@ -364,8 +364,8 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #1992 (
-+    0 => PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA Object #2026 (
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
++    0 => PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA Object #%d (
          'value' => 'a',
      ),
  ]

--- a/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
@@ -1,0 +1,322 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysAreEqualIgnoringOrder')]
+#[TestDox('assertArraysAreEqualIgnoringOrder()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysAreEqualIgnoringOrderTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'integer vs float (loose comparison)' => [
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1 (loose comparison)' => [
+                [true],
+                [1],
+            ],
+
+            'false vs 0 (loose comparison)' => [
+                [false],
+                [0],
+            ],
+
+            'different object instances (loose comparison)' => [
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+            ],
+
+            'identical keys, identical values, different order' => [
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+                ['a' => 'b', 0 => 1, 2 => 'c'],
+            ],
+
+            'null vs empty string (loose comparison)' => [
+                ['a' => null],
+                ['a' => ''],
+            ],
+
+            'false vs null (loose comparison)' => [
+                [false],
+                [null],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different keys, identical values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => 1,
+-    'b' => 2,
++    'c' => 2,
+ ]
+
+EOT,
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'c' => 2],
+            ],
+
+            'identical keys, different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 2,
+     'a' => 'b',
+     2 => 'c',
+ ]
+
+EOT,
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+                [0 => 2, 'a' => 'b', 2 => 'c'],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        'b' => 1,
++        'b' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1]],
+                ['a' => ['b' => 2]],
+            ],
+
+            'missing nested key' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+         'b' => 1,
+-        'c' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1, 'c' => 2]],
+                ['a' => ['b' => 1]],
+            ],
+
+            'different nested array order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        0 => 1,
++        0 => 3,
+         1 => 2,
+-        2 => 3,
++        2 => 1,
+     ],
+ ]
+
+EOT,
+                ['a' => [1, 2, 3]],
+                ['a' => [3, 2, 1]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysAreEqualIgnoringOrder($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysAreEqualIgnoringOrder($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are equal while ignoring order.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA;
+use PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA;
+use PHPUnit\TestFixture\ObjectComparison\ValueObjectA;
 use stdClass;
 
 #[CoversMethod(Assert::class, 'assertArraysAreEqualIgnoringOrder')]
@@ -119,6 +122,21 @@ final class assertArraysAreEqualIgnoringOrderTest extends TestCase
             'different object instances (loose comparison)' => [
                 ['obj' => new stdClass],
                 ['obj' => new stdClass],
+            ],
+
+            'different object instances with strictly equal properties' => [
+                ['obj' => new ValueObjectA('value')],
+                ['obj' => new ValueObjectA('value')],
+            ],
+
+            'different object instances with loosely equal properties' => [
+                ['obj' => new ValueObjectA(false)],
+                ['obj' => new ValueObjectA(0)],
+            ],
+
+            'different object instances with strictly equal properties, different order' => [
+                [new ValueObjectA('v1'), new ValueObjectA('v2')],
+                [new ValueObjectA('v2'), new ValueObjectA('v1')],
             ],
 
             'identical keys, identical values, different order' => [
@@ -300,6 +318,61 @@ EOT,
 EOT,
                 ['a' => [1, 2, 3]],
                 ['a' => [3, 2, 1]],
+            ],
+
+            'object instances with different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => stdClass Object #1991 (
+-        'a' => 'a',
++    0 => stdClass Object #1995 (
++        'a' => 'A',
+     ),
+ ]
+
+EOT,
+                [(object) ['a' => 'a']],
+                [(object) ['a' => 'A']],
+            ],
+
+            'object instances with the same structure but of different classes' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #1994 (
++    0 => PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA Object #1993 (
+         'value' => 'a',
+     ),
+ ]
+
+EOT,
+                [new ValueObjectA('a')],
+                [new SameStructAsValueObjectA('a')],
+            ],
+
+            'object instances with the same structure but of different classes but with a common root' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #1992 (
++    0 => PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA Object #2026 (
+         'value' => 'a',
+     ),
+ ]
+
+EOT,
+                [new ValueObjectA('a')],
+                [new ChildOfValueObjectA('a')],
             ],
         ];
     }

--- a/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualIgnoringOrderTest.php
@@ -374,6 +374,62 @@ EOT,
                 [new ValueObjectA('a')],
                 [new ChildOfValueObjectA('a')],
             ],
+
+            'identical keys in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'x' => 1,
++    'y' => 99,
+     'z' => 3,
+-    'y' => 2,
+-    'x' => 1,
+ ]
+
+EOT,
+                ['z' => 3, 'y' => 2, 'x' => 1],
+                ['x' => 1, 'y' => 99, 'z' => 3],
+            ],
+
+            'identical integer keys in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    0 => 'a',
++    1 => 'B',
+     2 => 'c',
+-    1 => 'b',
+-    0 => 'a',
+ ]
+
+EOT,
+                [2 => 'c', 1 => 'b', 0 => 'a'],
+                [0 => 'a', 1 => 'B', 2 => 'c'],
+            ],
+
+            'mixed keys in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'baz' => 'QUX',
+     'foo' => 'bar',
+     0 => 1,
+-    'baz' => 'qux',
+ ]
+
+EOT,
+                ['foo' => 'bar', 0 => 1, 'baz' => 'qux'],
+                ['baz' => 'QUX', 'foo' => 'bar', 0 => 1],
+            ],
         ];
     }
 

--- a/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
@@ -56,6 +56,11 @@ final class assertArraysAreEqualTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
@@ -1,0 +1,322 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysAreEqual')]
+#[TestDox('assertArraysAreEqual()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysAreEqualTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'integer vs float (loose comparison)' => [
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1 (loose comparison)' => [
+                [true],
+                [1],
+            ],
+
+            'false vs 0 (loose comparison)' => [
+                [false],
+                [0],
+            ],
+
+            'different object instances (loose comparison)' => [
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+            ],
+
+            'null vs empty string (loose comparison)' => [
+                ['a' => null],
+                ['a' => ''],
+            ],
+
+            'false vs null (loose comparison)' => [
+                [false],
+                [null],
+            ],
+
+            'identical keys, identical values, different order (loose comparison)' => [
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+                ['a' => 'b', 0 => 1, 2 => 'c'],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different keys, identical values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => 1,
+-    'b' => 2,
++    'c' => 2,
+ ]
+
+EOT,
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'c' => 2],
+            ],
+
+            'identical keys, different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 2,
+     'a' => 'b',
+     2 => 'c',
+ ]
+
+EOT,
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+                [0 => 2, 'a' => 'b', 2 => 'c'],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        'b' => 1,
++        'b' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1]],
+                ['a' => ['b' => 2]],
+            ],
+
+            'missing nested key' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+         'b' => 1,
+-        'c' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1, 'c' => 2]],
+                ['a' => ['b' => 1]],
+            ],
+
+            'different nested array order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        0 => 1,
++        0 => 3,
+         1 => 2,
+-        2 => 3,
++        2 => 1,
+     ],
+ ]
+
+EOT,
+                ['a' => [1, 2, 3]],
+                ['a' => [3, 2, 1]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysAreEqual($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysAreEqual($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are equal.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
@@ -14,6 +14,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA;
+use PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA;
+use PHPUnit\TestFixture\ObjectComparison\ValueObjectA;
 use stdClass;
 
 #[CoversMethod(Assert::class, 'assertArraysAreEqual')]
@@ -119,6 +122,16 @@ final class assertArraysAreEqualTest extends TestCase
             'different object instances (loose comparison)' => [
                 ['obj' => new stdClass],
                 ['obj' => new stdClass],
+            ],
+
+            'different object instances with strictly equal properties' => [
+                ['obj' => new ValueObjectA('value')],
+                ['obj' => new ValueObjectA('value')],
+            ],
+
+            'different object instances with loosely equal properties' => [
+                ['obj' => new ValueObjectA(false)],
+                ['obj' => new ValueObjectA(0)],
             ],
 
             'null vs empty string (loose comparison)' => [
@@ -300,6 +313,85 @@ EOT,
 EOT,
                 ['a' => [1, 2, 3]],
                 ['a' => [3, 2, 1]],
+            ],
+
+            'different object instances with strictly equal properties, different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #466 (
++    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #178 (
++        'value' => 'v2',
++    ),
++    1 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #468 (
+         'value' => 'v1',
+-    ),
+-    1 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #177 (
+-        'value' => 'v2',
+     ),
+ ]
+
+EOT,
+                [new ValueObjectA('v1'), new ValueObjectA('v2')],
+                [new ValueObjectA('v2'), new ValueObjectA('v1')],
+            ],
+
+            'object instances with different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => stdClass Object #467 (
+-        'a' => 'a',
++    0 => stdClass Object #498 (
++        'a' => 'A',
+     ),
+ ]
+
+EOT,
+                [(object) ['a' => 'a']],
+                [(object) ['a' => 'A']],
+            ],
+
+            'object instances with the same structure but of different classes' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #445 (
++    0 => PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA Object #446 (
+         'value' => 'a',
+     ),
+ ]
+
+EOT,
+                [new ValueObjectA('a')],
+                [new SameStructAsValueObjectA('a')],
+            ],
+
+            'object instances with the same structure but of different classes but with a common root' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #447 (
++    0 => PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA Object #448 (
+         'value' => 'a',
+     ),
+ ]
+
+EOT,
+                [new ValueObjectA('a')],
+                [new ChildOfValueObjectA('a')],
             ],
         ];
     }

--- a/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreEqualTest.php
@@ -322,14 +322,14 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #466 (
-+    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #178 (
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
++    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
 +        'value' => 'v2',
 +    ),
-+    1 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #468 (
++    1 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
          'value' => 'v1',
 -    ),
--    1 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #177 (
+-    1 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
 -        'value' => 'v2',
      ),
  ]
@@ -346,9 +346,9 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => stdClass Object #467 (
+-    0 => stdClass Object #%d (
 -        'a' => 'a',
-+    0 => stdClass Object #498 (
++    0 => stdClass Object #%d (
 +        'a' => 'A',
      ),
  ]
@@ -365,8 +365,8 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #445 (
-+    0 => PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA Object #446 (
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
++    0 => PHPUnit\TestFixture\ObjectComparison\SameStructAsValueObjectA Object #%d (
          'value' => 'a',
      ),
  ]
@@ -383,8 +383,8 @@ EOT,
 +++ Actual
 @@ @@
  Array &0 [
--    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #447 (
-+    0 => PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA Object #448 (
+-    0 => PHPUnit\TestFixture\ObjectComparison\ValueObjectA Object #%d (
++    0 => PHPUnit\TestFixture\ObjectComparison\ChildOfValueObjectA Object #%d (
          'value' => 'a',
      ),
  ]

--- a/tests/unit/Framework/Assert/assertArraysAreIdenticalIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreIdenticalIgnoringOrderTest.php
@@ -367,6 +367,62 @@ EOT,
                 ['a' => [1, 2, 3]],
                 ['a' => [3, 2, 1]],
             ],
+
+            'identical keys in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'x' => 1,
++    'y' => 99,
+     'z' => 3,
+-    'y' => 2,
+-    'x' => 1,
+ ]
+
+EOT,
+                ['z' => 3, 'y' => 2, 'x' => 1],
+                ['x' => 1, 'y' => 99, 'z' => 3],
+            ],
+
+            'identical integer keys in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    0 => 'a',
++    1 => 'B',
+     2 => 'c',
+-    1 => 'b',
+-    0 => 'a',
+ ]
+
+EOT,
+                [2 => 'c', 1 => 'b', 0 => 'a'],
+                [0 => 'a', 1 => 'B', 2 => 'c'],
+            ],
+
+            'mixed keys in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'baz' => 'QUX',
+     'foo' => 'bar',
+     0 => 1,
+-    'baz' => 'qux',
+ ]
+
+EOT,
+                ['foo' => 'bar', 0 => 1, 'baz' => 'qux'],
+                ['baz' => 'QUX', 'foo' => 'bar', 0 => 1],
+            ],
         ];
     }
 

--- a/tests/unit/Framework/Assert/assertArraysAreIdenticalIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreIdenticalIgnoringOrderTest.php
@@ -1,0 +1,388 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysAreIdenticalIgnoringOrder')]
+#[TestDox('assertArraysAreIdenticalIgnoringOrder()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysAreIdenticalIgnoringOrderTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'identical keys, identical values, different order' => [
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+                ['a' => 'b', 0 => 1, 2 => 'c'],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different keys, identical values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => 1,
+-    'b' => 2,
++    'c' => 2,
+ ]
+
+EOT,
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'c' => 2],
+            ],
+
+            'identical keys, different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => '1',
++    0 => 1,
+     'a' => 'b',
+     2 => 'c',
+ ]
+
+EOT,
+                [0 => '1', 'a' => 'b', 2 => 'c'],
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        'b' => 1,
++        'b' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1]],
+                ['a' => ['b' => 2]],
+            ],
+
+            'different object instances' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'obj' => stdClass Object #%d (),
++    'obj' => stdClass Object #%d (),
+ ]
+
+EOT,
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+            ],
+
+            'null vs empty string' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'a' => null,
++    'a' => '',
+ ]
+
+EOT,
+                ['a' => null],
+                ['a' => ''],
+            ],
+
+            'integer vs float' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 1.0,
+ ]
+
+EOT,
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => true,
++    0 => 1,
+ ]
+
+EOT,
+                [true],
+                [1],
+            ],
+
+            'false vs 0' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => 0,
+ ]
+
+EOT,
+                [false],
+                [0],
+            ],
+
+            'false vs null' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => null,
+ ]
+
+EOT,
+                [false],
+                [null],
+            ],
+
+            'missing nested key' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+         'b' => 1,
+-        'c' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1, 'c' => 2]],
+                ['a' => ['b' => 1]],
+            ],
+
+            'different nested array order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        0 => 1,
++        0 => 3,
+         1 => 2,
+-        2 => 3,
++        2 => 1,
+     ],
+ ]
+
+EOT,
+                ['a' => [1, 2, 3]],
+                ['a' => [3, 2, 1]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysAreIdenticalIgnoringOrder($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysAreIdenticalIgnoringOrder($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are identical while ignoring order.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysAreIdenticalIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreIdenticalIgnoringOrderTest.php
@@ -56,6 +56,11 @@ final class assertArraysAreIdenticalIgnoringOrderTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysAreIdenticalTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreIdenticalTest.php
@@ -56,6 +56,11 @@ final class assertArraysAreIdenticalTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysAreIdenticalTest.php
+++ b/tests/unit/Framework/Assert/assertArraysAreIdenticalTest.php
@@ -1,0 +1,401 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysAreIdentical')]
+#[TestDox('assertArraysAreIdentical()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysAreIdenticalTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different keys, identical values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => 1,
+-    'b' => 2,
++    'c' => 2,
+ ]
+
+EOT,
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'c' => 2],
+            ],
+
+            'identical keys, different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => '1',
++    0 => 1,
+     'a' => 'b',
+     2 => 'c',
+ ]
+
+EOT,
+                [0 => '1', 'a' => 'b', 2 => 'c'],
+                [0 => 1, 'a' => 'b', 2 => 'c'],
+            ],
+
+            'identical keys, identical values, different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'a' => 'b',
+     0 => 1,
+-    'a' => 'b',
+     2 => 'c',
+ ]
+
+EOT,
+                [0   => 1, 'a' => 'b', 2 => 'c'],
+                ['a' => 'b', 0 => 1, 2 => 'c'],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        'b' => 1,
++        'b' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1]],
+                ['a' => ['b' => 2]],
+            ],
+
+            'different object instances' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'obj' => stdClass Object #%d (),
++    'obj' => stdClass Object #%d (),
+ ]
+
+EOT,
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+            ],
+
+            'null vs empty string' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'a' => null,
++    'a' => '',
+ ]
+
+EOT,
+                ['a' => null],
+                ['a' => ''],
+            ],
+
+            'integer vs float' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 1.0,
+ ]
+
+EOT,
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => true,
++    0 => 1,
+ ]
+
+EOT,
+                [true],
+                [1],
+            ],
+
+            'false vs 0' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => 0,
+ ]
+
+EOT,
+                [false],
+                [0],
+            ],
+
+            'false vs null' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => null,
+ ]
+
+EOT,
+                [false],
+                [null],
+            ],
+
+            'missing nested key' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+         'b' => 1,
+-        'c' => 2,
+     ],
+ ]
+
+EOT,
+                ['a' => ['b' => 1, 'c' => 2]],
+                ['a' => ['b' => 1]],
+            ],
+
+            'different nested array order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     'a' => Array &1 [
+-        0 => 1,
++        0 => 3,
+         1 => 2,
+-        2 => 3,
++        2 => 1,
+     ],
+ ]
+
+EOT,
+                ['a' => [1, 2, 3]],
+                ['a' => [3, 2, 1]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysAreIdentical($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysAreIdentical($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are identical.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysHaveEqualValuesIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveEqualValuesIgnoringOrderTest.php
@@ -56,6 +56,11 @@ final class assertArraysHaveEqualValuesIgnoringOrderTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysHaveEqualValuesIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveEqualValuesIgnoringOrderTest.php
@@ -1,0 +1,280 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysHaveEqualValuesIgnoringOrder')]
+#[TestDox('assertArraysHaveEqualValuesIgnoringOrder()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysHaveEqualValuesIgnoringOrderTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'integer vs float (loose comparison)' => [
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1 (loose comparison)' => [
+                [true],
+                [1],
+            ],
+
+            'false vs 0 (loose comparison)' => [
+                [false],
+                [0],
+            ],
+
+            'different object instances (loose comparison)' => [
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+            ],
+
+            'different keys, equal values in same order' => [
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+            ],
+
+            'integer keys vs string keys, equal values in same order' => [
+                [0 => 'a', 1 => 'b'],
+                ['x' => 'a', 'y' => 'b'],
+            ],
+
+            'equal values, different order' => [
+                [1, 2, 3],
+                [3, 2, 1],
+            ],
+
+            'different keys, equal values, different order' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['z' => 3, 'y' => 2, 'x' => 1],
+            ],
+
+            'null vs empty string (loose comparison)' => [
+                [null],
+                [''],
+            ],
+
+            'false vs null (loose comparison)' => [
+                [false],
+                [null],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+-    1 => 2,
++    1 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 3],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => Array &1 [
+-        'b' => 1,
++        'b' => 3,
+     ],
+ ]
+
+EOT,
+                [['b' => 1]],
+                [['b' => 3]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysHaveEqualValuesIgnoringOrder($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysHaveEqualValuesIgnoringOrder($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are equal while ignoring keys and order.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysHaveEqualValuesIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveEqualValuesIgnoringOrderTest.php
@@ -259,6 +259,65 @@ EOT,
                 [['b' => 1]],
                 [['b' => 3]],
             ],
+
+            'values in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 3,
+-    1 => 2,
+-    2 => 1,
++    0 => 1,
++    1 => 99,
++    2 => 3,
+ ]
+
+EOT,
+                [3, 2, 1],
+                [1, 99, 3],
+            ],
+
+            'string keyed arrays with values in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'x' => 1,
++    'y' => 99,
+     'z' => 3,
+-    'y' => 2,
+-    'x' => 1,
+ ]
+
+EOT,
+                ['z' => 3, 'y' => 2, 'x' => 1],
+                ['x' => 1, 'y' => 99, 'z' => 3],
+            ],
+
+            'different keys with values in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'a' => 3,
+-    'b' => 2,
+-    'c' => 1,
++    'x' => 1,
++    'y' => 99,
++    'z' => 3,
+ ]
+
+EOT,
+                ['a' => 3, 'b' => 2, 'c' => 1],
+                ['x' => 1, 'y' => 99, 'z' => 3],
+            ],
         ];
     }
 

--- a/tests/unit/Framework/Assert/assertArraysHaveEqualValuesTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveEqualValuesTest.php
@@ -56,6 +56,11 @@ final class assertArraysHaveEqualValuesTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysHaveEqualValuesTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveEqualValuesTest.php
@@ -1,0 +1,310 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysHaveEqualValues')]
+#[TestDox('assertArraysHaveEqualValues()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysHaveEqualValuesTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'integer vs float (loose comparison)' => [
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1 (loose comparison)' => [
+                [true],
+                [1],
+            ],
+
+            'false vs 0 (loose comparison)' => [
+                [false],
+                [0],
+            ],
+
+            'different object instances (loose comparison)' => [
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+            ],
+
+            'different keys, equal values in same order' => [
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+            ],
+
+            'integer keys vs string keys, equal values in same order' => [
+                [0 => 'a', 1 => 'b'],
+                ['x' => 'a', 'y' => 'b'],
+            ],
+
+            'null vs empty string (loose comparison)' => [
+                [null],
+                [''],
+            ],
+
+            'false vs null (loose comparison)' => [
+                [false],
+                [null],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different values in same order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+-    1 => 2,
++    1 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 3],
+            ],
+
+            'equal values, different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 3,
+     1 => 2,
+-    2 => 3,
++    2 => 1,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [3, 2, 1],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => Array &1 [
+-        'b' => 1,
++        'b' => 3,
+     ],
+ ]
+
+EOT,
+                [['b' => 1]],
+                [['b' => 3]],
+            ],
+
+            'different nested array order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => Array &1 [
+-        0 => 1,
++        0 => 3,
+         1 => 2,
+-        2 => 3,
++        2 => 1,
+     ],
+ ]
+
+EOT,
+                [[1, 2, 3]],
+                [[3, 2, 1]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysHaveEqualValues($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysHaveEqualValues($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are equal while ignoring keys.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysHaveEqualValuesTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveEqualValuesTest.php
@@ -289,6 +289,44 @@ EOT,
                 [[1, 2, 3]],
                 [[3, 2, 1]],
             ],
+
+            'string keyed arrays with values in different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'x' => 1,
++    'y' => 2,
+     'z' => 3,
+-    'y' => 2,
+-    'x' => 1,
+ ]
+
+EOT,
+                ['z' => 3, 'y' => 2, 'x' => 1],
+                ['x' => 1, 'y' => 2, 'z' => 3],
+            ],
+
+            'different keys with values in different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'a' => 3,
++    'x' => 1,
+     'b' => 2,
+-    'c' => 1,
++    'z' => 3,
+ ]
+
+EOT,
+                ['a' => 3, 'b' => 2, 'c' => 1],
+                ['x' => 1, 'b' => 2, 'z' => 3],
+            ],
         ];
     }
 

--- a/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesIgnoringOrderTest.php
@@ -56,6 +56,11 @@ final class assertArraysHaveIdenticalValuesIgnoringOrderTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesIgnoringOrderTest.php
@@ -1,0 +1,346 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysHaveIdenticalValuesIgnoringOrder')]
+#[TestDox('assertArraysHaveIdenticalValuesIgnoringOrder()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysHaveIdenticalValuesIgnoringOrderTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'different keys, identical values in same order' => [
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+            ],
+
+            'integer keys vs string keys, identical values in same order' => [
+                [0 => 'a', 1 => 'b'],
+                ['x' => 'a', 'y' => 'b'],
+            ],
+
+            'identical values, different order' => [
+                [1, 2, 3],
+                [3, 2, 1],
+            ],
+
+            'different keys, identical values, different order' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['z' => 3, 'y' => 2, 'x' => 1],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+-    1 => 2,
++    1 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 3],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => Array &1 [
+-        'b' => 1,
++        'b' => 2,
+     ],
+ ]
+
+EOT,
+                [['b' => 1]],
+                [['b' => 2]],
+            ],
+
+            'different object instances' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => stdClass Object #%d (),
++    0 => stdClass Object #%d (),
+ ]
+
+EOT,
+                [new stdClass],
+                [new stdClass],
+            ],
+
+            'null vs empty string' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => null,
++    0 => '',
+ ]
+
+EOT,
+                [null],
+                [''],
+            ],
+
+            'integer vs float' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 1.0,
+ ]
+
+EOT,
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => true,
++    0 => 1,
+ ]
+
+EOT,
+                [true],
+                [1],
+            ],
+
+            'false vs 0' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => 0,
+ ]
+
+EOT,
+                [false],
+                [0],
+            ],
+
+            'false vs null' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => null,
+ ]
+
+EOT,
+                [false],
+                [null],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysHaveIdenticalValuesIgnoringOrder($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysHaveIdenticalValuesIgnoringOrder($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are identical while ignoring keys and order.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesIgnoringOrderTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesIgnoringOrderTest.php
@@ -325,6 +325,65 @@ EOT,
                 [false],
                 [null],
             ],
+
+            'values in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 3,
+-    1 => 2,
+-    2 => 1,
++    0 => 1,
++    1 => 99,
++    2 => 3,
+ ]
+
+EOT,
+                [3, 2, 1],
+                [1, 99, 3],
+            ],
+
+            'string keyed arrays with values in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'x' => 1,
++    'y' => 99,
+     'z' => 3,
+-    'y' => 2,
+-    'x' => 1,
+ ]
+
+EOT,
+                ['z' => 3, 'y' => 2, 'x' => 1],
+                ['x' => 1, 'y' => 99, 'z' => 3],
+            ],
+
+            'different keys with values in different order, one value differs' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'a' => 3,
+-    'b' => 2,
+-    'c' => 1,
++    'x' => 1,
++    'y' => 99,
++    'z' => 3,
+ ]
+
+EOT,
+                ['a' => 3, 'b' => 2, 'c' => 1],
+                ['x' => 1, 'y' => 99, 'z' => 3],
+            ],
         ];
     }
 

--- a/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesTest.php
@@ -56,6 +56,11 @@ final class assertArraysHaveIdenticalValuesTest extends TestCase
                 ['1' => 'a', '2' => 'b', '4' => 'c'],
             ],
 
+            'different explicit numeric keys (literal strings, auto-cast to int)' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
             'string keys' => [
                 ['a' => 1, 'b' => 2, 'c' => 3],
                 ['a' => 1, 'b' => 2, 'c' => 3],

--- a/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesTest.php
@@ -355,6 +355,44 @@ EOT,
                 [[1, 2, 3]],
                 [[3, 2, 1]],
             ],
+
+            'string keyed arrays with values in different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
++    'x' => 1,
++    'y' => 2,
+     'z' => 3,
+-    'y' => 2,
+-    'x' => 1,
+ ]
+
+EOT,
+                ['z' => 3, 'y' => 2, 'x' => 1],
+                ['x' => 1, 'y' => 2, 'z' => 3],
+            ],
+
+            'different keys with values in different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    'a' => 3,
++    'x' => 1,
+     'b' => 2,
+-    'c' => 1,
++    'z' => 3,
+ ]
+
+EOT,
+                ['a' => 3, 'b' => 2, 'c' => 1],
+                ['x' => 1, 'b' => 2, 'z' => 3],
+            ],
         ];
     }
 

--- a/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesTest.php
+++ b/tests/unit/Framework/Assert/assertArraysHaveIdenticalValuesTest.php
@@ -1,0 +1,376 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use stdClass;
+
+#[CoversMethod(Assert::class, 'assertArraysHaveIdenticalValues')]
+#[TestDox('assertArraysHaveIdenticalValues()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertArraysHaveIdenticalValuesTest extends TestCase
+{
+    /**
+     * @return non-empty-array<non-empty-string, array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function successProvider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays' => [
+                [],
+                [],
+            ],
+
+            'implicit integer keys' => [
+                ['a', 'b', 'c'],
+                ['a', 'b', 'c'],
+            ],
+
+            'explicit integer keys' => [
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+                [1 => 'a', 2 => 'b', 4 => 'c'],
+            ],
+
+            'explicit negative integer keys' => [
+                [-1 => 'a', -2 => 'b'],
+                [-1 => 'a', -2 => 'b'],
+            ],
+
+            'explicit numeric keys (literal strings, auto-cast to int)' => [
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+                ['1' => 'a', '2' => 'b', '4' => 'c'],
+            ],
+
+            'string keys' => [
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['a' => 1, 'b' => 2, 'c' => 3],
+            ],
+
+            'nested arrays' => [
+                ['a' => ['b' => ['c' => 1]]],
+                ['a' => ['b' => ['c' => 1]]],
+            ],
+
+            'more deeply nested arrays' => [
+                [['a' => [['b' => 'c']]]],
+                [['a' => [['b' => 'c']]]],
+            ],
+
+            'mixed value types' => [
+                [1, 'string', 3.14, true, null],
+                [1, 'string', 3.14, true, null],
+            ],
+
+            'object references' => [
+                ['obj' => $object],
+                ['obj' => $object],
+            ],
+
+            'null values' => [
+                ['a' => null, 'b' => null],
+                ['a' => null, 'b' => null],
+            ],
+
+            'boolean values' => [
+                [true, false, true],
+                [true, false, true],
+            ],
+
+            'float values' => [
+                [1.1, 2.2, 3.3],
+                [1.1, 2.2, 3.3],
+            ],
+
+            'different keys, identical values in same order' => [
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+            ],
+
+            'integer keys vs string keys, identical values in same order' => [
+                [0 => 'a', 1 => 'b'],
+                ['x' => 'a', 'y' => 'b'],
+            ],
+        ];
+    }
+
+    /**
+     * @return non-empty-array<non-empty-string, array{0: non-empty-string, 1: array<mixed>, 2: array<mixed>}>
+     */
+    public static function failureProvider(): array
+    {
+        return [
+            'empty expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 []
++Array &0 [
++    0 => 1,
++]
+
+EOT,
+                [],
+                [1],
+            ],
+
+            'empty actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+-Array &0 [
+-    0 => 1,
+-]
++Array &0 []
+
+EOT,
+                [1],
+                [],
+            ],
+
+            'extra element in expected' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
+-    2 => 3,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [1, 2],
+            ],
+
+            'extra element in actual' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+     1 => 2,
++    2 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 2, 3],
+            ],
+
+            'different values in same order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => 1,
+-    1 => 2,
++    1 => 3,
+ ]
+
+EOT,
+                [1, 2],
+                [1, 3],
+            ],
+
+            'identical values, different order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 3,
+     1 => 2,
+-    2 => 3,
++    2 => 1,
+ ]
+
+EOT,
+                [1, 2, 3],
+                [3, 2, 1],
+            ],
+
+            'different nested values' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => Array &1 [
+-        'b' => 1,
++        'b' => 2,
+     ],
+ ]
+
+EOT,
+                [['b' => 1]],
+                [['b' => 2]],
+            ],
+
+            'different object instances' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => stdClass Object #%d (),
++    0 => stdClass Object #%d (),
+ ]
+
+EOT,
+                [new stdClass],
+                [new stdClass],
+            ],
+
+            'null vs empty string' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => null,
++    0 => '',
+ ]
+
+EOT,
+                [null],
+                [''],
+            ],
+
+            'integer vs float' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => 1,
++    0 => 1.0,
+ ]
+
+EOT,
+                [1],
+                [1.0],
+            ],
+
+            'true vs 1' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => true,
++    0 => 1,
+ ]
+
+EOT,
+                [true],
+                [1],
+            ],
+
+            'false vs 0' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => 0,
+ ]
+
+EOT,
+                [false],
+                [0],
+            ],
+
+            'false vs null' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+-    0 => false,
++    0 => null,
+ ]
+
+EOT,
+                [false],
+                [null],
+            ],
+
+            'different nested array order' => [
+                <<<'EOT'
+
+--- Expected
++++ Actual
+@@ @@
+ Array &0 [
+     0 => Array &1 [
+-        0 => 1,
++        0 => 3,
+         1 => 2,
+-        2 => 3,
++        2 => 1,
+     ],
+ ]
+
+EOT,
+                [[1, 2, 3]],
+                [[3, 2, 1]],
+            ],
+        ];
+    }
+
+    #[DataProvider('successProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(array $expected, array $actual): void
+    {
+        $this->assertArraysHaveIdenticalValues($expected, $actual);
+    }
+
+    #[DataProvider('failureProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $comparisonFailure, array $expected, array $actual): void
+    {
+        try {
+            $this->assertArraysHaveIdenticalValues($expected, $actual);
+        } catch (ExpectationFailedException $e) {
+            $this->assertSame('Failed asserting that two arrays are identical while ignoring keys.', $e->getMessage());
+            $this->assertStringMatchesFormat($comparisonFailure, $e->getComparisonFailure()->toString());
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/tests/unit/Framework/Constraint/Array/ArraysAreEqualTest.php
+++ b/tests/unit/Framework/Constraint/Array/ArraysAreEqualTest.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArraysAreEqual::class)]
+#[CoversClass(Constraint::class)]
+#[Small]
+#[Group('framework')]
+#[Group('framework/constraints')]
+final class ArraysAreEqualTest extends TestCase
+{
+    public static function provider(): array
+    {
+        return [
+            'empty arrays, keys and order matter' => [
+                true,
+                '',
+                [],
+                [],
+                true,
+                true,
+            ],
+            'identical arrays, keys and order matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'b' => 2],
+                true,
+                true,
+            ],
+            'equal arrays with type coercion, keys and order matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => '2'],
+                ['a' => '1', 'b' => 2],
+                true,
+                true,
+            ],
+            'numeric indexed arrays, keys and order matter' => [
+                true,
+                '',
+                [1, 2, 3],
+                [1, 2, 3],
+                true,
+                true,
+            ],
+            'same key-value pairs different order, keys matter, order does not matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2],
+                ['b' => 2, 'a' => 1],
+                true,
+                false,
+            ],
+            'empty arrays, keys matter, order does not matter' => [
+                true,
+                '',
+                [],
+                [],
+                true,
+                false,
+            ],
+            'same values different keys, keys do not matter, order matters' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+                false,
+                true,
+            ],
+            'numeric arrays same values, keys do not matter, order matters' => [
+                true,
+                '',
+                [1, 2, 3],
+                [1, 2, 3],
+                false,
+                true,
+            ],
+            'different order and keys, neither keys nor order matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['z' => 3, 'y' => 1, 'x' => 2],
+                false,
+                false,
+            ],
+            'empty arrays, neither keys nor order matter' => [
+                true,
+                '',
+                [],
+                [],
+                false,
+                false,
+            ],
+            'different values, keys and order matter' => [
+                false,
+                'Failed asserting that two arrays are equal',
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'b' => 3],
+                true,
+                true,
+            ],
+            'different number of elements' => [
+                false,
+                'Failed asserting that two arrays are equal',
+                [1, 2, 3],
+                [1, 2],
+                true,
+                true,
+            ],
+            'different order when order matters' => [
+                false,
+                'Failed asserting that two arrays are equal',
+                [1, 2, 3],
+                [3, 2, 1],
+                true,
+                true,
+            ],
+            'different keys when keys matter' => [
+                false,
+                'Failed asserting that two arrays are equal while ignoring order',
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+                true,
+                false,
+            ],
+            'different order when only order matters' => [
+                false,
+                'Failed asserting that two arrays are equal while ignoring keys',
+                [1, 2, 3],
+                [3, 2, 1],
+                false,
+                true,
+            ],
+        ];
+    }
+
+    #[DataProvider('provider')]
+    public function testCanBeEvaluated(bool $result, string $failureDescription, array $expected, mixed $actual, bool $keysMatter, bool $orderMatters): void
+    {
+        $constraint = new ArraysAreEqual($expected, $keysMatter, $orderMatters);
+
+        $this->assertSame($result, $constraint->evaluate($actual, returnResult: true));
+
+        if ($result) {
+            return;
+        }
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage($failureDescription);
+
+        $constraint->evaluate($actual);
+    }
+
+    public function testRejectActualThatIsNotAnArray(): void
+    {
+        $constraint = new ArraysAreEqual([], false, false);
+
+        $this->assertFalse($constraint->evaluate('string', returnResult: true));
+    }
+
+    public function testCanBeRepresentedAsString(): void
+    {
+        $this->assertSame('two arrays are equal while ignoring keys and order', new ArraysAreEqual([], false, false)->toString());
+        $this->assertSame('two arrays are equal while ignoring order', new ArraysAreEqual([], true, false)->toString());
+        $this->assertSame('two arrays are equal while ignoring keys', new ArraysAreEqual([], false, true)->toString());
+        $this->assertSame('two arrays are equal', new ArraysAreEqual([], true, true)->toString());
+    }
+
+    public function testIsCountable(): void
+    {
+        $this->assertCount(1, new ArraysAreEqual([], false, false));
+    }
+}

--- a/tests/unit/Framework/Constraint/Array/ArraysAreIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/Array/ArraysAreIdenticalTest.php
@@ -1,0 +1,215 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(ArraysAreIdentical::class)]
+#[CoversClass(Constraint::class)]
+#[Small]
+#[Group('framework')]
+#[Group('framework/constraints')]
+final class ArraysAreIdenticalTest extends TestCase
+{
+    public static function provider(): array
+    {
+        $object = new stdClass;
+
+        return [
+            'empty arrays, keys and order matter' => [
+                true,
+                '',
+                [],
+                [],
+                true,
+                true,
+            ],
+            'identical arrays, keys and order matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'b' => 2],
+                true,
+                true,
+            ],
+            'numeric indexed arrays, keys and order matter' => [
+                true,
+                '',
+                [1, 2, 3],
+                [1, 2, 3],
+                true,
+                true,
+            ],
+            'arrays with same object instance, keys and order matter' => [
+                true,
+                '',
+                ['obj' => $object],
+                ['obj' => $object],
+                true,
+                true,
+            ],
+            'same key-value pairs different order, keys matter, order does not matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2],
+                ['b' => 2, 'a' => 1],
+                true,
+                false,
+            ],
+            'empty arrays, keys matter, order does not matter' => [
+                true,
+                '',
+                [],
+                [],
+                true,
+                false,
+            ],
+            'same values different keys, keys do not matter, order matters' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+                false,
+                true,
+            ],
+            'numeric arrays same values, keys do not matter, order matters' => [
+                true,
+                '',
+                [1, 2, 3],
+                [1, 2, 3],
+                false,
+                true,
+            ],
+            'different order and keys, neither keys nor order matter' => [
+                true,
+                '',
+                ['a' => 1, 'b' => 2, 'c' => 3],
+                ['z' => 3, 'y' => 1, 'x' => 2],
+                false,
+                false,
+            ],
+            'empty arrays, neither keys nor order matter' => [
+                true,
+                '',
+                [],
+                [],
+                false,
+                false,
+            ],
+            'different values, keys and order matter' => [
+                false,
+                'Failed asserting that two arrays are identical',
+                ['a' => 1, 'b' => 2],
+                ['a' => 1, 'b' => 3],
+                true,
+                true,
+            ],
+            'different number of elements' => [
+                false,
+                'Failed asserting that two arrays are identical',
+                [1, 2, 3],
+                [1, 2],
+                true,
+                true,
+            ],
+            'type difference integer vs string, keys and order matter' => [
+                false,
+                'Failed asserting that two arrays are identical',
+                ['a' => 1, 'b' => 2],
+                ['a' => '1', 'b' => '2'],
+                true,
+                true,
+            ],
+            'type difference boolean vs integer, keys and order matter' => [
+                false,
+                'Failed asserting that two arrays are identical',
+                ['a' => true],
+                ['a' => 1],
+                true,
+                true,
+            ],
+            'different object instances, keys and order matter' => [
+                false,
+                'Failed asserting that two arrays are identical',
+                ['obj' => new stdClass],
+                ['obj' => new stdClass],
+                true,
+                true,
+            ],
+            'different order when order matters' => [
+                false,
+                'Failed asserting that two arrays are identical',
+                [1, 2, 3],
+                [3, 2, 1],
+                true,
+                true,
+            ],
+            'different keys when keys matter' => [
+                false,
+                'Failed asserting that two arrays are identical while ignoring order',
+                ['a' => 1, 'b' => 2],
+                ['x' => 1, 'y' => 2],
+                true,
+                false,
+            ],
+            'different order when only order matters' => [
+                false,
+                'Failed asserting that two arrays are identical while ignoring keys',
+                [1, 2, 3],
+                [3, 2, 1],
+                false,
+                true,
+            ],
+        ];
+    }
+
+    #[DataProvider('provider')]
+    public function testCanBeEvaluated(bool $result, string $failureDescription, array $expected, mixed $actual, bool $keysMatter, bool $orderMatters): void
+    {
+        $constraint = new ArraysAreIdentical($expected, $keysMatter, $orderMatters);
+
+        $this->assertSame($result, $constraint->evaluate($actual, returnResult: true));
+
+        if ($result) {
+            return;
+        }
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage($failureDescription);
+
+        $constraint->evaluate($actual);
+    }
+
+    public function testRejectActualThatIsNotAnArray(): void
+    {
+        $constraint = new ArraysAreIdentical([], false, false);
+
+        $this->assertFalse($constraint->evaluate('string', returnResult: true));
+    }
+
+    public function testCanBeRepresentedAsString(): void
+    {
+        $this->assertSame('two arrays are identical while ignoring keys and order', new ArraysAreIdentical([], false, false)->toString());
+        $this->assertSame('two arrays are identical while ignoring order', new ArraysAreIdentical([], true, false)->toString());
+        $this->assertSame('two arrays are identical while ignoring keys', new ArraysAreIdentical([], false, true)->toString());
+        $this->assertSame('two arrays are identical', new ArraysAreIdentical([], true, true)->toString());
+    }
+
+    public function testIsCountable(): void
+    {
+        $this->assertCount(1, new ArraysAreIdentical([], false, false));
+    }
+}


### PR DESCRIPTION
This implements the `assertArraysAreIdentical()`, `assertArraysAreIdenticalIgnoringOrder()`, `assertArraysHaveIdenticalValues()`, `assertArraysHaveIdenticalValuesIgnoringOrder()`, `assertArraysAreEqual()`, `assertArraysAreEqualIgnoringOrder()`, `assertArraysHaveEqualValues()`, and `assertArraysHaveEqualValuesIgnoringOrder()` assertions as requested in #6423.

The implementation follows the specification in https://github.com/sebastianbergmann/phpunit/issues/6423#issuecomment-3758745111:

| Method                                           | Comparison | Keys matter | Order matters |
|--------------------------------------------------|------------|-----------------------------------|-----------------------|
| `assertArraysAreIdentical()`                     | Strict     | ✅                                 | ✅                     |
| `assertArraysAreIdenticalIgnoringOrder()`        | Strict     | ✅                                 | ❌                     | 
| `assertArraysHaveIdenticalValues()`              | Strict     | ❌                                 | ✅                     |  
| `assertArraysHaveIdenticalValuesIgnoringOrder()` | Strict     | ❌                                 | ❌                     |  
| `assertArraysAreEqual()`                         | Loose      | ✅                                 | ✅                     | 
| `assertArraysAreEqualIgnoringOrder()`            | Loose      | ✅                                 | ❌                     | 
| `assertArraysHaveEqualValues()`                  | Loose      | ❌                                 | ✅                     |  
| `assertArraysHaveEqualValuesIgnoringOrder()`     | Loose      | ❌                                 | ❌                     |  

It is worth noting that the implementation uses the `==` operator for the new equality-related assertions and does not delegate the comparison to a chain of `Comparator` objects, as is the case with `assertEquals()`, for example.