### PR TITLE
Improve failure description

### DIFF
--- a/src/Framework/Constraint/String/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/String/StringMatchesFormatDescription.php
@@ -121,13 +121,7 @@ final class StringMatchesFormatDescription extends Constraint
                             $synced[] = $actual[$i];
                         }
 
-                        if ($expected[$anchorExpectedIndex] === $actual[$anchorActualIndex]) {
-                            $synced[] = $actual[$anchorActualIndex];
-                        } elseif (@preg_match($this->regularExpressionForFormatDescription($expected[$anchorExpectedIndex]), $actual[$anchorActualIndex]) > 0) {
-                            $synced[] = $actual[$anchorActualIndex];
-                        } else {
-                            $synced[] = $expected[$anchorExpectedIndex];
-                        }
+                        $synced[] = $actual[$anchorActualIndex];
 
                         $expectedIndex = $anchorExpectedIndex + 1;
                         $actualIndex   = $anchorActualIndex + 1;

--- a/src/Framework/Constraint/String/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/String/StringMatchesFormatDescription.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
+use function count;
 use function explode;
 use function implode;
 use function preg_last_error_msg;
@@ -18,6 +19,7 @@ use function preg_match;
 use function preg_quote;
 use function preg_replace;
 use function sprintf;
+use function str_replace;
 use function strtr;
 use PHPUnit\Framework\Exception as FrameworkException;
 use SebastianBergmann\Diff\Differ;
@@ -83,34 +85,87 @@ final class StringMatchesFormatDescription extends Constraint
      * This method removes the expected differences by figuring out if a difference
      * is allowed by the use of a placeholder.
      *
-     * The problem here are %A and %a multiline placeholders since we look at the
-     * expected and actual output line by line. If differences allowed by those placeholders
-     * stretch over multiple lines they will still end up in the final diff.
-     * And since they mess up the line sync between the expected and actual output
-     * all following allowed changes will not be detected/removed anymore.
+     * For %A and %a multiline placeholders that can match across multiple lines,
+     * we use anchor lookahead: find the next non-multiline expected line and search
+     * for it in the actual output to determine how many actual lines the placeholder
+     * consumed, keeping expected and actual in sync.
      */
     protected function additionalFailureDescription(mixed $other): string
     {
-        $from = explode("\n", $this->formatDescription);
-        $to   = explode("\n", $this->convertNewlines($other));
+        $expected      = explode("\n", $this->formatDescription);
+        $expectedCount = count($expected);
+        $actual        = explode("\n", $this->convertNewlines($other));
+        $actualCount   = count($actual);
+        $synced        = [];
+        $expectedIndex = 0;
+        $actualIndex   = 0;
 
-        foreach ($from as $index => $line) {
-            // is the expected output line different from the actual output line
-            if (isset($to[$index]) && $line !== $to[$index]) {
-                $line = $this->regularExpressionForFormatDescription($line);
+        while ($expectedIndex < $expectedCount && $actualIndex < $actualCount) {
+            if ($expected[$expectedIndex] === $actual[$actualIndex]) {
+                $synced[] = $actual[$actualIndex];
 
-                // if the difference is allowed by a placeholder
-                // overwrite the expected line with the actual line to prevent it from showing up in the diff
-                if (preg_match($line, $to[$index]) > 0) {
-                    $from[$index] = $to[$index];
+                $expectedIndex++;
+                $actualIndex++;
+
+                continue;
+            }
+
+            if ($this->isMultilineMatch($expected[$expectedIndex])) {
+                $anchorExpectedIndex = $this->findNextAnchor($expected, $expectedIndex + 1);
+
+                if ($anchorExpectedIndex !== null) {
+                    $anchorActualIndex = $this->findAnchorInActual($expected[$anchorExpectedIndex], $actual, $actualIndex);
+
+                    if ($anchorActualIndex !== null) {
+                        for ($i = $actualIndex; $i < $anchorActualIndex; $i++) {
+                            $synced[] = $actual[$i];
+                        }
+
+                        if ($expected[$anchorExpectedIndex] === $actual[$anchorActualIndex]) {
+                            $synced[] = $actual[$anchorActualIndex];
+                        } elseif (@preg_match($this->regularExpressionForFormatDescription($expected[$anchorExpectedIndex]), $actual[$anchorActualIndex]) > 0) {
+                            $synced[] = $actual[$anchorActualIndex];
+                        } else {
+                            $synced[] = $expected[$anchorExpectedIndex];
+                        }
+
+                        $expectedIndex = $anchorExpectedIndex + 1;
+                        $actualIndex   = $anchorActualIndex + 1;
+
+                        continue;
+                    }
+                } else {
+                    // No anchor after multiline placeholder(s): consume all remaining actual lines
+                    for ($i = $actualIndex; $i < $actualCount; $i++) {
+                        $synced[] = $actual[$i];
+                    }
+
+                    $expectedIndex = $expectedCount;
+                    $actualIndex   = $actualCount;
+
+                    continue;
                 }
             }
+
+            // Single-line comparison
+            $regex = $this->regularExpressionForFormatDescription($expected[$expectedIndex]);
+
+            if (@preg_match($regex, $actual[$actualIndex]) > 0) {
+                $synced[] = $actual[$actualIndex];
+            } else {
+                $synced[] = $expected[$expectedIndex];
+            }
+
+            $expectedIndex++;
+            $actualIndex++;
         }
 
-        $from = implode("\n", $from);
-        $to   = implode("\n", $to);
+        while ($expectedIndex < $expectedCount) {
+            $synced[] = $expected[$expectedIndex];
+            $expectedIndex++;
+        }
 
-        return $this->differ()->diff($from, $to);
+        return $this->differ()->diff(implode("\n", $synced), implode("\n", $actual));
     }
 
     private function regularExpressionForFormatDescription(string $string): string
@@ -135,6 +190,41 @@ final class StringMatchesFormatDescription extends Constraint
         );
 
         return '/^' . $string . '$/s';
+    }
+
+    private function isMultilineMatch(string $line): bool
+    {
+        return preg_match('/%[aA]/', str_replace('%%', '', $line)) > 0;
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    private function findNextAnchor(array $expected, int $startIdx): ?int
+    {
+        for ($i = $startIdx, $len = count($expected); $i < $len; $i++) {
+            if (!$this->isMultilineMatch($expected[$i])) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $actual
+     */
+    private function findAnchorInActual(string $anchorLine, array $actual, int $startIdx): ?int
+    {
+        $anchorRegex = $this->regularExpressionForFormatDescription($anchorLine);
+
+        for ($i = $startIdx, $len = count($actual); $i < $len; $i++) {
+            if ($anchorLine === $actual[$i] || @preg_match($anchorRegex, $actual[$i]) > 0) {
+                return $i;
+            }
+        }
+
+        return null;
     }
 
     private function convertNewlines(string $text): string

--- a/tests/unit/Framework/Constraint/String/StringMatchesFormatDescriptionTest.php
+++ b/tests/unit/Framework/Constraint/String/StringMatchesFormatDescriptionTest.php
@@ -294,21 +294,10 @@ Failed asserting that string matches format description.
 --- Expected
 +++ Actual
 @@ @@
- ## before first A
- some multiline
-+text for
-+A to match
- ## after first A
+ ## after second A
  *
- ## before second A
-+more multiline text
-+for A to match
-+## after second A
- *
--## after second A
-+Foo: s match
- *
--Foo: %s
+ Foo: s match
++*
 +Additional Text that is not matched
 
 EOD
@@ -332,6 +321,72 @@ Foo: s match
 Additional Text that is not matched
 EOD
         );
+    }
+
+    public function testFailureMessageWithMultilineMatchAndAnchorContainingPlaceholder(): void
+    {
+        $constraint = new StringMatchesFormatDescription("header\n%A\nFoo: %s\nfooter");
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(
+            <<<'EOD'
+Failed asserting that string matches format description.
+--- Expected
++++ Actual
+@@ @@
+ header
+ stuff
+ Foo: bar
+-footer
++wrong
+EOD
+        );
+
+        $constraint->evaluate("header\nstuff\nFoo: bar\nwrong");
+    }
+
+    public function testFailureMessageWithMultilineMatchAtEndOfExpected(): void
+    {
+        $constraint = new StringMatchesFormatDescription("header\nfoo\n%A");
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(
+            <<<'EOD'
+Failed asserting that string matches format description.
+--- Expected
++++ Actual
+@@ @@
+ header
+-foo
++bar
+ extra
+ lines
+EOD
+        );
+
+        $constraint->evaluate("header\nbar\nextra\nlines");
+    }
+
+    public function testFailureMessageWithMultilineMatchAndAnchorNotFoundInActual(): void
+    {
+        $constraint = new StringMatchesFormatDescription("start\n%A\nunique_anchor\nend");
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage(
+            <<<'EOD'
+Failed asserting that string matches format description.
+--- Expected
++++ Actual
+@@ @@
+ start
+ foo
+-unique_anchor
++bar
+ end
+EOD
+        );
+
+        $constraint->evaluate("start\nfoo\nbar\nend");
     }
 
     public function testCanBeRepresentedAsString(): void


### PR DESCRIPTION
Improve the failure description for the `StringMatchesFormatDescription` constraint when `%a`/`%A` multiline placeholders match content spanning multiple lines.

Previously, `additionalFailureDescription()` compared expected and actual output line-by-line using a single shared index. When `%a` or `%A` consumed multiple actual lines, the arrays went out of sync and all subsequent lines appeared as false diffs — burying the real failure in noise.

This was attempted before in 72ea2b54d60c by modifying `regularExpressionForFormatDescription()` to remove the `$` end-of-string anchor for multiline patterns.

That approach caused regression [#6200](https://github.com/sebastianbergmann/phpunit/issues/6200) because `regularExpressionForFormatDescription()` is shared with `matches()`, which changed test pass/fail outcomes. It was reverted in 9bd312d59af5.

This implementation takes a different approach that avoids the regression:

- Rewrites only `additionalFailureDescription()`
- `matches()` and `regularExpressionForFormatDescription()` are unchanged
- Uses a two-pointer algorithm with anchor lookahead: when a `%a`/`%A` line is encountered, find the next non-multiline expected line (the "anchor") and search for it in the actual output to determine how many lines the placeholder consumed
- Builds a fresh synced array instead of mutating in-place with `array_splice()`

**Before** (multiline `%A` causes full desync):
```diff
 ## before first A
 some multiline
+text for
+A to match
 ## after first A
 *
 ## before second A
+more multiline text
+for A to match
+## after second A
 *
-## after second A
+Foo: s match
 *
-Foo: %s
+Additional Text that is not matched
```

**After** (only the real mismatch is shown):
```diff
 ## after second A
 *
 Foo: s match
+*
+Additional Text that is not matched
```
