### PR TITLE
Debug non-deterministic tests failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,14 +243,31 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+#          - windows-latest
 
         php-version:
-          - "8.2"
-          - "8.3"
-          - "8.4"
-          - "8.5"
-          - "8.6"
+#          - "8.2"
+#          - "8.3"
+          - "8.4.0"
+          - "8.4.1"
+          - "8.4.2"
+          - "8.4.3"
+          - "8.4.4"
+          - "8.4.5"
+          - "8.4.6"
+          - "8.4.7"
+          - "8.4.8"
+          - "8.4.9"
+          - "8.4.10"
+          - "8.4.11"
+          - "8.4.12"
+          - "8.4.13"
+          - "8.4.14"
+          - "8.4.15"
+          - "8.4.16"
+          - "8.4.17"
+#          - "8.5"
+#          - "8.6"
 
     steps:
       - name: Configure Git to avoid issues with line endings
@@ -296,7 +313,7 @@ jobs:
         run: php ./tools/composer install --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: php ./phpunit --testsuite end-to-end --order-by depends,random --display-all-issues
+        run: php ./phpunit tests/end-to-end/regression/2085.phpt tests/end-to-end/regression/2085a.phpt
 
   code-coverage:
     name: Code Coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,7 +313,7 @@ jobs:
         run: php ./tools/composer install --no-ansi --no-interaction --no-progress
 
       - name: Run tests with PHPUnit
-        run: php ./phpunit tests/end-to-end/regression/2085.phpt tests/end-to-end/regression/2085a.phpt
+        run: php ./phpunit tests/end-to-end/regression/2085a.phpt tests/end-to-end/regression/2085.phpt
 
   code-coverage:
     name: Code Coverage

--- a/tests/end-to-end/regression/2085/Issue2085ATest.php
+++ b/tests/end-to-end/regression/2085/Issue2085ATest.php
@@ -9,27 +9,14 @@
  */
 namespace PHPUnit\TestFixture;
 
-use IteratorAggregate;
+use function sleep;
 use PHPUnit\Framework\TestCase;
-use Traversable;
 
 class Issue2085ATest extends TestCase
 {
     public function testShouldAbortSlowTestByEnforcingTimeLimit(): void
     {
-        $this->assertCount(
-            0,
-            new class implements IteratorAggregate
-            {
-                public function __construct()
-                {
-                }
-
-                public function getIterator(): Traversable
-                {
-                    return $this;
-                }
-            },
-        );
+        $this->assertTrue(true);
+        sleep(3);
     }
 }

--- a/tests/end-to-end/regression/2085/Issue2085ATest.php
+++ b/tests/end-to-end/regression/2085/Issue2085ATest.php
@@ -9,14 +9,27 @@
  */
 namespace PHPUnit\TestFixture;
 
-use function sleep;
+use IteratorAggregate;
 use PHPUnit\Framework\TestCase;
+use Traversable;
 
 class Issue2085ATest extends TestCase
 {
     public function testShouldAbortSlowTestByEnforcingTimeLimit(): void
     {
-        $this->assertTrue(true);
-        sleep(3);
+        $this->assertCount(
+            0,
+            new class implements IteratorAggregate
+            {
+                public function __construct()
+                {
+                }
+
+                public function getIterator(): Traversable
+                {
+                    return $this;
+                }
+            },
+        );
     }
 }

--- a/tests/end-to-end/regression/2085/Issue2085ATest.php
+++ b/tests/end-to-end/regression/2085/Issue2085ATest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use IteratorAggregate;
+use PHPUnit\Framework\TestCase;
+use Traversable;
+
+class Issue2085ATest extends TestCase
+{
+    public function testShouldAbortSlowTestByEnforcingTimeLimit(): void
+    {
+        $this->assertCount(
+            0,
+            new class implements IteratorAggregate
+            {
+                public function __construct()
+                {
+                }
+
+                public function getIterator(): Traversable
+                {
+                    return $this;
+                }
+            },
+        );
+    }
+}

--- a/tests/end-to-end/regression/2085a.phpt
+++ b/tests/end-to-end/regression/2085a.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test CLI flags --enforce-time-limit --default-time-limit
+--DESCRIPTION--
+https://github.com/sebastianbergmann/phpunit/issues/2085
+--SKIPIF--
+<?php declare(strict_types=1);
+require_once __DIR__ . '/../../bootstrap.php';
+
+if (!\class_exists(SebastianBergmann\Invoker\Invoker::class)) {
+    print "Skip: package phpunit/php-invoker is required for enforcing time limits" . PHP_EOL;
+}
+
+if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
+    print "Skip: extension pcntl is required for enforcing time limits" . PHP_EOL;
+}
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--enforce-time-limit';
+$_SERVER['argv'][] = '--default-time-limit=2';
+$_SERVER['argv'][] = __DIR__ . '/2085/Issue2085ATest.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+R                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) PHPUnit\TestFixture\Issue2085ATest::testShouldAbortSlowTestByEnforcingTimeLimit
+This test was aborted after 2 seconds
+
+%s:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Risky: 1.

--- a/tests/end-to-end/regression/2085a.phpt
+++ b/tests/end-to-end/regression/2085a.phpt
@@ -18,7 +18,7 @@ if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--enforce-time-limit';
-$_SERVER['argv'][] = '--default-time-limit=2';
+$_SERVER['argv'][] = '--default-time-limit=1';
 $_SERVER['argv'][] = __DIR__ . '/2085/Issue2085ATest.php';
 
 require_once __DIR__ . '/../../bootstrap.php';
@@ -35,7 +35,7 @@ Time: %s, Memory: %s
 There was 1 risky test:
 
 1) PHPUnit\TestFixture\Issue2085ATest::testShouldAbortSlowTestByEnforcingTimeLimit
-This test was aborted after 2 seconds
+This test was aborted after 1 second
 
 %s:%d
 

--- a/tests/end-to-end/regression/2085a.phpt
+++ b/tests/end-to-end/regression/2085a.phpt
@@ -18,7 +18,7 @@ if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl
 $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = '--enforce-time-limit';
-$_SERVER['argv'][] = '--default-time-limit=1';
+$_SERVER['argv'][] = '--default-time-limit=2';
 $_SERVER['argv'][] = __DIR__ . '/2085/Issue2085ATest.php';
 
 require_once __DIR__ . '/../../bootstrap.php';
@@ -35,7 +35,7 @@ Time: %s, Memory: %s
 There was 1 risky test:
 
 1) PHPUnit\TestFixture\Issue2085ATest::testShouldAbortSlowTestByEnforcingTimeLimit
-This test was aborted after 1 second
+This test was aborted after 2 seconds
 
 %s:%d
 


### PR DESCRIPTION
Running test at all 18 PHP 8.4 tags - to have 18 different runs.

Time limits - `2085.phpt` has a time limit of 1 second, `2085a.phpt` has 1 or 2 seconds
Timeout source - where the timeout happens - inside of PHPUnit or in a test case.
 
| Order | Time limits | Timeout source | non-deterministic tests failure?
| :--: | :--: | :--: | :--: |
| 2085, 2085a | different | PHPUnit | yes
| 2085, 2085a | the same  | PHPUnit | yes
| 2085, 2085a | the same  | test case | no
| 2085, 2085a | different | test case | no
| 2085a, 2085 | different | PHPUnit | yes
| 2085a, 2085 | the same | PHPUnit | yes