### PR TITLE
chore: remove extensions that are enabled by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.4.1",
-        "ext-dom": "*",
-        "ext-json": "*",
-        "ext-libxml": "*",
         "ext-mbstring": "*",
-        "ext-xml": "*",
-        "ext-xmlwriter": "*",
         "myclabs/deep-copy": "^1.13.4",
         "phar-io/manifest": "^2.0.4",
         "phar-io/version": "^3.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e500578c0dd05c77d3fce803067a76ce",
+    "content-hash": "213834aa71928e77135f061780be6964",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1704,12 +1704,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4.1",
-        "ext-dom": "*",
-        "ext-json": "*",
-        "ext-libxml": "*",
-        "ext-mbstring": "*",
-        "ext-xml": "*",
-        "ext-xmlwriter": "*"
+        "ext-mbstring": "*"
     },
     "platform-dev": {},
     "platform-overrides": {


### PR DESCRIPTION
This PR removes the following `ext-*` requirements from `composer.json`, as they are enabled by default.
The `composer.lock` file was updated accordingly.

Motivation: downstream packaging / devshells (notably Nix) flag these as redundant constraints and it can create unnecessary friction when building minimal environments.

Origin of the issue: https://github.com/loophp/nix-shell/issues/295
