### PR TITLE
Skip data providers whose method cannot match `--filter`

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Framework;
 use function array_merge;
 use function assert;
 use function get_parent_class;
+use function preg_match;
 use PHPUnit\Metadata\Api\DataProvider;
 use PHPUnit\Metadata\Api\Groups;
 use PHPUnit\Metadata\Api\ProvidedData;
@@ -23,6 +24,7 @@ use PHPUnit\Metadata\ExcludeStaticPropertyFromBackup;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
 use PHPUnit\Metadata\PreserveGlobalState;
 use PHPUnit\Runner\ErrorHandler;
+use PHPUnit\Runner\Filter\MethodNameFilterCompiler;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
 use ReflectionClass;
 
@@ -48,7 +50,8 @@ final readonly class TestBuilder
 
         $data = null;
 
-        if ($this->requirementsSatisfied($className, $methodName)) {
+        if ($this->requirementsSatisfied($className, $methodName) &&
+            !$this->filterExcludesMethod($className, $methodName)) {
             try {
                 ErrorHandler::instance()->enterTestCaseContext($className, $methodName);
 
@@ -292,5 +295,32 @@ final readonly class TestBuilder
     private function requirementsSatisfied(string $className, string $methodName): bool
     {
         return (new Requirements)->requirementsNotSatisfiedFor($className, $methodName) === [];
+    }
+
+    /**
+     * @param class-string<TestCase> $className
+     * @param non-empty-string       $methodName
+     */
+    private function filterExcludesMethod(string $className, string $methodName): bool
+    {
+        $configuration = ConfigurationRegistry::get();
+
+        if (!$configuration->hasFilter()) {
+            return false;
+        }
+
+        $regularExpression = MethodNameFilterCompiler::compile($configuration->filter());
+
+        if ($regularExpression === null) {
+            return false;
+        }
+
+        $result = @preg_match($regularExpression, $className . '::' . $methodName);
+
+        if ($result === false) {
+            return false;
+        }
+
+        return $result === 0;
     }
 }

--- a/src/Runner/Filter/MethodNameFilterCompiler.php
+++ b/src/Runner/Filter/MethodNameFilterCompiler.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use function preg_match;
+use function sprintf;
+use function substr;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class MethodNameFilterCompiler
+{
+    /**
+     * Returns null when the filter does not constrain the method name.
+     * Callers should treat null as "cannot prove a mismatch, keep the data provider".
+     *
+     * Mirrors the parsing in NameFilterIterator::prepareFilter(): the two must
+     * stay in lockstep so the early skip never disagrees with the final filter.
+     *
+     * @return null|non-empty-string
+     */
+    public static function compile(string $filter): ?string
+    {
+        if (preg_match('/[a-zA-Z0-9]/', substr($filter, 0, 1)) !== 1 &&
+            @preg_match($filter, '') !== false) {
+            return null;
+        }
+
+        $methodNamePortion = $filter;
+
+        if (preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches) === 1) {
+            $methodNamePortion = $matches[1];
+        } elseif (preg_match('/^(.*?)#(.+)$/', $filter, $matches) === 1) {
+            $methodNamePortion = $matches[1];
+        } elseif (preg_match('/^(.*?)@(.+)$/', $filter, $matches) === 1) {
+            $methodNamePortion = $matches[1];
+        }
+
+        if ($methodNamePortion === '') {
+            return null;
+        }
+
+        return sprintf('{%s}i', $methodNamePortion);
+    }
+}

--- a/tests/end-to-end/_files/DataProviderSkipWhenFilteredTest.php
+++ b/tests/end-to-end/_files/DataProviderSkipWhenFilteredTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DataProviderSkipWhenFilteredTest extends TestCase
+{
+    public static function providerForA(): array
+    {
+        return [[1], [2]];
+    }
+
+    public static function providerForB(): array
+    {
+        return [[1], [2]];
+    }
+
+    #[DataProvider('providerForA')]
+    public function testA(int $i): void
+    {
+        $this->assertGreaterThan(0, $i);
+    }
+
+    #[DataProvider('providerForB')]
+    public function testB(int $i): void
+    {
+        $this->assertGreaterThan(0, $i);
+    }
+}

--- a/tests/end-to-end/cli/filter/filter-empty-method-portion-keeps-all-providers.phpt
+++ b/tests/end-to-end/cli/filter/filter-empty-method-portion-keeps-all-providers.phpt
@@ -1,0 +1,46 @@
+--TEST--
+phpunit --filter '#1' keeps all data providers running (no method-name portion to prune by)
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = '#1';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderSkipWhenFilteredTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForB for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForB
+Test Suite Loaded (4 tests)
+Test Runner Started
+Test Suite Sorted
+Test Suite Filtered (2 tests)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Prepared (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Passed (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA, 1 test)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB#1)
+Test Prepared (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB#1)
+Test Passed (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB#1)
+Test Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB#1)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB, 1 test)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest, 2 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/filter/filter-explicit-regex-keeps-all-providers.phpt
+++ b/tests/end-to-end/cli/filter/filter-explicit-regex-keeps-all-providers.phpt
@@ -1,0 +1,44 @@
+--TEST--
+phpunit --filter '/.../' (user-supplied regex) keeps all data providers running
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = '/testA/';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderSkipWhenFilteredTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForB for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForB
+Test Suite Loaded (4 tests)
+Test Runner Started
+Test Suite Sorted
+Test Suite Filtered (2 tests)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Prepared (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Passed (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Preparation Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Prepared (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Passed (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA, 2 tests)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest, 2 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/cli/filter/filter-invalid-regex-keeps-all-providers.phpt
+++ b/tests/end-to-end/cli/filter/filter-invalid-regex-keeps-all-providers.phpt
@@ -1,0 +1,32 @@
+--TEST--
+phpunit --filter 'foo}' (filter that compiles to an invalid regex) keeps all data providers running
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'foo}';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderSkipWhenFilteredTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForB for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testB:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForB
+Test Suite Loaded (4 tests)
+Test Runner Started
+Test Suite Sorted
+Test Suite Filtered (0 tests)
+Test Runner Execution Started (0 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 1)

--- a/tests/end-to-end/cli/filter/filter-skips-data-provider-for-non-matching-method.phpt
+++ b/tests/end-to-end/cli/filter/filter-skips-data-provider-for-non-matching-method.phpt
@@ -1,0 +1,41 @@
+--TEST--
+phpunit --filter testA does not invoke data providers for non-matching methods
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testA';
+$_SERVER['argv'][] = __DIR__ . '/../../_files/DataProviderSkipWhenFilteredTest.php';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Data Provider Method Called (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA for test method PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA)
+Data Provider Method Finished for PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA:
+- PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::providerForA
+Test Suite Loaded (3 tests)
+Test Runner Started
+Test Suite Sorted
+Test Suite Filtered (2 tests)
+Test Runner Execution Started (2 tests)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Prepared (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Passed (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#0)
+Test Preparation Started (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Prepared (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Passed (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA#1)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest::testA, 2 tests)
+Test Suite Finished (PHPUnit\TestFixture\DataProviderSkipWhenFilteredTest, 2 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/regression/2137-filter.phpt
+++ b/tests/end-to-end/regression/2137-filter.phpt
@@ -6,7 +6,7 @@ $_SERVER['argv'][] = '--do-not-cache-result';
 $_SERVER['argv'][] = '--no-configuration';
 $_SERVER['argv'][] = __DIR__ . '/2137/Issue2137Test.php';
 $_SERVER['argv'][] = '--filter';
-$_SERVER['argv'][] = 'BrandService';
+$_SERVER['argv'][] = 'test';
 
 require_once __DIR__ . '/../../bootstrap.php';
 (new PHPUnit\TextUI\Application)->run($_SERVER['argv']);

--- a/tests/unit/Runner/Filter/MethodNameFilterCompilerTest.php
+++ b/tests/unit/Runner/Filter/MethodNameFilterCompilerTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Filter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MethodNameFilterCompiler::class)]
+#[Small]
+#[Group('test-runner')]
+#[Group('test-runner/filter')]
+final class MethodNameFilterCompilerTest extends TestCase
+{
+    /**
+     * @return non-empty-list<array{non-empty-string, non-empty-string}>
+     */
+    public static function provideFiltersWithMethodNamePortion(): array
+    {
+        return [
+            'plain method name'                                            => ['testFoo', '{testFoo}i'],
+            'with numeric data set index'                                  => ['testFoo#0', '{testFoo}i'],
+            'with numeric data set range'                                  => ['testFoo#0-3', '{testFoo}i'],
+            'with named data set'                                          => ['testFoo#named', '{testFoo}i'],
+            'with attribute constant'                                      => ['testFoo@CONST', '{testFoo}i'],
+            'fully qualified method name'                                  => ['PHPUnit\\TestFixture\\FooTest::testFoo', '{PHPUnit\\TestFixture\\FooTest::testFoo}i'],
+            'non-alphanumeric leading character that is not a valid regex' => ['_test#0', '{_test}i'],
+        ];
+    }
+
+    /**
+     * @return non-empty-list<array{string}>
+     */
+    public static function provideFiltersThatYieldNull(): array
+    {
+        return [
+            'empty string'                     => [''],
+            'numeric index only'               => ['#0'],
+            'numeric range only'               => ['#0-3'],
+            'named data set only'              => ['#named'],
+            'attribute constant only'          => ['@CONST'],
+            'valid regex delimited by slashes' => ['/testFoo/'],
+            'valid regex delimited by hashes'  => ['#testFoo#i'],
+            'valid regex delimited by braces'  => ['{testFoo}'],
+        ];
+    }
+
+    /**
+     * @param non-empty-string $filter
+     * @param non-empty-string $expected
+     */
+    #[DataProvider('provideFiltersWithMethodNamePortion')]
+    #[TestDox('Returns substring regex for filter "$filter"')]
+    public function testReturnsCompiledRegexWhenMethodNamePortionIsPresent(string $filter, string $expected): void
+    {
+        $this->assertSame($expected, MethodNameFilterCompiler::compile($filter));
+    }
+
+    #[DataProvider('provideFiltersThatYieldNull')]
+    #[TestDox('Returns null for filter "$filter"')]
+    public function testReturnsNullWhenMethodNamePortionCannotBeDetermined(string $filter): void
+    {
+        $this->assertNull(MethodNameFilterCompiler::compile($filter));
+    }
+}


### PR DESCRIPTION
When PHPUnit is invoked with `--filter`, every data provider in every loaded test class is executed at suite-build time, including the data providers for test methods that cannot possibly match the filter. The filter is only applied later, by `NameFilterIterator`, after the suite (and all its data sets) is fully constructed.

For test suites with a narrow `--filter` and expensive data providers, this is wasted work.

The "obviously correct" solution would be to make data provider method execution lazy: defer it until a test is actually selected for execution. That is a large, invasive refactor: a `DataProviderTestSuite` cannot know how many test instances it contains without first invoking the provider, so deferral would push the unknown through the entire suite-iteration, sorting, and event emission machinery.

Instead, this PR keeps the current pipeline and adds a small early-reject gate in front of the data provider invocation. The gate is a pure function of the configured `--filter` and the candidate `Class::method`: no global state, no new events, no changes to the filter iterator or the test runner.

The gate's contract is "skip only when we can prove no extension of `Class::method` could match the configured filter":

1. No `--filter` configured → do not skip
2. Compile the method-name portion of the filter (the part before any `#` or `@` data-set separator) into a substring regular expression
3. If that compilation returns `null` (filter has no method-name portion, or is a user-supplied regular expression) → do not skip
4. If the compiled regular expression fails to match `Class::method` and `preg_match()` did not error → skip

False positives (skipping when we should not) are precluded by the conservative `null` return. False negatives (failing to skip when we could) are acceptable.