### PR TITLE
skip XML schema validation if libxml2 has been built without LIBXML_S…

### DIFF
--- a/src/TextUI/Configuration/Xml/Validator/Validator.php
+++ b/src/TextUI/Configuration/Xml/Validator/Validator.php
@@ -29,14 +29,18 @@ final readonly class Validator
 
         assert($buffer !== false);
 
-        $originalErrorHandling = libxml_use_internal_errors(true);
+        if (method_exists($document, 'schemaValidateSource')) {
+            $originalErrorHandling = libxml_use_internal_errors(true);
 
-        $document->schemaValidateSource($buffer);
+            $document->schemaValidateSource($buffer);
 
-        $errors = libxml_get_errors();
-        libxml_clear_errors();
-        libxml_use_internal_errors($originalErrorHandling);
+            $errors = libxml_get_errors();
+            libxml_clear_errors();
+            libxml_use_internal_errors($originalErrorHandling);
 
-        return ValidationResult::fromArray($errors);
+            return ValidationResult::fromArray($errors);
+        } else {
+            return ValidationResult::fromArray([]);
+        }
     }
 }


### PR DESCRIPTION
libxml2 can be built without schema support (e.g. by  configuring `--without-schemas`). While no PHP is currently available that would build with libxml/dom support with such a libxml2, we do have appropriate patches locally and intend to upstream them next week. Right now, we need to replace DOMDocument::schemaValidateSource with a stub function that always returns true so that PHPUnit does not fail with a validation error. 

We would prefer if PHPUnit would skip validation if the schemaValidateSource() method is unavailable.  This (untested) pull request should accomplish this.