### PR TITLE
Improve empty coverage source warning

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -504,7 +504,8 @@ final class CodeCoverage
 
         EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
             sprintf(
-                'Configured source filter (include-path: %s) does not match any files, code coverage will not be processed',
+                'Configured source filter (include-path: %s) does not match any files, code coverage will not be processed. ' .
+                'Make sure <source> includes existing files and that directory paths are relative to the XML configuration file.',
                 implode(', ', $paths),
             ),
         );

--- a/tests/end-to-end/generic/empty-source-filter.phpt
+++ b/tests/end-to-end/generic/empty-source-filter.phpt
@@ -29,7 +29,7 @@ Time: %s, Memory: %s
 
 There was 1 PHPUnit test runner warning:
 
-1) Configured source filter (include-path: %snonexistent-directory) does not match any files, code coverage will not be processed
+1) Configured source filter (include-path: %snonexistent-directory) does not match any files, code coverage will not be processed. Make sure <source> includes existing files and that directory paths are relative to the XML configuration file.
 
 OK, but there were issues!
 Tests: 1, Assertions: 1, PHPUnit Warnings: 1.


### PR DESCRIPTION
This keeps the existing empty source-filter warning, but adds the hint that has come up in #4440: when the filter matches no files, users should check that `<source>` points at existing files and that directory paths are relative to the XML configuration file.

I also updated the existing PHPT expectation for the warning text.

Not run locally: this environment does not have `php`, `composer`, or `vendor/` installed.

Fixes #4440