### PR TITLE
Share source map with child processes for process isolation

### DIFF
--- a/src/Framework/TestRunner/SeparateProcessTestRunner.php
+++ b/src/Framework/TestRunner/SeparateProcessTestRunner.php
@@ -182,7 +182,9 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
 
         register_shutdown_function(static function () use ($path): void
         {
+            // @codeCoverageIgnoreStart
             @unlink($path);
+            // @codeCoverageIgnoreEnd
         });
 
         self::$sourceMapFile = $path;

--- a/src/Framework/TestRunner/SeparateProcessTestRunner.php
+++ b/src/Framework/TestRunner/SeparateProcessTestRunner.php
@@ -13,6 +13,7 @@ use function assert;
 use function defined;
 use function get_include_path;
 use function hrtime;
+use function register_shutdown_function;
 use function serialize;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -22,6 +23,7 @@ use function var_export;
 use PHPUnit\Event\NoPreviousThrowableException;
 use PHPUnit\Runner\CodeCoverage;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
+use PHPUnit\TextUI\Configuration\SourceMapper;
 use PHPUnit\Util\GlobalState;
 use PHPUnit\Util\PHP\Job;
 use PHPUnit\Util\PHP\JobRunnerRegistry;
@@ -36,6 +38,8 @@ use SebastianBergmann\Template\Template;
  */
 final class SeparateProcessTestRunner implements IsolatedTestRunner
 {
+    private static ?string $sourceMapFile = null;
+
     /**
      * @throws \PHPUnit\Runner\Exception
      * @throws \PHPUnit\Util\Exception
@@ -102,6 +106,7 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         $offset                  = hrtime();
         $serializedConfiguration = $this->saveConfigurationForChildProcess();
         $processResultFile       = tempnam(sys_get_temp_dir(), 'phpunit_');
+        $sourceMapFile           = $this->sourceMapFileForChildProcess();
 
         $file = $class->getFileName();
 
@@ -127,6 +132,7 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
             'offsetNanoseconds'              => (string) $offset[1],
             'serializedConfiguration'        => $serializedConfiguration,
             'processResultFile'              => $processResultFile,
+            'sourceMapFile'                  => $sourceMapFile,
         ];
 
         if (!$runEntireClass) {
@@ -142,6 +148,42 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         JobRunnerRegistry::runTestJob(new Job($code, requiresXdebug: $requiresXdebug), $processResultFile, $test);
 
         @unlink($serializedConfiguration);
+    }
+
+    private function sourceMapFileForChildProcess(): string
+    {
+        if (self::$sourceMapFile !== null) {
+            return self::$sourceMapFile;
+        }
+
+        if (!ConfigurationRegistry::get()->source()->notEmpty()) {
+            self::$sourceMapFile = '';
+
+            return self::$sourceMapFile;
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'phpunit_');
+
+        if ($path === false) {
+            self::$sourceMapFile = '';
+
+            return self::$sourceMapFile;
+        }
+
+        if (!SourceMapper::saveTo($path, ConfigurationRegistry::get()->source())) {
+            self::$sourceMapFile = '';
+
+            return self::$sourceMapFile;
+        }
+
+        register_shutdown_function(static function () use ($path): void
+        {
+            @unlink($path);
+        });
+
+        self::$sourceMapFile = $path;
+
+        return self::$sourceMapFile;
     }
 
     /**

--- a/src/Framework/TestRunner/SeparateProcessTestRunner.php
+++ b/src/Framework/TestRunner/SeparateProcessTestRunner.php
@@ -165,15 +165,19 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         $path = tempnam(sys_get_temp_dir(), 'phpunit_');
 
         if ($path === false) {
+            // @codeCoverageIgnoreStart
             self::$sourceMapFile = '';
 
             return self::$sourceMapFile;
+            // @codeCoverageIgnoreEnd
         }
 
         if (!SourceMapper::saveTo($path, ConfigurationRegistry::get()->source())) {
+            // @codeCoverageIgnoreStart
             self::$sourceMapFile = '';
 
             return self::$sourceMapFile;
+            // @codeCoverageIgnoreEnd
         }
 
         register_shutdown_function(static function () use ($path): void
@@ -194,11 +198,15 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         $path = tempnam(sys_get_temp_dir(), 'phpunit_');
 
         if ($path === false) {
+            // @codeCoverageIgnoreStart
             throw new ProcessIsolationException;
+            // @codeCoverageIgnoreEnd
         }
 
         if (!ConfigurationRegistry::saveTo($path)) {
+            // @codeCoverageIgnoreStart
             throw new ProcessIsolationException;
+            // @codeCoverageIgnoreEnd
         }
 
         return $path;

--- a/src/Framework/TestRunner/SeparateProcessTestRunner.php
+++ b/src/Framework/TestRunner/SeparateProcessTestRunner.php
@@ -105,7 +105,7 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         $includePath             = "'." . $includePath . ".'";
         $offset                  = hrtime();
         $serializedConfiguration = $this->saveConfigurationForChildProcess();
-        $processResultFile       = tempnam(sys_get_temp_dir(), 'phpunit_');
+        $processResultFile       = $this->pathForCachedSourceMap();
         $sourceMapFile           = $this->sourceMapFileForChildProcess();
 
         $file = $class->getFileName();
@@ -162,7 +162,7 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
             return self::$sourceMapFile;
         }
 
-        $path = tempnam(sys_get_temp_dir(), 'phpunit_');
+        $path = $this->pathForCachedSourceMap();
 
         if ($path === false) {
             // @codeCoverageIgnoreStart
@@ -197,7 +197,7 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
      */
     private function saveConfigurationForChildProcess(): string
     {
-        $path = tempnam(sys_get_temp_dir(), 'phpunit_');
+        $path = $this->pathForCachedSourceMap();
 
         if ($path === false) {
             // @codeCoverageIgnoreStart
@@ -212,5 +212,10 @@ final class SeparateProcessTestRunner implements IsolatedTestRunner
         }
 
         return $path;
+    }
+
+    private function pathForCachedSourceMap(): false|string
+    {
+        return tempnam(sys_get_temp_dir(), 'phpunit_');
     }
 }

--- a/src/Framework/TestRunner/templates/class.tpl
+++ b/src/Framework/TestRunner/templates/class.tpl
@@ -5,6 +5,7 @@ use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use PHPUnit\TextUI\Configuration\PhpHandler;
+use PHPUnit\TextUI\Configuration\SourceMapper;
 use PHPUnit\TestRunner\TestResult\PassedTests;
 
 // php://stdout does not obey output buffering. Any output would break
@@ -128,6 +129,11 @@ set_error_handler('__phpunit_error_handler');
 restore_error_handler();
 
 ConfigurationRegistry::loadFrom('{serializedConfiguration}');
+
+if ('{sourceMapFile}' !== '') {
+    SourceMapper::loadFrom('{sourceMapFile}', ConfigurationRegistry::get()->source());
+}
+
 (new PhpHandler)->handle(ConfigurationRegistry::get()->php());
 
 if ('{bootstrap}' !== '') {

--- a/src/Framework/TestRunner/templates/method.tpl
+++ b/src/Framework/TestRunner/templates/method.tpl
@@ -5,6 +5,7 @@ use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
 use PHPUnit\TextUI\Configuration\PhpHandler;
+use PHPUnit\TextUI\Configuration\SourceMapper;
 use PHPUnit\TestRunner\TestResult\PassedTests;
 
 // php://stdout does not obey output buffering. Any output would break
@@ -128,6 +129,11 @@ set_error_handler('__phpunit_error_handler');
 restore_error_handler();
 
 ConfigurationRegistry::loadFrom('{serializedConfiguration}');
+
+if ('{sourceMapFile}' !== '') {
+    SourceMapper::loadFrom('{sourceMapFile}', ConfigurationRegistry::get()->source());
+}
+
 (new PhpHandler)->handle(ConfigurationRegistry::get()->php());
 
 if ('{bootstrap}' !== '') {

--- a/src/TextUI/Configuration/SourceMapper.php
+++ b/src/TextUI/Configuration/SourceMapper.php
@@ -9,7 +9,12 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use function file_get_contents;
+use function file_put_contents;
+use function is_array;
 use function realpath;
+use function serialize;
+use function unserialize;
 use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 use SplObjectStorage;
 
@@ -24,6 +29,35 @@ final class SourceMapper
      * @var ?SplObjectStorage<Source, array<non-empty-string, true>>
      */
     private static ?SplObjectStorage $files = null;
+
+    public static function saveTo(string $path, Source $source): bool
+    {
+        $map = (new self)->map($source);
+
+        return file_put_contents($path, serialize($map)) !== false;
+    }
+
+    public static function loadFrom(string $path, Source $source): void
+    {
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            return;
+        }
+
+        $map = unserialize($content, ['allowed_classes' => false]);
+
+        if (!is_array($map)) {
+            return;
+        }
+
+        if (self::$files === null) {
+            self::$files = new SplObjectStorage;
+        }
+
+        /** @phpstan-ignore offsetAssign.valueType */
+        self::$files[$source] = $map;
+    }
 
     /**
      * @return array<non-empty-string, true>

--- a/src/TextUI/Configuration/SourceMapper.php
+++ b/src/TextUI/Configuration/SourceMapper.php
@@ -37,6 +37,9 @@ final class SourceMapper
         return file_put_contents($path, serialize($map)) !== false;
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
     public static function loadFrom(string $path, Source $source): void
     {
         $content = file_get_contents($path);


### PR DESCRIPTION
Make the map generated in the parent process using `SourceMapper::map()` available in child processes to avoid generating the map using expensive filesystem operations more than once.

See #6493 for context and motivation.

Two new static methods are added to `SourceMapper` to enable serializing/deserializing the source map:
- `saveTo(string $path, Source $source): bool` computes the source map via `map()`, serializes it, and writes it to a file in the system's temporary directory
- `loadFrom(string $path, Source $source): void` Reads a serialized source map from a file and populates the static `$files` cache, skipping the expensive filesystem operations

The new static property `SeparateProcessTestRunner::$sourceMapFile` is used to cache the temporary file path across invocations (computed once, reused for all child processes). It is managed through the new private method `sourceMapFileForChildProcess()`.