### PR TITLE
Reporting incorrect source of error

### DIFF
--- a/src/Framework/TestSuite.php
+++ b/src/Framework/TestSuite.php
@@ -511,7 +511,7 @@ class TestSuite implements IteratorAggregate, Reorderable, Test
                 new TestMethod(
                     $className,
                     $methodName,
-                    $class->getFileName(),
+                    $method->getFileName(),
                     $method->getStartLine(),
                     Event\Code\TestDoxBuilder::fromClassNameAndMethodName(
                         $className,

--- a/tests/end-to-end/regression/6486.phpt
+++ b/tests/end-to-end/regression/6486.phpt
@@ -1,0 +1,30 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6486
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/6486/Issue6486Test.php';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit error:
+
+1) PHPUnit\TestFixture\Issue6486\Issue6486Test::testWithMissingDataProvider
+The data provider specified for PHPUnit\TestFixture\Issue6486\Issue6486Test::testWithMissingDataProvider is invalid
+Method PHPUnit\TestFixture\Issue6486\Issue6486Test::Abracadabra() does not exist
+
+%sIssue6486Test.php:22
+
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.

--- a/tests/end-to-end/regression/6486.phpt
+++ b/tests/end-to-end/regression/6486.phpt
@@ -24,7 +24,7 @@ There was 1 PHPUnit error:
 The data provider specified for PHPUnit\TestFixture\Issue6486\Issue6486Test::testWithMissingDataProvider is invalid
 Method PHPUnit\TestFixture\Issue6486\Issue6486Test::Abracadabra() does not exist
 
-%sIssue6486Test.php:22
+%sTheTrait.php:22
 
 ERRORS!
 Tests: 1, Assertions: 1, Errors: 1.

--- a/tests/end-to-end/regression/6486/Issue6486Test.php
+++ b/tests/end-to-end/regression/6486/Issue6486Test.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6486;
+
+use PHPUnit\Framework\TestCase;
+
+require __DIR__ . '/TheTrait.php';
+
+final class Issue6486Test extends TestCase
+{
+    use TheTrait;
+}

--- a/tests/end-to-end/regression/6486/TheTrait.php
+++ b/tests/end-to-end/regression/6486/TheTrait.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6486;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+trait TheTrait
+{
+    public function testToMoveDataProviderAttributeToTheLineThatDoesNotExistInTheOtherFile(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('Abracadabra')]
+    public function testWithMissingDataProvider(): void
+    {
+        $this->assertTrue(false);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/6486

In the first commit, you can see the source of error being `Issue6486Test.php:22` - there is no line 22 in that file.