### PR TITLE
Allow `expectOutputString()` and `expectOutputRegex()` to be combined and repeated

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -1041,14 +1041,12 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
 
     final protected function expectOutputRegex(string $expectedRegex): void
     {
-        $this->warnAboutMultipleOutputExpectations();
-
         $this->outputBuffer->expectRegularExpression($expectedRegex);
     }
 
     final protected function expectOutputString(string $expectedString): void
     {
-        $this->warnAboutMultipleOutputExpectations();
+        $this->warnAboutConflictingOutputStringExpectation($expectedString);
 
         $this->outputBuffer->expectString($expectedString);
     }
@@ -1687,12 +1685,12 @@ abstract class TestCase extends Assert implements Reorderable, SelfDescribing, T
         );
     }
 
-    private function warnAboutMultipleOutputExpectations(): void
+    private function warnAboutConflictingOutputStringExpectation(string $expectedString): void
     {
-        if ($this->outputBuffer->hasExpectation()) {
+        if ($this->outputBuffer->conflictsWithExpectedString($expectedString)) {
             Event\Facade::emitter()->testTriggeredPhpunitWarning(
                 $this->valueObjectForEvents(),
-                'Only one expectation on output can be configured: expectOutputString() and expectOutputRegex() cannot be combined and must not be called more than once',
+                'Output cannot be expected to be identical to more than one string; expectOutputString() was already called with a different argument',
             );
         }
     }

--- a/src/Framework/TestCase/OutputBuffer.php
+++ b/src/Framework/TestCase/OutputBuffer.php
@@ -11,7 +11,7 @@ namespace PHPUnit\Framework\TestCase;
 
 use const PHP_OUTPUT_HANDLER_CLEAN;
 use const PHP_OUTPUT_HANDLER_FINAL;
-use function is_string;
+use function in_array;
 use function ob_end_clean;
 use function ob_get_contents;
 use function ob_get_level;
@@ -27,28 +27,55 @@ use PHPUnit\Framework\ExpectationFailedException;
  */
 final class OutputBuffer
 {
-    private string $output                     = '';
-    private ?string $expectedRegularExpression = null;
-    private ?string $expectedString            = null;
-    private bool $bufferingActive              = false;
-    private int $bufferingLevel                = 0;
-    private string $bufferingCaptured          = '';
-    private bool $bufferingDestroyed           = false;
-    private bool $retrievedForAssertion        = false;
+    private string $output = '';
+
+    /**
+     * @var list<string>
+     */
+    private array $expectedRegularExpressions = [];
+
+    /**
+     * @var list<string>
+     */
+    private array $expectedStrings      = [];
+    private bool $bufferingActive       = false;
+    private int $bufferingLevel         = 0;
+    private string $bufferingCaptured   = '';
+    private bool $bufferingDestroyed    = false;
+    private bool $retrievedForAssertion = false;
 
     public function expectRegularExpression(string $expectedRegularExpression): void
     {
-        $this->expectedRegularExpression = $expectedRegularExpression;
+        if (in_array($expectedRegularExpression, $this->expectedRegularExpressions, true)) {
+            return;
+        }
+
+        $this->expectedRegularExpressions[] = $expectedRegularExpression;
     }
 
     public function expectString(string $expectedString): void
     {
-        $this->expectedString = $expectedString;
+        if (in_array($expectedString, $this->expectedStrings, true)) {
+            return;
+        }
+
+        $this->expectedStrings[] = $expectedString;
+    }
+
+    public function conflictsWithExpectedString(string $expectedString): bool
+    {
+        foreach ($this->expectedStrings as $alreadyExpectedString) {
+            if ($alreadyExpectedString !== $expectedString) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function hasExpectation(): bool
     {
-        return is_string($this->expectedString) || is_string($this->expectedRegularExpression);
+        return $this->expectedStrings !== [] || $this->expectedRegularExpressions !== [];
     }
 
     public function expectsOutput(): bool
@@ -167,10 +194,12 @@ final class OutputBuffer
      */
     public function performAssertions(): void
     {
-        if ($this->expectedRegularExpression !== null) {
-            Assert::assertMatchesRegularExpression($this->expectedRegularExpression, $this->output);
-        } elseif ($this->expectedString !== null) {
-            Assert::assertSame($this->expectedString, $this->output);
+        foreach ($this->expectedRegularExpressions as $expectedRegularExpression) {
+            Assert::assertMatchesRegularExpression($expectedRegularExpression, $this->output);
+        }
+
+        foreach ($this->expectedStrings as $expectedString) {
+            Assert::assertSame($expectedString, $this->output);
         }
     }
 }

--- a/tests/_files/MultipleOutputExpectationsTest.php
+++ b/tests/_files/MultipleOutputExpectationsTest.php
@@ -13,19 +13,22 @@ use PHPUnit\Framework\TestCase;
 
 final class MultipleOutputExpectationsTest extends TestCase
 {
-    public function testExpectOutputStringThenExpectOutputRegex(): void
+    public function testCombinedAndRepeatedExpectationsAreAllVerified(): void
     {
+        $this->expectOutputRegex('/^f/');
+        $this->expectOutputRegex('/^f/');
+        $this->expectOutputRegex('/o$/');
         $this->expectOutputString('foo');
-        $this->expectOutputRegex('/.*/');
+        $this->expectOutputString('foo');
 
-        print 'bar';
+        print 'foo';
     }
 
-    public function testExpectOutputRegexThenExpectOutputString(): void
+    public function testConflictingStringExpectationsTriggerWarning(): void
     {
-        $this->expectOutputRegex('/.*/');
+        $this->expectOutputString('foo');
         $this->expectOutputString('bar');
 
-        print 'bar';
+        print 'foo';
     }
 }

--- a/tests/end-to-end/generic/multiple-output-expectations.phpt
+++ b/tests/end-to-end/generic/multiple-output-expectations.phpt
@@ -1,5 +1,5 @@
 --TEST--
-A PHPUnit warning is triggered when an output expectation is configured more than once
+expectOutputString() and expectOutputRegex() can be combined and repeated; conflicting exact strings trigger a PHPUnit warning
 --FILE--
 <?php declare(strict_types=1);
 $_SERVER['argv'][] = '--do-not-cache-result';
@@ -14,21 +14,28 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-WW                                                                  2 / 2 (100%)
+.F                                                                  2 / 2 (100%)
 
 Time: %s, Memory: %s
 
-2 tests triggered 2 PHPUnit warnings:
+There was 1 failure:
 
-1) PHPUnit\TestFixture\MultipleOutputExpectationsTest::testExpectOutputStringThenExpectOutputRegex
-Only one expectation on output can be configured: expectOutputString() and expectOutputRegex() cannot be combined and must not be called more than once
+1) PHPUnit\TestFixture\MultipleOutputExpectationsTest::testConflictingStringExpectationsTriggerWarning
+Failed asserting that two strings are identical.
+--- Expected
++++ Actual
+@@ @@
+-'bar'
++'foo'
 
-%s%eMultipleOutputExpectationsTest.php:16
+--
 
-2) PHPUnit\TestFixture\MultipleOutputExpectationsTest::testExpectOutputRegexThenExpectOutputString
-Only one expectation on output can be configured: expectOutputString() and expectOutputRegex() cannot be combined and must not be called more than once
+1 test triggered 1 PHPUnit warning:
 
-%s%eMultipleOutputExpectationsTest.php:24
+1) PHPUnit\TestFixture\MultipleOutputExpectationsTest::testConflictingStringExpectationsTriggerWarning
+Output cannot be expected to be identical to more than one string; expectOutputString() was already called with a different argument
 
-OK, but there were issues!
-Tests: 2, Assertions: 2, PHPUnit Warnings: 2.
+%s%eMultipleOutputExpectationsTest.php:27
+
+FAILURES!
+Tests: 2, Assertions: 5, Failures: 1, PHPUnit Warnings: 1.

--- a/tests/unit/Framework/TestRunner/ChildProcessOutputCollectorTest.php
+++ b/tests/unit/Framework/TestRunner/ChildProcessOutputCollectorTest.php
@@ -31,7 +31,7 @@ final class ChildProcessOutputCollectorTest extends TestCase
         $test = new Success('testOne');
 
         $outputBuffer = new ReflectionProperty(TestCase::class, 'outputBuffer')->getValue($test);
-        new ReflectionProperty(OutputBuffer::class, 'expectedString')->setValue($outputBuffer, 'whatever');
+        $outputBuffer->expectString('whatever');
 
         $this->assertSame('', ChildProcessOutputCollector::collect($test));
     }


### PR DESCRIPTION
Previously, the two methods for configuring an expectation on output silently replaced one another:

- Calling `expectOutputString()` (or `expectOutputRegex()`) more than once kept only the last value
- When both a string and a regular expression were configured, only the regular expression was ever verified

This meant a configured expectation on the output could be discarded without any indication, and a test could pass even though one of its output expectations was never checked.

Since bebab12e188baf49cd283d1ac2f62ed36d6f73b2, this discarding when `expectOutputString()` and `expectOutputRegex()` are combined or repeated in no longer silent.

The changes proposed here make output expectations additive: every call to `expectOutputString()` and `expectOutputRegex()` contributes an expectation, and the output must satisfy all of them:

- Multiple regular expressions can be registered: the output must match each of them
- A string expectation and one or more regular expressions can be combined: the output must be identical to the string and match every pattern
- Registering the same string or the same pattern more than once is harmless and has no additional effect

The single case that cannot be satisfied, expecting the output to be identical to two different strings, is reported with a PHPUnit warning explaining the conflict, since no output can ever fulfil it.

This is a behavioural change: a test that previously passed only because an earlier output expectation was silently discarded may now fail, because that expectation is finally being verified. In practice such tests were already not testing what they appeared to.