### PR TITLE
Improve handling of empty code coverage source filter

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -482,31 +482,12 @@ final class CodeCoverage
             return;
         }
 
-        if (!$codeCoverageFilterRegistry->configured()) {
-            EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
-                'No filter is configured, code coverage will not be processed',
-            );
-
-            $this->deactivate();
-
+        if ($codeCoverageFilterRegistry->configured()) {
             return;
         }
 
-        $paths = [];
-
-        foreach ($configuration->source()->includeDirectories() as $directory) {
-            $paths[] = $directory->path();
-        }
-
-        foreach ($configuration->source()->includeFiles() as $file) {
-            $paths[] = $file->path();
-        }
-
         EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
-            sprintf(
-                'Configured source filter (include-path: %s) does not match any files, code coverage will not be processed',
-                implode(', ', $paths),
-            ),
+            'No filter is configured, code coverage will not be processed',
         );
 
         $this->deactivate();

--- a/tests/end-to-end/generic/empty-source-filter.phpt
+++ b/tests/end-to-end/generic/empty-source-filter.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Warning when configured source filter does not match any files
+No warning when configured source filter does not match any files
 --SKIPIF--
 <?php declare(strict_types=1);
 require __DIR__ . '/../../_files/skip-if-requires-code-coverage-driver.php';
@@ -25,9 +25,4 @@ Configuration: %s
 
 Time: %s, Memory: %s
 
-There was 1 PHPUnit test runner warning:
-
-1) Configured source filter (include-path: %snonexistent-directory) does not match any files, code coverage will not be processed
-
-OK, but there were issues!
-Tests: 1, Assertions: 1, PHPUnit Warnings: 1.
+OK (%d test, %d assertion)


### PR DESCRIPTION
Suppress the misleading warning when a source filter is configured but resolves to no files.

Regression test updated for the empty-source-filter fixture.