### PR TITLE
Optional `$skipWhenEmpty` parameter for `#[DataProvider]` and `#[DataProviderExternal]`

### DIFF
--- a/src/Framework/Attributes/DataProvider.php
+++ b/src/Framework/Attributes/DataProvider.php
@@ -24,14 +24,16 @@ final readonly class DataProvider
      */
     private string $methodName;
     private bool $validateArgumentCount;
+    private bool $skipWhenEmpty;
 
     /**
      * @param non-empty-string $methodName
      */
-    public function __construct(string $methodName, bool $validateArgumentCount = true)
+    public function __construct(string $methodName, bool $validateArgumentCount = true, bool $skipWhenEmpty = false)
     {
         $this->methodName            = $methodName;
         $this->validateArgumentCount = $validateArgumentCount;
+        $this->skipWhenEmpty         = $skipWhenEmpty;
     }
 
     /**
@@ -45,5 +47,10 @@ final readonly class DataProvider
     public function validateArgumentCount(): bool
     {
         return $this->validateArgumentCount;
+    }
+
+    public function skipWhenEmpty(): bool
+    {
+        return $this->skipWhenEmpty;
     }
 }

--- a/src/Framework/Attributes/DataProviderExternal.php
+++ b/src/Framework/Attributes/DataProviderExternal.php
@@ -29,16 +29,18 @@ final readonly class DataProviderExternal
      */
     private string $methodName;
     private bool $validateArgumentCount;
+    private bool $skipWhenEmpty;
 
     /**
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    public function __construct(string $className, string $methodName, bool $validateArgumentCount = true)
+    public function __construct(string $className, string $methodName, bool $validateArgumentCount = true, bool $skipWhenEmpty = false)
     {
         $this->className             = $className;
         $this->methodName            = $methodName;
         $this->validateArgumentCount = $validateArgumentCount;
+        $this->skipWhenEmpty         = $skipWhenEmpty;
     }
 
     /**
@@ -60,5 +62,10 @@ final readonly class DataProviderExternal
     public function validateArgumentCount(): bool
     {
         return $this->validateArgumentCount;
+    }
+
+    public function skipWhenEmpty(): bool
+    {
+        return $this->skipWhenEmpty;
     }
 }

--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -55,7 +55,7 @@ final readonly class TestBuilder
             }
         }
 
-        if ($data !== null) {
+        if ($data !== null && $data !== []) {
             return $this->buildDataProviderTestSuite(
                 $methodName,
                 $className,
@@ -68,6 +68,12 @@ final readonly class TestBuilder
         }
 
         $test = new $className($methodName);
+
+        if ($data === []) {
+            $test->setEmptyDataProviderSkipMessage(
+                'The data provider for this test provided no data, which is explicitly permitted',
+            );
+        }
 
         $this->configureTestCase(
             $test,

--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -229,8 +229,9 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     /**
      * @var false|resource
      */
-    private mixed $errorLogCapture               = false;
-    private false|string $previousErrorLogTarget = false;
+    private mixed $errorLogCapture                = false;
+    private false|string $previousErrorLogTarget  = false;
+    private ?string $emptyDataProviderSkipMessage = null;
 
     /**
      * @param non-empty-string $name
@@ -499,6 +500,10 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         try {
             $this->checkRequirements();
             $hasMetRequirements = true;
+
+            if ($this->emptyDataProviderSkipMessage !== null) {
+                $this->markTestSkipped($this->emptyDataProviderSkipMessage);
+            }
 
             if ($this->inIsolation) {
                 // @codeCoverageIgnoreStart
@@ -786,6 +791,14 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
     final public function setInIsolation(bool $inIsolation): void
     {
         $this->inIsolation = $inIsolation;
+    }
+
+    /**
+     * @internal This method is not covered by the backward compatibility promise for PHPUnit
+     */
+    final public function setEmptyDataProviderSkipMessage(string $message): void
+    {
+        $this->emptyDataProviderSkipMessage = $message;
     }
 
     /**

--- a/src/Metadata/Api/DataProvider.php
+++ b/src/Metadata/Api/DataProvider.php
@@ -86,6 +86,7 @@ final readonly class DataProvider
 
         $methodsCalled                = [];
         $result                       = [];
+        $skipWhenEmpty                = false;
         $testMethodNumberOfParameters = $testMethod->getNumberOfParameters();
         $testMethodIsNonVariadic      = !$testMethod->isVariadic();
 
@@ -95,6 +96,10 @@ final readonly class DataProvider
             $providerLabel         = $_dataProvider->className() . '::' . $_dataProvider->methodName();
             $dataProviderMethod    = new Event\Code\ClassMethod($_dataProvider->className(), $_dataProvider->methodName());
             $validateArgumentCount = $testMethodIsNonVariadic && $_dataProvider->validateArgumentCount();
+
+            if ($_dataProvider->skipWhenEmpty()) {
+                $skipWhenEmpty = true;
+            }
 
             Event\Facade::emitter()->dataProviderMethodCalled(
                 $testMethodValueObject,
@@ -331,6 +336,10 @@ final readonly class DataProvider
         );
 
         if ($result === []) {
+            if ($skipWhenEmpty) {
+                return [];
+            }
+
             throw new InvalidDataProviderException(
                 'Empty data set provided by data provider',
             );

--- a/src/Metadata/DataProvider.php
+++ b/src/Metadata/DataProvider.php
@@ -26,18 +26,20 @@ final readonly class DataProvider extends Metadata
      */
     private string $methodName;
     private bool $validateArgumentCount;
+    private bool $skipWhenEmpty;
 
     /**
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(Level $level, string $className, string $methodName, bool $validateArgumentCount)
+    protected function __construct(Level $level, string $className, string $methodName, bool $validateArgumentCount, bool $skipWhenEmpty)
     {
         parent::__construct($level);
 
         $this->className             = $className;
         $this->methodName            = $methodName;
         $this->validateArgumentCount = $validateArgumentCount;
+        $this->skipWhenEmpty         = $skipWhenEmpty;
     }
 
     public function isDataProvider(): true
@@ -64,5 +66,10 @@ final readonly class DataProvider extends Metadata
     public function validateArgumentCount(): bool
     {
         return $this->validateArgumentCount;
+    }
+
+    public function skipWhenEmpty(): bool
+    {
+        return $this->skipWhenEmpty;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -143,9 +143,9 @@ abstract readonly class Metadata
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    public static function dataProvider(string $className, string $methodName, bool $validateArgumentCount): DataProvider
+    public static function dataProvider(string $className, string $methodName, bool $validateArgumentCount, bool $skipWhenEmpty): DataProvider
     {
-        return new DataProvider(Level::METHOD_LEVEL, $className, $methodName, $validateArgumentCount);
+        return new DataProvider(Level::METHOD_LEVEL, $className, $methodName, $validateArgumentCount, $skipWhenEmpty);
     }
 
     public static function dataProviderClosure(Closure $callable, bool $validateArgumentCount): DataProviderClosure

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -608,14 +608,14 @@ final readonly class AttributeParser implements Parser
                 case DataProvider::class:
                     assert($attributeInstance instanceof DataProvider);
 
-                    $result[] = Metadata::dataProvider($className, $attributeInstance->methodName(), $attributeInstance->validateArgumentCount());
+                    $result[] = Metadata::dataProvider($className, $attributeInstance->methodName(), $attributeInstance->validateArgumentCount(), $attributeInstance->skipWhenEmpty());
 
                     break;
 
                 case DataProviderExternal::class:
                     assert($attributeInstance instanceof DataProviderExternal);
 
-                    $result[] = Metadata::dataProvider($attributeInstance->className(), $attributeInstance->methodName(), $attributeInstance->validateArgumentCount());
+                    $result[] = Metadata::dataProvider($attributeInstance->className(), $attributeInstance->methodName(), $attributeInstance->validateArgumentCount(), $attributeInstance->skipWhenEmpty());
 
                     break;
 

--- a/tests/end-to-end/event/_files/EmptyDataProviderSkipWhenEmptyTest.php
+++ b/tests/end-to-end/event/_files/EmptyDataProviderSkipWhenEmptyTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EmptyDataProviderSkipWhenEmptyTest extends TestCase
+{
+    public static function providerMethod(): array
+    {
+        return [];
+    }
+
+    #[DataProvider('providerMethod', skipWhenEmpty: true)]
+    public function testCase(): void
+    {
+    }
+}

--- a/tests/end-to-end/event/data-provider-empty-skip-when-empty.phpt
+++ b/tests/end-to-end/event/data-provider-empty-skip-when-empty.phpt
@@ -1,0 +1,31 @@
+--TEST--
+The right events are emitted in the right order for a test that uses an empty data provider with skipWhenEmpty
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = __DIR__ . '/_files/EmptyDataProviderSkipWhenEmptyTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Data Provider Method Called (PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest::providerMethod for test method PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest::testCase)
+Data Provider Method Finished for PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest::testCase:
+- PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest::providerMethod
+Test Suite Loaded (1 test)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (1 test)
+Test Suite Started (PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest::testCase)
+Test Skipped (PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest::testCase)
+The data provider for this test provided no data, which is explicitly permitted
+Test Suite Finished (PHPUnit\TestFixture\Event\EmptyDataProviderSkipWhenEmptyTest, 1 test)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Metadata/MetadataCollectionTest.php
+++ b/tests/unit/Metadata/MetadataCollectionTest.php
@@ -602,7 +602,7 @@ final class MetadataCollectionTest extends TestCase
                 Metadata::coversFunction(''),
                 Metadata::coversMethod('', ''),
                 Metadata::coversNothingOnClass(),
-                Metadata::dataProvider('', '', true),
+                Metadata::dataProvider('', '', true, false),
                 Metadata::dataProviderClosure($closure, true),
                 Metadata::dependsOnClass('', false, false),
                 Metadata::dependsOnMethod('', '', false, false),

--- a/tests/unit/Metadata/MetadataTest.php
+++ b/tests/unit/Metadata/MetadataTest.php
@@ -1210,7 +1210,7 @@ final class MetadataTest extends TestCase
 
     public function testCanBeDataProvider(): void
     {
-        $metadata = Metadata::dataProvider(self::class, 'method', true);
+        $metadata = Metadata::dataProvider(self::class, 'method', true, false);
 
         $this->assertFalse($metadata->isAfter());
         $this->assertFalse($metadata->isAfterClass());


### PR DESCRIPTION
This implements an optional `$skipWhenEmpty` parameter (defaulting to `false`) for the `#[DataProvider]` and `#[DataProviderExternal]` attributes. When set to `true`, a data provider that returns an empty iterable will cause the test to be skipped instead of triggering an error.

Usage:

```php
#[DataProvider('provider', skipWhenEmpty: true)]
public function testSomething(string $value): void
{
    // ...
}
```

Note: Parameter names are not covered by the backward compatibility promise for PHPUnit.

When all data providers for a test method return no data and at least one of them has `skipWhenEmpty: true`, the test is created as a single test case that skips itself with the message "The data provider for this test provided no data, which is explicitly permitted". The default behavior (error on empty data provider) is unchanged.

Closes #6404.