### PR TITLE
Generate failure messages for inverse assertions by authoring negations, not by rewriting strings

### DIFF
--- a/src/Framework/Constraint/Array/ArrayComparison.php
+++ b/src/Framework/Constraint/Array/ArrayComparison.php
@@ -86,19 +86,21 @@ abstract class ArrayComparison extends Constraint
      */
     public function toString(): string
     {
-        if ($this->keysMatter && $this->orderMatters) {
-            return 'two arrays are ' . $this->comparisonType();
+        return 'two arrays are ' . $this->comparisonDescription();
+    }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
-        if (!$this->keysMatter && !$this->orderMatters) {
-            return 'two arrays are ' . $this->comparisonType() . ' while ignoring keys and order';
-        }
-
-        if (!$this->keysMatter) {
-            return 'two arrays are ' . $this->comparisonType() . ' while ignoring keys';
-        }
-
-        return 'two arrays are ' . $this->comparisonType() . ' while ignoring order';
+        return 'two arrays are not ' . $this->comparisonDescription();
     }
 
     /**
@@ -112,6 +114,15 @@ abstract class ArrayComparison extends Constraint
         return $this->toString();
     }
 
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->toStringInContext($operator, $role);
+    }
+
     /**
      * @return 'equal'|'identical'
      */
@@ -123,6 +134,23 @@ abstract class ArrayComparison extends Constraint
      * concrete subclass.
      */
     abstract protected function compareLeaf(mixed $expected, mixed $actual): bool;
+
+    private function comparisonDescription(): string
+    {
+        if ($this->keysMatter && $this->orderMatters) {
+            return $this->comparisonType();
+        }
+
+        if (!$this->keysMatter && !$this->orderMatters) {
+            return $this->comparisonType() . ' while ignoring keys and order';
+        }
+
+        if (!$this->keysMatter) {
+            return $this->comparisonType() . ' while ignoring keys';
+        }
+
+        return $this->comparisonType() . ' while ignoring order';
+    }
 
     /**
      * Compares two values, recursing into arrays as needed.

--- a/src/Framework/Constraint/Array/ArrayHasKey.php
+++ b/src/Framework/Constraint/Array/ArrayHasKey.php
@@ -67,4 +67,27 @@ final class ArrayHasKey extends Constraint
     {
         return 'an array ' . $this->toString();
     }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'does not have the key ' . Exporter::export($this->key);
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'an array ' . $this->toStringInContext($operator, $role);
+    }
 }

--- a/src/Framework/Constraint/Array/IsList.php
+++ b/src/Framework/Constraint/Array/IsList.php
@@ -48,4 +48,27 @@ final class IsList extends Constraint
     {
         return $this->valueToTypeStringFragment($other) . $this->toString();
     }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not a list';
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->valueToTypeStringFragment($other) . $this->toStringInContext($operator, $role);
+    }
 }

--- a/src/Framework/Constraint/Boolean/IsFalse.php
+++ b/src/Framework/Constraint/Boolean/IsFalse.php
@@ -27,6 +27,20 @@ final class IsFalse extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not false';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Boolean/IsTrue.php
+++ b/src/Framework/Constraint/Boolean/IsTrue.php
@@ -27,6 +27,20 @@ final class IsTrue extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not true';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Cardinality/Count.php
+++ b/src/Framework/Constraint/Cardinality/Count.php
@@ -43,6 +43,23 @@ class Count extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'count does not match %d',
+            $this->expectedCount,
+        );
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
@@ -130,6 +147,22 @@ class Count extends Constraint
     {
         return sprintf(
             'actual size %d matches expected size %d',
+            (int) $this->getCountOf($other),
+            $this->expectedCount,
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'actual size %d does not match expected size %d',
             (int) $this->getCountOf($other),
             $this->expectedCount,
         );

--- a/src/Framework/Constraint/Cardinality/GreaterThan.php
+++ b/src/Framework/Constraint/Cardinality/GreaterThan.php
@@ -32,6 +32,20 @@ final class GreaterThan extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not greater than ' . Exporter::export($this->value);
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Cardinality/IsEmpty.php
+++ b/src/Framework/Constraint/Cardinality/IsEmpty.php
@@ -30,6 +30,20 @@ final class IsEmpty extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not empty';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -55,13 +69,27 @@ final class IsEmpty extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
+        return $this->describe($other, $this->toString());
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->describe($other, $this->toStringInContext($operator, $role));
+    }
+
+    private function describe(mixed $other, string $description): string
+    {
         $type = gettype($other);
 
         return sprintf(
             '%s %s %s',
             str_starts_with($type, 'a') || str_starts_with($type, 'o') ? 'an' : 'a',
             $type,
-            $this->toString(),
+            $description,
         );
     }
 }

--- a/src/Framework/Constraint/Cardinality/LessThan.php
+++ b/src/Framework/Constraint/Cardinality/LessThan.php
@@ -32,6 +32,20 @@ final class LessThan extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not less than ' . Exporter::export($this->value);
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Equality/IsEqual.php
+++ b/src/Framework/Constraint/Equality/IsEqual.php
@@ -71,23 +71,35 @@ final class IsEqual extends Constraint
      */
     public function toString(): string
     {
-        $delta = '';
+        return 'is equal to ' . $this->valueAsString();
+    }
 
-        if (is_string($this->value)) {
-            if (str_contains($this->value, "\n")) {
-                return 'is equal to <text>';
-            }
-
-            return sprintf(
-                "is equal to '%s'",
-                $this->value,
-            );
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here, instead of letting
+     * LogicalNot rewrite the affirmative description, keeps the exported value
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
-        return sprintf(
-            'is equal to %s%s',
-            Exporter::export($this->value),
-            $delta,
-        );
+        return 'is not equal to ' . $this->valueAsString();
+    }
+
+    private function valueAsString(): string
+    {
+        if (is_string($this->value)) {
+            if (str_contains($this->value, "\n")) {
+                return '<text>';
+            }
+
+            return sprintf("'%s'", $this->value);
+        }
+
+        return Exporter::export($this->value);
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
+++ b/src/Framework/Constraint/Equality/IsEqualCanonicalizing.php
@@ -71,20 +71,35 @@ final class IsEqualCanonicalizing extends Constraint
      */
     public function toString(): string
     {
-        if (is_string($this->value)) {
-            if (str_contains($this->value, "\n")) {
-                return 'is equal to <text>';
-            }
+        return 'is equal to ' . $this->valueAsString();
+    }
 
-            return sprintf(
-                "is equal to '%s'",
-                $this->value,
-            );
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here, instead of letting
+     * LogicalNot rewrite the affirmative description, keeps the exported value
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
-        return sprintf(
-            'is equal to %s',
-            Exporter::export($this->value),
-        );
+        return 'is not equal to ' . $this->valueAsString();
+    }
+
+    private function valueAsString(): string
+    {
+        if (is_string($this->value)) {
+            if (str_contains($this->value, "\n")) {
+                return '<text>';
+            }
+
+            return sprintf("'%s'", $this->value);
+        }
+
+        return Exporter::export($this->value);
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
+++ b/src/Framework/Constraint/Equality/IsEqualIgnoringCase.php
@@ -71,20 +71,35 @@ final class IsEqualIgnoringCase extends Constraint
      */
     public function toString(): string
     {
-        if (is_string($this->value)) {
-            if (str_contains($this->value, "\n")) {
-                return 'is equal to <text>';
-            }
+        return 'is equal to ' . $this->valueAsString();
+    }
 
-            return sprintf(
-                "is equal to '%s'",
-                $this->value,
-            );
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here, instead of letting
+     * LogicalNot rewrite the affirmative description, keeps the exported value
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
-        return sprintf(
-            'is equal to %s',
-            Exporter::export($this->value),
-        );
+        return 'is not equal to ' . $this->valueAsString();
+    }
+
+    private function valueAsString(): string
+    {
+        if (is_string($this->value)) {
+            if (str_contains($this->value, "\n")) {
+                return '<text>';
+            }
+
+            return sprintf("'%s'", $this->value);
+        }
+
+        return Exporter::export($this->value);
     }
 }

--- a/src/Framework/Constraint/Equality/IsEqualWithDelta.php
+++ b/src/Framework/Constraint/Equality/IsEqualWithDelta.php
@@ -71,8 +71,29 @@ final class IsEqualWithDelta extends Constraint
      */
     public function toString(): string
     {
+        return 'is equal to ' . $this->valueAsString();
+    }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here, instead of letting
+     * LogicalNot rewrite the affirmative description, keeps the exported value
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not equal to ' . $this->valueAsString();
+    }
+
+    private function valueAsString(): string
+    {
         return sprintf(
-            'is equal to %s with delta <%F>',
+            '%s with delta <%F>',
             Exporter::export($this->value),
             $this->delta,
         );

--- a/src/Framework/Constraint/Filesystem/DirectoryExists.php
+++ b/src/Framework/Constraint/Filesystem/DirectoryExists.php
@@ -27,6 +27,20 @@ final class DirectoryExists extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'directory does not exist';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -47,15 +61,30 @@ final class DirectoryExists extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
-        if (is_string($other)) {
-            $path = $other;
-        } else {
-            $path = '';
+        return sprintf(
+            'directory "%s" exists',
+            $this->path($other),
+        );
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
         return sprintf(
-            'directory "%s" exists',
-            $path,
+            'directory "%s" does not exist',
+            $this->path($other),
         );
+    }
+
+    private function path(mixed $other): string
+    {
+        if (is_string($other)) {
+            return $other;
+        }
+
+        return '';
     }
 }

--- a/src/Framework/Constraint/Filesystem/FileExists.php
+++ b/src/Framework/Constraint/Filesystem/FileExists.php
@@ -27,6 +27,20 @@ final class FileExists extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'file does not exist';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -47,15 +61,30 @@ final class FileExists extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
-        if (is_string($other)) {
-            $path = $other;
-        } else {
-            $path = '';
+        return sprintf(
+            'file "%s" exists',
+            $this->path($other),
+        );
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
         return sprintf(
-            'file "%s" exists',
-            $path,
+            'file "%s" does not exist',
+            $this->path($other),
         );
+    }
+
+    private function path(mixed $other): string
+    {
+        if (is_string($other)) {
+            return $other;
+        }
+
+        return '';
     }
 }

--- a/src/Framework/Constraint/Filesystem/IsReadable.php
+++ b/src/Framework/Constraint/Filesystem/IsReadable.php
@@ -27,6 +27,20 @@ final class IsReadable extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not readable';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -47,15 +61,30 @@ final class IsReadable extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
-        if (is_string($other)) {
-            $path = $other;
-        } else {
-            $path = '';
+        return sprintf(
+            '"%s" is readable',
+            $this->path($other),
+        );
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
         return sprintf(
-            '"%s" is readable',
-            $path,
+            '"%s" is not readable',
+            $this->path($other),
         );
+    }
+
+    private function path(mixed $other): string
+    {
+        if (is_string($other)) {
+            return $other;
+        }
+
+        return '';
     }
 }

--- a/src/Framework/Constraint/Filesystem/IsWritable.php
+++ b/src/Framework/Constraint/Filesystem/IsWritable.php
@@ -27,6 +27,20 @@ final class IsWritable extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not writable';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -47,15 +61,30 @@ final class IsWritable extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
-        if (is_string($other)) {
-            $path = $other;
-        } else {
-            $path = '';
+        return sprintf(
+            '"%s" is writable',
+            $this->path($other),
+        );
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
         return sprintf(
-            '"%s" is writable',
-            $path,
+            '"%s" is not writable',
+            $this->path($other),
         );
+    }
+
+    private function path(mixed $other): string
+    {
+        if (is_string($other)) {
+            return $other;
+        }
+
+        return '';
     }
 }

--- a/src/Framework/Constraint/IsIdentical.php
+++ b/src/Framework/Constraint/IsIdentical.php
@@ -86,12 +86,21 @@ final class IsIdentical extends Constraint
      */
     public function toString(): string
     {
-        if (is_object($this->value)) {
-            return 'is identical to an object of class "' .
-                $this->value::class . '"';
+        return 'is identical to ' . $this->valueAsString();
+    }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
         }
 
-        return 'is identical to ' . Exporter::export($this->value);
+        return 'is not identical to ' . $this->valueAsString();
     }
 
     /**
@@ -119,5 +128,39 @@ final class IsIdentical extends Constraint
         }
 
         return parent::failureDescription($other);
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        if (is_object($this->value) && is_object($other)) {
+            return 'two variables do not reference the same object';
+        }
+
+        if (explode(' ', gettype($this->value), 2)[0] === 'resource' && explode(' ', gettype($other), 2)[0] === 'resource') {
+            return 'two variables do not reference the same resource';
+        }
+
+        if (is_string($this->value) && is_string($other)) {
+            return 'two strings are not identical';
+        }
+
+        if (is_array($this->value) && is_array($other)) {
+            return 'two arrays are not identical';
+        }
+
+        return Exporter::export($other) . ' ' . $this->toStringInContext($operator, $role);
+    }
+
+    private function valueAsString(): string
+    {
+        if (is_object($this->value)) {
+            return 'an object of class "' . $this->value::class . '"';
+        }
+
+        return Exporter::export($this->value);
     }
 }

--- a/src/Framework/Constraint/JsonMatches.php
+++ b/src/Framework/Constraint/JsonMatches.php
@@ -41,6 +41,24 @@ final class JsonMatches extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the expected JSON
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'does not match JSON string "%s"',
+            $this->value,
+        );
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *

--- a/src/Framework/Constraint/Math/IsFinite.php
+++ b/src/Framework/Constraint/Math/IsFinite.php
@@ -30,6 +30,20 @@ final class IsFinite extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not finite';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Math/IsInfinite.php
+++ b/src/Framework/Constraint/Math/IsInfinite.php
@@ -30,6 +30,20 @@ final class IsInfinite extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not infinite';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Math/IsNan.php
+++ b/src/Framework/Constraint/Math/IsNan.php
@@ -30,6 +30,20 @@ final class IsNan extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not nan';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Object/ObjectEquals.php
+++ b/src/Framework/Constraint/Object/ObjectEquals.php
@@ -42,6 +42,20 @@ final class ObjectEquals extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'two objects are not equal';
+    }
+
+    /**
      * @throws ActualValueIsNotAnObjectException
      * @throws ComparisonMethodDoesNotAcceptParameterTypeException
      * @throws ComparisonMethodDoesNotDeclareBoolReturnTypeException
@@ -149,5 +163,14 @@ final class ObjectEquals extends Constraint
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->toStringInContext($operator, $role);
     }
 }

--- a/src/Framework/Constraint/Object/ObjectHasProperty.php
+++ b/src/Framework/Constraint/Object/ObjectHasProperty.php
@@ -39,6 +39,23 @@ final class ObjectHasProperty extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'does not have property "%s"',
+            $this->propertyName,
+        );
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
@@ -63,11 +80,25 @@ final class ObjectHasProperty extends Constraint
      */
     protected function failureDescription(mixed $other): string
     {
+        return $this->describe($other, $this->toString());
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->describe($other, $this->toStringInContext($operator, $role));
+    }
+
+    private function describe(mixed $other, string $propertyDescription): string
+    {
         if (is_object($other)) {
             return sprintf(
                 'object of class "%s" %s',
                 $other::class,
-                $this->toString(),
+                $propertyDescription,
             );
         }
 
@@ -81,7 +112,7 @@ final class ObjectHasProperty extends Constraint
             '"%s" (%s) %s',
             $value,
             gettype($other),
-            $this->toString(),
+            $propertyDescription,
         );
     }
 }

--- a/src/Framework/Constraint/String/IsJson.php
+++ b/src/Framework/Constraint/String/IsJson.php
@@ -34,6 +34,20 @@ final class IsJson extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not valid JSON';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -72,6 +86,28 @@ final class IsJson extends Constraint
             'a string is valid JSON (%s)',
             $this->determineJsonError($other),
         );
+    }
+
+    /**
+     * When this constraint is wrapped in a LogicalNot operator, the failure
+     * only occurs for a value that *is* valid JSON, so the parse-error detail
+     * that the affirmative description carries is not applicable here.
+     */
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        if (!is_string($other)) {
+            return $this->valueToTypeStringFragment($other) . 'is not valid JSON';
+        }
+
+        if ($other === '') {
+            return 'an empty string is not valid JSON';
+        }
+
+        return 'a string is not valid JSON';
     }
 
     private function determineJsonError(string $json): string

--- a/src/Framework/Constraint/String/RegularExpression.php
+++ b/src/Framework/Constraint/String/RegularExpression.php
@@ -39,6 +39,24 @@ final class RegularExpression extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the pattern out of
+     * the negation entirely. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'does not match PCRE pattern "%s"',
+            $this->pattern,
+        );
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *

--- a/src/Framework/Constraint/String/StringContains.php
+++ b/src/Framework/Constraint/String/StringContains.php
@@ -44,36 +44,36 @@ final class StringContains extends Constraint
      */
     public function toString(): string
     {
-        $needle = $this->needle;
-
-        if ($this->ignoreCase) {
-            $needle = mb_strtolower($this->needle, 'UTF-8');
-        }
-
-        return sprintf(
-            'contains "%s" [%s](length: %s)',
-            $needle,
-            $this->detectedEncoding($needle),
-            strlen($needle),
-        );
+        return 'contains ' . $this->needleAsString();
     }
 
     public function failureDescription(mixed $other): string
     {
-        $stringifiedHaystack = Exporter::export($other);
-        $haystackEncoding    = $this->detectedEncoding($other);
-        $haystackLength      = $this->haystackLength($other);
+        return $this->haystackAsString($other) . 'contains ' . $this->needleAsString();
+    }
 
-        $haystackInformation = sprintf(
-            '%s [%s](length: %s) ',
-            $stringifiedHaystack,
-            $haystackEncoding,
-            $haystackLength,
-        );
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the needle and the
+     * haystack out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
 
-        $needleInformation = $this->toString();
+        return 'does not contain ' . $this->needleAsString();
+    }
 
-        return $haystackInformation . $needleInformation;
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->haystackAsString($other) . 'does not contain ' . $this->needleAsString();
     }
 
     /**
@@ -113,6 +113,32 @@ final class StringContains extends Constraint
          * data.
          */
         return str_contains($haystack, $this->needle);
+    }
+
+    private function needleAsString(): string
+    {
+        $needle = $this->needle;
+
+        if ($this->ignoreCase) {
+            $needle = mb_strtolower($this->needle, 'UTF-8');
+        }
+
+        return sprintf(
+            '"%s" [%s](length: %s)',
+            $needle,
+            $this->detectedEncoding($needle),
+            strlen($needle),
+        );
+    }
+
+    private function haystackAsString(mixed $other): string
+    {
+        return sprintf(
+            '%s [%s](length: %s) ',
+            Exporter::export($other),
+            $this->detectedEncoding($other),
+            $this->haystackLength($other),
+        );
     }
 
     private function detectedEncoding(mixed $other): string

--- a/src/Framework/Constraint/String/StringEndsWith.php
+++ b/src/Framework/Constraint/String/StringEndsWith.php
@@ -41,6 +41,21 @@ final class StringEndsWith extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the suffix out of
+     * the negation entirely. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'does not end with "' . $this->suffix . '"';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/String/StringEqualsStringIgnoringLineEndings.php
+++ b/src/Framework/Constraint/String/StringEqualsStringIgnoringLineEndings.php
@@ -30,10 +30,22 @@ final class StringEqualsStringIgnoringLineEndings extends Constraint
      */
     public function toString(): string
     {
-        return sprintf(
-            'is equal to "%s" ignoring line endings',
-            $this->string,
-        );
+        return 'is equal to ' . $this->valueAsString();
+    }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the expected value
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not equal to ' . $this->valueAsString();
     }
 
     /**
@@ -47,6 +59,14 @@ final class StringEqualsStringIgnoringLineEndings extends Constraint
         }
 
         return $this->string === $this->normalizeLineEndings($other);
+    }
+
+    private function valueAsString(): string
+    {
+        return sprintf(
+            '"%s" ignoring line endings',
+            $this->string,
+        );
     }
 
     private function normalizeLineEndings(string $string): string

--- a/src/Framework/Constraint/String/StringEqualsStringIgnoringWhitespace.php
+++ b/src/Framework/Constraint/String/StringEqualsStringIgnoringWhitespace.php
@@ -32,10 +32,22 @@ final class StringEqualsStringIgnoringWhitespace extends Constraint
      */
     public function toString(): string
     {
-        return sprintf(
-            'is equal to "%s" ignoring whitespace',
-            $this->string,
-        );
+        return 'is equal to ' . $this->valueAsString();
+    }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the expected value
+     * out of the negation entirely. The guard ensures that LogicalAnd,
+     * LogicalOr, and LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not equal to ' . $this->valueAsString();
     }
 
     /**
@@ -49,6 +61,14 @@ final class StringEqualsStringIgnoringWhitespace extends Constraint
         }
 
         return $this->string === $this->normalizeWhitespace($other);
+    }
+
+    private function valueAsString(): string
+    {
+        return sprintf(
+            '"%s" ignoring whitespace',
+            $this->string,
+        );
     }
 
     private function normalizeWhitespace(string $string): string

--- a/src/Framework/Constraint/String/StringMatchesFormatDescription.php
+++ b/src/Framework/Constraint/String/StringMatchesFormatDescription.php
@@ -48,6 +48,20 @@ final class StringMatchesFormatDescription extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'does not match format description:' . PHP_EOL . $this->formatDescription;
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      *
@@ -83,6 +97,15 @@ final class StringMatchesFormatDescription extends Constraint
     protected function failureDescription(mixed $other): string
     {
         return 'string matches format description';
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'string does not match format description';
     }
 
     /**

--- a/src/Framework/Constraint/String/StringStartsWith.php
+++ b/src/Framework/Constraint/String/StringStartsWith.php
@@ -41,6 +41,21 @@ final class StringStartsWith extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. Authoring the negation here keeps the prefix out of
+     * the negation entirely. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'does not start with "' . $this->prefix . '"';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Traversable/TraversableContains.php
+++ b/src/Framework/Constraint/Traversable/TraversableContains.php
@@ -34,6 +34,20 @@ abstract class TraversableContains extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'does not contain ' . Exporter::export($this->value);
+    }
+
+    /**
      * Returns the description of the failure.
      *
      * The beginning of failure messages is "Failed asserting that" in most
@@ -45,6 +59,19 @@ abstract class TraversableContains extends Constraint
             '%s %s',
             is_array($other) ? 'an array' : 'a traversable',
             $this->toString(),
+        );
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            '%s %s',
+            is_array($other) ? 'an array' : 'a traversable',
+            $this->toStringInContext($operator, $role),
         );
     }
 

--- a/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
+++ b/src/Framework/Constraint/Traversable/TraversableContainsOnly.php
@@ -82,4 +82,18 @@ final class TraversableContainsOnly extends Constraint
     {
         return 'contains only values of type "' . $this->type . '"';
     }
+
+    /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'does not contain only values of type "' . $this->type . '"';
+    }
 }

--- a/src/Framework/Constraint/Type/IsInstanceOf.php
+++ b/src/Framework/Constraint/Type/IsInstanceOf.php
@@ -58,6 +58,24 @@ final class IsInstanceOf extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'is not an instance of %s %s',
+            $this->type,
+            $this->name,
+        );
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */
@@ -75,5 +93,14 @@ final class IsInstanceOf extends Constraint
     protected function failureDescription(mixed $other): string
     {
         return $this->valueToTypeStringFragment($other) . $this->toString();
+    }
+
+    protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return $this->valueToTypeStringFragment($other) . $this->toStringInContext($operator, $role);
     }
 }

--- a/src/Framework/Constraint/Type/IsNull.php
+++ b/src/Framework/Constraint/Type/IsNull.php
@@ -27,6 +27,20 @@ final class IsNull extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return 'is not null';
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/src/Framework/Constraint/Type/IsType.php
+++ b/src/Framework/Constraint/Type/IsType.php
@@ -47,6 +47,23 @@ final class IsType extends Constraint
     }
 
     /**
+     * Returns the negated description when this constraint is wrapped in a
+     * LogicalNot operator. The guard ensures that LogicalAnd, LogicalOr, and
+     * LogicalXor keep using the affirmative toString().
+     */
+    protected function toStringInContext(Operator $operator, mixed $role): string
+    {
+        if (!$operator instanceof LogicalNot) {
+            return '';
+        }
+
+        return sprintf(
+            'is not of type %s',
+            $this->type->value,
+        );
+    }
+
+    /**
      * Evaluates the constraint for parameter $other. Returns true if the
      * constraint is met, false otherwise.
      */

--- a/tests/unit/Framework/Constraint/Array/ArrayHasKeyTest.php
+++ b/tests/unit/Framework/Constraint/Array/ArrayHasKeyTest.php
@@ -104,6 +104,18 @@ final class ArrayHasKeyTest extends TestCase
         $this->assertSame('has the key \'key\'', new ArrayHasKey('key')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new ArrayHasKey('key'));
+
+        $this->assertSame('does not have the key \'key\'', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that an array does not have the key \'key\'.');
+
+        $constraint->evaluate(['key' => 'value']);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new ArrayHasKey(0)));

--- a/tests/unit/Framework/Constraint/Array/ArraysAreEqualTest.php
+++ b/tests/unit/Framework/Constraint/Array/ArraysAreEqualTest.php
@@ -184,6 +184,18 @@ final class ArraysAreEqualTest extends TestCase
         $this->assertSame('two arrays are equal', new ArraysAreEqual([], true, true)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new ArraysAreEqual([1, 2], true, true));
+
+        $this->assertSame('two arrays are not equal', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that two arrays are not equal.');
+
+        $constraint->evaluate([1, 2]);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new ArraysAreEqual([], false, false));

--- a/tests/unit/Framework/Constraint/Array/ArraysAreIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/Array/ArraysAreIdenticalTest.php
@@ -243,6 +243,18 @@ final class ArraysAreIdenticalTest extends TestCase
         $this->assertSame('two arrays are identical', new ArraysAreIdentical([], true, true)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new ArraysAreIdentical([1, 2], true, true));
+
+        $this->assertSame('two arrays are not identical', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that two arrays are not identical.');
+
+        $constraint->evaluate([1, 2]);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new ArraysAreIdentical([], false, false));

--- a/tests/unit/Framework/Constraint/Array/IsListTest.php
+++ b/tests/unit/Framework/Constraint/Array/IsListTest.php
@@ -110,6 +110,18 @@ final class IsListTest extends TestCase
         $this->assertSame('is a list', (new IsList)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsList);
+
+        $this->assertSame('is not a list', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that an array is not a list.');
+
+        $constraint->evaluate([1, 2]);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsList));

--- a/tests/unit/Framework/Constraint/Boolean/IsFalseTest.php
+++ b/tests/unit/Framework/Constraint/Boolean/IsFalseTest.php
@@ -34,6 +34,18 @@ final class IsFalseTest extends TestCase
         $this->assertSame('is false', (new IsFalse)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsFalse);
+
+        $this->assertSame('is not false', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that false is not false.');
+
+        $constraint->evaluate(false);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsFalse));

--- a/tests/unit/Framework/Constraint/Boolean/IsTrueTest.php
+++ b/tests/unit/Framework/Constraint/Boolean/IsTrueTest.php
@@ -34,6 +34,18 @@ final class IsTrueTest extends TestCase
         $this->assertSame('is true', (new IsTrue)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsTrue);
+
+        $this->assertSame('is not true', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that true is not true.');
+
+        $constraint->evaluate(true);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsTrue));

--- a/tests/unit/Framework/Constraint/Cardinality/CountTest.php
+++ b/tests/unit/Framework/Constraint/Cardinality/CountTest.php
@@ -129,6 +129,18 @@ final class CountTest extends TestCase
         $this->assertSame('count matches 1', new Count(1)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new Count(1));
+
+        $this->assertSame('count does not match 1', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that actual size 1 does not match expected size 1.');
+
+        $constraint->evaluate([2]);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new Count(1)));

--- a/tests/unit/Framework/Constraint/Cardinality/GreaterThanTest.php
+++ b/tests/unit/Framework/Constraint/Cardinality/GreaterThanTest.php
@@ -67,6 +67,18 @@ final class GreaterThanTest extends TestCase
         $this->assertSame('is greater than 0', new GreaterThan(0)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new GreaterThan(0));
+
+        $this->assertSame('is not greater than 0', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that 1 is not greater than 0.');
+
+        $constraint->evaluate(1);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new GreaterThan(1)));

--- a/tests/unit/Framework/Constraint/Cardinality/IsEmptyTest.php
+++ b/tests/unit/Framework/Constraint/Cardinality/IsEmptyTest.php
@@ -86,6 +86,18 @@ final class IsEmptyTest extends TestCase
         $this->assertSame('is empty', (new IsEmpty)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsEmpty);
+
+        $this->assertSame('is not empty', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that an array is not empty.');
+
+        $constraint->evaluate([]);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new IsEmpty);

--- a/tests/unit/Framework/Constraint/Cardinality/LessThanTest.php
+++ b/tests/unit/Framework/Constraint/Cardinality/LessThanTest.php
@@ -67,6 +67,18 @@ final class LessThanTest extends TestCase
         $this->assertSame('is less than 0', new LessThan(0)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new LessThan(0));
+
+        $this->assertSame('is not less than 0', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that -1 is not less than 0.');
+
+        $constraint->evaluate(-1);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new LessThan(1)));

--- a/tests/unit/Framework/Constraint/Cardinality/SameSizeTest.php
+++ b/tests/unit/Framework/Constraint/Cardinality/SameSizeTest.php
@@ -12,6 +12,7 @@ namespace PHPUnit\Framework\Constraint;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SameSize::class)]
@@ -25,6 +26,18 @@ final class SameSizeTest extends TestCase
     public function testCanBeRepresentedAsString(): void
     {
         $this->assertSame('count matches 0', new SameSize([])->toString());
+    }
+
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new SameSize([1]));
+
+        $this->assertSame('count does not match 1', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that actual size 1 does not match expected size 1.');
+
+        $constraint->evaluate([2]);
     }
 
     public function testIsCountable(): void

--- a/tests/unit/Framework/Constraint/Equality/IsEqualCanonicalizingTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualCanonicalizingTest.php
@@ -321,6 +321,18 @@ EOT,
         $this->assertStringMatchesFormat($constraintAsString, $constraint->toString(true));
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsEqualCanonicalizing('foo'));
+
+        $this->assertSame("is not equal to 'foo'", $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs("Failed asserting that 'foo' is not equal to 'foo'.");
+
+        $constraint->evaluate('foo');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsEqualCanonicalizing(true)));

--- a/tests/unit/Framework/Constraint/Equality/IsEqualIgnoringCaseTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualIgnoringCaseTest.php
@@ -298,6 +298,18 @@ EOT,
         $this->assertStringMatchesFormat($constraintAsString, $constraint->toString(true));
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsEqualIgnoringCase('foo'));
+
+        $this->assertSame("is not equal to 'foo'", $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs("Failed asserting that 'FOO' is not equal to 'foo'.");
+
+        $constraint->evaluate('FOO');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsEqualIgnoringCase(true)));

--- a/tests/unit/Framework/Constraint/Equality/IsEqualTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualTest.php
@@ -390,6 +390,39 @@ EOT,
         $this->assertStringMatchesFormat($constraintAsString, $constraint->toString(true));
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsEqual('foo'));
+
+        $this->assertSame("is not equal to 'foo'", $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs("Failed asserting that 'foo' is not equal to 'foo'.");
+
+        $constraint->evaluate('foo');
+    }
+
+    #[Group('regression')]
+    #[Group('regression/6683')]
+    public function testNegationDoesNotRewriteKeywordsContainedInTheValue(): void
+    {
+        $value = "it's equal to and contains that";
+
+        $constraint = new LogicalNot(new IsEqual($value));
+
+        $this->assertSame(
+            "is not equal to 'it's equal to and contains that'",
+            $constraint->toString(),
+        );
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs(
+            "Failed asserting that 'it's equal to and contains that' is not equal to 'it's equal to and contains that'.",
+        );
+
+        $constraint->evaluate($value);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsEqual(true)));

--- a/tests/unit/Framework/Constraint/Equality/IsEqualWithDeltaTest.php
+++ b/tests/unit/Framework/Constraint/Equality/IsEqualWithDeltaTest.php
@@ -197,6 +197,18 @@ EOT,
         $this->assertStringMatchesFormat($constraintAsString, $constraint->toString(true));
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsEqualWithDelta(1.0, 0.1));
+
+        $this->assertSame('is not equal to 1.0 with delta <0.100000>', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that 1.05 is not equal to 1.0 with delta <0.100000>.');
+
+        $constraint->evaluate(1.05);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsEqualWithDelta(1.0, 0.0)));

--- a/tests/unit/Framework/Constraint/Filesystem/DirectoryExistsTest.php
+++ b/tests/unit/Framework/Constraint/Filesystem/DirectoryExistsTest.php
@@ -65,6 +65,18 @@ final class DirectoryExistsTest extends TestCase
         $this->assertSame('directory exists', (new DirectoryExists)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new DirectoryExists);
+
+        $this->assertSame('directory does not exist', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that directory "' . __DIR__ . '" does not exist.');
+
+        $constraint->evaluate(__DIR__);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new DirectoryExists));

--- a/tests/unit/Framework/Constraint/Filesystem/FileExistsTest.php
+++ b/tests/unit/Framework/Constraint/Filesystem/FileExistsTest.php
@@ -65,6 +65,18 @@ final class FileExistsTest extends TestCase
         $this->assertSame('file exists', (new FileExists)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new FileExists);
+
+        $this->assertSame('file does not exist', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that file "' . __FILE__ . '" does not exist.');
+
+        $constraint->evaluate(__FILE__);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new FileExists));

--- a/tests/unit/Framework/Constraint/Filesystem/IsReadableTest.php
+++ b/tests/unit/Framework/Constraint/Filesystem/IsReadableTest.php
@@ -65,6 +65,18 @@ final class IsReadableTest extends TestCase
         $this->assertSame('is readable', (new IsReadable)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsReadable);
+
+        $this->assertSame('is not readable', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that "' . __FILE__ . '" is not readable.');
+
+        $constraint->evaluate(__FILE__);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsReadable));

--- a/tests/unit/Framework/Constraint/Filesystem/IsWritableTest.php
+++ b/tests/unit/Framework/Constraint/Filesystem/IsWritableTest.php
@@ -65,6 +65,18 @@ final class IsWritableTest extends TestCase
         $this->assertSame('is writable', (new IsWritable)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsWritable);
+
+        $this->assertSame('is not writable', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that "' . __FILE__ . '" is not writable.');
+
+        $constraint->evaluate(__FILE__);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsWritable));

--- a/tests/unit/Framework/Constraint/IsIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/IsIdenticalTest.php
@@ -203,4 +203,64 @@ EOT,
             fclose($actual);
         }
     }
+
+    public function testCanBeNegated(): void
+    {
+        $this->assertSame(
+            'is not identical to an object of class "stdClass"',
+            new LogicalNot(new IsIdentical(new stdClass))->toString(),
+        );
+
+        $this->assertSame(
+            'is not identical to 0',
+            new LogicalNot(new IsIdentical(0))->toString(),
+        );
+
+        $object = new stdClass;
+
+        $this->assertSame(
+            'Failed asserting that two variables do not reference the same object.',
+            $this->negatedFailureDescription(new IsIdentical($object), $object),
+        );
+
+        $this->assertSame(
+            'Failed asserting that two strings are not identical.',
+            $this->negatedFailureDescription(new IsIdentical('foo'), 'foo'),
+        );
+
+        $this->assertSame(
+            'Failed asserting that two arrays are not identical.',
+            $this->negatedFailureDescription(new IsIdentical([1, 2]), [1, 2]),
+        );
+
+        $this->assertSame(
+            'Failed asserting that 0 is not identical to 0.',
+            $this->negatedFailureDescription(new IsIdentical(0), 0),
+        );
+    }
+
+    public function testCanBeNegatedForResources(): void
+    {
+        $resource = fopen('php://memory', 'r');
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that two variables do not reference the same resource.');
+
+        try {
+            new LogicalNot(new IsIdentical($resource))->evaluate($resource);
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    private function negatedFailureDescription(IsIdentical $constraint, mixed $actual): string
+    {
+        try {
+            new LogicalNot($constraint)->evaluate($actual);
+        } catch (ExpectationFailedException $e) {
+            return $e->getMessage();
+        }
+
+        $this->fail();
+    }
 }

--- a/tests/unit/Framework/Constraint/JsonMatchesTest.php
+++ b/tests/unit/Framework/Constraint/JsonMatchesTest.php
@@ -417,6 +417,18 @@ EOT,
         $this->assertSame('matches JSON string "{"key":"value"}"', $constraint->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new JsonMatches(json_encode(['key' => 'value'])));
+
+        $this->assertSame('does not match JSON string "{"key":"value"}"', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'{"key":"value"}\' does not match JSON string "{"key":"value"}".');
+
+        $constraint->evaluate(json_encode(['key' => 'value']));
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new JsonMatches(json_encode(['key' => 'value']))));

--- a/tests/unit/Framework/Constraint/Math/IsFiniteTest.php
+++ b/tests/unit/Framework/Constraint/Math/IsFiniteTest.php
@@ -38,6 +38,18 @@ final class IsFiniteTest extends TestCase
         $this->assertSame('is finite', (new IsFinite)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsFinite);
+
+        $this->assertSame('is not finite', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that 1.0 is not finite.');
+
+        $constraint->evaluate(1.0);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsFinite));

--- a/tests/unit/Framework/Constraint/Math/IsInfiniteTest.php
+++ b/tests/unit/Framework/Constraint/Math/IsInfiniteTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
+use const INF;
 use function acos;
 use function log;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -36,6 +37,18 @@ final class IsInfiniteTest extends TestCase
     public function testCanBeRepresentedAsString(): void
     {
         $this->assertSame('is infinite', (new IsInfinite)->toString());
+    }
+
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsInfinite);
+
+        $this->assertSame('is not infinite', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that INF is not infinite.');
+
+        $constraint->evaluate(INF);
     }
 
     public function testIsCountable(): void

--- a/tests/unit/Framework/Constraint/Math/IsNanTest.php
+++ b/tests/unit/Framework/Constraint/Math/IsNanTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Framework\Constraint;
 
+use const NAN;
 use function acos;
 use function log;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -36,6 +37,18 @@ final class IsNanTest extends TestCase
     public function testCanBeRepresentedAsString(): void
     {
         $this->assertSame('is nan', (new IsNan)->toString());
+    }
+
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsNan);
+
+        $this->assertSame('is not nan', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that NAN is not nan.');
+
+        $constraint->evaluate(NAN);
     }
 
     public function testIsCountable(): void

--- a/tests/unit/Framework/Constraint/Object/ObjectEqualsTest.php
+++ b/tests/unit/Framework/Constraint/Object/ObjectEqualsTest.php
@@ -49,6 +49,18 @@ final class ObjectEqualsTest extends TestCase
         $this->assertSame('two objects are equal', new ObjectEquals(new ValueObject(1))->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new ObjectEquals(new ValueObject(1)));
+
+        $this->assertSame('two objects are not equal', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that two objects are not equal.');
+
+        $constraint->evaluate(new ValueObject(1));
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new ObjectEquals(new ValueObject(1))));

--- a/tests/unit/Framework/Constraint/Object/ObjectHasPropertyTest.php
+++ b/tests/unit/Framework/Constraint/Object/ObjectHasPropertyTest.php
@@ -56,6 +56,21 @@ final class ObjectHasPropertyTest extends TestCase
         $this->assertSame('has property "theProperty"', $constraint->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new ObjectHasProperty('theProperty'));
+
+        $this->assertSame('does not have property "theProperty"', $constraint->toString());
+
+        $object              = new stdClass;
+        $object->theProperty = 'value';
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that object of class "stdClass" does not have property "theProperty".');
+
+        $constraint->evaluate($object);
+    }
+
     public function testIsCountable(): void
     {
         $constraint = new ObjectHasProperty('theProperty');

--- a/tests/unit/Framework/Constraint/Operator/LogicalOrTest.php
+++ b/tests/unit/Framework/Constraint/Operator/LogicalOrTest.php
@@ -110,4 +110,14 @@ final class LogicalOrTest extends TestCase
 
         $this->assertCount(2, $constraint);
     }
+
+    public function testDoesNotNegateOperandsThatAuthorTheirNegation(): void
+    {
+        $constraint = $this->logicalOr(
+            $this->isFalse(),
+            'foo',
+        );
+
+        $this->assertSame("is false or is equal to 'foo'", $constraint->toString());
+    }
 }

--- a/tests/unit/Framework/Constraint/String/IsJsonTest.php
+++ b/tests/unit/Framework/Constraint/String/IsJsonTest.php
@@ -97,6 +97,18 @@ final class IsJsonTest extends TestCase
         $this->assertSame('is valid JSON', (new IsJson)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsJson);
+
+        $this->assertSame('is not valid JSON', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that a string is not valid JSON.');
+
+        $constraint->evaluate('{}');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new IsJson));

--- a/tests/unit/Framework/Constraint/String/RegularExpressionTest.php
+++ b/tests/unit/Framework/Constraint/String/RegularExpressionTest.php
@@ -69,6 +69,18 @@ final class RegularExpressionTest extends TestCase
         $this->assertSame('matches PCRE pattern "/.*/"', new RegularExpression('/.*/')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new RegularExpression('/foo/'));
+
+        $this->assertSame('does not match PCRE pattern "/foo/"', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'foo\' does not match PCRE pattern "/foo/".');
+
+        $constraint->evaluate('foo');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new RegularExpression('/.*/')));

--- a/tests/unit/Framework/Constraint/String/StringContainsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringContainsTest.php
@@ -246,6 +246,18 @@ final class StringContainsTest extends TestCase
         $this->assertSame($expected, new StringContains($needle, $ignoreCase, $ignoreLineEndings)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new StringContains('needle'));
+
+        $this->assertSame('does not contain "needle" [ASCII](length: 6)', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'prefix needle suffix\' [ASCII](length: 20) does not contain "needle" [ASCII](length: 6).');
+
+        $constraint->evaluate('prefix needle suffix');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new StringContains('needle')));

--- a/tests/unit/Framework/Constraint/String/StringEndsWithTest.php
+++ b/tests/unit/Framework/Constraint/String/StringEndsWithTest.php
@@ -68,6 +68,18 @@ final class StringEndsWithTest extends TestCase
         $this->assertSame('ends with "suffix"', new StringEndsWith('suffix')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new StringEndsWith('suffix'));
+
+        $this->assertSame('does not end with "suffix"', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'prefix suffix\' does not end with "suffix".');
+
+        $constraint->evaluate('prefix suffix');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new StringEndsWith('suffix')));

--- a/tests/unit/Framework/Constraint/String/StringEqualsStringIgnoringLineEndingsTest.php
+++ b/tests/unit/Framework/Constraint/String/StringEqualsStringIgnoringLineEndingsTest.php
@@ -67,6 +67,18 @@ final class StringEqualsStringIgnoringLineEndingsTest extends TestCase
         $this->assertSame('is equal to "string" ignoring line endings', new StringEqualsStringIgnoringLineEndings('string')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new StringEqualsStringIgnoringLineEndings('string'));
+
+        $this->assertSame('is not equal to "string" ignoring line endings', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'string\' is not equal to "string" ignoring line endings.');
+
+        $constraint->evaluate('string');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new StringEqualsStringIgnoringLineEndings('string')));

--- a/tests/unit/Framework/Constraint/String/StringEqualsStringIgnoringWhitespaceTest.php
+++ b/tests/unit/Framework/Constraint/String/StringEqualsStringIgnoringWhitespaceTest.php
@@ -102,6 +102,18 @@ final class StringEqualsStringIgnoringWhitespaceTest extends TestCase
         $this->assertSame('is equal to "hello world" ignoring whitespace', new StringEqualsStringIgnoringWhitespace('hello world')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new StringEqualsStringIgnoringWhitespace('hello world'));
+
+        $this->assertSame('is not equal to "hello world" ignoring whitespace', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'hello world\' is not equal to "hello world" ignoring whitespace.');
+
+        $constraint->evaluate('hello world');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new StringEqualsStringIgnoringWhitespace('hello world'));

--- a/tests/unit/Framework/Constraint/String/StringMatchesFormatDescriptionTest.php
+++ b/tests/unit/Framework/Constraint/String/StringMatchesFormatDescriptionTest.php
@@ -476,6 +476,18 @@ EOD
         );
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new StringMatchesFormatDescription('%d'));
+
+        $this->assertSame('does not match format description:' . PHP_EOL . '%d', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that string does not match format description.');
+
+        $constraint->evaluate('42');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new StringMatchesFormatDescription('string')));

--- a/tests/unit/Framework/Constraint/String/StringStartsWithTest.php
+++ b/tests/unit/Framework/Constraint/String/StringStartsWithTest.php
@@ -68,6 +68,18 @@ final class StringStartsWithTest extends TestCase
         $this->assertSame('starts with "prefix"', new StringStartsWith('prefix')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new StringStartsWith('prefix'));
+
+        $this->assertSame('does not start with "prefix"', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that \'prefix suffix\' does not start with "prefix".');
+
+        $constraint->evaluate('prefix suffix');
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new StringStartsWith('prefix')));

--- a/tests/unit/Framework/Constraint/Traversable/TraversableContainsEqualTest.php
+++ b/tests/unit/Framework/Constraint/Traversable/TraversableContainsEqualTest.php
@@ -139,6 +139,18 @@ final class TraversableContainsEqualTest extends TestCase
         $this->assertSame('contains \'value\'', new TraversableContainsEqual('value')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new TraversableContainsEqual('value'));
+
+        $this->assertSame('does not contain \'value\'', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that an array does not contain \'value\'.');
+
+        $constraint->evaluate(['value']);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new TraversableContainsEqual('value')));

--- a/tests/unit/Framework/Constraint/Traversable/TraversableContainsIdenticalTest.php
+++ b/tests/unit/Framework/Constraint/Traversable/TraversableContainsIdenticalTest.php
@@ -117,6 +117,18 @@ final class TraversableContainsIdenticalTest extends TestCase
         $this->assertSame('contains \'value\'', new TraversableContainsIdentical('value')->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new TraversableContainsIdentical('value'));
+
+        $this->assertSame('does not contain \'value\'', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that an array does not contain \'value\'.');
+
+        $constraint->evaluate(['value']);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, (new TraversableContainsIdentical('value')));

--- a/tests/unit/Framework/Constraint/Traversable/TraversableContainsOnlyTest.php
+++ b/tests/unit/Framework/Constraint/Traversable/TraversableContainsOnlyTest.php
@@ -126,6 +126,18 @@ EOT,
         $this->assertSame('contains only values of type "stdClass"', TraversableContainsOnly::forClassOrInterface(stdClass::class)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(TraversableContainsOnly::forNativeType(NativeType::Int));
+
+        $this->assertSame('does not contain only values of type "int"', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageMatches('/does not contain only values of type "int"/');
+
+        $constraint->evaluate([1, 2]);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, TraversableContainsOnly::forNativeType(NativeType::Int));

--- a/tests/unit/Framework/Constraint/Type/IsInstanceOfTest.php
+++ b/tests/unit/Framework/Constraint/Type/IsInstanceOfTest.php
@@ -88,6 +88,18 @@ final class IsInstanceOfTest extends TestCase
         $this->assertSame('is an instance of interface Throwable', new IsInstanceOf(Throwable::class)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsInstanceOf(stdClass::class));
+
+        $this->assertSame('is not an instance of class stdClass', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that an instance of class stdClass is not an instance of class stdClass.');
+
+        $constraint->evaluate(new stdClass);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new IsInstanceOf(stdClass::class));

--- a/tests/unit/Framework/Constraint/Type/IsNullTest.php
+++ b/tests/unit/Framework/Constraint/Type/IsNullTest.php
@@ -36,6 +36,18 @@ final class IsNullTest extends TestCase
         $this->assertSame('is null', (new IsNull)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsNull);
+
+        $this->assertSame('is not null', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that null is not null.');
+
+        $constraint->evaluate(null);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new IsNull);

--- a/tests/unit/Framework/Constraint/Type/IsTypeTest.php
+++ b/tests/unit/Framework/Constraint/Type/IsTypeTest.php
@@ -148,6 +148,18 @@ final class IsTypeTest extends TestCase
         $this->assertSame('is of type array', new IsType(NativeType::Array)->toString());
     }
 
+    public function testCanBeNegated(): void
+    {
+        $constraint = new LogicalNot(new IsType(NativeType::Int));
+
+        $this->assertSame('is not of type int', $constraint->toString());
+
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessageIs('Failed asserting that 1 is not of type int.');
+
+        $constraint->evaluate(1);
+    }
+
     public function testIsCountable(): void
     {
         $this->assertCount(1, new IsType(NativeType::Array));


### PR DESCRIPTION
Inverse assertions (`assertNotEquals()`, `assertStringNotContainsString()`, `assertNotSame()`, `logicalNot(...)`, ...) wrap a constraint in `LogicalNot` and need to describe the negated expectation in the failure message.

Until now, `LogicalNot` produced that negated description by string rewriting: `LogicalNot::negate()` ran word-boundary regular expression replacements over the wrapped constraint's already-rendered, human-readable description, turning `is equal to` into `is not equal to`, `contains ` into `does not contain `, `has ` into `does not have `, and so on.

This is the design that issue #6683 ran into, and it was not the first time: #5516 is an earlier round of the same class of bug.

Each was fixed by making `negate()` a little "smarter", most recently by splitting the string on quoted segments so that quoted values are left alone. But this is fundamentally whack-a-mole: by the time `negate()` runs, the constraint's own words and the exported value have already been concatenated into one flat string, and no amount of regular-expression cleverness can reliably tell them apart.

This PR removes the root cause instead of patching another symptom.

The most recent hardening of `negate()` protects single- and double-quoted segments. It still breaks as soon as a value contains a quote of its own. With the previous approach, this assertion:

```php
$value = "it's equal to and contains that";

self::assertNotEquals($value, $value);
```

produces a message that is wrong in two different ways at once:

```
Failed asserting that 'it's equal to and does not contain that' is equal to 'it's equal to and contains that'.
```

The apostrophe in `it's` desynchronises the quote-pairing heuristic, so `negate()`:

1. rewrites `contains` → `does not contain` inside the user's value, and
2. fails to negate the constraint's actual verb, leaving `is equal to` in a message that is supposed to describe a not equal expectation.

After this PR the same assertion produces:

```
Failed asserting that 'it's equal to and contains that' is not equal to 'it's equal to and contains that'.
```

The value is reproduced verbatim and only the constraint's own wording is negated.

PHPUnit already had the right extension point. `Constraint` defines two hooks whose documented purpose is to let a constraint describe itself when it appears inside an operator such as `LogicalNot`:

```php
protected function toStringInContext(Operator $operator, mixed $role): string;
protected function failureDescriptionInContext(Operator $operator, mixed $role, mixed $other): string;
```

`UnaryOperator` (the base of `LogicalNot`) already consults these hooks and only falls back to the `negate()`-based `transformString()` when they return an empty string:

```php
$string = $constraint->failureDescriptionInContext($this, 0, $other);

if ($string === '') {
    return $this->transformString($constraint->failureDescription($other));
}

return $string;
```

The irony was that no first-party constraint implemented these hooks. They were reserved, by their own docblocks, for externally developed constraints, while PHPUnit's own constraints relied on the fragile `negate()` approach.

This PR fixes that: every first-party constraint now authors its own negated description through these hooks. A constraint knows its verb phrase and its value separately, so it composes the negation directly, e.g. `IsEqual`:

```php
public function toString(): string
{
    return 'is equal to ' . $this->valueAsString();
}

protected function toStringInContext(Operator $operator, mixed $role): string
{
    if (!$operator instanceof LogicalNot) {
        return '';
    }

    return 'is not equal to ' . $this->valueAsString();
}
```

The exported value (`$this->valueAsString()`) is appended, never parsed. The `negate()` regular expressions are never applied to it. The whole class of bug behind #6683 becomes structurally impossible for migrated constraints.

The internal exception constraints (used by `expectException()` and never wrapped in `LogicalNot`), as well as `IsAnything` and `Callback`, are intentionally left on the `negate()` fallback: their descriptions contain no exported value, so the failure mode behind #6683 cannot occur for them.

Because the negated wording is now authored rather than derived, it is both correct and more idiomatic. Failure messages are not covered by the backward compatibility promise, so a few awkward phrasings produced by `negate()` were improved along the way.