### PR TITLE
Add an option to ignore undefined deprecation triggers

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -372,6 +372,7 @@
                 <xs:element name="method" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
         </xs:sequence>
+        <xs:attribute name="ignoreUndefinedTriggers" type="xs:boolean" default="false"/>
     </xs:complexType>
     <xs:complexType name="issueTriggerResolversType">
         <xs:sequence>

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -793,14 +793,18 @@ final readonly class Application
             'methods'   => [],
         ];
 
+        $ignoreUndefinedTriggers = $configuration->source()->deprecationTriggers()['ignoreUndefinedTriggers'] ?? false;
+
         foreach ($configuration->source()->deprecationTriggers()['functions'] as $function) {
             if (!function_exists($function)) {
-                EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
-                    sprintf(
-                        'Function %s cannot be configured as a deprecation trigger because it is not declared',
-                        $function,
-                    ),
-                );
+                if (!$ignoreUndefinedTriggers) {
+                    EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
+                        sprintf(
+                            'Function %s cannot be configured as a deprecation trigger because it is not declared',
+                            $function,
+                        ),
+                    );
+                }
 
                 continue;
             }
@@ -823,13 +827,15 @@ final readonly class Application
             [$className, $methodName] = explode('::', $method);
 
             if (!class_exists($className) || !method_exists($className, $methodName)) {
-                EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
-                    sprintf(
-                        'Method %s::%s cannot be configured as a deprecation trigger because it is not declared',
-                        $className,
-                        $methodName,
-                    ),
-                );
+                if (!$ignoreUndefinedTriggers) {
+                    EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
+                        sprintf(
+                            'Method %s::%s cannot be configured as a deprecation trigger because it is not declared',
+                            $className,
+                            $methodName,
+                        ),
+                    );
+                }
 
                 continue;
             }

--- a/src/TextUI/Configuration/Value/Source.php
+++ b/src/TextUI/Configuration/Value/Source.php
@@ -40,7 +40,7 @@ final readonly class Source
     private bool $identifyIssueTrigger;
 
     /**
-     * @var array{functions: list<non-empty-string>, methods: list<non-empty-string>}
+     * @var array{functions: list<non-empty-string>, methods: list<non-empty-string>, ignoreUndefinedTriggers: bool}
      */
     private array $deprecationTriggers;
 
@@ -50,9 +50,9 @@ final readonly class Source
     private array $issueTriggerResolvers;
 
     /**
-     * @param ?non-empty-string                                                         $baseline
-     * @param array{functions: list<non-empty-string>, methods: list<non-empty-string>} $deprecationTriggers
-     * @param list<class-string>                                                        $issueTriggerResolvers
+     * @param ?non-empty-string                                                                                        $baseline
+     * @param array{functions: list<non-empty-string>, methods: list<non-empty-string>, ignoreUndefinedTriggers: bool} $deprecationTriggers
+     * @param list<class-string>                                                                                       $issueTriggerResolvers
      */
     public function __construct(?string $baseline, bool $ignoreBaseline, FilterDirectoryCollection $includeDirectories, FilterFileCollection $includeFiles, FilterDirectoryCollection $excludeDirectories, FilterFileCollection $excludeFiles, bool $restrictNotices, bool $restrictWarnings, bool $ignoreSuppressionOfDeprecations, bool $ignoreSuppressionOfPhpDeprecations, bool $ignoreSuppressionOfErrors, bool $ignoreSuppressionOfNotices, bool $ignoreSuppressionOfPhpNotices, bool $ignoreSuppressionOfWarnings, bool $ignoreSuppressionOfPhpWarnings, array $deprecationTriggers, bool $ignoreSelfDeprecations, bool $ignoreDirectDeprecations, bool $ignoreIndirectDeprecations, bool $identifyIssueTrigger, array $issueTriggerResolvers = [])
     {
@@ -180,7 +180,7 @@ final readonly class Source
     }
 
     /**
-     * @return array{functions: list<non-empty-string>, methods: list<non-empty-string>}
+     * @return array{functions: list<non-empty-string>, methods: list<non-empty-string>, ignoreUndefinedTriggers: bool}
      */
     public function deprecationTriggers(): array
     {

--- a/src/TextUI/Configuration/Xml/DefaultConfiguration.php
+++ b/src/TextUI/Configuration/Xml/DefaultConfiguration.php
@@ -54,8 +54,9 @@ final readonly class DefaultConfiguration extends Configuration
                 false,
                 false,
                 [
-                    'functions' => [],
-                    'methods'   => [],
+                    'functions'               => [],
+                    'methods'                 => [],
+                    'ignoreUndefinedTriggers' => false,
                 ],
                 false,
                 false,

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -340,9 +340,13 @@ final readonly class Loader
             $identifyIssueTrigger               = $this->parseBooleanAttribute($element, 'identifyIssueTrigger', true);
         }
 
+        $deprecationTriggerElement = $this->element($xpath, 'source/deprecationTrigger');
+
         $deprecationTriggers = [
-            'functions' => [],
-            'methods'   => [],
+            'functions'               => [],
+            'methods'                 => [],
+            'ignoreUndefinedTriggers' => $deprecationTriggerElement !== null &&
+                $this->parseBooleanAttribute($deprecationTriggerElement, 'ignoreUndefinedTriggers', false),
         ];
 
         $functionNodes = $xpath->query('source/deprecationTrigger/function');

--- a/tests/end-to-end/error-handler/_files/invalid-deprecation-trigger-ignored/phpunit.xml
+++ b/tests/end-to-end/error-handler/_files/invalid-deprecation-trigger-ignored/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <deprecationTrigger ignoreUndefinedTriggers="true">
+            <function>does_not_exist</function>
+            <method>invalid-string</method>
+            <method>DoesNotExist::doesNotExist</method>
+        </deprecationTrigger>
+    </source>
+</phpunit>

--- a/tests/end-to-end/error-handler/_files/invalid-deprecation-trigger-ignored/tests/ExampleTest.php
+++ b/tests/end-to-end/error-handler/_files/invalid-deprecation-trigger-ignored/tests/ExampleTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\SelfDirectIndirect;
+
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/error-handler/invalid-deprecation-trigger-is-ignored.phpt
+++ b/tests/end-to-end/error-handler/invalid-deprecation-trigger-is-ignored.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Runner warnings are displayed correctly when invalid deprecation triggers are configured in the XML configuration file
+--FILE--
+<?php declare(strict_types=1);
+
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/invalid-deprecation-trigger-ignored';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) invalid-string cannot be configured as a deprecation trigger because it is not in ClassName::methodName format
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, PHPUnit Warnings: 1.

--- a/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
@@ -176,6 +176,7 @@ final class LoaderTest extends TestCase
                 'methods' => [
                     'PHPUnit\TestFixture\DeprecationTrigger\DeprecationTrigger::triggerDeprecation',
                 ],
+                'ignoreUndefinedTriggers' => false,
             ],
             $source->deprecationTriggers(),
         );


### PR DESCRIPTION
We would like to configure our deprecation triggers properly on Symfony's individual components.

There's just one problem though: The deprecation triggers may or may not be defined, depending on wheter or not one of our dependencies pulls one of the packages `symfony/deprecation-contracts` or `doctrine/deprecations` as a dependency. PHPUnit however triggers a warning if we configure a trigger that is undefined.

```
There were 3 PHPUnit test runner warnings:

1) Function trigger_deprecation cannot be configured as a deprecation trigger because it is not declared

2) Method Doctrine\Deprecations\Deprecation::trigger cannot be configured as a deprecation trigger because it is not declared

3) Method Doctrine\Deprecations\Deprecation::triggerIfCalledFromOutside cannot be configured as a deprecation trigger because it is not declared
```

However, if one of these triggers is undefined, it's okay for us that PHPUnit does not configure it. We'd like to silence those warnings because we're aware of the issue and we're happy with how PHPUnit handles it.

With this PR I'd like to propose an option that allows us to not emit a warning if one of the deprecation triggers is undefined:

```XML
<deprecationTrigger ignoreUndefinedTriggers="true">
    <function>trigger_deprecation</function>
    <method>Doctrine\Deprecations\Deprecation::trigger</method>
    <method>Doctrine\Deprecations\Deprecation::triggerIfCalledFromOutside</method>
</deprecationTrigger>
```