### PR TITLE
INI metacharacters `;` and `"` are not preserved when forwarding settings to child processes

### DIFF
--- a/src/Util/PHP/JobRunner.php
+++ b/src/Util/PHP/JobRunner.php
@@ -26,6 +26,7 @@ use function is_file;
 use function is_resource;
 use function proc_close;
 use function proc_open;
+use function str_contains;
 use function str_replace;
 use function str_starts_with;
 use function stream_get_contents;
@@ -335,9 +336,14 @@ final readonly class JobRunner
     }
 
     /**
-     * Wraps the value portion of a "name=value" INI setting in double quotes
-     * so PHP's INI parser treats characters such as `;` (comment) and `"`
-     * (string delimiter) as literal data instead of metacharacters.
+     * Quotes the value portion of a "name=value" INI setting only when it
+     * contains characters PHP's INI parser would otherwise interpret as
+     * metacharacters (`;` starts a comment, `"` is a string delimiter).
+     *
+     * Quoting is avoided for plain values so that boolean keywords such as
+     * `On` / `Off` keep their special INI semantics; wrapping them in quotes
+     * turns them into the literal strings `"On"` / `"Off"` and breaks
+     * settings like `output_buffering`.
      */
     private function quoteSettingValue(string $setting): string
     {
@@ -347,8 +353,13 @@ final readonly class JobRunner
             return $setting;
         }
 
-        $name  = substr($setting, 0, $position);
         $value = substr($setting, $position + 1);
+
+        if (!str_contains($value, ';') && !str_contains($value, '"')) {
+            return $setting;
+        }
+
+        $name = substr($setting, 0, $position);
 
         return $name . '="' . str_replace('"', '\\"', $value) . '"';
     }

--- a/src/Util/PHP/JobRunner.php
+++ b/src/Util/PHP/JobRunner.php
@@ -26,8 +26,11 @@ use function is_file;
 use function is_resource;
 use function proc_close;
 use function proc_open;
+use function str_replace;
 use function str_starts_with;
 use function stream_get_contents;
+use function strpos;
+use function substr;
 use function sys_get_temp_dir;
 use function tempnam;
 use function trim;
@@ -325,9 +328,28 @@ final readonly class JobRunner
 
         foreach ($settings as $setting) {
             $buffer[] = '-d';
-            $buffer[] = $setting;
+            $buffer[] = $this->quoteSettingValue($setting);
         }
 
         return $buffer;
+    }
+
+    /**
+     * Wraps the value portion of a "name=value" INI setting in double quotes
+     * so PHP's INI parser treats characters such as `;` (comment) and `"`
+     * (string delimiter) as literal data instead of metacharacters.
+     */
+    private function quoteSettingValue(string $setting): string
+    {
+        $position = strpos($setting, '=');
+
+        if ($position === false) {
+            return $setting;
+        }
+
+        $name  = substr($setting, 0, $position);
+        $value = substr($setting, $position + 1);
+
+        return $name . '="' . str_replace('"', '\\"', $value) . '"';
     }
 }

--- a/tests/unit/Util/PHP/JobRunnerTest.php
+++ b/tests/unit/Util/PHP/JobRunnerTest.php
@@ -110,6 +110,20 @@ EOT,
                 input: 'test',
             ),
         ];
+
+        $obfuscationRegex = '(?i)(?:(?:"|%22)?)(?:(?:old[-_]?|new[-_]?)?p(?:ass)?w(?:or)?d(?:1|2)?|pass(?:[-_]?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]+|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|-{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY-{5}[^\-]+-{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY(?:-{5})?(?:\n|%0A)?';
+
+        yield 'php setting value containing INI metacharacters' => [
+            new Result($obfuscationRegex, ''),
+            new Job(
+                <<<'EOT'
+<?php declare(strict_types=1);
+print ini_get('highlight.string');
+
+EOT,
+                phpSettings: ['highlight.string=' . $obfuscationRegex],
+            ),
+        ];
     }
 
     #[DataProvider('provider')]


### PR DESCRIPTION
## The bug

`JobRunner` forwards every PHP setting to the child process as `-d name=value`. PHP CLI then parses the value as an INI string, where `;` starts a comment and `"` is a string delimiter. So if your value contains those characters, PHP silently eats parts of it.

I hit this with the `ddtrace` extension. Its default `datadog.appsec.obfuscation_parameter_value_regexp` is a long regex full of `"` (it matches JSON / URL-encoded keys). Every time PHPUnit forks a worker, that regex arrives mangled inside the child, and the extension stops working correctly.

## The fix

When the value contains `;` or `"`, wrap it in `"..."` and escape inner `"` as `\"`. Otherwise pass it through untouched, so values like `output_buffering=Off` or `error_reporting=E_ALL & ~E_NOTICE` keep their existing INI semantics (boolean keywords / bitwise expressions).

```
Before: -d highlight.string=(?:"foo";bar)   → child sees (?:foo
After:  -d highlight.string="(?:\"foo\";bar)" → child sees (?:"foo";bar)
```

## Security side-effect (defense in depth)

The pre-fix code also allowed INI directive injection: a value containing a literal newline would be parsed by PHP as multiple `-d` directives, letting the value override unrelated settings (`memory_limit`, `disable_functions`, `auto_prepend_file`, …).

In PHPUnit's threat model the values come from XML config or the host's own PHP runtime, so an attacker would already need filesystem write access to abuse it. Still, the new quoting closes that path because the value never escapes its quoted string.

## Test

Added one case to `JobRunnerTest`: feed the real ddtrace regex (634 bytes, lots of `"`) through a forked process, have the child `print ini_get(...)`, assert the output equals the input byte-for-byte. Fails on `main`, passes with this change. Full unit + end-to-end suites green on Ubuntu / Windows × PHP 8.4 / 8.5 / 8.6.
