### PR TITLE
Infinite recursion in `Count::getCountOf()` for unusal implementations of `Iterator` or `IteratorAggregate`

### DIFF
--- a/src/Framework/Constraint/Cardinality/Count.php
+++ b/src/Framework/Constraint/Cardinality/Count.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Framework\Constraint;
 use function count;
 use function is_countable;
 use function iterator_count;
+use function spl_object_id;
 use function sprintf;
 use EmptyIterator;
 use Generator;
@@ -66,7 +67,16 @@ class Count extends Constraint
         }
 
         if ($other instanceof Traversable) {
+            $traversableSeen = [];
+
             while ($other instanceof IteratorAggregate) {
+                $id = spl_object_id($other);
+
+                if (isset($traversableSeen[$id])) {
+                    throw new Exception('IteratorAggregate::getIterator() returned an object that was already seen');
+                }
+                $traversableSeen[$id] = true;
+
                 try {
                     $other = $other->getIterator();
                 } catch (\Exception $e) {

--- a/tests/end-to-end/regression/6476.phpt
+++ b/tests/end-to-end/regression/6476.phpt
@@ -1,0 +1,31 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6476
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--enforce-time-limit';
+$_SERVER['argv'][] = '--default-time-limit=4';
+$_SERVER['argv'][] = __DIR__ . '/6476/Issue6476Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+R                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) PHPUnit\TestFixture\Issue6408\Issue6476Test::testIteratorAggregate
+This test was aborted after 4 seconds
+
+%sIssue6476Test.php:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Risky: 1.

--- a/tests/end-to-end/regression/6476.phpt
+++ b/tests/end-to-end/regression/6476.phpt
@@ -4,8 +4,6 @@ https://github.com/sebastianbergmann/phpunit/issues/6476
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
-$_SERVER['argv'][] = '--enforce-time-limit';
-$_SERVER['argv'][] = '--default-time-limit=4';
 $_SERVER['argv'][] = __DIR__ . '/6476/Issue6476Test.php';
 
 require_once __DIR__ . '/../../bootstrap.php';
@@ -16,16 +14,16 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-R                                                                   1 / 1 (100%)
+E                                                                   1 / 1 (100%)
 
 Time: %s, Memory: %s
 
-There was 1 risky test:
+There was 1 error:
 
 1) PHPUnit\TestFixture\Issue6408\Issue6476Test::testIteratorAggregate
-This test was aborted after 4 seconds
+PHPUnit\Framework\Exception: IteratorAggregate::getIterator() returned an object that was already seen
 
 %sIssue6476Test.php:%d
 
-OK, but there were issues!
-Tests: 1, Assertions: 1, Risky: 1.
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.

--- a/tests/end-to-end/regression/6476/Issue6476Test.php
+++ b/tests/end-to-end/regression/6476/Issue6476Test.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6408;
+
+use IteratorAggregate;
+use PHPUnit\Framework\TestCase;
+use Traversable;
+
+final class Issue6476Test extends TestCase
+{
+    public function testIteratorAggregate(): void
+    {
+        $this->assertCount(
+            0,
+            new class implements IteratorAggregate
+            {
+                public function __construct()
+                {
+                }
+
+                public function getIterator(): Traversable
+                {
+                    return $this;
+                }
+            },
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/6476

The problem is that `PHPUnit\Framework\Constraint\Count::getCountOf` [calls `getIterator` recursively](https://github.com/sebastianbergmann/phpunit/blob/11.5.48/src/Framework/Constraint/Cardinality/Count.php#L71), which can fall into infinite recursion - which is happening for the case reported in https://github.com/sebastianbergmann/phpunit/issues/6476.

- 1st commit is the test case where "test was aborted after 4 seconds".
  - CI randomly fails here: running `php ./phpunit --testsuite end-to-end --order-by depends,random --display-all-issues tests/end-to-end/regression/2085.phpt tests/end-to-end/regression/6476.php` non-deterministically fails (I have restarted them until all passed in [my fork](https://github.com/6b7562617765726c6f73/phpunit/actions/runs/21311535008) - I will investigate it and raise a separate issue/PR 
- 2nd commit is the idea for the solution, which works for both -  `tests/end-to-end/regression/6476/Issue6476Test.php` and the case from https://github.com/sebastianbergmann/phpunit/issues/6476 with `Ds\Set`.

