### PR TITLE
Add CPU time to telemetry

### DIFF
--- a/src/Event/Emitter/DispatchingEmitter.php
+++ b/src/Event/Emitter/DispatchingEmitter.php
@@ -1618,6 +1618,12 @@ final class DispatchingEmitter implements Emitter
             $current->memoryUsage()->diff($this->startSnapshot->memoryUsage()),
             $current->time()->duration($this->previousSnapshot->time()),
             $current->memoryUsage()->diff($this->previousSnapshot->memoryUsage()),
+            $current->userCpuTime()->diff($this->startSnapshot->userCpuTime()),
+            $current->systemCpuTime()->diff($this->startSnapshot->systemCpuTime()),
+            $current->totalCpuTime()->diff($this->startSnapshot->totalCpuTime()),
+            $current->userCpuTime()->diff($this->previousSnapshot->userCpuTime()),
+            $current->systemCpuTime()->diff($this->previousSnapshot->systemCpuTime()),
+            $current->totalCpuTime()->diff($this->previousSnapshot->totalCpuTime()),
         );
 
         $this->previousSnapshot = $current;

--- a/src/Event/Facade.php
+++ b/src/Event/Facade.php
@@ -102,6 +102,7 @@ final class Facade
                 new Telemetry\SystemStopWatchWithOffset($offset),
                 new Telemetry\SystemMemoryMeter,
                 new SystemGarbageCollectorStatusProvider,
+                new Telemetry\SystemCpuTimeMeter,
             ),
         );
 
@@ -142,6 +143,7 @@ final class Facade
             new Telemetry\SystemStopWatch,
             new Telemetry\SystemMemoryMeter,
             new SystemGarbageCollectorStatusProvider,
+            new Telemetry\SystemCpuTimeMeter,
         );
     }
 

--- a/src/Event/Value/Telemetry/CpuTime.php
+++ b/src/Event/Value/Telemetry/CpuTime.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Telemetry;
+
+use function sprintf;
+use PHPUnit\Event\InvalidArgumentException;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class CpuTime
+{
+    private int $seconds;
+    private int $nanoseconds;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public static function fromSecondsAndNanoseconds(int $seconds, int $nanoseconds): self
+    {
+        return new self($seconds, $nanoseconds);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function __construct(int $seconds, int $nanoseconds)
+    {
+        $this->ensureNotNegative($seconds, 'seconds');
+        $this->ensureNotNegative($nanoseconds, 'nanoseconds');
+        $this->ensureNanoSecondsInRange($nanoseconds);
+
+        $this->seconds     = $seconds;
+        $this->nanoseconds = $nanoseconds;
+    }
+
+    public function seconds(): int
+    {
+        return $this->seconds;
+    }
+
+    public function nanoseconds(): int
+    {
+        return $this->nanoseconds;
+    }
+
+    public function asFloat(): float
+    {
+        return $this->seconds + ($this->nanoseconds / 1000000000);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function add(self $other): self
+    {
+        $seconds     = $this->seconds + $other->seconds;
+        $nanoseconds = $this->nanoseconds + $other->nanoseconds;
+
+        if ($nanoseconds >= 1000000000) {
+            $seconds++;
+
+            $nanoseconds -= 1000000000;
+        }
+
+        return new self($seconds, $nanoseconds);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function diff(self $other): self
+    {
+        $seconds     = $this->seconds - $other->seconds;
+        $nanoseconds = $this->nanoseconds - $other->nanoseconds;
+
+        if ($nanoseconds < 0) {
+            $seconds--;
+
+            $nanoseconds += 1000000000;
+        }
+
+        if ($seconds < 0) {
+            return new self(0, 0);
+        }
+
+        return new self($seconds, $nanoseconds);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function ensureNotNegative(int $value, string $type): void
+    {
+        if ($value < 0) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Value for %s must not be negative.',
+                    $type,
+                ),
+            );
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function ensureNanoSecondsInRange(int $nanoseconds): void
+    {
+        if ($nanoseconds > 999999999) {
+            throw new InvalidArgumentException(
+                'Value for nanoseconds must not be greater than 999999999.',
+            );
+        }
+    }
+}

--- a/src/Event/Value/Telemetry/CpuTimeMeter.php
+++ b/src/Event/Value/Telemetry/CpuTimeMeter.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Telemetry;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This interface is not covered by the backward compatibility promise for PHPUnit
+ */
+interface CpuTimeMeter
+{
+    public function userCpuTime(): CpuTime;
+
+    public function systemCpuTime(): CpuTime;
+}

--- a/src/Event/Value/Telemetry/Info.php
+++ b/src/Event/Value/Telemetry/Info.php
@@ -23,17 +23,29 @@ final readonly class Info
     private MemoryUsage $memorySinceStart;
     private Duration $durationSincePrevious;
     private MemoryUsage $memorySincePrevious;
+    private CpuTime $userCpuTimeSinceStart;
+    private CpuTime $systemCpuTimeSinceStart;
+    private CpuTime $totalCpuTimeSinceStart;
+    private CpuTime $userCpuTimeSincePrevious;
+    private CpuTime $systemCpuTimeSincePrevious;
+    private CpuTime $totalCpuTimeSincePrevious;
 
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function __construct(Snapshot $current, Duration $durationSinceStart, MemoryUsage $memorySinceStart, Duration $durationSincePrevious, MemoryUsage $memorySincePrevious)
+    public function __construct(Snapshot $current, Duration $durationSinceStart, MemoryUsage $memorySinceStart, Duration $durationSincePrevious, MemoryUsage $memorySincePrevious, CpuTime $userCpuTimeSinceStart, CpuTime $systemCpuTimeSinceStart, CpuTime $totalCpuTimeSinceStart, CpuTime $userCpuTimeSincePrevious, CpuTime $systemCpuTimeSincePrevious, CpuTime $totalCpuTimeSincePrevious)
     {
-        $this->current               = $current;
-        $this->durationSinceStart    = $durationSinceStart;
-        $this->memorySinceStart      = $memorySinceStart;
-        $this->durationSincePrevious = $durationSincePrevious;
-        $this->memorySincePrevious   = $memorySincePrevious;
+        $this->current                    = $current;
+        $this->durationSinceStart         = $durationSinceStart;
+        $this->memorySinceStart           = $memorySinceStart;
+        $this->durationSincePrevious      = $durationSincePrevious;
+        $this->memorySincePrevious        = $memorySincePrevious;
+        $this->userCpuTimeSinceStart      = $userCpuTimeSinceStart;
+        $this->systemCpuTimeSinceStart    = $systemCpuTimeSinceStart;
+        $this->totalCpuTimeSinceStart     = $totalCpuTimeSinceStart;
+        $this->userCpuTimeSincePrevious   = $userCpuTimeSincePrevious;
+        $this->systemCpuTimeSincePrevious = $systemCpuTimeSincePrevious;
+        $this->totalCpuTimeSincePrevious  = $totalCpuTimeSincePrevious;
     }
 
     public function time(): HRTime
@@ -74,6 +86,51 @@ final readonly class Info
     public function garbageCollectorStatus(): GarbageCollectorStatus
     {
         return $this->current->garbageCollectorStatus();
+    }
+
+    public function userCpuTime(): CpuTime
+    {
+        return $this->current->userCpuTime();
+    }
+
+    public function systemCpuTime(): CpuTime
+    {
+        return $this->current->systemCpuTime();
+    }
+
+    public function totalCpuTime(): CpuTime
+    {
+        return $this->current->totalCpuTime();
+    }
+
+    public function userCpuTimeSinceStart(): CpuTime
+    {
+        return $this->userCpuTimeSinceStart;
+    }
+
+    public function systemCpuTimeSinceStart(): CpuTime
+    {
+        return $this->systemCpuTimeSinceStart;
+    }
+
+    public function totalCpuTimeSinceStart(): CpuTime
+    {
+        return $this->totalCpuTimeSinceStart;
+    }
+
+    public function userCpuTimeSincePrevious(): CpuTime
+    {
+        return $this->userCpuTimeSincePrevious;
+    }
+
+    public function systemCpuTimeSincePrevious(): CpuTime
+    {
+        return $this->systemCpuTimeSincePrevious;
+    }
+
+    public function totalCpuTimeSincePrevious(): CpuTime
+    {
+        return $this->totalCpuTimeSincePrevious;
     }
 
     public function asString(): string

--- a/src/Event/Value/Telemetry/Snapshot.php
+++ b/src/Event/Value/Telemetry/Snapshot.php
@@ -20,16 +20,22 @@ final readonly class Snapshot
     private MemoryUsage $memoryUsage;
     private MemoryUsage $peakMemoryUsage;
     private GarbageCollectorStatus $garbageCollectorStatus;
+    private CpuTime $userCpuTime;
+    private CpuTime $systemCpuTime;
+    private CpuTime $totalCpuTime;
 
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function __construct(HRTime $time, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage, GarbageCollectorStatus $garbageCollectorStatus)
+    public function __construct(HRTime $time, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage, GarbageCollectorStatus $garbageCollectorStatus, CpuTime $userCpuTime, CpuTime $systemCpuTime, CpuTime $totalCpuTime)
     {
         $this->time                   = $time;
         $this->memoryUsage            = $memoryUsage;
         $this->peakMemoryUsage        = $peakMemoryUsage;
         $this->garbageCollectorStatus = $garbageCollectorStatus;
+        $this->userCpuTime            = $userCpuTime;
+        $this->systemCpuTime          = $systemCpuTime;
+        $this->totalCpuTime           = $totalCpuTime;
     }
 
     public function time(): HRTime
@@ -50,5 +56,20 @@ final readonly class Snapshot
     public function garbageCollectorStatus(): GarbageCollectorStatus
     {
         return $this->garbageCollectorStatus;
+    }
+
+    public function userCpuTime(): CpuTime
+    {
+        return $this->userCpuTime;
+    }
+
+    public function systemCpuTime(): CpuTime
+    {
+        return $this->systemCpuTime;
+    }
+
+    public function totalCpuTime(): CpuTime
+    {
+        return $this->totalCpuTime;
     }
 }

--- a/src/Event/Value/Telemetry/System.php
+++ b/src/Event/Value/Telemetry/System.php
@@ -19,24 +19,32 @@ final readonly class System
     private StopWatch $stopWatch;
     private MemoryMeter $memoryMeter;
     private GarbageCollectorStatusProvider $garbageCollectorStatusProvider;
+    private CpuTimeMeter $cpuTimeMeter;
 
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function __construct(StopWatch $stopWatch, MemoryMeter $memoryMeter, GarbageCollectorStatusProvider $garbageCollectorStatusProvider)
+    public function __construct(StopWatch $stopWatch, MemoryMeter $memoryMeter, GarbageCollectorStatusProvider $garbageCollectorStatusProvider, CpuTimeMeter $cpuTimeMeter)
     {
         $this->stopWatch                      = $stopWatch;
         $this->memoryMeter                    = $memoryMeter;
         $this->garbageCollectorStatusProvider = $garbageCollectorStatusProvider;
+        $this->cpuTimeMeter                   = $cpuTimeMeter;
     }
 
     public function snapshot(): Snapshot
     {
+        $userCpuTime   = $this->cpuTimeMeter->userCpuTime();
+        $systemCpuTime = $this->cpuTimeMeter->systemCpuTime();
+
         return new Snapshot(
             $this->stopWatch->current(),
             $this->memoryMeter->memoryUsage(),
             $this->memoryMeter->peakMemoryUsage(),
             $this->garbageCollectorStatusProvider->status(),
+            $userCpuTime,
+            $systemCpuTime,
+            $userCpuTime->add($systemCpuTime),
         );
     }
 }

--- a/src/Event/Value/Telemetry/SystemCpuTimeMeter.php
+++ b/src/Event/Value/Telemetry/SystemCpuTimeMeter.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Telemetry;
+
+use function getrusage;
+use function is_int;
+use function sprintf;
+use PHPUnit\Event\RuntimeException;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class SystemCpuTimeMeter implements CpuTimeMeter
+{
+    /**
+     * @throws RuntimeException
+     */
+    public function userCpuTime(): CpuTime
+    {
+        return $this->cpuTime('ru_utime.tv_sec', 'ru_utime.tv_usec');
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function systemCpuTime(): CpuTime
+    {
+        return $this->cpuTime('ru_stime.tv_sec', 'ru_stime.tv_usec');
+    }
+
+    /**
+     * @param 'ru_stime.tv_sec'|'ru_utime.tv_sec'   $secondsKey
+     * @param 'ru_stime.tv_usec'|'ru_utime.tv_usec' $microsecondsKey
+     *
+     * @throws RuntimeException
+     */
+    private function cpuTime(string $secondsKey, string $microsecondsKey): CpuTime
+    {
+        $usage = getrusage();
+
+        if ($usage === false) {
+            // @codeCoverageIgnoreStart
+            throw new RuntimeException('getrusage() failed.');
+            // @codeCoverageIgnoreEnd
+        }
+
+        if (!isset($usage[$secondsKey]) || !isset($usage[$microsecondsKey])) {
+            // @codeCoverageIgnoreStart
+            throw new RuntimeException(
+                sprintf(
+                    'getrusage() did not return the expected keys "%s" and "%s".',
+                    $secondsKey,
+                    $microsecondsKey,
+                ),
+            );
+            // @codeCoverageIgnoreEnd
+        }
+
+        $seconds      = $usage[$secondsKey];
+        $microseconds = $usage[$microsecondsKey];
+
+        if (!is_int($seconds) || !is_int($microseconds)) {
+            // @codeCoverageIgnoreStart
+            throw new RuntimeException(
+                sprintf(
+                    'getrusage() returned non-integer values for "%s" and/or "%s".',
+                    $secondsKey,
+                    $microsecondsKey,
+                ),
+            );
+            // @codeCoverageIgnoreEnd
+        }
+
+        return CpuTime::fromSecondsAndNanoseconds($seconds, $microseconds * 1000);
+    }
+}

--- a/src/Logging/OpenTestReporting/OtrXmlLogger.php
+++ b/src/Logging/OpenTestReporting/OtrXmlLogger.php
@@ -25,6 +25,7 @@ use PHPUnit\Event\Code\Test;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\HRTime;
 use PHPUnit\Event\Telemetry\MemoryUsage;
@@ -101,11 +102,29 @@ final class OtrXmlLogger
     private ?bool $pendingAssertionError                 = null;
     private ?ComparisonFailure $pendingComparisonFailure = null;
     private ?HRTime $testStartTime                       = null;
+    private ?CpuTime $testStartUserCpuTime               = null;
+    private ?CpuTime $testStartSystemCpuTime             = null;
+    private ?CpuTime $testStartTotalCpuTime              = null;
 
     /**
      * @var list<HRTime>
      */
     private array $suiteStartTimeStack = [];
+
+    /**
+     * @var list<CpuTime>
+     */
+    private array $suiteStartUserCpuTimeStack = [];
+
+    /**
+     * @var list<CpuTime>
+     */
+    private array $suiteStartSystemCpuTimeStack = [];
+
+    /**
+     * @var list<CpuTime>
+     */
+    private array $suiteStartTotalCpuTimeStack = [];
     private bool $includeGitInformation;
     private ?int $randomOrderSeed;
 
@@ -231,9 +250,14 @@ final class OtrXmlLogger
 
         $this->writer->flush();
 
-        $this->parentId              = $id;
-        $this->parentIdStack[]       = $id;
-        $this->suiteStartTimeStack[] = $event->telemetryInfo()->time();
+        $info = $event->telemetryInfo();
+
+        $this->parentId                       = $id;
+        $this->parentIdStack[]                = $id;
+        $this->suiteStartTimeStack[]          = $info->time();
+        $this->suiteStartUserCpuTimeStack[]   = $info->userCpuTime();
+        $this->suiteStartSystemCpuTimeStack[] = $info->systemCpuTime();
+        $this->suiteStartTotalCpuTimeStack[]  = $info->totalCpuTime();
     }
 
     public function testSuiteSkipped(TestSuiteSkipped $event): void
@@ -244,7 +268,14 @@ final class OtrXmlLogger
         $this->writer->writeAttribute('id', (string) $this->parentId);
         $this->writer->writeAttribute('time', $this->timestamp());
 
-        $this->writeSuiteResourceUsage($info->time(), $info->memoryUsage(), $info->peakMemoryUsage());
+        $this->writeSuiteResourceUsage(
+            $info->time(),
+            $info->memoryUsage(),
+            $info->peakMemoryUsage(),
+            $info->userCpuTime(),
+            $info->systemCpuTime(),
+            $info->totalCpuTime(),
+        );
 
         $this->writer->startElement('result');
         $this->writer->writeAttribute('status', 'SKIPPED');
@@ -266,7 +297,14 @@ final class OtrXmlLogger
         $this->writer->writeAttribute('id', (string) $this->parentId);
         $this->writer->writeAttribute('time', $this->timestamp());
 
-        $this->writeSuiteResourceUsage($info->time(), $info->memoryUsage(), $info->peakMemoryUsage());
+        $this->writeSuiteResourceUsage(
+            $info->time(),
+            $info->memoryUsage(),
+            $info->peakMemoryUsage(),
+            $info->userCpuTime(),
+            $info->systemCpuTime(),
+            $info->totalCpuTime(),
+        );
 
         if ($this->parentErrored !== null) {
             $this->writer->startElement('result');
@@ -294,8 +332,13 @@ final class OtrXmlLogger
 
     public function testPrepared(PreparationErrored|PreparationFailed|TestStarted $event): void
     {
-        $this->testId        = $this->nextId();
-        $this->testStartTime = $event->telemetryInfo()->time();
+        $info = $event->telemetryInfo();
+
+        $this->testId                 = $this->nextId();
+        $this->testStartTime          = $info->time();
+        $this->testStartUserCpuTime   = $info->userCpuTime();
+        $this->testStartSystemCpuTime = $info->systemCpuTime();
+        $this->testStartTotalCpuTime  = $info->totalCpuTime();
 
         $this->writeTestStarted(
             $event->test(),
@@ -460,6 +503,9 @@ final class OtrXmlLogger
                 $info->time(),
                 $info->memoryUsage(),
                 $info->peakMemoryUsage(),
+                $info->userCpuTime(),
+                $info->systemCpuTime(),
+                $info->totalCpuTime(),
                 $event->numberOfAssertionsPerformed(),
             );
 
@@ -496,6 +542,9 @@ final class OtrXmlLogger
         $this->testWasPrepared          = false;
         $this->testId                   = null;
         $this->testStartTime            = null;
+        $this->testStartUserCpuTime     = null;
+        $this->testStartSystemCpuTime   = null;
+        $this->testStartTotalCpuTime    = null;
         $this->pendingStatus            = null;
         $this->pendingReason            = null;
         $this->pendingThrowable         = null;
@@ -524,7 +573,15 @@ final class OtrXmlLogger
         $this->writer->writeAttribute('id', (string) $this->testId);
         $this->writer->writeAttribute('time', $this->timestamp());
 
-        $this->writeTestAttachments($info->time(), $info->memoryUsage(), $info->peakMemoryUsage(), null);
+        $this->writeTestAttachments(
+            $info->time(),
+            $info->memoryUsage(),
+            $info->peakMemoryUsage(),
+            $info->userCpuTime(),
+            $info->systemCpuTime(),
+            $info->totalCpuTime(),
+            null,
+        );
 
         $this->writer->startElement('result');
         $this->writer->writeAttribute('status', Status::Failed->value);
@@ -561,7 +618,15 @@ final class OtrXmlLogger
         $this->writer->writeAttribute('id', (string) $this->testId);
         $this->writer->writeAttribute('time', $this->timestamp());
 
-        $this->writeTestAttachments($info->time(), $info->memoryUsage(), $info->peakMemoryUsage(), null);
+        $this->writeTestAttachments(
+            $info->time(),
+            $info->memoryUsage(),
+            $info->peakMemoryUsage(),
+            $info->userCpuTime(),
+            $info->systemCpuTime(),
+            $info->totalCpuTime(),
+            null,
+        );
 
         $this->writer->startElement('result');
         $this->writer->writeAttribute('status', Status::Errored->value);
@@ -832,15 +897,21 @@ final class OtrXmlLogger
     /**
      * @param ?non-negative-int $numberOfAssertionsPerformed
      */
-    private function writeTestAttachments(HRTime $endTime, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage, ?int $numberOfAssertionsPerformed): void
+    private function writeTestAttachments(HRTime $endTime, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage, CpuTime $userCpuTime, CpuTime $systemCpuTime, CpuTime $totalCpuTime, ?int $numberOfAssertionsPerformed): void
     {
         assert($this->testStartTime !== null);
+        assert($this->testStartUserCpuTime !== null);
+        assert($this->testStartSystemCpuTime !== null);
+        assert($this->testStartTotalCpuTime !== null);
 
-        $duration = $endTime->duration($this->testStartTime);
+        $duration          = $endTime->duration($this->testStartTime);
+        $userCpuTimeUsed   = $userCpuTime->diff($this->testStartUserCpuTime);
+        $systemCpuTimeUsed = $systemCpuTime->diff($this->testStartSystemCpuTime);
+        $totalCpuTimeUsed  = $totalCpuTime->diff($this->testStartTotalCpuTime);
 
         $this->writer->startElement('attachments');
 
-        $this->writeResourceUsageElement($duration, $memoryUsage, $peakMemoryUsage);
+        $this->writeResourceUsageElement($duration, $memoryUsage, $peakMemoryUsage, $userCpuTimeUsed, $systemCpuTimeUsed, $totalCpuTimeUsed);
 
         if ($numberOfAssertionsPerformed !== null) {
             $this->writer->startElement('phpunit:assertions');
@@ -851,25 +922,37 @@ final class OtrXmlLogger
         $this->writer->endElement();
     }
 
-    private function writeSuiteResourceUsage(HRTime $endTime, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage): void
+    private function writeSuiteResourceUsage(HRTime $endTime, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage, CpuTime $userCpuTime, CpuTime $systemCpuTime, CpuTime $totalCpuTime): void
     {
-        $startTime = array_pop($this->suiteStartTimeStack);
+        $startTime          = array_pop($this->suiteStartTimeStack);
+        $startUserCpuTime   = array_pop($this->suiteStartUserCpuTimeStack);
+        $startSystemCpuTime = array_pop($this->suiteStartSystemCpuTimeStack);
+        $startTotalCpuTime  = array_pop($this->suiteStartTotalCpuTimeStack);
 
         assert($startTime !== null);
+        assert($startUserCpuTime !== null);
+        assert($startSystemCpuTime !== null);
+        assert($startTotalCpuTime !== null);
 
-        $duration = $endTime->duration($startTime);
+        $duration          = $endTime->duration($startTime);
+        $userCpuTimeUsed   = $userCpuTime->diff($startUserCpuTime);
+        $systemCpuTimeUsed = $systemCpuTime->diff($startSystemCpuTime);
+        $totalCpuTimeUsed  = $totalCpuTime->diff($startTotalCpuTime);
 
         $this->writer->startElement('attachments');
-        $this->writeResourceUsageElement($duration, $memoryUsage, $peakMemoryUsage);
+        $this->writeResourceUsageElement($duration, $memoryUsage, $peakMemoryUsage, $userCpuTimeUsed, $systemCpuTimeUsed, $totalCpuTimeUsed);
         $this->writer->endElement();
     }
 
-    private function writeResourceUsageElement(Duration $duration, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage): void
+    private function writeResourceUsageElement(Duration $duration, MemoryUsage $memoryUsage, MemoryUsage $peakMemoryUsage, CpuTime $userCpuTime, CpuTime $systemCpuTime, CpuTime $totalCpuTime): void
     {
         $this->writer->startElement('phpunit:resourceUsage');
         $this->writer->writeAttribute('time', sprintf('%d.%09d', $duration->seconds(), $duration->nanoseconds()));
         $this->writer->writeAttribute('memoryUsage', (string) $memoryUsage->bytes());
         $this->writer->writeAttribute('peakMemoryUsage', (string) $peakMemoryUsage->bytes());
+        $this->writer->writeAttribute('userCpuTime', sprintf('%d.%09d', $userCpuTime->seconds(), $userCpuTime->nanoseconds()));
+        $this->writer->writeAttribute('systemCpuTime', sprintf('%d.%09d', $systemCpuTime->seconds(), $systemCpuTime->nanoseconds()));
+        $this->writer->writeAttribute('cpuTime', sprintf('%d.%09d', $totalCpuTime->seconds(), $totalCpuTime->nanoseconds()));
         $this->writer->endElement();
     }
 

--- a/src/Logging/OpenTestReporting/schema/phpunit.xsd
+++ b/src/Logging/OpenTestReporting/schema/phpunit.xsd
@@ -90,6 +90,9 @@
             <xs:attribute name="time"            type="xs:decimal"            use="required"/>
             <xs:attribute name="memoryUsage"     type="xs:nonNegativeInteger" use="required"/>
             <xs:attribute name="peakMemoryUsage" type="xs:nonNegativeInteger" use="required"/>
+            <xs:attribute name="userCpuTime"     type="xs:decimal"            use="required"/>
+            <xs:attribute name="systemCpuTime"   type="xs:decimal"            use="required"/>
+            <xs:attribute name="cpuTime"         type="xs:decimal"            use="required"/>
         </xs:complexType>
     </xs:element>
 

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-class-method.phpt
@@ -49,14 +49,14 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="FAILED">
    <reason>Failed asserting that false is true.</reason>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-after-test-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -62,7 +62,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-class-method.phpt
@@ -41,7 +41,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="FAILED">
    <reason>Failed asserting that false is true.</reason>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-before-test-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="FAILED">
    <reason>Failed asserting that false is true.</reason>
@@ -61,7 +61,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-postcondition-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-postcondition-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -62,7 +62,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-precondition-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/assertion-failure-in-precondition-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="FAILED">
    <reason>Failed asserting that false is true.</reason>
@@ -61,7 +61,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument-with-git-information.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument-with-git-information.phpt
@@ -54,7 +54,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -69,7 +69,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -90,7 +90,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="4" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -111,7 +111,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="5" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ABORTED">
@@ -131,7 +131,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="6" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SKIPPED">
@@ -153,7 +153,7 @@ unlink($logfile);
  </e:reported>
  <e:finished id="7" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -168,7 +168,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="8" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -183,7 +183,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="9" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -206,7 +206,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="10" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -227,7 +227,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="11" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ABORTED">
@@ -261,7 +261,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="13" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SKIPPED">
@@ -283,14 +283,14 @@ Failed asserting that false is true.
  </e:reported>
  <e:finished id="14" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-case-class-source-file-as-cli-argument.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -64,7 +64,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -85,7 +85,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="4" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -106,7 +106,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="5" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ABORTED">
@@ -126,7 +126,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="6" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SKIPPED">
@@ -148,7 +148,7 @@ unlink($logfile);
  </e:reported>
  <e:finished id="7" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -163,7 +163,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="8" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -178,7 +178,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="9" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -201,7 +201,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="10" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -222,7 +222,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="11" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ABORTED">
@@ -256,7 +256,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="13" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SKIPPED">
@@ -278,14 +278,14 @@ Failed asserting that false is true.
  </e:reported>
  <e:finished id="14" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/basic-test-suite-from-xml-configuration-file.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/basic-test-suite-from-xml-configuration-file.phpt
@@ -51,7 +51,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="4" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -66,7 +66,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="5" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -87,7 +87,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="6" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -108,7 +108,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="7" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ABORTED">
@@ -128,7 +128,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="8" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SKIPPED">
@@ -150,7 +150,7 @@ unlink($logfile);
  </e:reported>
  <e:finished id="9" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -165,7 +165,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="10" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -180,7 +180,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="11" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -203,7 +203,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="12" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -224,7 +224,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="13" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ABORTED">
@@ -258,7 +258,7 @@ Failed asserting that false is true.
  </e:started>
  <e:finished id="15" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SKIPPED">
@@ -280,24 +280,24 @@ Failed asserting that false is true.
  </e:reported>
  <e:finished id="16" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/comparison-failure-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/comparison-failure-in-before-test-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="FAILED">
    <reason>Failed asserting that two arrays are identical.</reason>
@@ -93,7 +93,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/comparison-failure.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/comparison-failure.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="FAILED">
@@ -94,7 +94,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-after-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-after-class-method.phpt
@@ -49,14 +49,14 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="ERRORED">
    <reason></reason>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-after-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-after-test-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -62,7 +62,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-before-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-before-class-method.phpt
@@ -41,7 +41,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="ERRORED">
    <reason></reason>

--- a/tests/end-to-end/logging/open-test-reporting/exception-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/exception-in-before-test-method.phpt
@@ -49,7 +49,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="ERRORED">
    <reason></reason>
@@ -61,7 +61,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/groups.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/groups.phpt
@@ -55,7 +55,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
@@ -77,14 +77,14 @@ unlink($logfile);
  </e:started>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-direct-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-direct-trigger.phpt
@@ -57,24 +57,24 @@ unlink($logfile);
  </e:reported>
  <e:finished id="4" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-indirect-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-indirect-trigger.phpt
@@ -57,24 +57,24 @@ unlink($logfile);
  </e:reported>
  <e:finished id="4" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation-self-trigger.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation-self-trigger.phpt
@@ -57,24 +57,24 @@ unlink($logfile);
  </e:reported>
  <e:finished id="4" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="3" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-deprecation.phpt
@@ -55,14 +55,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-error.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-error.phpt
@@ -60,7 +60,7 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="ERRORED">
@@ -72,7 +72,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-notice.phpt
@@ -55,14 +55,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-deprecation.phpt
@@ -55,14 +55,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-notice.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-php-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-php-warning.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-deprecation.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-deprecation.phpt
@@ -55,14 +55,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-error.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-error.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-notice.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-notice.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-phpunit-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-phpunit-warning.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-risky.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-risky.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/issue-warning.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/issue-warning.phpt
@@ -55,14 +55,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/random-order-seed.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/random-order-seed.phpt
@@ -52,14 +52,14 @@ unlink($logfile);
  </e:started>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/skipped-in-before-class-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/skipped-in-before-class-method.phpt
@@ -41,7 +41,7 @@ unlink($logfile);
  </e:started>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
   <result status="SKIPPED">
    <reason>message</reason>

--- a/tests/end-to-end/logging/open-test-reporting/skipped-in-before-test-method.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/skipped-in-before-test-method.phpt
@@ -54,7 +54,7 @@ unlink($logfile);
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/end-to-end/logging/open-test-reporting/unexpected-output.phpt
+++ b/tests/end-to-end/logging/open-test-reporting/unexpected-output.phpt
@@ -54,14 +54,14 @@ unlink($logfile);
  </e:reported>
  <e:finished id="2" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
    <phpunit:assertions count="%d"/>
   </attachments>
   <result status="SUCCESSFUL"/>
  </e:finished>
  <e:finished id="1" time="%s">
   <attachments>
-   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d"/>
+   <phpunit:resourceUsage time="%f" memoryUsage="%d" peakMemoryUsage="%d" userCpuTime="%f" systemCpuTime="%f" cpuTime="%f"/>
   </attachments>
  </e:finished>
 </e:events>

--- a/tests/unit/Event/AbstractEventTestCase.php
+++ b/tests/unit/Event/AbstractEventTestCase.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Event;
 use function hrtime;
 use PHPUnit\Event\Code\TestCollection;
 use PHPUnit\Event\Code\TestDoxBuilder;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\HRTime;
 use PHPUnit\Event\TestData\TestDataCollection;
@@ -29,11 +30,20 @@ abstract class AbstractEventTestCase extends TestCase
                 Telemetry\MemoryUsage::fromBytes(1000),
                 Telemetry\MemoryUsage::fromBytes(2000),
                 new Telemetry\GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             Telemetry\MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             Telemetry\MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 

--- a/tests/unit/Event/Emitter/DispatchingEmitterTest.php
+++ b/tests/unit/Event/Emitter/DispatchingEmitterTest.php
@@ -3817,6 +3817,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
             new Telemetry\SystemStopWatch,
             new Telemetry\SystemMemoryMeter,
             new SystemGarbageCollectorStatusProvider,
+            new Telemetry\SystemCpuTimeMeter,
         );
     }
 

--- a/tests/unit/Event/Value/Telemetry/CpuTimeTest.php
+++ b/tests/unit/Event/Value/Telemetry/CpuTimeTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Telemetry;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CpuTime::class)]
+#[Small]
+#[Group('event-system')]
+#[Group('event-system/value-objects')]
+final class CpuTimeTest extends TestCase
+{
+    public function testCanBeCreatedFromSecondsAndNanoseconds(): void
+    {
+        $seconds     = 123;
+        $nanoseconds = 999999999;
+
+        $cpuTime = CpuTime::fromSecondsAndNanoseconds($seconds, $nanoseconds);
+
+        $this->assertSame($seconds, $cpuTime->seconds());
+        $this->assertSame($nanoseconds, $cpuTime->nanoseconds());
+    }
+
+    public function testSecondsMustNotBeNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIs('Value for seconds must not be negative.');
+
+        CpuTime::fromSecondsAndNanoseconds(-1, 0);
+    }
+
+    public function testNanosecondsMustNotBeNegative(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIs('Value for nanoseconds must not be negative.');
+
+        CpuTime::fromSecondsAndNanoseconds(0, -1);
+    }
+
+    public function testNanosecondsMustNotBeGreaterThan999999999(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIs('Value for nanoseconds must not be greater than 999999999.');
+
+        CpuTime::fromSecondsAndNanoseconds(0, 1000000000);
+    }
+
+    public function testCanBeRepresentedAsFloat(): void
+    {
+        $this->assertSame(0.0, CpuTime::fromSecondsAndNanoseconds(0, 0)->asFloat());
+        $this->assertSame(1.5, CpuTime::fromSecondsAndNanoseconds(1, 500000000)->asFloat());
+    }
+
+    public function testCanBeAdded(): void
+    {
+        $one = CpuTime::fromSecondsAndNanoseconds(1, 200);
+        $two = CpuTime::fromSecondsAndNanoseconds(2, 300);
+
+        $sum = $one->add($two);
+
+        $this->assertSame(3, $sum->seconds());
+        $this->assertSame(500, $sum->nanoseconds());
+    }
+
+    public function testAdditionCarriesNanosecondsOverflow(): void
+    {
+        $one = CpuTime::fromSecondsAndNanoseconds(1, 800000000);
+        $two = CpuTime::fromSecondsAndNanoseconds(2, 500000000);
+
+        $sum = $one->add($two);
+
+        $this->assertSame(4, $sum->seconds());
+        $this->assertSame(300000000, $sum->nanoseconds());
+    }
+
+    public function testCanBeSubtracted(): void
+    {
+        $one = CpuTime::fromSecondsAndNanoseconds(5, 700);
+        $two = CpuTime::fromSecondsAndNanoseconds(2, 300);
+
+        $diff = $one->diff($two);
+
+        $this->assertSame(3, $diff->seconds());
+        $this->assertSame(400, $diff->nanoseconds());
+    }
+
+    public function testSubtractionBorrowsFromSecondsWhenNanosecondsUnderflow(): void
+    {
+        $one = CpuTime::fromSecondsAndNanoseconds(5, 100000000);
+        $two = CpuTime::fromSecondsAndNanoseconds(2, 500000000);
+
+        $diff = $one->diff($two);
+
+        $this->assertSame(2, $diff->seconds());
+        $this->assertSame(600000000, $diff->nanoseconds());
+    }
+
+    public function testSubtractionReturnsZeroWhenResultWouldBeNegative(): void
+    {
+        $one = CpuTime::fromSecondsAndNanoseconds(1, 0);
+        $two = CpuTime::fromSecondsAndNanoseconds(5, 0);
+
+        $diff = $one->diff($two);
+
+        $this->assertSame(0, $diff->seconds());
+        $this->assertSame(0, $diff->nanoseconds());
+    }
+}

--- a/tests/unit/Event/Value/Telemetry/InfoTest.php
+++ b/tests/unit/Event/Value/Telemetry/InfoTest.php
@@ -60,6 +60,57 @@ final class InfoTest extends TestCase
         $this->assertInstanceOf(GarbageCollectorStatus::class, $this->info()->garbageCollectorStatus());
     }
 
+    public function testHasUserCpuTime(): void
+    {
+        $this->assertInstanceOf(CpuTime::class, $this->info()->userCpuTime());
+    }
+
+    public function testHasSystemCpuTime(): void
+    {
+        $this->assertInstanceOf(CpuTime::class, $this->info()->systemCpuTime());
+    }
+
+    public function testHasTotalCpuTime(): void
+    {
+        $this->assertInstanceOf(CpuTime::class, $this->info()->totalCpuTime());
+    }
+
+    public function testHasUserCpuTimeSinceStart(): void
+    {
+        $this->assertSame(0, $this->info()->userCpuTimeSinceStart()->nanoseconds());
+        $this->assertSame(0, $this->info()->userCpuTimeSinceStart()->seconds());
+    }
+
+    public function testHasSystemCpuTimeSinceStart(): void
+    {
+        $this->assertSame(0, $this->info()->systemCpuTimeSinceStart()->nanoseconds());
+        $this->assertSame(0, $this->info()->systemCpuTimeSinceStart()->seconds());
+    }
+
+    public function testHasTotalCpuTimeSinceStart(): void
+    {
+        $this->assertSame(0, $this->info()->totalCpuTimeSinceStart()->nanoseconds());
+        $this->assertSame(0, $this->info()->totalCpuTimeSinceStart()->seconds());
+    }
+
+    public function testHasUserCpuTimeSincePrevious(): void
+    {
+        $this->assertSame(0, $this->info()->userCpuTimeSincePrevious()->nanoseconds());
+        $this->assertSame(0, $this->info()->userCpuTimeSincePrevious()->seconds());
+    }
+
+    public function testHasSystemCpuTimeSincePrevious(): void
+    {
+        $this->assertSame(0, $this->info()->systemCpuTimeSincePrevious()->nanoseconds());
+        $this->assertSame(0, $this->info()->systemCpuTimeSincePrevious()->seconds());
+    }
+
+    public function testHasTotalCpuTimeSincePrevious(): void
+    {
+        $this->assertSame(0, $this->info()->totalCpuTimeSincePrevious()->nanoseconds());
+        $this->assertSame(0, $this->info()->totalCpuTimeSincePrevious()->seconds());
+    }
+
     public function testCanBeFormattedAsString(): void
     {
         $this->assertStringMatchesFormat(
@@ -78,6 +129,12 @@ final class InfoTest extends TestCase
             $current->memoryUsage()->diff($current->memoryUsage()),
             $current->time()->duration($current->time()),
             $current->memoryUsage()->diff($current->memoryUsage()),
+            $current->userCpuTime()->diff($current->userCpuTime()),
+            $current->systemCpuTime()->diff($current->systemCpuTime()),
+            $current->totalCpuTime()->diff($current->totalCpuTime()),
+            $current->userCpuTime()->diff($current->userCpuTime()),
+            $current->systemCpuTime()->diff($current->systemCpuTime()),
+            $current->totalCpuTime()->diff($current->totalCpuTime()),
         );
     }
 
@@ -87,6 +144,7 @@ final class InfoTest extends TestCase
             new SystemStopWatch,
             new SystemMemoryMeter,
             new SystemGarbageCollectorStatusProvider,
+            new SystemCpuTimeMeter,
         );
     }
 }

--- a/tests/unit/Event/Value/Telemetry/SnapshotTest.php
+++ b/tests/unit/Event/Value/Telemetry/SnapshotTest.php
@@ -27,17 +27,26 @@ final class SnapshotTest extends TestCase
         $memoryUsage            = MemoryUsage::fromBytes(2000);
         $peakMemoryUsage        = MemoryUsage::fromBytes(3000);
         $garbageCollectorStatus = new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0);
+        $userCpuTime            = CpuTime::fromSecondsAndNanoseconds(1, 200);
+        $systemCpuTime          = CpuTime::fromSecondsAndNanoseconds(2, 300);
+        $totalCpuTime           = CpuTime::fromSecondsAndNanoseconds(3, 500);
 
         $snapshot = new Snapshot(
             $time,
             $memoryUsage,
             $peakMemoryUsage,
             $garbageCollectorStatus,
+            $userCpuTime,
+            $systemCpuTime,
+            $totalCpuTime,
         );
 
         $this->assertSame($time, $snapshot->time());
         $this->assertSame($memoryUsage, $snapshot->memoryUsage());
         $this->assertSame($peakMemoryUsage, $snapshot->peakMemoryUsage());
         $this->assertSame($garbageCollectorStatus, $snapshot->garbageCollectorStatus());
+        $this->assertSame($userCpuTime, $snapshot->userCpuTime());
+        $this->assertSame($systemCpuTime, $snapshot->systemCpuTime());
+        $this->assertSame($totalCpuTime, $snapshot->totalCpuTime());
     }
 }

--- a/tests/unit/Event/Value/Telemetry/SystemCpuTimeMeterTest.php
+++ b/tests/unit/Event/Value/Telemetry/SystemCpuTimeMeterTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Telemetry;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SystemCpuTimeMeter::class)]
+#[Small]
+#[Group('event-system')]
+#[Group('event-system/value-objects')]
+final class SystemCpuTimeMeterTest extends TestCase
+{
+    public function testUserCpuTimeReturnsCpuTime(): void
+    {
+        $this->assertInstanceOf(CpuTime::class, new SystemCpuTimeMeter()->userCpuTime());
+    }
+
+    public function testSystemCpuTimeReturnsCpuTime(): void
+    {
+        $this->assertInstanceOf(CpuTime::class, new SystemCpuTimeMeter()->systemCpuTime());
+    }
+
+    public function testUserCpuTimeIsMonotonicallyNonDecreasing(): void
+    {
+        $meter = new SystemCpuTimeMeter;
+
+        $first = $meter->userCpuTime();
+
+        $sink = 0;
+
+        for ($i = 0; $i < 100000; $i++) {
+            $sink += $i;
+        }
+
+        $second = $meter->userCpuTime();
+
+        $this->assertGreaterThan(0, $sink);
+        $this->assertGreaterThanOrEqual($first->asFloat(), $second->asFloat());
+    }
+}

--- a/tests/unit/Event/Value/Telemetry/SystemTest.php
+++ b/tests/unit/Event/Value/Telemetry/SystemTest.php
@@ -82,11 +82,40 @@ final class SystemTest extends TestCase
             }
         };
 
-        $snapshot = new System($clock, $memoryMeter, $garbageCollectorProvider)->snapshot();
+        $userCpuTime   = CpuTime::fromSecondsAndNanoseconds(1, 200);
+        $systemCpuTime = CpuTime::fromSecondsAndNanoseconds(2, 300);
+
+        $cpuTimeMeter = new readonly class($userCpuTime, $systemCpuTime) implements CpuTimeMeter
+        {
+            private CpuTime $userCpuTime;
+            private CpuTime $systemCpuTime;
+
+            public function __construct(CpuTime $userCpuTime, CpuTime $systemCpuTime)
+            {
+                $this->userCpuTime   = $userCpuTime;
+                $this->systemCpuTime = $systemCpuTime;
+            }
+
+            public function userCpuTime(): CpuTime
+            {
+                return $this->userCpuTime;
+            }
+
+            public function systemCpuTime(): CpuTime
+            {
+                return $this->systemCpuTime;
+            }
+        };
+
+        $snapshot = new System($clock, $memoryMeter, $garbageCollectorProvider, $cpuTimeMeter)->snapshot();
 
         $this->assertSame($time, $snapshot->time());
         $this->assertSame($memoryUsage, $snapshot->memoryUsage());
         $this->assertSame($peakMemoryUsage, $snapshot->peakMemoryUsage());
         $this->assertSame($garbageCollectorStatus, $snapshot->garbageCollectorStatus());
+        $this->assertSame($userCpuTime, $snapshot->userCpuTime());
+        $this->assertSame($systemCpuTime, $snapshot->systemCpuTime());
+        $this->assertSame(3, $snapshot->totalCpuTime()->seconds());
+        $this->assertSame(500, $snapshot->totalCpuTime()->nanoseconds());
     }
 }

--- a/tests/unit/Logging/TestDox/TestResult/TestResultCollectorTest.php
+++ b/tests/unit/Logging/TestDox/TestResult/TestResultCollectorTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -404,11 +405,20 @@ final class TestResultCollectorTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 

--- a/tests/unit/Runner/DeprecationCollector/InIsolationCollectorTest.php
+++ b/tests/unit/Runner/DeprecationCollector/InIsolationCollectorTest.php
@@ -13,6 +13,7 @@ use function hrtime;
 use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
 use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -117,11 +118,20 @@ final class InIsolationCollectorTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 

--- a/tests/unit/Runner/IssueFilterTest.php
+++ b/tests/unit/Runner/IssueFilterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
 use PHPUnit\Event\Code\Phpt;
 use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -531,11 +532,20 @@ final class IssueFilterTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 

--- a/tests/unit/TextUI/Output/Compact/ProgressPrinterTest.php
+++ b/tests/unit/TextUI/Output/Compact/ProgressPrinterTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\ThrowableBuilder;
 use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -248,11 +249,20 @@ final class ProgressPrinterTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 }

--- a/tests/unit/TextUI/Output/Compact/ResultPrinterTest.php
+++ b/tests/unit/TextUI/Output/Compact/ResultPrinterTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
 use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -1057,11 +1058,20 @@ final class ResultPrinterTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 }

--- a/tests/unit/TextUI/Output/Default/ProgressPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/ProgressPrinterTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\ThrowableBuilder;
 use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -938,11 +939,20 @@ final class ProgressPrinterTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 }

--- a/tests/unit/TextUI/Output/Default/ResultPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/ResultPrinterTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Event\Code\TestDoxBuilder;
 use PHPUnit\Event\Code\TestMethod;
 use PHPUnit\Event\Code\Throwable;
 use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -1076,11 +1077,20 @@ final class ResultPrinterTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 

--- a/tests/unit/TextUI/Output/Default/UnexpectedOutputPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/UnexpectedOutputPrinterTest.php
@@ -11,6 +11,7 @@ namespace PHPUnit\TextUI\Output\Default;
 
 use function hrtime;
 use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Event\Telemetry\CpuTime;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -47,11 +48,20 @@ final class UnexpectedOutputPrinterTest extends TestCase
                 MemoryUsage::fromBytes(1000),
                 MemoryUsage::fromBytes(2000),
                 new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
+                CpuTime::fromSecondsAndNanoseconds(0, 0),
             ),
             Duration::fromSecondsAndNanoseconds(123, 456),
             MemoryUsage::fromBytes(2000),
             Duration::fromSecondsAndNanoseconds(234, 567),
             MemoryUsage::fromBytes(3000),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
+            CpuTime::fromSecondsAndNanoseconds(0, 0),
         );
     }
 }


### PR DESCRIPTION
Every emitted event now carries CPU time information (user, system, and total) alongside wall-clock time, memory usage, and garbage collector status. This makes it possible to distinguish CPU-bound from I/O-bound test work, wall-clock time alone conflates the two.

The `Telemetry` value object that is part of each `Event` emitted now exposes user, system, and total CPU time, plus deltas since the test run started and since the previous event (mirroring how duration and memory usage are already exposed).

The `<phpunit:resourceUsage>` element of Open Test Reporting XML gains three new attributes (`userCpuTime`, `systemCpuTime`, `cpuTime`) for both test and test-suite entries. The schema is updated accordingly.

JUnit XML and TeamCity output formats as well as other outputs are unchanged.