### PR TITLE
Keep XML comparison assertions comment-insensitive by default and add comment-aware variants

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2597,7 +2597,7 @@ abstract class Assert
     }
 
     /**
-     * Asserts that two XML files are equal.
+     * Asserts that two XML files are equal, ignoring comments.
      *
      * @throws Exception
      * @throws ExpectationFailedException
@@ -2605,20 +2605,105 @@ abstract class Assert
      */
     final public static function assertXmlFileEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
-        $expected = (new XmlLoader)->loadFile($expectedFile);
-        $actual   = (new XmlLoader)->loadFile($actualFile);
+        $expected = (new XmlLoader)->loadFile($expectedFile, true);
+        $actual   = (new XmlLoader)->loadFile($actualFile, true);
 
         self::assertEquals($expected, $actual, $message);
     }
 
     /**
-     * Asserts that two XML files are not equal.
+     * Asserts that two XML files are not equal, ignoring comments.
      *
      * @throws \PHPUnit\Util\Exception
      * @throws ExpectationFailedException
      */
     final public static function assertXmlFileNotEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
+        $expected = (new XmlLoader)->loadFile($expectedFile, true);
+        $actual   = (new XmlLoader)->loadFile($actualFile, true);
+
+        self::assertNotEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two XML documents are equal, ignoring comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     */
+    final public static function assertXmlStringEqualsXmlFile(string $expectedFile, string $actualXml, string $message = ''): void
+    {
+        $expected = (new XmlLoader)->loadFile($expectedFile, true);
+        $actual   = (new XmlLoader)->load($actualXml, true);
+
+        self::assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two XML documents are not equal, ignoring comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     */
+    final public static function assertXmlStringNotEqualsXmlFile(string $expectedFile, string $actualXml, string $message = ''): void
+    {
+        $expected = (new XmlLoader)->loadFile($expectedFile, true);
+        $actual   = (new XmlLoader)->load($actualXml, true);
+
+        self::assertNotEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two XML documents are equal, ignoring comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     */
+    final public static function assertXmlStringEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
+    {
+        $expected = (new XmlLoader)->load($expectedXml, true);
+        $actual   = (new XmlLoader)->load($actualXml, true);
+
+        self::assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two XML documents are not equal, ignoring comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     */
+    final public static function assertXmlStringNotEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
+    {
+        $expected = (new XmlLoader)->load($expectedXml, true);
+        $actual   = (new XmlLoader)->load($actualXml, true);
+
+        self::assertNotEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two XML files are equal, considering comments.
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     */
+    final public static function assertXmlFileEqualsXmlFileConsideringComments(string $expectedFile, string $actualFile, string $message = ''): void
+    {
+        $expected = (new XmlLoader)->loadFile($expectedFile);
+        $actual   = (new XmlLoader)->loadFile($actualFile);
+
+        self::assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that two XML files are not equal, considering comments.
+     *
+     * @throws \PHPUnit\Util\Exception
+     * @throws ExpectationFailedException
+     */
+    final public static function assertXmlFileNotEqualsXmlFileConsideringComments(string $expectedFile, string $actualFile, string $message = ''): void
+    {
         $expected = (new XmlLoader)->loadFile($expectedFile);
         $actual   = (new XmlLoader)->loadFile($actualFile);
 
@@ -2626,12 +2711,12 @@ abstract class Assert
     }
 
     /**
-     * Asserts that two XML documents are equal.
+     * Asserts that two XML documents are equal, considering comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
      */
-    final public static function assertXmlStringEqualsXmlFile(string $expectedFile, string $actualXml, string $message = ''): void
+    final public static function assertXmlStringEqualsXmlFileConsideringComments(string $expectedFile, string $actualXml, string $message = ''): void
     {
         $expected = (new XmlLoader)->loadFile($expectedFile);
         $actual   = (new XmlLoader)->load($actualXml);
@@ -2640,12 +2725,12 @@ abstract class Assert
     }
 
     /**
-     * Asserts that two XML documents are not equal.
+     * Asserts that two XML documents are not equal, considering comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
      */
-    final public static function assertXmlStringNotEqualsXmlFile(string $expectedFile, string $actualXml, string $message = ''): void
+    final public static function assertXmlStringNotEqualsXmlFileConsideringComments(string $expectedFile, string $actualXml, string $message = ''): void
     {
         $expected = (new XmlLoader)->loadFile($expectedFile);
         $actual   = (new XmlLoader)->load($actualXml);
@@ -2654,12 +2739,12 @@ abstract class Assert
     }
 
     /**
-     * Asserts that two XML documents are equal.
+     * Asserts that two XML documents are equal, considering comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
      */
-    final public static function assertXmlStringEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
+    final public static function assertXmlStringEqualsXmlStringConsideringComments(string $expectedXml, string $actualXml, string $message = ''): void
     {
         $expected = (new XmlLoader)->load($expectedXml);
         $actual   = (new XmlLoader)->load($actualXml);
@@ -2668,12 +2753,12 @@ abstract class Assert
     }
 
     /**
-     * Asserts that two XML documents are not equal.
+     * Asserts that two XML documents are not equal, considering comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
      */
-    final public static function assertXmlStringNotEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
+    final public static function assertXmlStringNotEqualsXmlStringConsideringComments(string $expectedXml, string $actualXml, string $message = ''): void
     {
         $expected = (new XmlLoader)->load($expectedXml);
         $actual   = (new XmlLoader)->load($actualXml);

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -2884,7 +2884,7 @@ if (!function_exists('PHPUnit\Framework\assertStringEndsNotWith')) {
 
 if (!function_exists('PHPUnit\Framework\assertXmlFileEqualsXmlFile')) {
     /**
-     * Asserts that two XML files are equal.
+     * Asserts that two XML files are equal, ignoring comments.
      *
      * @throws Exception
      * @throws ExpectationFailedException
@@ -2902,7 +2902,7 @@ if (!function_exists('PHPUnit\Framework\assertXmlFileEqualsXmlFile')) {
 
 if (!function_exists('PHPUnit\Framework\assertXmlFileNotEqualsXmlFile')) {
     /**
-     * Asserts that two XML files are not equal.
+     * Asserts that two XML files are not equal, ignoring comments.
      *
      * @throws \PHPUnit\Util\Exception
      * @throws ExpectationFailedException
@@ -2919,7 +2919,7 @@ if (!function_exists('PHPUnit\Framework\assertXmlFileNotEqualsXmlFile')) {
 
 if (!function_exists('PHPUnit\Framework\assertXmlStringEqualsXmlFile')) {
     /**
-     * Asserts that two XML documents are equal.
+     * Asserts that two XML documents are equal, ignoring comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
@@ -2936,7 +2936,7 @@ if (!function_exists('PHPUnit\Framework\assertXmlStringEqualsXmlFile')) {
 
 if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlFile')) {
     /**
-     * Asserts that two XML documents are not equal.
+     * Asserts that two XML documents are not equal, ignoring comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
@@ -2953,7 +2953,7 @@ if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlFile')) {
 
 if (!function_exists('PHPUnit\Framework\assertXmlStringEqualsXmlString')) {
     /**
-     * Asserts that two XML documents are equal.
+     * Asserts that two XML documents are equal, ignoring comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
@@ -2970,7 +2970,7 @@ if (!function_exists('PHPUnit\Framework\assertXmlStringEqualsXmlString')) {
 
 if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlString')) {
     /**
-     * Asserts that two XML documents are not equal.
+     * Asserts that two XML documents are not equal, ignoring comments.
      *
      * @throws ExpectationFailedException
      * @throws XmlException
@@ -2982,6 +2982,109 @@ if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlString')) {
     function assertXmlStringNotEqualsXmlString(string $expectedXml, string $actualXml, string $message = ''): void
     {
         Assert::assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertXmlFileEqualsXmlFileConsideringComments')) {
+    /**
+     * Asserts that two XML files are equal, considering comments.
+     *
+     * @throws Exception
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertXmlFileEqualsXmlFileConsideringComments
+     */
+    function assertXmlFileEqualsXmlFileConsideringComments(string $expectedFile, string $actualFile, string $message = ''): void
+    {
+        Assert::assertXmlFileEqualsXmlFileConsideringComments($expectedFile, $actualFile, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertXmlFileNotEqualsXmlFileConsideringComments')) {
+    /**
+     * Asserts that two XML files are not equal, considering comments.
+     *
+     * @throws \PHPUnit\Util\Exception
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertXmlFileNotEqualsXmlFileConsideringComments
+     */
+    function assertXmlFileNotEqualsXmlFileConsideringComments(string $expectedFile, string $actualFile, string $message = ''): void
+    {
+        Assert::assertXmlFileNotEqualsXmlFileConsideringComments($expectedFile, $actualFile, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertXmlStringEqualsXmlFileConsideringComments')) {
+    /**
+     * Asserts that two XML documents are equal, considering comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertXmlStringEqualsXmlFileConsideringComments
+     */
+    function assertXmlStringEqualsXmlFileConsideringComments(string $expectedFile, string $actualXml, string $message = ''): void
+    {
+        Assert::assertXmlStringEqualsXmlFileConsideringComments($expectedFile, $actualXml, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlFileConsideringComments')) {
+    /**
+     * Asserts that two XML documents are not equal, considering comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertXmlStringNotEqualsXmlFileConsideringComments
+     */
+    function assertXmlStringNotEqualsXmlFileConsideringComments(string $expectedFile, string $actualXml, string $message = ''): void
+    {
+        Assert::assertXmlStringNotEqualsXmlFileConsideringComments($expectedFile, $actualXml, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertXmlStringEqualsXmlStringConsideringComments')) {
+    /**
+     * Asserts that two XML documents are equal, considering comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertXmlStringEqualsXmlStringConsideringComments
+     */
+    function assertXmlStringEqualsXmlStringConsideringComments(string $expectedXml, string $actualXml, string $message = ''): void
+    {
+        Assert::assertXmlStringEqualsXmlStringConsideringComments($expectedXml, $actualXml, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertXmlStringNotEqualsXmlStringConsideringComments')) {
+    /**
+     * Asserts that two XML documents are not equal, considering comments.
+     *
+     * @throws ExpectationFailedException
+     * @throws XmlException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertXmlStringNotEqualsXmlStringConsideringComments
+     */
+    function assertXmlStringNotEqualsXmlStringConsideringComments(string $expectedXml, string $actualXml, string $message = ''): void
+    {
+        Assert::assertXmlStringNotEqualsXmlStringConsideringComments($expectedXml, $actualXml, $message);
     }
 }
 

--- a/src/Util/Xml/Loader.php
+++ b/src/Util/Xml/Loader.php
@@ -10,6 +10,7 @@
 namespace PHPUnit\Util\Xml;
 
 use const LIBXML_NONET;
+use function assert;
 use function error_reporting;
 use function file_get_contents;
 use function libxml_get_errors;
@@ -17,6 +18,8 @@ use function libxml_use_internal_errors;
 use function sprintf;
 use function trim;
 use DOMDocument;
+use DOMNode;
+use DOMXPath;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -28,7 +31,7 @@ final readonly class Loader
     /**
      * @throws XmlException
      */
-    public function loadFile(string $filename): DOMDocument
+    public function loadFile(string $filename, bool $ignoreComments = false): DOMDocument
     {
         $reporting = error_reporting(0);
         $contents  = file_get_contents($filename);
@@ -53,13 +56,13 @@ final readonly class Loader
             );
         }
 
-        return $this->load($contents);
+        return $this->load($contents, $ignoreComments);
     }
 
     /**
      * @throws XmlException
      */
-    public function load(string $actual): DOMDocument
+    public function load(string $actual, bool $ignoreComments = false): DOMDocument
     {
         if ($actual === '') {
             throw new XmlException('Could not parse XML from empty string');
@@ -90,6 +93,25 @@ final readonly class Loader
             throw new XmlException($message);
         }
 
+        if ($ignoreComments) {
+            $this->removeComments($document);
+        }
+
         return $document;
+    }
+
+    private function removeComments(DOMDocument $document): void
+    {
+        $xpath    = new DOMXPath($document);
+        $comments = $xpath->query('//comment()');
+
+        assert($comments !== false);
+
+        foreach ($comments as $comment) {
+            assert($comment instanceof DOMNode);
+            assert($comment->parentNode !== null);
+
+            $comment->parentNode->removeChild($comment);
+        }
     }
 }

--- a/tests/_files/xml-different.xml
+++ b/tests/_files/xml-different.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<root>
+    <other/>
+</root>

--- a/tests/_files/xml-with-comments.xml
+++ b/tests/_files/xml-with-comments.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<root>
+    <!-- a comment -->
+    <node/>
+</root>

--- a/tests/_files/xml-without-comments.xml
+++ b/tests/_files/xml-without-comments.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<root>
+    <node/>
+</root>

--- a/tests/unit/Framework/Assert/assertXmlFileEqualsXmlFileConsideringCommentsTest.php
+++ b/tests/unit/Framework/Assert/assertXmlFileEqualsXmlFileConsideringCommentsTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertXmlFileEqualsXmlFileConsideringComments')]
+#[TestDox('assertXmlFileEqualsXmlFileConsideringComments()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertXmlFileEqualsXmlFileConsideringCommentsTest extends TestCase
+{
+    public function testSucceedsWhenConstraintEvaluatesToTrue(): void
+    {
+        $this->assertXmlFileEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+        );
+    }
+
+    public function testFailsWhenConstraintEvaluatesToFalse(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlFileEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            TEST_FILES_PATH . 'xml-without-comments.xml',
+        );
+    }
+}

--- a/tests/unit/Framework/Assert/assertXmlFileEqualsXmlFileTest.php
+++ b/tests/unit/Framework/Assert/assertXmlFileEqualsXmlFileTest.php
@@ -38,4 +38,12 @@ final class assertXmlFileEqualsXmlFileTest extends TestCase
             TEST_FILES_PATH . 'bar.xml',
         );
     }
+
+    public function testIgnoresComments(): void
+    {
+        $this->assertXmlFileEqualsXmlFile(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            TEST_FILES_PATH . 'xml-without-comments.xml',
+        );
+    }
 }

--- a/tests/unit/Framework/Assert/assertXmlFileNotEqualsXmlFileConsideringCommentsTest.php
+++ b/tests/unit/Framework/Assert/assertXmlFileNotEqualsXmlFileConsideringCommentsTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertXmlFileNotEqualsXmlFileConsideringComments')]
+#[TestDox('assertXmlFileNotEqualsXmlFileConsideringComments()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertXmlFileNotEqualsXmlFileConsideringCommentsTest extends TestCase
+{
+    public function testSucceedsWhenConstraintEvaluatesToTrue(): void
+    {
+        $this->assertXmlFileNotEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            TEST_FILES_PATH . 'xml-without-comments.xml',
+        );
+    }
+
+    public function testFailsWhenConstraintEvaluatesToFalse(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlFileNotEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+        );
+    }
+}

--- a/tests/unit/Framework/Assert/assertXmlFileNotEqualsXmlFileTest.php
+++ b/tests/unit/Framework/Assert/assertXmlFileNotEqualsXmlFileTest.php
@@ -38,4 +38,14 @@ final class assertXmlFileNotEqualsXmlFileTest extends TestCase
             TEST_FILES_PATH . 'foo.xml',
         );
     }
+
+    public function testTreatsDocumentsDifferingOnlyInCommentsAsEqual(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlFileNotEqualsXmlFile(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            TEST_FILES_PATH . 'xml-without-comments.xml',
+        );
+    }
 }

--- a/tests/unit/Framework/Assert/assertXmlStringEqualsXmlFileConsideringCommentsTest.php
+++ b/tests/unit/Framework/Assert/assertXmlStringEqualsXmlFileConsideringCommentsTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertXmlStringEqualsXmlFileConsideringComments')]
+#[TestDox('assertXmlStringEqualsXmlFileConsideringComments()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertXmlStringEqualsXmlFileConsideringCommentsTest extends TestCase
+{
+    public function testSucceedsWhenConstraintEvaluatesToTrue(): void
+    {
+        $this->assertXmlStringEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            '<root><!-- a comment --><node/></root>',
+        );
+    }
+
+    public function testFailsWhenConstraintEvaluatesToFalse(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlStringEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            '<root><node/></root>',
+        );
+    }
+}

--- a/tests/unit/Framework/Assert/assertXmlStringEqualsXmlFileTest.php
+++ b/tests/unit/Framework/Assert/assertXmlStringEqualsXmlFileTest.php
@@ -39,4 +39,12 @@ final class assertXmlStringEqualsXmlFileTest extends TestCase
             file_get_contents(TEST_FILES_PATH . 'bar.xml'),
         );
     }
+
+    public function testIgnoresComments(): void
+    {
+        $this->assertXmlStringEqualsXmlFile(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            '<root><node/></root>',
+        );
+    }
 }

--- a/tests/unit/Framework/Assert/assertXmlStringEqualsXmlStringConsideringCommentsTest.php
+++ b/tests/unit/Framework/Assert/assertXmlStringEqualsXmlStringConsideringCommentsTest.php
@@ -15,12 +15,12 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestDox;
 
-#[CoversMethod(Assert::class, 'assertXmlStringEqualsXmlString')]
-#[TestDox('assertXmlStringEqualsXmlString()')]
+#[CoversMethod(Assert::class, 'assertXmlStringEqualsXmlStringConsideringComments')]
+#[TestDox('assertXmlStringEqualsXmlStringConsideringComments()')]
 #[Small]
 #[Group('framework')]
 #[Group('framework/assertions')]
-final class assertXmlStringEqualsXmlStringTest extends TestCase
+final class assertXmlStringEqualsXmlStringConsideringCommentsTest extends TestCase
 {
     /**
      * @return non-empty-list<array{0: non-empty-string, 1: non-empty-string}>
@@ -28,23 +28,8 @@ final class assertXmlStringEqualsXmlStringTest extends TestCase
     public static function successProvider(): array
     {
         return [
-            ['<root/>', '<root/>'],
-            ['<root/>', '<root></root>'],
-            ['<root><!-- comment --><node/></root>', '<root><node/></root>'],
-            [
-                <<<'XML'
-<?xml version="1.0"?>
-<root>
-    <node />
-</root>
-XML,
-                <<<'XML'
-<?xml version="1.0"?>
-<root>
-<node />
-</root>
-XML
-            ],
+            ['<root><node/></root>', '<root><node/></root>'],
+            ['<root><!-- comment --><node/></root>', '<root><!-- comment --><node/></root>'],
         ];
     }
 
@@ -55,13 +40,15 @@ XML
     {
         return [
             ['<foo/>', '<bar/>'],
+            ['<root><!-- comment --><node/></root>', '<root><node/></root>'],
+            ['<root><!-- expected --><node/></root>', '<root><!-- actual --><node/></root>'],
         ];
     }
 
     #[DataProvider('successProvider')]
     public function testSucceedsWhenConstraintEvaluatesToTrue(string $expectedXml, string $actualXml): void
     {
-        $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
+        $this->assertXmlStringEqualsXmlStringConsideringComments($expectedXml, $actualXml);
     }
 
     #[DataProvider('failureProvider')]
@@ -69,6 +56,6 @@ XML
     {
         $this->expectException(AssertionFailedError::class);
 
-        $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
+        $this->assertXmlStringEqualsXmlStringConsideringComments($expectedXml, $actualXml);
     }
 }

--- a/tests/unit/Framework/Assert/assertXmlStringNotEqualsXmlFileConsideringCommentsTest.php
+++ b/tests/unit/Framework/Assert/assertXmlStringNotEqualsXmlFileConsideringCommentsTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertXmlStringNotEqualsXmlFileConsideringComments')]
+#[TestDox('assertXmlStringNotEqualsXmlFileConsideringComments()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertXmlStringNotEqualsXmlFileConsideringCommentsTest extends TestCase
+{
+    public function testSucceedsWhenConstraintEvaluatesToTrue(): void
+    {
+        $this->assertXmlStringNotEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            '<root><node/></root>',
+        );
+    }
+
+    public function testFailsWhenConstraintEvaluatesToFalse(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlStringNotEqualsXmlFileConsideringComments(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            '<root><!-- a comment --><node/></root>',
+        );
+    }
+}

--- a/tests/unit/Framework/Assert/assertXmlStringNotEqualsXmlFileTest.php
+++ b/tests/unit/Framework/Assert/assertXmlStringNotEqualsXmlFileTest.php
@@ -39,4 +39,14 @@ final class assertXmlStringNotEqualsXmlFileTest extends TestCase
             file_get_contents(TEST_FILES_PATH . 'foo.xml'),
         );
     }
+
+    public function testTreatsDocumentsDifferingOnlyInCommentsAsEqual(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlStringNotEqualsXmlFile(
+            TEST_FILES_PATH . 'xml-with-comments.xml',
+            '<root><node/></root>',
+        );
+    }
 }

--- a/tests/unit/Framework/Assert/assertXmlStringNotEqualsXmlStringConsideringCommentsTest.php
+++ b/tests/unit/Framework/Assert/assertXmlStringNotEqualsXmlStringConsideringCommentsTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertXmlStringNotEqualsXmlStringConsideringComments')]
+#[TestDox('assertXmlStringNotEqualsXmlStringConsideringComments()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertXmlStringNotEqualsXmlStringConsideringCommentsTest extends TestCase
+{
+    #[DataProviderExternal(assertXmlStringEqualsXmlStringConsideringCommentsTest::class, 'failureProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(string $expectedXml, string $actualXml): void
+    {
+        $this->assertXmlStringNotEqualsXmlStringConsideringComments($expectedXml, $actualXml);
+    }
+
+    #[DataProviderExternal(assertXmlStringEqualsXmlStringConsideringCommentsTest::class, 'successProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $expectedXml, string $actualXml): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertXmlStringNotEqualsXmlStringConsideringComments($expectedXml, $actualXml);
+    }
+}

--- a/tests/unit/Util/Xml/LoaderTest.php
+++ b/tests/unit/Util/Xml/LoaderTest.php
@@ -70,4 +70,32 @@ final class LoaderTest extends TestCase
 
         (new Loader)->load('<test>');
     }
+
+    public function testKeepsCommentsInStringByDefault(): void
+    {
+        $document = (new Loader)->load('<root><!-- comment --><node/></root>');
+
+        $this->assertStringContainsString('<!-- comment -->', (string) $document->saveXML());
+    }
+
+    public function testCanRemoveCommentsFromString(): void
+    {
+        $document = (new Loader)->load('<root><!-- comment --><node/></root>', true);
+
+        $this->assertStringNotContainsString('<!-- comment -->', (string) $document->saveXML());
+    }
+
+    public function testCanRemoveCommentsFromStringWithoutComments(): void
+    {
+        $document = (new Loader)->load('<root><node/></root>', true);
+
+        $this->assertStringNotContainsString('<!--', (string) $document->saveXML());
+    }
+
+    public function testCanRemoveCommentsFromFile(): void
+    {
+        $document = (new Loader)->loadFile(__DIR__ . '/../../../_files/xml-with-comments.xml', true);
+
+        $this->assertStringNotContainsString('<!--', (string) $document->saveXML());
+    }
 }


### PR DESCRIPTION
A recent change in `sebastianbergmann/comparator` made XML comments significant when comparing DOM documents (`C14N(false, true)`). Because PHPUnit's XML assertions delegate to that comparator, their behavior silently changed — two documents that differ only in comments are now treated as different. This surfaced in https://github.com/sebastianbergmann/comparator/issues/107#issuecomment-4553052370.

That change cuts both ways, and the second direction is the dangerous one. For two documents that differ only in comments:

| Assertion | Long-standing behavior | After the comparator change |
|---|---|---|
| `assertXmlStringEqualsXmlString()` | passes | fails (loud, you notice) |
| `assertXmlStringNotEqualsXmlString()` | fails | passes (silent, you do not notice |

The `Equals` regression is loud: a green test turns red and you fix it. The `NotEquals` regression is silent: a test written to prove that output actually changed now passes even when the only difference is a comment. This is a real assertion that quietly stops protecting you.

This pull request restores the long-standing, comment-insensitive behavior as the default for all six XML assertions, so existing test suites keep working as before:

- `assertXmlFileEqualsXmlFile()` / `assertXmlFileNotEqualsXmlFile()`
- `assertXmlStringEqualsXmlFile()` / `assertXmlStringNotEqualsXmlFile()`
- `assertXmlStringEqualsXmlString()` / `assertXmlStringNotEqualsXmlString()`

For the cases where comments should be part of the comparison, six new opt-in variants make that explicit:

- `assertXmlFileEqualsXmlFileConsideringComments()` / `assertXmlFileNotEqualsXmlFileConsideringComments()`
- `assertXmlStringEqualsXmlFileConsideringComments()` / `assertXmlStringNotEqualsXmlFileConsideringComments()`
- `assertXmlStringEqualsXmlStringConsideringComments()` / `assertXmlStringNotEqualsXmlStringConsideringComments()`

**Example**

```php
$expected = '<order><!-- generated at 2026-05-27 --><id>42</id></order>';
$actual   = '<order><id>42</id></order>';

// Default: comments are ignored — these are equal
$this->assertXmlStringEqualsXmlString($expected, $actual);

// Opt in to treating comments as significant — these differ
$this->assertXmlStringNotEqualsXmlStringConsideringComments($expected, $actual);
```

The default behavior matches what PHPUnit did before the comparator change, so no test-suite migration is required.

Only comments are ignored by the default assertions; element structure, attributes, and text content are always compared.