### PR TITLE
Use `sebastian/file-filter` in `SourceFilter::includes()` for issue trigger identification

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -233,6 +233,13 @@
             </fileset>
         </copy>
 
+        <copy file="${basedir}/vendor/sebastian/file-filter/LICENSE" tofile="${basedir}/build/tmp/phar/sebastian-file-filter/LICENSE"/>
+        <copy todir="${basedir}/build/tmp/phar/sebastian-file-filter">
+            <fileset dir="${basedir}/vendor/sebastian/file-filter/src">
+                <include name="**/*.php" />
+            </fileset>
+        </copy>
+
         <copy file="${basedir}/vendor/sebastian/git-state/LICENSE" tofile="${basedir}/build/tmp/phar/sebastian-git-state/LICENSE"/>
         <copy todir="${basedir}/build/tmp/phar/sebastian-git-state">
             <fileset dir="${basedir}/vendor/sebastian/git-state/src">

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "sebastian/diff": "^8.1.0",
         "sebastian/environment": "^9.3.0",
         "sebastian/exporter": "^8.0.2",
+        "sebastian/file-filter": "^1.0@dev",
         "sebastian/git-state": "^1.0",
         "sebastian/global-state": "^9.0.0",
         "sebastian/object-enumerator": "^8.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9ba32b5dc3025f933f30101042cd8da",
+    "content-hash": "bf13c616f13f3f522b08dab630e2613e",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1101,6 +1101,76 @@
             "time": "2026-04-15T12:38:05+00:00"
         },
         {
+            "name": "sebastian/file-filter",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/file-filter.git",
+                "reference": "7eca11eb139041bbbee0f61321459b3a604846e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/7eca11eb139041bbbee0f61321459b3a604846e6",
+                "reference": "7eca11eb139041bbbee0f61321459b3a604846e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^13.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for filtering files",
+            "homepage": "https://github.com/sebastianbergmann/file-filter",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/file-filter/issues",
+                "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/file-filter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-09T05:20:01+00:00"
+        },
+        {
             "name": "sebastian/git-state",
             "version": "1.0.0",
             "source": {
@@ -1768,7 +1838,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "sebastian/file-filter": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1106,12 +1106,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/file-filter.git",
-                "reference": "7eca11eb139041bbbee0f61321459b3a604846e6"
+                "reference": "34b12baea1e48f179f11ce4910858d18b8a7ffb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/7eca11eb139041bbbee0f61321459b3a604846e6",
-                "reference": "7eca11eb139041bbbee0f61321459b3a604846e6",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/34b12baea1e48f179f11ce4910858d18b8a7ffb9",
+                "reference": "34b12baea1e48f179f11ce4910858d18b8a7ffb9",
                 "shasum": ""
             },
             "require": {
@@ -1168,7 +1168,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:20:01+00:00"
+            "time": "2026-04-22T06:34:28+00:00"
         },
         {
             "name": "sebastian/git-state",

--- a/src/TextUI/Configuration/FileFilterMapper.php
+++ b/src/TextUI/Configuration/FileFilterMapper.php
@@ -26,7 +26,6 @@ final class FileFilterMapper
             $this->files($source->includeFiles()),
             $this->directories($source->excludeDirectories()),
             $this->files($source->excludeFiles()),
-            false,
         );
     }
 

--- a/src/TextUI/Configuration/FileFilterMapper.php
+++ b/src/TextUI/Configuration/FileFilterMapper.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use function realpath;
 use SebastianBergmann\FileFilter\Builder as FilterBuilder;
 use SebastianBergmann\FileFilter\Filter as FileFilter;
 
@@ -37,8 +38,10 @@ final class FileFilterMapper
         $result = [];
 
         foreach ($directories as $directory) {
+            $path = realpath($directory->path());
+
             $result[] = [
-                'path'   => $directory->path(),
+                'path'   => $path !== false ? $path : $directory->path(),
                 'prefix' => $directory->prefix(),
                 'suffix' => $directory->suffix(),
             ];
@@ -55,7 +58,9 @@ final class FileFilterMapper
         $result = [];
 
         foreach ($files as $file) {
-            $result[] = $file->path();
+            $path = realpath($file->path());
+
+            $result[] = $path !== false ? $path : $file->path();
         }
 
         return $result;

--- a/src/TextUI/Configuration/FileFilterMapper.php
+++ b/src/TextUI/Configuration/FileFilterMapper.php
@@ -26,6 +26,7 @@ final class FileFilterMapper
             $this->files($source->includeFiles()),
             $this->directories($source->excludeDirectories()),
             $this->files($source->excludeFiles()),
+            false,
         );
     }
 

--- a/src/TextUI/Configuration/FileFilterMapper.php
+++ b/src/TextUI/Configuration/FileFilterMapper.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\Configuration;
+
+use SebastianBergmann\FileFilter\Builder as FilterBuilder;
+use SebastianBergmann\FileFilter\Filter as FileFilter;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class FileFilterMapper
+{
+    public function map(Source $source): FileFilter
+    {
+        return (new FilterBuilder)->build(
+            $this->directories($source->includeDirectories()),
+            $this->files($source->includeFiles()),
+            $this->directories($source->excludeDirectories()),
+            $this->files($source->excludeFiles()),
+        );
+    }
+
+    /**
+     * @return list<array{path: non-empty-string, prefix: string, suffix: string}>
+     */
+    private function directories(FilterDirectoryCollection $directories): array
+    {
+        $result = [];
+
+        foreach ($directories as $directory) {
+            $result[] = [
+                'path'   => $directory->path(),
+                'prefix' => $directory->prefix(),
+                'suffix' => $directory->suffix(),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private function files(FilterFileCollection $files): array
+    {
+        $result = [];
+
+        foreach ($files as $file) {
+            $result[] = $file->path();
+        }
+
+        return $result;
+    }
+}

--- a/src/TextUI/Configuration/SourceFilter.php
+++ b/src/TextUI/Configuration/SourceFilter.php
@@ -9,6 +9,8 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use SebastianBergmann\FileFilter\Filter;
+
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -17,31 +19,26 @@ namespace PHPUnit\TextUI\Configuration;
 final class SourceFilter
 {
     private static ?self $instance = null;
-
-    /**
-     * @var array<non-empty-string, true>
-     */
-    private readonly array $map;
+    private readonly Filter $filter;
 
     public static function instance(): self
     {
-        if (self::$instance === null) {
-            self::$instance = new self(
-                (new SourceMapper)->map(
-                    Registry::get()->source(),
-                ),
-            );
+        if (self::$instance !== null) {
+            return self::$instance;
         }
+
+        self::$instance = new self(
+            (new FileFilterMapper)->map(
+                Registry::get()->source(),
+            ),
+        );
 
         return self::$instance;
     }
 
-    /**
-     * @param array<non-empty-string, true> $map
-     */
-    public function __construct(array $map)
+    public function __construct(Filter $filter)
     {
-        $this->map = $map;
+        $this->filter = $filter;
     }
 
     /**
@@ -49,6 +46,6 @@ final class SourceFilter
      */
     public function includes(string $path): bool
     {
-        return isset($this->map[$path]);
+        return $this->filter->accepts($path);
     }
 }

--- a/tests/unit/TextUI/SourceFilterTest.php
+++ b/tests/unit/TextUI/SourceFilterTest.php
@@ -514,6 +514,62 @@ final class SourceFilterTest extends AbstractSourceFilterTestCase
                     ),
                 ),
             ],
+            'file included using directory with non-canonical path' => [
+                [
+                    self::fixturePath('a/PrefixSuffix.php') => true,
+                ],
+                self::createSource(
+                    includeDirectories: FilterDirectoryCollection::fromArray(
+                        [
+                            new FilterDirectory(self::fixturePath('/b/../a'), '', '.php'),
+                        ],
+                    ),
+                ),
+            ],
+            'file included using file with non-canonical path' => [
+                [
+                    self::fixturePath('a/PrefixSuffix.php') => true,
+                ],
+                self::createSource(includeFiles: FilterFileCollection::fromArray(
+                    [
+                        new FilterFile(self::fixturePath('/b/../a/PrefixSuffix.php')),
+                    ],
+                )),
+            ],
+            'file excluded using directory with non-canonical path' => [
+                [
+                    self::fixturePath('a/PrefixSuffix.php') => false,
+                ],
+                self::createSource(
+                    includeDirectories: FilterDirectoryCollection::fromArray(
+                        [
+                            new FilterDirectory(self::fixturePath(), '', '.php'),
+                        ],
+                    ),
+                    excludeDirectories: FilterDirectoryCollection::fromArray(
+                        [
+                            new FilterDirectory(self::fixturePath('/b/../a'), '', '.php'),
+                        ],
+                    ),
+                ),
+            ],
+            'file excluded using file with non-canonical path' => [
+                [
+                    self::fixturePath('a/PrefixSuffix.php') => false,
+                ],
+                self::createSource(
+                    includeDirectories: FilterDirectoryCollection::fromArray(
+                        [
+                            new FilterDirectory(self::fixturePath(), '', '.php'),
+                        ],
+                    ),
+                    excludeFiles: FilterFileCollection::fromArray(
+                        [
+                            new FilterFile(self::fixturePath('/b/../a/PrefixSuffix.php')),
+                        ],
+                    ),
+                ),
+            ],
             'files included using same directory and different prefixes' => [
                 [
                     self::fixturePath('a/c/Suffix.php')              => true,

--- a/tests/unit/TextUI/SourceFilterTest.php
+++ b/tests/unit/TextUI/SourceFilterTest.php
@@ -428,6 +428,30 @@ final class SourceFilterTest extends AbstractSourceFilterTestCase
                     ),
                 ),
             ],
+            'file in hidden directory is included when listed explicitly' => [
+                [
+                    self::fixturePath('a/c/.hidden/PrefixSuffix.php') => true,
+                ],
+                self::createSource(
+                    includeFiles: FilterFileCollection::fromArray(
+                        [
+                            new FilterFile(self::fixturePath('a/c/.hidden/PrefixSuffix.php')),
+                        ],
+                    ),
+                ),
+            ],
+            'file in hidden directory is included when the hidden segment is part of the include root' => [
+                [
+                    self::fixturePath('a/c/.hidden/PrefixSuffix.php') => true,
+                ],
+                self::createSource(
+                    includeDirectories: FilterDirectoryCollection::fromArray(
+                        [
+                            new FilterDirectory(self::fixturePath('a/c/.hidden'), '', '.php'),
+                        ],
+                    ),
+                ),
+            ],
             'files included using directory and prefix' => [
                 [
                     self::fixturePath('b/e/PrefixExampleSuffix.php') => true,

--- a/tests/unit/TextUI/SourceFilterTest.php
+++ b/tests/unit/TextUI/SourceFilterTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
 
 #[CoversClass(SourceFilter::class)]
+#[CoversClass(FileFilterMapper::class)]
 #[Small]
 #[Group('textui')]
 #[Group('textui/configuration')]
@@ -561,7 +562,7 @@ final class SourceFilterTest extends AbstractSourceFilterTestCase
             $this->assertFileExists($file);
             $this->assertSame(
                 $shouldInclude,
-                new SourceFilter((new SourceMapper)->map($source))->includes($file),
+                new SourceFilter((new FileFilterMapper)->map($source))->includes($file),
                 sprintf('expected match to return %s for: %s', json_encode($shouldInclude), $file),
             );
         }

--- a/tests/unit/TextUI/SourceMapperTest.php
+++ b/tests/unit/TextUI/SourceMapperTest.php
@@ -369,6 +369,110 @@ final class SourceMapperTest extends AbstractSourceFilterTestCase
                 ]),
             ),
         ];
+
+        yield 'file included using directory with non-canonical path' => [
+            [
+                self::fixturePath('a/PrefixSuffix.php')     => true,
+                self::fixturePath('a/c/Prefix.php')         => true,
+                self::fixturePath('a/c/PrefixSuffix.php')   => true,
+                self::fixturePath('a/c/Suffix.php')         => true,
+                self::fixturePath('a/c/d/Prefix.php')       => true,
+                self::fixturePath('a/c/d/PrefixSuffix.php') => true,
+                self::fixturePath('a/c/d/Suffix.php')       => true,
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(self::fixturePath('/b/../a'), '', '.php'),
+                    ],
+                ),
+            ),
+        ];
+
+        yield 'file included using file with non-canonical path' => [
+            [
+                self::fixturePath('a/PrefixSuffix.php') => true,
+            ],
+            self::createSource(
+                includeFiles: FilterFileCollection::fromArray([
+                    new FilterFile(self::fixturePath('/b/../a/PrefixSuffix.php')),
+                ]),
+            ),
+        ];
+
+        yield 'file excluded using directory with non-canonical path' => [
+            [
+                self::fixturePath('b/PrefixSuffix.php')          => true,
+                self::fixturePath('b/e/PrefixSuffix.php')        => true,
+                self::fixturePath('b/e/PrefixExampleSuffix.php') => true,
+                self::fixturePath('b/e/g/PrefixSuffix.php')      => true,
+                self::fixturePath('b/f/PrefixSuffix.php')        => true,
+                self::fixturePath('b/f/h/PrefixSuffix.php')      => true,
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(self::fixturePath(), '', '.php'),
+                    ],
+                ),
+                excludeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(self::fixturePath('/b/../a'), '', '.php'),
+                    ],
+                ),
+            ),
+        ];
+
+        yield 'file excluded using file with non-canonical path' => [
+            [
+                self::fixturePath('a/c/Prefix.php')              => true,
+                self::fixturePath('a/c/PrefixSuffix.php')        => true,
+                self::fixturePath('a/c/Suffix.php')              => true,
+                self::fixturePath('a/c/d/Prefix.php')            => true,
+                self::fixturePath('a/c/d/PrefixSuffix.php')      => true,
+                self::fixturePath('a/c/d/Suffix.php')            => true,
+                self::fixturePath('b/PrefixSuffix.php')          => true,
+                self::fixturePath('b/e/PrefixSuffix.php')        => true,
+                self::fixturePath('b/e/PrefixExampleSuffix.php') => true,
+                self::fixturePath('b/e/g/PrefixSuffix.php')      => true,
+                self::fixturePath('b/f/PrefixSuffix.php')        => true,
+                self::fixturePath('b/f/h/PrefixSuffix.php')      => true,
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(self::fixturePath(), '', '.php'),
+                    ],
+                ),
+                excludeFiles: FilterFileCollection::fromArray([
+                    new FilterFile(self::fixturePath('/b/../a/PrefixSuffix.php')),
+                ]),
+            ),
+        ];
+
+        yield 'file in hidden directory is included when listed explicitly' => [
+            [
+                self::fixturePath('a/c/.hidden/PrefixSuffix.php') => true,
+            ],
+            self::createSource(
+                includeFiles: FilterFileCollection::fromArray([
+                    new FilterFile(self::fixturePath('a/c/.hidden/PrefixSuffix.php')),
+                ]),
+            ),
+        ];
+
+        yield 'file in hidden directory is included when the hidden segment is part of the include root' => [
+            [
+                self::fixturePath('a/c/.hidden/PrefixSuffix.php') => true,
+            ],
+            self::createSource(
+                includeDirectories: FilterDirectoryCollection::fromArray(
+                    [
+                        new FilterDirectory(self::fixturePath('a/c/.hidden'), '', '.php'),
+                    ],
+                ),
+            ),
+        ];
     }
 
     public static function providerForCodeCoverage(): Generator


### PR DESCRIPTION
`FileFilterMapper::map()` maps a `PHPUnit\TextUI\Configuration\Source` object to a `SebastianBergmann\FileFilter\Filter` object. `SebastianBergmann\FileFilter\Filter\SourceFilter` now uses this `SebastianBergmann\FileFilter\Filter` object.

### Backward Compatibility

The changes proposed here mostly preserve backward compatibility. The following sections describe backward compatibility breaks in detail.

- File and directory inclusion/exclusion semantics are preserved
- Prefix and suffix filtering works identically
- Explicit file includes are still overridden by directory excludes (same precedence as old implementation)
- The includes() method signature and return type are unchanged for all callers
- Code coverage filtering is unaffected (still uses SourceMapper::mapForCodeCoverage())
- All tests for `SourceFilter` pass, including the additional tests that were implemented on `main` while working on these changes

I think the backward compatibility breaks discussed below are acceptable, even in a minor version such as PHPUnit 13.x, considering the performance improvement.

The only way to [improve performance of issue trigger identification](https://github.com/sebastianbergmann/phpunit/issues/6493) I see is implemented by these changes. We *could* keep the old implementation, introduce the new implementation as an alternative that can be opted-in using the XML configuration file. In the future, we could then deprecate the old implementation and later remove it. However, I want to avoid having to maintain two implementations.

#### Symlinks

The old implementation resolved symlinks and relative paths via `realpath()`. The new implementation does string-based matching only.

#### Hidden directories

The old implementation excluded hidden directories as a side effect of `SebastianBergmann\FileIterator\Facade` skipping hidden directories during filesystem traversal. This only happened on non-Windows platforms.

The new implementation excludes hidden directories on all platforms, including Windows. This is a minor behavioral change that only affects Windows users who have source code in hidden directories. The new behavior is arguably more consistent across platforms.