### PR TITLE
Improve error message when configured code coverage filter is empty

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -442,9 +442,15 @@ final class CodeCoverage
                 $filter,
             );
         } catch (CodeCoverageException $e) {
-            EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
-                $e->getMessage(),
-            );
+            if ($filter->isEmpty()) {
+                EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
+                    'Configured filter does not match any files, code coverage will not be processed',
+                );
+            } else {
+                EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
+                    $e->getMessage(),
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the misleading error message shown when running PHPUnit with code coverage configured but no source files exist.

## Problem

When running `phpunit --coverage-text` with a configured filter that matches no files, the error shown was:

```
Incorrect filter configuration
```

This is misleading - the filter configuration is not incorrect, there are simply no files to cover.

## Solution

Modified `src/Runner/CodeCoverage.php` to check if the filter is empty before emitting the generic error message. When the filter is empty, a clearer message is shown:

```
Configured filter does not match any files, code coverage will not be processed
```

## Files Changed

- `src/Runner/CodeCoverage.php`: Added empty filter check in the catch block

## Testing

The fix follows the existing message style used elsewhere in the same file for the same scenario (line ~130).
