### PR TITLE
Improve empty coverage filter warning

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -504,7 +504,7 @@ final class CodeCoverage
 
         EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
             sprintf(
-                'Configured source filter (include-path: %s) does not match any files, code coverage will not be processed',
+                'Configured source filter includes no files (configured paths: %s), code coverage will not be processed',
                 implode(', ', $paths),
             ),
         );

--- a/tests/end-to-end/generic/empty-source-filter.phpt
+++ b/tests/end-to-end/generic/empty-source-filter.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Warning when configured source filter does not match any files
+Warning when configured source filter includes no files
 --SKIPIF--
 <?php declare(strict_types=1);
 if (!extension_loaded('xdebug') && !extension_loaded('pcov')) {
@@ -29,7 +29,7 @@ Time: %s, Memory: %s
 
 There was 1 PHPUnit test runner warning:
 
-1) Configured source filter (include-path: %snonexistent-directory) does not match any files, code coverage will not be processed
+1) Configured source filter includes no files (configured paths: %snonexistent-directory), code coverage will not be processed
 
 OK, but there were issues!
 Tests: 1, Assertions: 1, PHPUnit Warnings: 1.


### PR DESCRIPTION
Fixes #4440

Summary:
- Clarify the warning when a configured source filter resolves to no files.
- Update the existing PHPT expectation.

Testing:
- Not run locally: PHP is not installed in this environment.