### PR TITLE
Report issues in Open Test Reporting (OTR) XML logfile

### DIFF
--- a/src/Event/Value/Test/Issue/IssueTrigger.php
+++ b/src/Event/Value/Test/Issue/IssueTrigger.php
@@ -63,6 +63,24 @@ final readonly class IssueTrigger
         return !$this->isSelf() && !$this->isDirect() && !$this->isIndirect();
     }
 
+    public function callerAsString(): string
+    {
+        if ($this->caller !== null) {
+            return $this->caller->value;
+        }
+
+        return 'unknown';
+    }
+
+    public function calleeAsString(): string
+    {
+        if ($this->callee !== null) {
+            return $this->callee->value;
+        }
+
+        return 'unknown';
+    }
+
     public function asString(): string
     {
         if ($this->callee === null || $this->caller === null) {

--- a/src/Event/Value/Test/Issue/IssueTrigger.php
+++ b/src/Event/Value/Test/Issue/IssueTrigger.php
@@ -63,6 +63,9 @@ final readonly class IssueTrigger
         return !$this->isSelf() && !$this->isDirect() && !$this->isIndirect();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function callerAsString(): string
     {
         if ($this->caller !== null) {
@@ -72,6 +75,9 @@ final readonly class IssueTrigger
         return 'unknown';
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function calleeAsString(): string
     {
         if ($this->callee !== null) {
@@ -81,6 +87,9 @@ final readonly class IssueTrigger
         return 'unknown';
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function asString(): string
     {
         if ($this->callee === null || $this->caller === null) {

--- a/src/Event/Value/Test/Issue/IssueTrigger.php
+++ b/src/Event/Value/Test/Issue/IssueTrigger.php
@@ -68,11 +68,7 @@ final readonly class IssueTrigger
      */
     public function callerAsString(): string
     {
-        if ($this->caller !== null) {
-            return $this->caller->value;
-        }
-
-        return 'unknown';
+        return $this->codeAsString($this->caller);
     }
 
     /**
@@ -80,11 +76,7 @@ final readonly class IssueTrigger
      */
     public function calleeAsString(): string
     {
-        if ($this->callee !== null) {
-            return $this->callee->value;
-        }
-
-        return 'unknown';
+        return $this->codeAsString($this->callee);
     }
 
     /**
@@ -101,5 +93,17 @@ final readonly class IssueTrigger
             $this->caller->value,
             $this->callee->value,
         );
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function codeAsString(?Code $code): string
+    {
+        if ($code === null) {
+            return 'unknown';
+        }
+
+        return $code->value;
     }
 }

--- a/src/Logging/OpenTestReporting/OtrXmlLogger.php
+++ b/src/Logging/OpenTestReporting/OtrXmlLogger.php
@@ -18,6 +18,7 @@ use function error_get_last;
 use function str_replace;
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
 use PHPUnit\Event\Code\Test;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
@@ -26,14 +27,26 @@ use PHPUnit\Event\Test\AfterLastTestMethodErrored;
 use PHPUnit\Event\Test\AfterLastTestMethodFailed;
 use PHPUnit\Event\Test\BeforeFirstTestMethodErrored;
 use PHPUnit\Event\Test\BeforeFirstTestMethodFailed;
+use PHPUnit\Event\Test\ConsideredRisky;
+use PHPUnit\Event\Test\DeprecationTriggered;
 use PHPUnit\Event\Test\Errored;
+use PHPUnit\Event\Test\ErrorTriggered;
 use PHPUnit\Event\Test\Failed;
 use PHPUnit\Event\Test\MarkedIncomplete;
+use PHPUnit\Event\Test\NoticeTriggered;
+use PHPUnit\Event\Test\PhpDeprecationTriggered;
+use PHPUnit\Event\Test\PhpNoticeTriggered;
+use PHPUnit\Event\Test\PhpunitDeprecationTriggered;
+use PHPUnit\Event\Test\PhpunitErrorTriggered;
+use PHPUnit\Event\Test\PhpunitNoticeTriggered;
+use PHPUnit\Event\Test\PhpunitWarningTriggered;
+use PHPUnit\Event\Test\PhpWarningTriggered;
 use PHPUnit\Event\Test\PreparationErrored;
 use PHPUnit\Event\Test\PreparationFailed;
 use PHPUnit\Event\Test\Prepared as TestStarted;
 use PHPUnit\Event\Test\PrintedUnexpectedOutput;
 use PHPUnit\Event\Test\Skipped;
+use PHPUnit\Event\Test\WarningTriggered;
 use PHPUnit\Event\TestSuite\Skipped as TestSuiteSkipped;
 use PHPUnit\Event\TestSuite\Started as TestSuiteStarted;
 use PHPUnit\Event\TestSuite\TestSuiteForTestClass;
@@ -281,6 +294,126 @@ final class OtrXmlLogger
         $this->writer->flush();
     }
 
+    public function testDeprecationTriggered(DeprecationTriggered $event): void
+    {
+        $trigger = $event->trigger();
+
+        $this->writeIssue(
+            'deprecation',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+            $event->ignoredByBaseline(),
+            $event->ignoredByTest(),
+            $this->triggerAsString($trigger),
+            $trigger->callerAsString(),
+            $trigger->calleeAsString(),
+        );
+    }
+
+    public function testPhpDeprecationTriggered(PhpDeprecationTriggered $event): void
+    {
+        $trigger = $event->trigger();
+
+        $this->writeIssue(
+            'php-deprecation',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+            $event->ignoredByBaseline(),
+            $event->ignoredByTest(),
+            $this->triggerAsString($trigger),
+            $trigger->callerAsString(),
+            $trigger->calleeAsString(),
+        );
+    }
+
+    public function testPhpunitDeprecationTriggered(PhpunitDeprecationTriggered $event): void
+    {
+        $this->writeIssue('phpunit-deprecation', $event->message());
+    }
+
+    public function testErrorTriggered(ErrorTriggered $event): void
+    {
+        $this->writeIssue(
+            'error',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+        );
+    }
+
+    public function testPhpunitErrorTriggered(PhpunitErrorTriggered $event): void
+    {
+        $this->writeIssue('phpunit-error', $event->message());
+    }
+
+    public function testNoticeTriggered(NoticeTriggered $event): void
+    {
+        $this->writeIssue(
+            'notice',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+            $event->ignoredByBaseline(),
+        );
+    }
+
+    public function testPhpNoticeTriggered(PhpNoticeTriggered $event): void
+    {
+        $this->writeIssue(
+            'php-notice',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+            $event->ignoredByBaseline(),
+        );
+    }
+
+    public function testPhpunitNoticeTriggered(PhpunitNoticeTriggered $event): void
+    {
+        $this->writeIssue('phpunit-notice', $event->message());
+    }
+
+    public function testWarningTriggered(WarningTriggered $event): void
+    {
+        $this->writeIssue(
+            'warning',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+            $event->ignoredByBaseline(),
+        );
+    }
+
+    public function testPhpWarningTriggered(PhpWarningTriggered $event): void
+    {
+        $this->writeIssue(
+            'php-warning',
+            $event->message(),
+            $event->file(),
+            $event->line(),
+            $event->wasSuppressed(),
+            $event->ignoredByBaseline(),
+        );
+    }
+
+    public function testPhpunitWarningTriggered(PhpunitWarningTriggered $event): void
+    {
+        $this->writeIssue('phpunit-warning', $event->message(), null, null, null, null, $event->ignoredByTest());
+    }
+
+    public function testConsideredRisky(ConsideredRisky $event): void
+    {
+        $this->writeIssue('risky', $event->message());
+    }
+
     public function testFinished(): void
     {
         if (!$this->alreadyFinished) {
@@ -429,6 +562,72 @@ final class OtrXmlLogger
         $this->parentFailed = $event->throwable();
     }
 
+    private function writeIssue(string $type, string $message, ?string $file = null, ?int $line = null, ?bool $suppressed = null, ?bool $ignoredByBaseline = null, ?bool $ignoredByTest = null, ?string $trigger = null, ?string $caller = null, ?string $callee = null): void
+    {
+        $this->writer->startElement('e:reported');
+        $this->writer->writeAttribute('id', (string) $this->testId);
+        $this->writer->writeAttribute('time', $this->timestamp());
+
+        $this->writer->startElement('attachments');
+        $this->writer->startElement('phpunit:issue');
+        $this->writer->writeAttribute('type', $type);
+        $this->writer->writeAttribute('message', $message);
+
+        if ($file !== null) {
+            $this->writer->writeAttribute('file', $file);
+        }
+
+        if ($line !== null) {
+            $this->writer->writeAttribute('line', (string) $line);
+        }
+
+        if ($suppressed !== null) {
+            $this->writer->writeAttribute('suppressed', $suppressed ? 'true' : 'false');
+        }
+
+        if ($ignoredByBaseline !== null) {
+            $this->writer->writeAttribute('ignoredByBaseline', $ignoredByBaseline ? 'true' : 'false');
+        }
+
+        if ($ignoredByTest !== null) {
+            $this->writer->writeAttribute('ignoredByTest', $ignoredByTest ? 'true' : 'false');
+        }
+
+        if ($trigger !== null) {
+            $this->writer->writeAttribute('trigger', $trigger);
+        }
+
+        if ($caller !== null) {
+            $this->writer->writeAttribute('caller', $caller);
+        }
+
+        if ($callee !== null) {
+            $this->writer->writeAttribute('callee', $callee);
+        }
+
+        $this->writer->endElement();
+        $this->writer->endElement();
+        $this->writer->endElement();
+        $this->writer->flush();
+    }
+
+    private function triggerAsString(IssueTrigger $trigger): string
+    {
+        if ($trigger->isSelf()) {
+            return 'self';
+        }
+
+        if ($trigger->isDirect()) {
+            return 'direct';
+        }
+
+        if ($trigger->isIndirect()) {
+            return 'indirect';
+        }
+
+        return 'unknown';
+    }
+
     private function registerSubscribers(Facade $facade): void
     {
         $facade->registerSubscribers(
@@ -443,6 +642,18 @@ final class OtrXmlLogger
             new TestPreparationFailedSubscriber($this),
             new TestPreparedSubscriber($this),
             new TestPrintedUnexpectedOutputSubscriber($this),
+            new TestDeprecationTriggeredSubscriber($this),
+            new TestPhpDeprecationTriggeredSubscriber($this),
+            new TestPhpunitDeprecationTriggeredSubscriber($this),
+            new TestErrorTriggeredSubscriber($this),
+            new TestPhpunitErrorTriggeredSubscriber($this),
+            new TestNoticeTriggeredSubscriber($this),
+            new TestPhpNoticeTriggeredSubscriber($this),
+            new TestPhpunitNoticeTriggeredSubscriber($this),
+            new TestWarningTriggeredSubscriber($this),
+            new TestPhpWarningTriggeredSubscriber($this),
+            new TestPhpunitWarningTriggeredSubscriber($this),
+            new TestConsideredRiskySubscriber($this),
             new TestAbortedSubscriber($this),
             new TestErroredSubscriber($this),
             new TestFailedSubscriber($this),

--- a/src/Logging/OpenTestReporting/OtrXmlLogger.php
+++ b/src/Logging/OpenTestReporting/OtrXmlLogger.php
@@ -132,8 +132,8 @@ final class OtrXmlLogger
             $this->writer->writeAttribute('xmlns:git', 'https://schemas.opentest4j.org/reporting/git/0.2.0');
         }
 
-        $this->writer->writeAttribute('xmlns:php', 'https://schema.phpunit.de/otr/php/0.0.1');
-        $this->writer->writeAttribute('xmlns:phpunit', 'https://schema.phpunit.de/otr/phpunit/0.0.1');
+        $this->writer->writeAttribute('xmlns:php', 'https://schema.phpunit.de/otr/php/0.1.0');
+        $this->writer->writeAttribute('xmlns:phpunit', 'https://schema.phpunit.de/otr/phpunit/0.1.0');
 
         $this->writer->startElement('infrastructure');
         $this->writer->writeElement('hostName', $infrastructure->hostName());

--- a/src/Logging/OpenTestReporting/Subscriber/TestConsideredRiskySubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestConsideredRiskySubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\ConsideredRisky;
+use PHPUnit\Event\Test\ConsideredRiskySubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestConsideredRiskySubscriber extends Subscriber implements ConsideredRiskySubscriber
+{
+    public function notify(ConsideredRisky $event): void
+    {
+        $this->logger()->testConsideredRisky($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestDeprecationTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestDeprecationTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\DeprecationTriggered;
+use PHPUnit\Event\Test\DeprecationTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestDeprecationTriggeredSubscriber extends Subscriber implements DeprecationTriggeredSubscriber
+{
+    public function notify(DeprecationTriggered $event): void
+    {
+        $this->logger()->testDeprecationTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestErrorTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestErrorTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\ErrorTriggered;
+use PHPUnit\Event\Test\ErrorTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestErrorTriggeredSubscriber extends Subscriber implements ErrorTriggeredSubscriber
+{
+    public function notify(ErrorTriggered $event): void
+    {
+        $this->logger()->testErrorTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestNoticeTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestNoticeTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\NoticeTriggered;
+use PHPUnit\Event\Test\NoticeTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestNoticeTriggeredSubscriber extends Subscriber implements NoticeTriggeredSubscriber
+{
+    public function notify(NoticeTriggered $event): void
+    {
+        $this->logger()->testNoticeTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpDeprecationTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpDeprecationTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpDeprecationTriggered;
+use PHPUnit\Event\Test\PhpDeprecationTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpDeprecationTriggeredSubscriber extends Subscriber implements PhpDeprecationTriggeredSubscriber
+{
+    public function notify(PhpDeprecationTriggered $event): void
+    {
+        $this->logger()->testPhpDeprecationTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpNoticeTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpNoticeTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpNoticeTriggered;
+use PHPUnit\Event\Test\PhpNoticeTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpNoticeTriggeredSubscriber extends Subscriber implements PhpNoticeTriggeredSubscriber
+{
+    public function notify(PhpNoticeTriggered $event): void
+    {
+        $this->logger()->testPhpNoticeTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpWarningTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpWarningTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpWarningTriggered;
+use PHPUnit\Event\Test\PhpWarningTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpWarningTriggeredSubscriber extends Subscriber implements PhpWarningTriggeredSubscriber
+{
+    public function notify(PhpWarningTriggered $event): void
+    {
+        $this->logger()->testPhpWarningTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpunitDeprecationTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpunitDeprecationTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpunitDeprecationTriggered;
+use PHPUnit\Event\Test\PhpunitDeprecationTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpunitDeprecationTriggeredSubscriber extends Subscriber implements PhpunitDeprecationTriggeredSubscriber
+{
+    public function notify(PhpunitDeprecationTriggered $event): void
+    {
+        $this->logger()->testPhpunitDeprecationTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpunitErrorTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpunitErrorTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpunitErrorTriggered;
+use PHPUnit\Event\Test\PhpunitErrorTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpunitErrorTriggeredSubscriber extends Subscriber implements PhpunitErrorTriggeredSubscriber
+{
+    public function notify(PhpunitErrorTriggered $event): void
+    {
+        $this->logger()->testPhpunitErrorTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpunitNoticeTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpunitNoticeTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpunitNoticeTriggered;
+use PHPUnit\Event\Test\PhpunitNoticeTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpunitNoticeTriggeredSubscriber extends Subscriber implements PhpunitNoticeTriggeredSubscriber
+{
+    public function notify(PhpunitNoticeTriggered $event): void
+    {
+        $this->logger()->testPhpunitNoticeTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestPhpunitWarningTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestPhpunitWarningTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\PhpunitWarningTriggered;
+use PHPUnit\Event\Test\PhpunitWarningTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestPhpunitWarningTriggeredSubscriber extends Subscriber implements PhpunitWarningTriggeredSubscriber
+{
+    public function notify(PhpunitWarningTriggered $event): void
+    {
+        $this->logger()->testPhpunitWarningTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/Subscriber/TestWarningTriggeredSubscriber.php
+++ b/src/Logging/OpenTestReporting/Subscriber/TestWarningTriggeredSubscriber.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Logging\OpenTestReporting;
+
+use PHPUnit\Event\Test\WarningTriggered;
+use PHPUnit\Event\Test\WarningTriggeredSubscriber;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class TestWarningTriggeredSubscriber extends Subscriber implements WarningTriggeredSubscriber
+{
+    public function notify(WarningTriggered $event): void
+    {
+        $this->logger()->testWarningTriggered($event);
+    }
+}

--- a/src/Logging/OpenTestReporting/schema/otr.xsd
+++ b/src/Logging/OpenTestReporting/schema/otr.xsd
@@ -2,6 +2,6 @@
     <xs:import namespace="https://schemas.opentest4j.org/reporting/core/0.2.0" schemaLocation="core-0.2.0.xsd"/>
     <xs:import namespace="https://schemas.opentest4j.org/reporting/events/0.2.0" schemaLocation="events-0.2.0.xsd"/>
     <xs:import namespace="https://schemas.opentest4j.org/reporting/git/0.2.0" schemaLocation="git-0.2.0.xsd"/>
-    <xs:import namespace="https://schema.phpunit.de/otr/php/0.0.1" schemaLocation="php.xsd"/>
-    <xs:import namespace="https://schema.phpunit.de/otr/phpunit/0.0.1" schemaLocation="phpunit.xsd"/>
+    <xs:import namespace="https://schema.phpunit.de/otr/php/0.1.0" schemaLocation="php.xsd"/>
+    <xs:import namespace="https://schema.phpunit.de/otr/phpunit/0.1.0" schemaLocation="phpunit.xsd"/>
 </xs:schema>

--- a/src/Logging/OpenTestReporting/schema/php.xsd
+++ b/src/Logging/OpenTestReporting/schema/php.xsd
@@ -1,5 +1,5 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="https://schema.phpunit.de/otr/php/0.0.1"
+           targetNamespace="https://schema.phpunit.de/otr/php/0.1.0"
            elementFormDefault="qualified">
 
     <xs:element name="phpVersion" type="xs:string"/>

--- a/src/Logging/OpenTestReporting/schema/phpunit.xsd
+++ b/src/Logging/OpenTestReporting/schema/phpunit.xsd
@@ -1,7 +1,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:core="https://schemas.opentest4j.org/reporting/core/0.2.0"
-           xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1"
-           targetNamespace="https://schema.phpunit.de/otr/phpunit/0.0.1"
+           xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0"
+           targetNamespace="https://schema.phpunit.de/otr/phpunit/0.1.0"
            elementFormDefault="qualified">
 
     <xs:import schemaLocation="core-0.2.0.xsd" namespace="https://schemas.opentest4j.org/reporting/core/0.2.0"/>
@@ -17,32 +17,32 @@
 
     <xs:element name="methodSource">
         <xs:complexType>
-            <xs:attribute name="className" type="xs:string" use="required"/>
+            <xs:attribute name="className"  type="xs:string" use="required"/>
             <xs:attribute name="methodName" type="xs:string" use="required"/>
         </xs:complexType>
     </xs:element>
 
-    <xs:simpleType name="IssueCode">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="first-party code"/>
-            <xs:enumeration value="third-party code"/>
-            <xs:enumeration value="test code"/>
-            <xs:enumeration value="PHP runtime"/>
-            <xs:enumeration value="PHPUnit"/>
-            <xs:enumeration value="unknown"/>
-        </xs:restriction>
-    </xs:simpleType>
+    <xs:element name="throwable">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="type"           type="xs:string"  use="required"/>
+                    <xs:attribute name="assertionError" type="xs:boolean" use="required"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
 
     <xs:element name="issue">
         <xs:complexType>
             <xs:attribute name="type" use="required">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
+                        <xs:enumeration value="error"/>
+                        <xs:enumeration value="phpunit-error"/>
                         <xs:enumeration value="deprecation"/>
                         <xs:enumeration value="php-deprecation"/>
                         <xs:enumeration value="phpunit-deprecation"/>
-                        <xs:enumeration value="error"/>
-                        <xs:enumeration value="phpunit-error"/>
                         <xs:enumeration value="notice"/>
                         <xs:enumeration value="php-notice"/>
                         <xs:enumeration value="phpunit-notice"/>
@@ -53,12 +53,12 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
-            <xs:attribute name="message"           type="xs:string"           use="required"/>
-            <xs:attribute name="file"              type="xs:string"           use="optional"/>
-            <xs:attribute name="line"              type="xs:positiveInteger"  use="optional"/>
-            <xs:attribute name="suppressed"        type="xs:boolean"          use="optional"/>
-            <xs:attribute name="ignoredByBaseline" type="xs:boolean"          use="optional"/>
-            <xs:attribute name="ignoredByTest"     type="xs:boolean"          use="optional"/>
+            <xs:attribute name="message"           type="xs:string"          use="required"/>
+            <xs:attribute name="file"              type="xs:string"          use="optional"/>
+            <xs:attribute name="line"              type="xs:positiveInteger" use="optional"/>
+            <xs:attribute name="suppressed"        type="xs:boolean"         use="optional"/>
+            <xs:attribute name="ignoredByBaseline" type="xs:boolean"         use="optional"/>
+            <xs:attribute name="ignoredByTest"     type="xs:boolean"         use="optional"/>
             <xs:attribute name="trigger"           use="optional">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
@@ -69,19 +69,19 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
-            <xs:attribute name="caller"  type="phpunit:IssueCode" use="optional"/>
-            <xs:attribute name="callee"  type="phpunit:IssueCode" use="optional"/>
+            <xs:attribute name="caller" type="phpunit:IssueCode" use="optional"/>
+            <xs:attribute name="callee" type="phpunit:IssueCode" use="optional"/>
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="throwable">
-        <xs:complexType>
-            <xs:simpleContent>
-                <xs:extension base="xs:string">
-                    <xs:attribute name="type" type="xs:string" use="required"/>
-                    <xs:attribute name="assertionError" type="xs:boolean" use="required"/>
-                </xs:extension>
-            </xs:simpleContent>
-        </xs:complexType>
-    </xs:element>
+    <xs:simpleType name="IssueCode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="test code"/>
+            <xs:enumeration value="first-party code"/>
+            <xs:enumeration value="third-party code"/>
+            <xs:enumeration value="PHPUnit"/>
+            <xs:enumeration value="PHP runtime"/>
+            <xs:enumeration value="unknown"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/src/Logging/OpenTestReporting/schema/phpunit.xsd
+++ b/src/Logging/OpenTestReporting/schema/phpunit.xsd
@@ -1,5 +1,6 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:core="https://schemas.opentest4j.org/reporting/core/0.2.0"
+           xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1"
            targetNamespace="https://schema.phpunit.de/otr/phpunit/0.0.1"
            elementFormDefault="qualified">
 
@@ -18,6 +19,58 @@
         <xs:complexType>
             <xs:attribute name="className" type="xs:string" use="required"/>
             <xs:attribute name="methodName" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="IssueCode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="first-party code"/>
+            <xs:enumeration value="third-party code"/>
+            <xs:enumeration value="test code"/>
+            <xs:enumeration value="PHP runtime"/>
+            <xs:enumeration value="PHPUnit"/>
+            <xs:enumeration value="unknown"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="issue">
+        <xs:complexType>
+            <xs:attribute name="type" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="deprecation"/>
+                        <xs:enumeration value="php-deprecation"/>
+                        <xs:enumeration value="phpunit-deprecation"/>
+                        <xs:enumeration value="error"/>
+                        <xs:enumeration value="phpunit-error"/>
+                        <xs:enumeration value="notice"/>
+                        <xs:enumeration value="php-notice"/>
+                        <xs:enumeration value="phpunit-notice"/>
+                        <xs:enumeration value="warning"/>
+                        <xs:enumeration value="php-warning"/>
+                        <xs:enumeration value="phpunit-warning"/>
+                        <xs:enumeration value="risky"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="message"           type="xs:string"           use="required"/>
+            <xs:attribute name="file"              type="xs:string"           use="optional"/>
+            <xs:attribute name="line"              type="xs:positiveInteger"  use="optional"/>
+            <xs:attribute name="suppressed"        type="xs:boolean"          use="optional"/>
+            <xs:attribute name="ignoredByBaseline" type="xs:boolean"          use="optional"/>
+            <xs:attribute name="ignoredByTest"     type="xs:boolean"          use="optional"/>
+            <xs:attribute name="trigger"           use="optional">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="self"/>
+                        <xs:enumeration value="direct"/>
+                        <xs:enumeration value="indirect"/>
+                        <xs:enumeration value="unknown"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="caller"  type="phpunit:IssueCode" use="optional"/>
+            <xs:attribute name="callee"  type="phpunit:IssueCode" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/tests/end-to-end/logging/open-test-reporting/_files/DeprecationIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/DeprecationIssueTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class DeprecationIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        trigger_error('message', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/ErrorIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/ErrorIssueTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use const E_USER_ERROR;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class ErrorIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        trigger_error('message', E_USER_ERROR);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/NoticeIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/NoticeIssueTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use const E_USER_NOTICE;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class NoticeIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        trigger_error('message', E_USER_NOTICE);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpDeprecationIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpDeprecationIssueTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use function utf8_encode;
+use PHPUnit\Framework\TestCase;
+
+final class PhpDeprecationIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        utf8_encode('test');
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpNoticeIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpNoticeIssueTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Framework\TestCase;
+
+final class PhpNoticeIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $f = static function (): void
+        {};
+        $a = &$f();
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpWarningIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpWarningIssueTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use function file_get_contents;
+use PHPUnit\Framework\TestCase;
+
+final class PhpWarningIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        file_get_contents('/non/existent/file');
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpunitDeprecationIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpunitDeprecationIssueTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitDeprecationIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        EventFacade::emitter()->testTriggeredPhpunitDeprecation(
+            $this->valueObjectForEvents(),
+            'message',
+        );
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpunitErrorIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpunitErrorIssueTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitErrorIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        EventFacade::emitter()->testTriggeredPhpunitError(
+            $this->valueObjectForEvents(),
+            'message',
+        );
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpunitNoticeIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpunitNoticeIssueTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitNoticeIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        EventFacade::emitter()->testTriggeredPhpunitNotice(
+            $this->valueObjectForEvents(),
+            'message',
+        );
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/PhpunitWarningIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/PhpunitWarningIssueTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\TestCase;
+
+final class PhpunitWarningIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        EventFacade::emitter()->testTriggeredPhpunitWarning(
+            $this->valueObjectForEvents(),
+            'message',
+        );
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/RiskyIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/RiskyIssueTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Framework\TestCase;
+
+final class RiskyIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/WarningIssueTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/WarningIssueTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use const E_USER_WARNING;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class WarningIssueTest extends TestCase
+{
+    public function testOne(): void
+    {
+        trigger_error('message', E_USER_WARNING);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-direct-trigger/DeprecationDirectTriggerTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-direct-trigger/DeprecationDirectTriggerTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/helper.php';
+
+final class DeprecationDirectTriggerTest extends TestCase
+{
+    public function testOne(): void
+    {
+        phpunit_otr_direct_trigger_helper();
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-direct-trigger/helper.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-direct-trigger/helper.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+function phpunit_otr_direct_trigger_helper(): void
+{
+    \trigger_error('message', \E_USER_DEPRECATED);
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-direct-trigger/phpunit.xml
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-direct-trigger/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <file>DeprecationDirectTriggerTest.php</file>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <file>DeprecationDirectTriggerTest.php</file>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-indirect-trigger/DeprecationIndirectTriggerTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-indirect-trigger/DeprecationIndirectTriggerTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/helper.php';
+
+final class DeprecationIndirectTriggerTest extends TestCase
+{
+    public function testOne(): void
+    {
+        phpunit_otr_indirect_trigger_outer();
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-indirect-trigger/helper.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-indirect-trigger/helper.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+function phpunit_otr_indirect_trigger_inner(): void
+{
+    \trigger_error('message', \E_USER_DEPRECATED);
+}
+
+function phpunit_otr_indirect_trigger_outer(): void
+{
+    phpunit_otr_indirect_trigger_inner();
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-indirect-trigger/phpunit.xml
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-indirect-trigger/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <file>DeprecationIndirectTriggerTest.php</file>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <file>DeprecationIndirectTriggerTest.php</file>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-self-trigger/DeprecationSelfTriggerTest.php
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-self-trigger/DeprecationSelfTriggerTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\OpenTestReporting;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class DeprecationSelfTriggerTest extends TestCase
+{
+    public function testOne(): void
+    {
+        trigger_error('message', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-self-trigger/phpunit.xml
+++ b/tests/end-to-end/logging/open-test-reporting/_files/issue-deprecation-self-trigger/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../../phpunit.xsd"
+         cacheResult="false"
+>
+    <testsuites>
+        <testsuite name="default">
+            <file>DeprecationSelfTriggerTest.php</file>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>.</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-class-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-test-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-class-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-test-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-postcondition-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-postcondition-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-precondition-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-precondition-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument-with-git-information.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument-with-git-information.phpt
@@ -126,6 +126,11 @@ unlink($logfile);
    <phpunit:methodSource className="PHPUnit\TestFixture\Basic\StatusTest" methodName="testRisky"/>
   </sources>
  </e:started>
+ <e:reported id="7" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
  <e:finished id="7" time="%s">
   <result status="SUCCESSFUL"/>
  </e:finished>
@@ -227,6 +232,11 @@ Failed asserting that false is true.
    <phpunit:methodSource className="PHPUnit\TestFixture\Basic\StatusTest" methodName="testRiskyWithMessage"/>
   </sources>
  </e:started>
+ <e:reported id="14" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
  <e:finished id="14" time="%s">
   <result status="SUCCESSFUL"/>
  </e:finished>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument-with-git-information.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument-with-git-information.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:git="https://schemas.opentest4j.org/reporting/git/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:git="https://schemas.opentest4j.org/reporting/git/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument.phpt
@@ -121,6 +121,11 @@ unlink($logfile);
    <phpunit:methodSource className="PHPUnit\TestFixture\Basic\StatusTest" methodName="testRisky"/>
   </sources>
  </e:started>
+ <e:reported id="7" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
  <e:finished id="7" time="%s">
   <result status="SUCCESSFUL"/>
  </e:finished>
@@ -222,6 +227,11 @@ Failed asserting that false is true.
    <phpunit:methodSource className="PHPUnit\TestFixture\Basic\StatusTest" methodName="testRiskyWithMessage"/>
   </sources>
  </e:started>
+ <e:reported id="14" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
  <e:finished id="14" time="%s">
   <result status="SUCCESSFUL"/>
  </e:finished>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-suite-from-xml-configuration-file.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-suite-from-xml-configuration-file.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-suite-from-xml-configuration-file.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-suite-from-xml-configuration-file.phpt
@@ -123,6 +123,11 @@ unlink($logfile);
    <phpunit:methodSource className="PHPUnit\TestFixture\Basic\StatusTest" methodName="testRisky"/>
   </sources>
  </e:started>
+ <e:reported id="9" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
  <e:finished id="9" time="%s">
   <result status="SUCCESSFUL"/>
  </e:finished>
@@ -224,6 +229,11 @@ Failed asserting that false is true.
    <phpunit:methodSource className="PHPUnit\TestFixture\Basic\StatusTest" methodName="testRiskyWithMessage"/>
   </sources>
  </e:started>
+ <e:reported id="16" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
  <e:finished id="16" time="%s">
   <result status="SUCCESSFUL"/>
  </e:finished>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-after-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-after-class-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-after-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-after-test-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-before-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-before-class-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-before-test-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/groups.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/groups.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-direct-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-direct-trigger.phpt
@@ -1,0 +1,64 @@
+--TEST--
+phpunit --configuration ../_files/issue-deprecation-direct-trigger/phpunit.xml --log-otr /path/to/logfile --display-deprecations
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/issue-deprecation-direct-trigger/phpunit.xml';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="%sphpunit.xml" time="%s"/>
+ <e:started id="2" parentId="1" name="default" time="%s"/>
+ <e:started id="3" parentId="2" name="PHPUnit\TestFixture\OpenTestReporting\DeprecationDirectTriggerTest" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationDirectTriggerTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationDirectTriggerTest"/>
+  </sources>
+ </e:started>
+ <e:started id="4" parentId="3" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationDirectTriggerTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationDirectTriggerTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="4" time="%s">
+  <attachments>
+   <phpunit:issue type="deprecation" message="message" file="%shelper.php" line="%d" suppressed="false" ignoredByBaseline="false" ignoredByTest="false" trigger="direct" caller="test code" callee="third-party code"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="4" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="3" time="%s"/>
+ <e:finished id="2" time="%s"/>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-direct-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-direct-trigger.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-indirect-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-indirect-trigger.phpt
@@ -1,0 +1,64 @@
+--TEST--
+phpunit --configuration ../_files/issue-deprecation-indirect-trigger/phpunit.xml --log-otr /path/to/logfile --display-deprecations
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/issue-deprecation-indirect-trigger/phpunit.xml';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="%sphpunit.xml" time="%s"/>
+ <e:started id="2" parentId="1" name="default" time="%s"/>
+ <e:started id="3" parentId="2" name="PHPUnit\TestFixture\OpenTestReporting\DeprecationIndirectTriggerTest" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationIndirectTriggerTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationIndirectTriggerTest"/>
+  </sources>
+ </e:started>
+ <e:started id="4" parentId="3" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationIndirectTriggerTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationIndirectTriggerTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="4" time="%s">
+  <attachments>
+   <phpunit:issue type="deprecation" message="message" file="%shelper.php" line="%d" suppressed="false" ignoredByBaseline="false" ignoredByTest="false" trigger="indirect" caller="third-party code" callee="third-party code"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="4" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="3" time="%s"/>
+ <e:finished id="2" time="%s"/>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-indirect-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-indirect-trigger.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-self-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-self-trigger.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-self-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-self-trigger.phpt
@@ -1,0 +1,64 @@
+--TEST--
+phpunit --configuration ../_files/issue-deprecation-self-trigger/phpunit.xml --log-otr /path/to/logfile --display-deprecations
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/issue-deprecation-self-trigger/phpunit.xml';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="%sphpunit.xml" time="%s"/>
+ <e:started id="2" parentId="1" name="default" time="%s"/>
+ <e:started id="3" parentId="2" name="PHPUnit\TestFixture\OpenTestReporting\DeprecationSelfTriggerTest" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationSelfTriggerTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationSelfTriggerTest"/>
+  </sources>
+ </e:started>
+ <e:started id="4" parentId="3" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationSelfTriggerTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationSelfTriggerTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="4" time="%s">
+  <attachments>
+   <phpunit:issue type="deprecation" message="message" file="%sDeprecationSelfTriggerTest.php" line="%d" suppressed="false" ignoredByBaseline="false" ignoredByTest="false" trigger="self" caller="PHPUnit" callee="test code"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="4" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="3" time="%s"/>
+ <e:finished id="2" time="%s"/>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation.phpt
@@ -1,0 +1,60 @@
+--TEST--
+phpunit --log-otr /path/to/logfile --display-deprecations ../_files/DeprecationIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/DeprecationIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\DeprecationIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sDeprecationIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\DeprecationIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="deprecation" message="message" file="%sDeprecationIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false" ignoredByTest="false" trigger="unknown" caller="unknown" callee="unknown"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-error.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-error.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-error.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-error.phpt
@@ -1,0 +1,70 @@
+--TEST--
+phpunit --log-otr /path/to/logfile --display-errors ../_files/ErrorIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-errors';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/ErrorIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\ErrorIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sErrorIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\ErrorIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sErrorIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\ErrorIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="php-deprecation" message="%s" file="%sErrorIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false" ignoredByTest="false" trigger="unknown" caller="unknown" callee="unknown"/>
+  </attachments>
+ </e:reported>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="error" message="message" file="%sErrorIssueTest.php" line="%d" suppressed="false"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="ERRORED">
+   <reason>E_USER_ERROR was triggered</reason>
+   <phpunit:throwable type="PHPUnit\Runner\ErrorException" assertionError="false"><![CDATA[E_USER_ERROR was triggered
+%sErrorIssueTest.php:%d
+]]></phpunit:throwable>
+  </result>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-notice.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-notice.phpt
@@ -1,0 +1,60 @@
+--TEST--
+phpunit --log-otr /path/to/logfile --display-notices ../_files/NoticeIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-notices';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/NoticeIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\NoticeIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sNoticeIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\NoticeIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sNoticeIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\NoticeIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="notice" message="message" file="%sNoticeIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-deprecation.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-deprecation.phpt
@@ -1,0 +1,60 @@
+--TEST--
+phpunit --log-otr /path/to/logfile --display-deprecations ../_files/PhpDeprecationIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-deprecations';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpDeprecationIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpDeprecationIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpDeprecationIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpDeprecationIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpDeprecationIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpDeprecationIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="php-deprecation" message="%s" file="%sPhpDeprecationIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false" ignoredByTest="false" trigger="unknown" caller="unknown" callee="unknown"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-notice.phpt
@@ -1,0 +1,59 @@
+--TEST--
+phpunit --log-otr /path/to/logfile ../_files/PhpNoticeIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpNoticeIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpNoticeIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpNoticeIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpNoticeIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpNoticeIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpNoticeIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="php-notice" message="Only variables should be assigned by reference" file="%sPhpNoticeIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-notice.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-warning.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-warning.phpt
@@ -1,0 +1,59 @@
+--TEST--
+phpunit --log-otr /path/to/logfile ../_files/PhpWarningIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpWarningIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpWarningIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpWarningIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpWarningIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpWarningIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpWarningIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="php-warning" message="%s" file="%sPhpWarningIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-deprecation.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-deprecation.phpt
@@ -1,0 +1,60 @@
+--TEST--
+phpunit --log-otr /path/to/logfile --display-phpunit-deprecations ../_files/PhpunitDeprecationIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-phpunit-deprecations';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpunitDeprecationIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpunitDeprecationIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitDeprecationIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitDeprecationIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitDeprecationIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitDeprecationIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="phpunit-deprecation" message="message"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-error.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-error.phpt
@@ -1,0 +1,59 @@
+--TEST--
+phpunit --log-otr /path/to/logfile ../_files/PhpunitErrorIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpunitErrorIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpunitErrorIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitErrorIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitErrorIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitErrorIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitErrorIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="phpunit-error" message="message"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-error.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-error.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-notice.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-notice.phpt
@@ -1,0 +1,59 @@
+--TEST--
+phpunit --log-otr /path/to/logfile ../_files/PhpunitNoticeIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpunitNoticeIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpunitNoticeIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitNoticeIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitNoticeIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitNoticeIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitNoticeIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="phpunit-notice" message="message"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-warning.phpt
@@ -1,0 +1,59 @@
+--TEST--
+phpunit --log-otr /path/to/logfile ../_files/PhpunitWarningIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/PhpunitWarningIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\PhpunitWarningIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitWarningIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitWarningIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sPhpunitWarningIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\PhpunitWarningIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="phpunit-warning" message="message" ignoredByTest="false"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-warning.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-risky.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-risky.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-risky.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-risky.phpt
@@ -1,0 +1,59 @@
+--TEST--
+phpunit --log-otr /path/to/logfile ../_files/RiskyIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/RiskyIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\RiskyIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sRiskyIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\RiskyIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sRiskyIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\RiskyIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="risky" message="This test did not perform any assertions"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-warning.phpt
@@ -24,7 +24,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/issue-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-warning.phpt
@@ -1,0 +1,60 @@
+--TEST--
+phpunit --log-otr /path/to/logfile --display-warnings ../_files/WarningIssueTest.php
+--FILE--
+<?php declare(strict_types=1);
+use function PHPUnit\TestFixture\validate_and_print;
+
+$logfile = tempnam(sys_get_temp_dir(), __FILE__);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--no-output';
+$_SERVER['argv'][] = '--display-warnings';
+$_SERVER['argv'][] = '--log-otr';
+$_SERVER['argv'][] = $logfile;
+$_SERVER['argv'][] = __DIR__ . '/_files/WarningIssueTest.php';
+
+require __DIR__ . '/../../../bootstrap.php';
+require __DIR__ . '/validate_and_print.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+
+validate_and_print($logfile);
+
+unlink($logfile);
+--EXPECTF--
+<?xml version="1.0"?>
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+ <infrastructure>
+  <hostName>%s</hostName>
+  <userName>%s</userName>
+  <operatingSystem>%s</operatingSystem>
+  <php:phpVersion>%s</php:phpVersion>
+  <php:threadModel>%s</php:threadModel>
+ </infrastructure>
+ <e:started id="1" name="PHPUnit\TestFixture\OpenTestReporting\WarningIssueTest" time="%s">
+  <sources>
+   <fileSource path="%sWarningIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:classSource className="PHPUnit\TestFixture\OpenTestReporting\WarningIssueTest"/>
+  </sources>
+ </e:started>
+ <e:started id="2" parentId="1" name="testOne" time="%s">
+  <sources>
+   <fileSource path="%sWarningIssueTest.php">
+    <filePosition line="%d"/>
+   </fileSource>
+   <phpunit:methodSource className="PHPUnit\TestFixture\OpenTestReporting\WarningIssueTest" methodName="testOne"/>
+  </sources>
+ </e:started>
+ <e:reported id="2" time="%s">
+  <attachments>
+   <phpunit:issue type="warning" message="message" file="%sWarningIssueTest.php" line="%d" suppressed="false" ignoredByBaseline="false"/>
+  </attachments>
+ </e:reported>
+ <e:finished id="2" time="%s">
+  <result status="SUCCESSFUL"/>
+ </e:finished>
+ <e:finished id="1" time="%s"/>
+</e:events>

--- a/tests/end-to-end/logging/open-test-reporting/skipped-in-before-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/skipped-in-before-class-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/skipped-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/skipped-in-before-test-method.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/end-to-end/logging/open-test-reporting/unexpected-output.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/unexpected-output.phpt
@@ -23,7 +23,7 @@ validate_and_print($logfile);
 unlink($logfile);
 --EXPECTF--
 <?xml version="1.0"?>
-<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.0.1" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.0.1">
+<e:events xmlns="https://schemas.opentest4j.org/reporting/core/0.2.0" xmlns:e="https://schemas.opentest4j.org/reporting/events/0.2.0" xmlns:php="https://schema.phpunit.de/otr/php/0.1.0" xmlns:phpunit="https://schema.phpunit.de/otr/phpunit/0.1.0">
  <infrastructure>
   <hostName>%s</hostName>
   <userName>%s</userName>

--- a/tests/unit/Event/Value/Test/IssueTriggerTest.php
+++ b/tests/unit/Event/Value/Test/IssueTriggerTest.php
@@ -28,6 +28,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('unknown', $issueTrigger->callerAsString());
+        $this->assertSame('unknown', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -40,6 +42,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('test code', $issueTrigger->callerAsString());
+        $this->assertSame('unknown', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -52,6 +56,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('first-party code', $issueTrigger->callerAsString());
+        $this->assertSame('unknown', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -64,6 +70,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('third-party code', $issueTrigger->callerAsString());
+        $this->assertSame('unknown', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -76,6 +84,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('PHPUnit', $issueTrigger->callerAsString());
+        $this->assertSame('unknown', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -88,6 +98,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('PHP runtime', $issueTrigger->callerAsString());
+        $this->assertSame('unknown', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -100,6 +112,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('unknown', $issueTrigger->callerAsString());
+        $this->assertSame('test code', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -112,6 +126,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('test code', $issueTrigger->callerAsString());
+        $this->assertSame('test code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by test code calling into test code', $issueTrigger->asString());
     }
 
@@ -124,6 +140,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('first-party code', $issueTrigger->callerAsString());
+        $this->assertSame('test code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by first-party code calling into test code', $issueTrigger->asString());
     }
 
@@ -136,6 +154,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('third-party code', $issueTrigger->callerAsString());
+        $this->assertSame('test code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by third-party code calling into test code', $issueTrigger->asString());
     }
 
@@ -148,6 +168,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHPUnit', $issueTrigger->callerAsString());
+        $this->assertSame('test code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHPUnit calling into test code', $issueTrigger->asString());
     }
 
@@ -160,6 +182,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHP runtime', $issueTrigger->callerAsString());
+        $this->assertSame('test code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHP runtime calling into test code', $issueTrigger->asString());
     }
 
@@ -172,6 +196,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('unknown', $issueTrigger->callerAsString());
+        $this->assertSame('first-party code', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -184,6 +210,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('test code', $issueTrigger->callerAsString());
+        $this->assertSame('first-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by test code calling into first-party code', $issueTrigger->asString());
     }
 
@@ -196,6 +224,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('first-party code', $issueTrigger->callerAsString());
+        $this->assertSame('first-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by first-party code calling into first-party code', $issueTrigger->asString());
     }
 
@@ -208,6 +238,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('third-party code', $issueTrigger->callerAsString());
+        $this->assertSame('first-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by third-party code calling into first-party code', $issueTrigger->asString());
     }
 
@@ -220,6 +252,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHPUnit', $issueTrigger->callerAsString());
+        $this->assertSame('first-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHPUnit calling into first-party code', $issueTrigger->asString());
     }
 
@@ -232,6 +266,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHP runtime', $issueTrigger->callerAsString());
+        $this->assertSame('first-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHP runtime calling into first-party code', $issueTrigger->asString());
     }
 
@@ -244,6 +280,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('unknown', $issueTrigger->callerAsString());
+        $this->assertSame('third-party code', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -256,6 +294,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertTrue($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('test code', $issueTrigger->callerAsString());
+        $this->assertSame('third-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by test code calling into third-party code', $issueTrigger->asString());
     }
 
@@ -268,6 +308,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertTrue($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('first-party code', $issueTrigger->callerAsString());
+        $this->assertSame('third-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by first-party code calling into third-party code', $issueTrigger->asString());
     }
 
@@ -280,6 +322,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('third-party code', $issueTrigger->callerAsString());
+        $this->assertSame('third-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by third-party code calling into third-party code', $issueTrigger->asString());
     }
 
@@ -292,6 +336,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHPUnit', $issueTrigger->callerAsString());
+        $this->assertSame('third-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHPUnit calling into third-party code', $issueTrigger->asString());
     }
 
@@ -304,6 +350,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHP runtime', $issueTrigger->callerAsString());
+        $this->assertSame('third-party code', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHP runtime calling into third-party code', $issueTrigger->asString());
     }
 
@@ -316,6 +364,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('unknown', $issueTrigger->callerAsString());
+        $this->assertSame('PHPUnit', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -328,6 +378,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertTrue($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('test code', $issueTrigger->callerAsString());
+        $this->assertSame('PHPUnit', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by test code calling into PHPUnit', $issueTrigger->asString());
     }
 
@@ -340,6 +392,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertTrue($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('first-party code', $issueTrigger->callerAsString());
+        $this->assertSame('PHPUnit', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by first-party code calling into PHPUnit', $issueTrigger->asString());
     }
 
@@ -352,6 +406,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('third-party code', $issueTrigger->callerAsString());
+        $this->assertSame('PHPUnit', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by third-party code calling into PHPUnit', $issueTrigger->asString());
     }
 
@@ -364,6 +420,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHPUnit', $issueTrigger->callerAsString());
+        $this->assertSame('PHPUnit', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHPUnit calling into PHPUnit', $issueTrigger->asString());
     }
 
@@ -376,6 +434,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHP runtime', $issueTrigger->callerAsString());
+        $this->assertSame('PHPUnit', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHP runtime calling into PHPUnit', $issueTrigger->asString());
     }
 
@@ -388,6 +448,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertTrue($issueTrigger->isUnknown());
+        $this->assertSame('unknown', $issueTrigger->callerAsString());
+        $this->assertSame('PHP runtime', $issueTrigger->calleeAsString());
         $this->assertSame('unknown if issue was triggered in first-party code or third-party code', $issueTrigger->asString());
     }
 
@@ -400,6 +462,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertTrue($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('test code', $issueTrigger->callerAsString());
+        $this->assertSame('PHP runtime', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by test code calling into PHP runtime', $issueTrigger->asString());
     }
 
@@ -412,6 +476,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertTrue($issueTrigger->isDirect());
         $this->assertFalse($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('first-party code', $issueTrigger->callerAsString());
+        $this->assertSame('PHP runtime', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by first-party code calling into PHP runtime', $issueTrigger->asString());
     }
 
@@ -424,6 +490,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('third-party code', $issueTrigger->callerAsString());
+        $this->assertSame('PHP runtime', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by third-party code calling into PHP runtime', $issueTrigger->asString());
     }
 
@@ -436,6 +504,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHPUnit', $issueTrigger->callerAsString());
+        $this->assertSame('PHP runtime', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHPUnit calling into PHP runtime', $issueTrigger->asString());
     }
 
@@ -448,6 +518,8 @@ final class IssueTriggerTest extends TestCase
         $this->assertFalse($issueTrigger->isDirect());
         $this->assertTrue($issueTrigger->isIndirect());
         $this->assertFalse($issueTrigger->isUnknown());
+        $this->assertSame('PHP runtime', $issueTrigger->callerAsString());
+        $this->assertSame('PHP runtime', $issueTrigger->calleeAsString());
         $this->assertSame('issue triggered by PHP runtime calling into PHP runtime', $issueTrigger->asString());
     }
 }


### PR DESCRIPTION
This adds reporting of deprecations, notices, warnings, errors, and risky tests to Open Test Reporting (OTR) XML logfiles:

`OtrXmlLogger` now subscribes to all issue-related events and writes an `<e:reported>` element for each one, containing a `<phpunit:issue>` attachment with structured metadata:

- `type`: the issue category (`deprecation`, `php-deprecation`, `phpunit-deprecation`, `error`, `phpunit-error`, `notice`, `php-notice`, `phpunit-notice`, `warning`, `php-warning`, `phpunit-warning`, `risky`)
- `message`: the issue message
-` file` / `line`: source location (where applicable)
- `suppressed`, `ignoredByBaseline`, `ignoredByTest`: boolean flags (where applicable)
- `trigger`: `self`, `direct`, `indirect`, or `unknown` (for deprecations)
- `caller` / `callee`: categorized code origin (`test code`, `first-party code`, `third-party code`, `PHP runtime`, `PHPUnit`, `unknown`) (for deprecations)
