### PR TITLE
Static analysis errors for `TestDoubleBuilder` method chaining

### DIFF
--- a/src/Framework/MockObject/TestDoubleBuilder.php
+++ b/src/Framework/MockObject/TestDoubleBuilder.php
@@ -56,7 +56,7 @@ abstract class TestDoubleBuilder
      *
      * @return $this
      */
-    public function onlyMethods(array $methods): self
+    public function onlyMethods(array $methods): static
     {
         if ($methods === []) {
             $this->emptyMethodsArray = true;
@@ -95,7 +95,7 @@ abstract class TestDoubleBuilder
      *
      * @return $this
      */
-    public function setConstructorArgs(array $arguments): self
+    public function setConstructorArgs(array $arguments): static
     {
         $this->constructorArgs = $arguments;
 
@@ -107,7 +107,7 @@ abstract class TestDoubleBuilder
      *
      * @return $this
      */
-    public function disableOriginalConstructor(): self
+    public function disableOriginalConstructor(): static
     {
         $this->originalConstructor = false;
 
@@ -119,7 +119,7 @@ abstract class TestDoubleBuilder
      *
      * @return $this
      */
-    public function enableOriginalConstructor(): self
+    public function enableOriginalConstructor(): static
     {
         $this->originalConstructor = true;
 
@@ -131,7 +131,7 @@ abstract class TestDoubleBuilder
      *
      * @return $this
      */
-    public function disableOriginalClone(): self
+    public function disableOriginalClone(): static
     {
         $this->originalClone = false;
 
@@ -143,7 +143,7 @@ abstract class TestDoubleBuilder
      *
      * @return $this
      */
-    public function enableOriginalClone(): self
+    public function enableOriginalClone(): static
     {
         $this->originalClone = true;
 
@@ -153,7 +153,7 @@ abstract class TestDoubleBuilder
     /**
      * @return $this
      */
-    public function enableAutoReturnValueGeneration(): self
+    public function enableAutoReturnValueGeneration(): static
     {
         $this->returnValueGeneration = true;
 
@@ -163,7 +163,7 @@ abstract class TestDoubleBuilder
     /**
      * @return $this
      */
-    public function disableAutoReturnValueGeneration(): self
+    public function disableAutoReturnValueGeneration(): static
     {
         $this->returnValueGeneration = false;
 


### PR DESCRIPTION
After updating to the latest version of phpunit i got a lot of errors from psalm about getMock() invocation

`Method PHPUnit\Framework\MockObject\TestDoubleBuilder::getMock does not exist`

I think that there are issues with return types in TestDoubleBuilder. And return type must be `static`.

My test code looks like this
```
/** @var  MockObject&Obj $mock */
$mock = $this->getMockBuilder(Obj::class)
    ->onlyMethods(['method'])
    ->getMock();
```