### PR TITLE
Fix tests count when tests were skipped in `BeforeClass` hook

### DIFF
--- a/src/Runner/TestResult/Collector.php
+++ b/src/Runner/TestResult/Collector.php
@@ -233,6 +233,8 @@ final class Collector
         }
 
         $this->testSuiteSkippedEvents[] = $event;
+
+        $this->numberOfTestsRun += $event->testSuite()->count();
     }
 
     public function testSuiteStarted(TestSuiteStarted $event): void

--- a/src/Runner/TestResult/TestResult.php
+++ b/src/Runner/TestResult/TestResult.php
@@ -9,6 +9,8 @@
  */
 namespace PHPUnit\TestRunner\TestResult;
 
+use function array_map;
+use function array_sum;
 use function count;
 use PHPUnit\Event\Test\AfterLastTestMethodErrored;
 use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
@@ -250,14 +252,19 @@ final readonly class TestResult
         return $this->testSuiteSkippedEvents;
     }
 
-    public function numberOfTestSuiteSkippedEvents(): int
+    public function numberOfTestSkippedByTestSuiteSkippedEvents(): int
     {
-        return count($this->testSuiteSkippedEvents);
+        return array_sum(
+            array_map(
+                static fn (TestSuiteSkipped $event): int => $event->testSuite()->count(),
+                $this->testSuiteSkippedEvents,
+            ),
+        );
     }
 
     public function hasTestSuiteSkippedEvents(): bool
     {
-        return $this->numberOfTestSuiteSkippedEvents() > 0;
+        return $this->numberOfTestSkippedByTestSuiteSkippedEvents() > 0;
     }
 
     /**

--- a/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php
+++ b/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php
@@ -94,6 +94,13 @@ final class ProgressPrinter
         }
     }
 
+    public function testSuiteSkipped(int $countTests): void
+    {
+        for ($i = 0; $i < $countTests; $i++) {
+            $this->testSkipped();
+        }
+    }
+
     public function testMarkedIncomplete(): void
     {
         $this->updateTestStatus(TestStatus::incomplete());
@@ -322,6 +329,7 @@ final class ProgressPrinter
             new TestPreparedSubscriber($this),
             new TestRunnerExecutionStartedSubscriber($this),
             new TestSkippedSubscriber($this),
+            new TestSuiteSkippedSubscriber($this),
             new TestTriggeredDeprecationSubscriber($this),
             new TestTriggeredNoticeSubscriber($this),
             new TestTriggeredPhpDeprecationSubscriber($this),

--- a/src/TextUI/Output/Default/ProgressPrinter/Subscriber/TestSuiteSkippedSubscriber.php
+++ b/src/TextUI/Output/Default/ProgressPrinter/Subscriber/TestSuiteSkippedSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\Output\Default\ProgressPrinter;
+
+use PHPUnit\Event\TestSuite\Skipped;
+use PHPUnit\Event\TestSuite\SkippedSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestSuiteSkippedSubscriber extends Subscriber implements SkippedSubscriber
+{
+    public function notify(Skipped $event): void
+    {
+        $this->printer()->testSuiteSkipped($event->testSuite()->count());
+    }
+}

--- a/src/TextUI/Output/SummaryPrinter.php
+++ b/src/TextUI/Output/SummaryPrinter.php
@@ -103,7 +103,7 @@ final class SummaryPrinter
         $this->printCountString($result->numberOfPhpOrUserDeprecations(), 'Deprecations', $color);
         $this->printCountString($result->numberOfPhpunitDeprecations(), 'PHPUnit Deprecations', $color);
         $this->printCountString($result->numberOfNotices(), 'Notices', $color);
-        $this->printCountString($result->numberOfTestSuiteSkippedEvents() + $result->numberOfTestSkippedEvents(), 'Skipped', $color);
+        $this->printCountString($result->numberOfTestSkippedByTestSuiteSkippedEvents() + $result->numberOfTestSkippedEvents(), 'Skipped', $color);
         $this->printCountString($result->numberOfTestMarkedIncompleteEvents(), 'Incomplete', $color);
         $this->printCountString($result->numberOfTestsWithTestConsideredRiskyEvents(), 'Risky', $color);
         $this->printWithColor($color, '.');

--- a/tests/end-to-end/event/_files/skip-in-before-class/NotSkippedTest.php
+++ b/tests/end-to-end/event/_files/skip-in-before-class/NotSkippedTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event\SkipInBeforeClass;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class NotSkippedTest extends TestCase
+{
+    #[DataProvider('provideData')]
+    public function test1(bool $bool): void
+    {
+        self::assertTrue($bool);
+    }
+
+    public static function provideData(): iterable
+    {
+        foreach (range(1, 100) as $item) {
+            yield [true];
+        }
+    }
+}

--- a/tests/end-to-end/event/_files/skip-in-before-class/NotSkippedTest.php
+++ b/tests/end-to-end/event/_files/skip-in-before-class/NotSkippedTest.php
@@ -9,21 +9,22 @@
  */
 namespace PHPUnit\TestFixture\Event\SkipInBeforeClass;
 
+use function range;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class NotSkippedTest extends TestCase
 {
-    #[DataProvider('provideData')]
-    public function test1(bool $bool): void
-    {
-        self::assertTrue($bool);
-    }
-
     public static function provideData(): iterable
     {
         foreach (range(1, 100) as $item) {
             yield [true];
         }
+    }
+
+    #[DataProvider('provideData')]
+    public function test1(bool $bool): void
+    {
+        $this->assertTrue($bool);
     }
 }

--- a/tests/end-to-end/event/_files/skip-in-before-class/SkippedBeforeClassTest.php
+++ b/tests/end-to-end/event/_files/skip-in-before-class/SkippedBeforeClassTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event\SkipInBeforeClass;
+
+use PHPUnit\Framework\TestCase;
+
+class SkippedBeforeClassTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        self::markTestSkipped('Skipped in before class');
+    }
+
+    public function test1(): void
+    {
+        self::assertTrue(true);
+    }
+
+    public function test2(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/end-to-end/event/_files/skip-in-before-class/SkippedBeforeClassTest.php
+++ b/tests/end-to-end/event/_files/skip-in-before-class/SkippedBeforeClassTest.php
@@ -9,22 +9,27 @@
  */
 namespace PHPUnit\TestFixture\Event\SkipInBeforeClass;
 
+use function range;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SkippedBeforeClassTest extends TestCase
 {
+    public static function provideData(): iterable
+    {
+        foreach (range(1, 100) as $item) {
+            yield [true];
+        }
+    }
+
     public static function setUpBeforeClass(): void
     {
         self::markTestSkipped('Skipped in before class');
     }
 
-    public function test1(): void
+    #[DataProvider('provideData')]
+    public function test1(bool $bool): void
     {
-        self::assertTrue(true);
-    }
-
-    public function test2(): void
-    {
-        self::assertTrue(true);
+        $this->assertTrue($bool);
     }
 }

--- a/tests/end-to-end/event/test-skip-before-class.phpt
+++ b/tests/end-to-end/event/test-skip-before-class.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Tests skipped before class should not be counted as executed tests
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/skip-in-before-class';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+
+...............................................................  63 / 102 ( 61%)
+.....................................SS                         102 / 102 (100%)
+
+Time: %s, Memory: %s MB
+
+OK, but some tests were skipped!
+Tests: 102, Assertions: 100, Skipped: 2.
+

--- a/tests/end-to-end/event/test-skip-before-class.phpt
+++ b/tests/end-to-end/event/test-skip-before-class.phpt
@@ -14,11 +14,13 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime:       PHP %s
 
-...............................................................  63 / 102 ( 61%)
-.....................................SS                         102 / 102 (100%)
+...............................................................  63 / 200 ( 31%)
+.....................................SSSSSSSSSSSSSSSSSSSSSSSSSS 126 / 200 ( 63%)
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 189 / 200 ( 94%)
+SSSSSSSSSSS                                                     200 / 200 (100%)
 
 Time: %s, Memory: %s MB
 
 OK, but some tests were skipped!
-Tests: 102, Assertions: 100, Skipped: 2.
+Tests: 200, Assertions: 100, Skipped: 100.
 

--- a/tests/end-to-end/regression/5165.phpt
+++ b/tests/end-to-end/regression/5165.phpt
@@ -14,9 +14,14 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
+SS                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s MB
+
 There was 1 skipped test suite:
 
 1) Issue5165Test
 message
 
-No tests executed!
+OK, but some tests were skipped!
+Tests: 2, Assertions: 0, Skipped: 2.


### PR DESCRIPTION
Hello,

when some tests are skipped in a "before class" hook, there is a problem in the output.

Let's say our test suite have:
- 100 tests in a class which is skipped using `#[RequiresPhp('^9.0')]`
- 100 other tests wich will run normally

here what its output looks like:
```
...............................................................  63 / 200 ( 31%)
.....................................SSSSSSSSSSSSSSSSSSSSSSSSSS 126 / 200 ( 63%)
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 189 / 200 ( 94%)
SSSSSSSSSSS                                                     200 / 200 (100%)
 
Time: 00:00.025, Memory: 10.00 MB
 
OK, but some tests were skipped!
Tests: 200, Assertions: 100, Skipped: 100.
```
(BTW, the output is the same if the tests are skipped by calling `self::markTestSkipped()` in a "before" hook)

and now, the very same suite, but `self::markTestSkipped()` is called in a "before class" hook:
```
...............................................................  63 / 200 ( 31%)
.....................................
 
Time: 00:00.016, Memory: 10.00 MB
 
OK, but some tests were skipped!
Tests: 100, Assertions: 100, Skipped: 1.
```

We can see several problems in the output, comparing to the previous one:
- the second line of the progress bar does not display any count
- skipped tests are not displayed in the progress bar
- there are only 100 dots int the progress whereas the total displayed at the end of the line is 200
- the summary seems to not reflect the total number of tests, nor the number of skipped tests

Here is a proposal to make this case coherent with any other mean to skip a full class of tests.