### PR TITLE
Improve error message when code coverage filter has no matching files

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -131,7 +131,7 @@ final class CodeCoverage
                 );
             } else {
                 EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
-                    'Incorrect filter configuration, code coverage will not be processed',
+                    'Configured filter does not match any files, code coverage will not be processed',
                 );
             }
 


### PR DESCRIPTION
Changed 'Incorrect filter configuration' to 'Configured filter does not match any files' to be more accurate when filter is configured but no files exist.