### PR TITLE
Deprecation Filters

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -25,6 +25,7 @@
             </xs:element>
             <xs:element name="deprecationTrigger" type="deprecationTriggerType" minOccurs="0"/>
             <xs:element name="issueTriggerResolvers" type="issueTriggerResolversType" minOccurs="0"/>
+            <xs:element name="deprecationFilters" type="deprecationFiltersType" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="baseline" type="xs:anyURI"/>
         <xs:attribute name="restrictNotices" type="xs:boolean" default="false"/>
@@ -406,6 +407,14 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="issueTriggerResolverType">
+        <xs:attribute name="className" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="deprecationFiltersType">
+        <xs:sequence>
+            <xs:element name="deprecationFilter" type="deprecationFilterType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="deprecationFilterType">
         <xs:attribute name="className" type="xs:string" use="required"/>
     </xs:complexType>
 </xs:schema>

--- a/src/Event/Emitter/DispatchingEmitter.php
+++ b/src/Event/Emitter/DispatchingEmitter.php
@@ -835,7 +835,7 @@ final class DispatchingEmitter implements Emitter
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function testTriggeredPhpDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, IssueTrigger $trigger): void
+    public function testTriggeredPhpDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, bool $ignoredByFilter, IssueTrigger $trigger): void
     {
         $this->dispatcher->dispatch(
             new Test\PhpDeprecationTriggered(
@@ -847,6 +847,7 @@ final class DispatchingEmitter implements Emitter
                 $suppressed,
                 $ignoredByBaseline,
                 $ignoredByTest,
+                $ignoredByFilter,
                 $trigger,
             ),
         );
@@ -861,7 +862,7 @@ final class DispatchingEmitter implements Emitter
      * @throws InvalidArgumentException
      * @throws UnknownEventTypeException
      */
-    public function testTriggeredDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, IssueTrigger $trigger, string $stackTrace): void
+    public function testTriggeredDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, bool $ignoredByFilter, IssueTrigger $trigger, string $stackTrace): void
     {
         $this->dispatcher->dispatch(
             new Test\DeprecationTriggered(
@@ -873,6 +874,7 @@ final class DispatchingEmitter implements Emitter
                 $suppressed,
                 $ignoredByBaseline,
                 $ignoredByTest,
+                $ignoredByFilter,
                 $trigger,
                 $stackTrace,
             ),

--- a/src/Event/Emitter/Emitter.php
+++ b/src/Event/Emitter/Emitter.php
@@ -184,7 +184,7 @@ interface Emitter
      * @param non-empty-string $file
      * @param positive-int     $line
      */
-    public function testTriggeredPhpDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, IssueTrigger $trigger): void;
+    public function testTriggeredPhpDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, bool $ignoredByFilter, IssueTrigger $trigger): void;
 
     /**
      * @param non-empty-string $message
@@ -192,7 +192,7 @@ interface Emitter
      * @param positive-int     $line
      * @param non-empty-string $stackTrace
      */
-    public function testTriggeredDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, IssueTrigger $trigger, string $stackTrace): void;
+    public function testTriggeredDeprecation(Code\Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, bool $ignoredByFilter, IssueTrigger $trigger, string $stackTrace): void;
 
     /**
      * @param non-empty-string $message

--- a/src/Event/Events/Test/Issue/DeprecationTriggered.php
+++ b/src/Event/Events/Test/Issue/DeprecationTriggered.php
@@ -44,6 +44,7 @@ final readonly class DeprecationTriggered implements Event
     private bool $suppressed;
     private bool $ignoredByBaseline;
     private bool $ignoredByTest;
+    private bool $ignoredByFilter;
     private IssueTrigger $trigger;
 
     /**
@@ -59,7 +60,7 @@ final readonly class DeprecationTriggered implements Event
      *
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, IssueTrigger $trigger, string $stackTrace)
+    public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, bool $ignoredByFilter, IssueTrigger $trigger, string $stackTrace)
     {
         $this->telemetryInfo     = $telemetryInfo;
         $this->test              = $test;
@@ -69,6 +70,7 @@ final readonly class DeprecationTriggered implements Event
         $this->suppressed        = $suppressed;
         $this->ignoredByBaseline = $ignoredByBaseline;
         $this->ignoredByTest     = $ignoredByTest;
+        $this->ignoredByFilter   = $ignoredByFilter;
         $this->trigger           = $trigger;
         $this->stackTrace        = $stackTrace;
     }
@@ -122,6 +124,11 @@ final readonly class DeprecationTriggered implements Event
         return $this->ignoredByTest;
     }
 
+    public function ignoredByFilter(): bool
+    {
+        return $this->ignoredByFilter;
+    }
+
     public function trigger(): IssueTrigger
     {
         return $this->trigger;
@@ -154,6 +161,10 @@ final readonly class DeprecationTriggered implements Event
 
         if ($this->ignoredByTest) {
             $details[] = 'ignored by test';
+        }
+
+        if ($this->ignoredByFilter) {
+            $details[] = 'ignored by filter';
         }
 
         if ($this->ignoredByBaseline) {

--- a/src/Event/Events/Test/Issue/PhpDeprecationTriggered.php
+++ b/src/Event/Events/Test/Issue/PhpDeprecationTriggered.php
@@ -44,6 +44,7 @@ final readonly class PhpDeprecationTriggered implements Event
     private bool $suppressed;
     private bool $ignoredByBaseline;
     private bool $ignoredByTest;
+    private bool $ignoredByFilter;
     private IssueTrigger $trigger;
 
     /**
@@ -53,7 +54,7 @@ final readonly class PhpDeprecationTriggered implements Event
      *
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, IssueTrigger $trigger)
+    public function __construct(Telemetry\Info $telemetryInfo, Test $test, string $message, string $file, int $line, bool $suppressed, bool $ignoredByBaseline, bool $ignoredByTest, bool $ignoredByFilter, IssueTrigger $trigger)
     {
         $this->telemetryInfo     = $telemetryInfo;
         $this->test              = $test;
@@ -63,6 +64,7 @@ final readonly class PhpDeprecationTriggered implements Event
         $this->suppressed        = $suppressed;
         $this->ignoredByBaseline = $ignoredByBaseline;
         $this->ignoredByTest     = $ignoredByTest;
+        $this->ignoredByFilter   = $ignoredByFilter;
         $this->trigger           = $trigger;
     }
 
@@ -115,6 +117,11 @@ final readonly class PhpDeprecationTriggered implements Event
         return $this->ignoredByTest;
     }
 
+    public function ignoredByFilter(): bool
+    {
+        return $this->ignoredByFilter;
+    }
+
     public function trigger(): IssueTrigger
     {
         return $this->trigger;
@@ -139,6 +146,10 @@ final readonly class PhpDeprecationTriggered implements Event
 
         if ($this->ignoredByTest) {
             $details[] = 'ignored by test';
+        }
+
+        if ($this->ignoredByFilter) {
+            $details[] = 'ignored by filter';
         }
 
         if ($this->ignoredByBaseline) {

--- a/src/Framework/TestRunner/ErrorHandlerBootstrapper.php
+++ b/src/Framework/TestRunner/ErrorHandlerBootstrapper.php
@@ -13,7 +13,7 @@ use function array_reverse;
 use function class_exists;
 use function count;
 use function explode;
-use PHPUnit\Runner\DeprecationFilter\Filter;
+use PHPUnit\Runner\DeprecationFilter;
 use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\Runner\IssueTriggerResolver\Resolver;
 use PHPUnit\TextUI\Configuration\Configuration;
@@ -76,7 +76,7 @@ final readonly class ErrorHandlerBootstrapper
 
             $filter = new $className;
 
-            if (!$filter instanceof Filter) {
+            if (!$filter instanceof DeprecationFilter) {
                 continue;
             }
 

--- a/src/Framework/TestRunner/ErrorHandlerBootstrapper.php
+++ b/src/Framework/TestRunner/ErrorHandlerBootstrapper.php
@@ -13,6 +13,7 @@ use function array_reverse;
 use function class_exists;
 use function count;
 use function explode;
+use PHPUnit\Runner\DeprecationFilter\Filter;
 use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\Runner\IssueTriggerResolver\Resolver;
 use PHPUnit\TextUI\Configuration\Configuration;
@@ -66,6 +67,20 @@ final readonly class ErrorHandlerBootstrapper
             }
 
             ErrorHandler::instance()->addIssueTriggerResolver($resolver);
+        }
+
+        foreach ($configuration->source()->deprecationFilters() as $className) {
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            $filter = new $className;
+
+            if (!$filter instanceof Filter) {
+                continue;
+            }
+
+            ErrorHandler::instance()->addDeprecationFilter($filter);
         }
     }
 }

--- a/src/Runner/DeprecationFilter.php
+++ b/src/Runner/DeprecationFilter.php
@@ -7,14 +7,14 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-namespace PHPUnit\Runner\DeprecationFilter;
+namespace PHPUnit\Runner;
 
 use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
 
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
-interface Filter
+interface DeprecationFilter
 {
     /**
      * Return true to ignore the deprecation, false to let PHPUnit process it.

--- a/src/Runner/DeprecationFilter/Filter.php
+++ b/src/Runner/DeprecationFilter/Filter.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\DeprecationFilter;
+
+use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface Filter
+{
+    /**
+     * Return true to ignore the deprecation, false to let PHPUnit process it.
+     */
+    public function ignores(string $message, string $file, int $line, IssueTrigger $trigger): bool;
+}

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -50,6 +50,7 @@ use PHPUnit\Metadata\IgnoreDeprecations;
 use PHPUnit\Metadata\Parser\Registry as MetadataParserRegistry;
 use PHPUnit\Runner\Baseline\Baseline;
 use PHPUnit\Runner\Baseline\Issue;
+use PHPUnit\Runner\DeprecationFilter\Filter as DeprecationFilter;
 use PHPUnit\Runner\IssueTriggerResolver\DefaultResolver as DefaultIssueTriggerResolver;
 use PHPUnit\Runner\IssueTriggerResolver\Resolver as IssueTriggerResolver;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
@@ -106,6 +107,11 @@ final class ErrorHandler
      * @var non-empty-list<IssueTriggerResolver>
      */
     private array $issueTriggerResolvers;
+
+    /**
+     * @var list<DeprecationFilter>
+     */
+    private array $deprecationFilters = [];
 
     public static function instance(): self
     {
@@ -220,6 +226,8 @@ final class ErrorHandler
                 break;
 
             case E_DEPRECATED:
+                $trigger = $this->trigger($test, false, $errorString, $errorFile);
+
                 Event\Facade::emitter()->testTriggeredPhpDeprecation(
                     $test,
                     $errorString,
@@ -228,12 +236,15 @@ final class ErrorHandler
                     $suppressed,
                     $ignoredByBaseline,
                     $ignoredByTest,
-                    $this->trigger($test, false, $errorString, $errorFile),
+                    $this->deprecationIgnoredByFilter($errorString, $errorFile, $errorLine, $trigger),
+                    $trigger,
                 );
 
                 break;
 
             case E_USER_DEPRECATED:
+                $trigger = $this->trigger($test, true, $errorString);
+
                 Event\Facade::emitter()->testTriggeredDeprecation(
                     $test,
                     $errorString,
@@ -242,7 +253,8 @@ final class ErrorHandler
                     $suppressed,
                     $ignoredByBaseline,
                     $ignoredByTest,
-                    $this->trigger($test, true, $errorString),
+                    $this->deprecationIgnoredByFilter($errorString, $errorFile, $errorLine, $trigger),
+                    $trigger,
                     $this->stackTrace($errorFile, $errorLine),
                 );
 
@@ -517,6 +529,11 @@ final class ErrorHandler
     public function addIssueTriggerResolver(IssueTriggerResolver $resolver): void
     {
         array_unshift($this->issueTriggerResolvers, $resolver);
+    }
+
+    public function addDeprecationFilter(DeprecationFilter $filter): void
+    {
+        $this->deprecationFilters[] = $filter;
     }
 
     public function enterTestCaseContext(string $className, string $methodName): void
@@ -977,6 +994,17 @@ final class ErrorHandler
 
             if ($ignoreDeprecationMessagePattern === null ||
                 (bool) preg_match('{' . $ignoreDeprecationMessagePattern . '}', $message)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function deprecationIgnoredByFilter(string $message, string $file, int $line, IssueTrigger $trigger): bool
+    {
+        foreach ($this->deprecationFilters as $filter) {
+            if ($filter->ignores($message, $file, $line, $trigger)) {
                 return true;
             }
         }

--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -50,7 +50,6 @@ use PHPUnit\Metadata\IgnoreDeprecations;
 use PHPUnit\Metadata\Parser\Registry as MetadataParserRegistry;
 use PHPUnit\Runner\Baseline\Baseline;
 use PHPUnit\Runner\Baseline\Issue;
-use PHPUnit\Runner\DeprecationFilter\Filter as DeprecationFilter;
 use PHPUnit\Runner\IssueTriggerResolver\DefaultResolver as DefaultIssueTriggerResolver;
 use PHPUnit\Runner\IssueTriggerResolver\Resolver as IssueTriggerResolver;
 use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;

--- a/src/Runner/IssueFilter.php
+++ b/src/Runner/IssueFilter.php
@@ -44,6 +44,10 @@ final readonly class IssueFilter
                 return false;
             }
 
+            if ($event->ignoredByFilter()) {
+                return false;
+            }
+
             if ($this->source->ignoreSelfDeprecations() && $event->trigger()->isSelf()) {
                 return false;
             }

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -54,7 +54,7 @@ use PHPUnit\Runner\Baseline\Writer;
 use PHPUnit\Runner\CodeCoverage;
 use PHPUnit\Runner\CodeCoverageInitializationStatus;
 use PHPUnit\Runner\DeprecationCollector\Facade as DeprecationCollector;
-use PHPUnit\Runner\DeprecationFilter\Filter;
+use PHPUnit\Runner\DeprecationFilter;
 use PHPUnit\Runner\DirectoryDoesNotExistException;
 use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\Runner\Extension\ExtensionBootstrapper;
@@ -1002,12 +1002,12 @@ final readonly class Application
 
             $filter = new $className;
 
-            if (!$filter instanceof Filter) {
+            if (!$filter instanceof DeprecationFilter) {
                 EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
                     sprintf(
                         'Class %s cannot be used as a deprecation filter because it does not implement %s',
                         $className,
-                        Filter::class,
+                        DeprecationFilter::class,
                     ),
                 );
 

--- a/src/TextUI/Application.php
+++ b/src/TextUI/Application.php
@@ -54,6 +54,7 @@ use PHPUnit\Runner\Baseline\Writer;
 use PHPUnit\Runner\CodeCoverage;
 use PHPUnit\Runner\CodeCoverageInitializationStatus;
 use PHPUnit\Runner\DeprecationCollector\Facade as DeprecationCollector;
+use PHPUnit\Runner\DeprecationFilter\Filter;
 use PHPUnit\Runner\DirectoryDoesNotExistException;
 use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\Runner\Extension\ExtensionBootstrapper;
@@ -242,6 +243,7 @@ final readonly class Application
 
             $this->configureDeprecationTriggers($configuration);
             $this->configureIssueTriggerResolvers($configuration);
+            $this->configureDeprecationFilters($configuration);
             $this->registerInterruptHandler();
 
             $timer = new Timer;
@@ -981,6 +983,38 @@ final readonly class Application
             }
 
             ErrorHandler::instance()->addIssueTriggerResolver($resolver);
+        }
+    }
+
+    private function configureDeprecationFilters(Configuration $configuration): void
+    {
+        foreach ($configuration->source()->deprecationFilters() as $className) {
+            if (!class_exists($className)) {
+                EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
+                    sprintf(
+                        'Class %s cannot be used as a deprecation filter because it does not exist',
+                        $className,
+                    ),
+                );
+
+                continue;
+            }
+
+            $filter = new $className;
+
+            if (!$filter instanceof Filter) {
+                EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
+                    sprintf(
+                        'Class %s cannot be used as a deprecation filter because it does not implement %s',
+                        $className,
+                        Filter::class,
+                    ),
+                );
+
+                continue;
+            }
+
+            ErrorHandler::instance()->addDeprecationFilter($filter);
         }
     }
 

--- a/src/TextUI/Configuration/Merger.php
+++ b/src/TextUI/Configuration/Merger.php
@@ -1150,6 +1150,7 @@ final readonly class Merger
                 $xmlConfiguration->source()->ignoreIndirectDeprecations(),
                 $xmlConfiguration->source()->identifyIssueTrigger(),
                 $xmlConfiguration->source()->issueTriggerResolvers(),
+                $xmlConfiguration->source()->deprecationFilters(),
             ),
             $testResultCacheFile,
             $coverageClover,

--- a/src/TextUI/Configuration/Value/Source.php
+++ b/src/TextUI/Configuration/Value/Source.php
@@ -52,11 +52,17 @@ final readonly class Source
     private array $issueTriggerResolvers;
 
     /**
+     * @var list<non-empty-string>
+     */
+    private array $deprecationFilters;
+
+    /**
      * @param ?non-empty-string      $baseline
      * @param DeprecationTriggers    $deprecationTriggers
      * @param list<non-empty-string> $issueTriggerResolvers
+     * @param list<non-empty-string> $deprecationFilters
      */
-    public function __construct(?string $baseline, bool $ignoreBaseline, FilterDirectoryCollection $includeDirectories, FilterFileCollection $includeFiles, FilterDirectoryCollection $excludeDirectories, FilterFileCollection $excludeFiles, bool $restrictNotices, bool $restrictWarnings, bool $ignoreSuppressionOfDeprecations, bool $ignoreSuppressionOfPhpDeprecations, bool $ignoreSuppressionOfErrors, bool $ignoreSuppressionOfNotices, bool $ignoreSuppressionOfPhpNotices, bool $ignoreSuppressionOfWarnings, bool $ignoreSuppressionOfPhpWarnings, array $deprecationTriggers, bool $ignoreSelfDeprecations, bool $ignoreDirectDeprecations, bool $ignoreIndirectDeprecations, bool $identifyIssueTrigger, array $issueTriggerResolvers = [])
+    public function __construct(?string $baseline, bool $ignoreBaseline, FilterDirectoryCollection $includeDirectories, FilterFileCollection $includeFiles, FilterDirectoryCollection $excludeDirectories, FilterFileCollection $excludeFiles, bool $restrictNotices, bool $restrictWarnings, bool $ignoreSuppressionOfDeprecations, bool $ignoreSuppressionOfPhpDeprecations, bool $ignoreSuppressionOfErrors, bool $ignoreSuppressionOfNotices, bool $ignoreSuppressionOfPhpNotices, bool $ignoreSuppressionOfWarnings, bool $ignoreSuppressionOfPhpWarnings, array $deprecationTriggers, bool $ignoreSelfDeprecations, bool $ignoreDirectDeprecations, bool $ignoreIndirectDeprecations, bool $identifyIssueTrigger, array $issueTriggerResolvers = [], array $deprecationFilters = [])
     {
         $this->baseline                           = $baseline;
         $this->ignoreBaseline                     = $ignoreBaseline;
@@ -79,6 +85,7 @@ final readonly class Source
         $this->ignoreIndirectDeprecations         = $ignoreIndirectDeprecations;
         $this->identifyIssueTrigger               = $identifyIssueTrigger;
         $this->issueTriggerResolvers              = $issueTriggerResolvers;
+        $this->deprecationFilters                 = $deprecationFilters;
     }
 
     /**
@@ -215,5 +222,13 @@ final readonly class Source
     public function issueTriggerResolvers(): array
     {
         return $this->issueTriggerResolvers;
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    public function deprecationFilters(): array
+    {
+        return $this->deprecationFilters;
     }
 }

--- a/src/TextUI/Configuration/Xml/Loader.php
+++ b/src/TextUI/Configuration/Xml/Loader.php
@@ -408,6 +408,23 @@ final readonly class Loader
             $issueTriggerResolvers[] = $className;
         }
 
+        $deprecationFilters     = [];
+        $deprecationFilterNodes = $xpath->query('source/deprecationFilters/deprecationFilter');
+
+        assert($deprecationFilterNodes instanceof DOMNodeList);
+
+        foreach ($deprecationFilterNodes as $node) {
+            assert($node instanceof DOMElement);
+
+            $className = $node->getAttribute('className');
+
+            if ($className === '') {
+                continue;
+            }
+
+            $deprecationFilters[] = $className;
+        }
+
         return new Source(
             $baseline,
             false,
@@ -430,6 +447,7 @@ final readonly class Loader
             $ignoreIndirectDeprecations,
             $identifyIssueTrigger,
             $issueTriggerResolvers,
+            $deprecationFilters,
         );
     }
 

--- a/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php
+++ b/src/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php
@@ -140,7 +140,7 @@ final class ProgressPrinter
 
     public function testTriggeredDeprecation(DeprecationTriggered $event): void
     {
-        if ($event->ignoredByBaseline() || $event->ignoredByTest()) {
+        if ($event->ignoredByBaseline() || $event->ignoredByTest() || $event->ignoredByFilter()) {
             return;
         }
 
@@ -165,7 +165,7 @@ final class ProgressPrinter
 
     public function testTriggeredPhpDeprecation(PhpDeprecationTriggered $event): void
     {
-        if ($event->ignoredByBaseline() || $event->ignoredByTest()) {
+        if ($event->ignoredByBaseline() || $event->ignoredByTest() || $event->ignoredByFilter()) {
             return;
         }
 

--- a/tests/_files/DeprecationFilter/FilterA.php
+++ b/tests/_files/DeprecationFilter/FilterA.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\DeprecationFilter;
+
+use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
+use PHPUnit\Runner\DeprecationFilter;
+
+final class FilterA implements DeprecationFilter
+{
+    public function ignores(string $message, string $file, int $line, IssueTrigger $trigger): bool
+    {
+        return false;
+    }
+}

--- a/tests/_files/DeprecationFilter/FilterB.php
+++ b/tests/_files/DeprecationFilter/FilterB.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\DeprecationFilter;
+
+use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
+use PHPUnit\Runner\DeprecationFilter;
+
+final class FilterB implements DeprecationFilter
+{
+    public function ignores(string $message, string $file, int $line, IssueTrigger $trigger): bool
+    {
+        return false;
+    }
+}

--- a/tests/_files/DeprecationFilter/NotADeprecationFilter.php
+++ b/tests/_files/DeprecationFilter/NotADeprecationFilter.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\DeprecationFilter;
+
+final class NotADeprecationFilter
+{
+}

--- a/tests/_files/configuration_deprecation_filters.xml
+++ b/tests/_files/configuration_deprecation_filters.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../phpunit.xsd">
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className=""/>
+            <deprecationFilter className="PHPUnit\TestFixture\DeprecationFilter\FilterA"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/phpunit.xml
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className="PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\InvalidFilter"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/src/InvalidFilter.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/src/InvalidFilter.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
+
+final class InvalidFilter
+{
+}

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/tests/DeprecationFilterTest.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/tests/DeprecationFilterTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
+
+use PHPUnit\Framework\TestCase;
+
+final class DeprecationFilterTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/vendor/autoload.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-invalid-class/vendor/autoload.php
@@ -1,0 +1,2 @@
+<?php declare(strict_types=1);
+require __DIR__ . '/../src/InvalidFilter.php';

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-nonexistent-class/phpunit.xml
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-nonexistent-class/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className="PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\NonExistentFilter"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-nonexistent-class/tests/DeprecationFilterTest.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-nonexistent-class/tests/DeprecationFilterTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
+
+use PHPUnit\Framework\TestCase;
+
+final class DeprecationFilterTest extends TestCase
+{
+    public function testSomething(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/error-handler/_files/deprecation-filter-nonexistent-class/vendor/autoload.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter-nonexistent-class/vendor/autoload.php
@@ -1,0 +1,1 @@
+<?php declare(strict_types=1);

--- a/tests/end-to-end/error-handler/_files/deprecation-filter/phpunit.xml
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+
+        <deprecationFilters>
+            <deprecationFilter className="PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\IgnoringDeprecationFilter"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/end-to-end/error-handler/_files/deprecation-filter/src/FirstPartyClass.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter/src/FirstPartyClass.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
+
+final class FirstPartyClass
+{
+}

--- a/tests/end-to-end/error-handler/_files/deprecation-filter/tests/DeprecationFilterTest.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter/tests/DeprecationFilterTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+use PHPUnit\Framework\TestCase;
+
+final class DeprecationFilterTest extends TestCase
+{
+    public function testIgnoredDeprecation(): void
+    {
+        @trigger_error('please ignore this deprecation', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+
+    public function testReportedDeprecation(): void
+    {
+        @trigger_error('this deprecation must be reported', E_USER_DEPRECATED);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/error-handler/_files/deprecation-filter/vendor/IgnoringDeprecationFilter.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter/vendor/IgnoringDeprecationFilter.php
@@ -3,9 +3,9 @@ namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
 
 use function str_contains;
 use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
-use PHPUnit\Runner\DeprecationFilter\Filter;
+use PHPUnit\Runner\DeprecationFilter;
 
-final class IgnoringDeprecationFilter implements Filter
+final class IgnoringDeprecationFilter implements DeprecationFilter
 {
     public function ignores(string $message, string $file, int $line, IssueTrigger $trigger): bool
     {

--- a/tests/end-to-end/error-handler/_files/deprecation-filter/vendor/IgnoringDeprecationFilter.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter/vendor/IgnoringDeprecationFilter.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace PHPUnit\TestFixture\ErrorHandler\DeprecationFilter;
+
+use function str_contains;
+use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
+use PHPUnit\Runner\DeprecationFilter\Filter;
+
+final class IgnoringDeprecationFilter implements Filter
+{
+    public function ignores(string $message, string $file, int $line, IssueTrigger $trigger): bool
+    {
+        return str_contains($message, 'please ignore this deprecation');
+    }
+}

--- a/tests/end-to-end/error-handler/_files/deprecation-filter/vendor/autoload.php
+++ b/tests/end-to-end/error-handler/_files/deprecation-filter/vendor/autoload.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+require __DIR__ . '/../src/FirstPartyClass.php';
+require __DIR__ . '/IgnoringDeprecationFilter.php';

--- a/tests/end-to-end/error-handler/deprecation-filter-invalid-class.phpt
+++ b/tests/end-to-end/error-handler/deprecation-filter-invalid-class.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Deprecation filter configuration: class not implementing the interface emits PHPUnit warning
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/deprecation-filter-invalid-class';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) Class PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\InvalidFilter cannot be used as a deprecation filter because it does not implement PHPUnit\Runner\DeprecationFilter
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, PHPUnit Warnings: 1.

--- a/tests/end-to-end/error-handler/deprecation-filter-nonexistent-class.phpt
+++ b/tests/end-to-end/error-handler/deprecation-filter-nonexistent-class.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Deprecation filter configuration: nonexistent class emits PHPUnit warning
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/deprecation-filter-nonexistent-class';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 PHPUnit test runner warning:
+
+1) Class PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\NonExistentFilter cannot be used as a deprecation filter because it does not exist
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, PHPUnit Warnings: 1.

--- a/tests/end-to-end/error-handler/deprecation-filter.phpt
+++ b/tests/end-to-end/error-handler/deprecation-filter.phpt
@@ -1,0 +1,42 @@
+--TEST--
+A registered deprecation filter marks matching deprecations as ignored without affecting others
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/deprecation-filter';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Bootstrap Finished (%sautoload.php)
+Event Facade Sealed
+Test Suite Loaded (2 tests)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (2 tests)
+Test Suite Started (%sphpunit.xml, 2 tests)
+Test Suite Started (default, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testIgnoredDeprecation)
+Test Prepared (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testIgnoredDeprecation)
+Test Triggered Deprecation (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testIgnoredDeprecation, issue triggered by PHPUnit calling into test code, suppressed using operator, ignored by filter) in %s:%d
+please ignore this deprecation
+Test Passed (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testIgnoredDeprecation)
+Test Finished (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testIgnoredDeprecation)
+Test Preparation Started (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testReportedDeprecation)
+Test Prepared (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testReportedDeprecation)
+Test Triggered Deprecation (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testReportedDeprecation, issue triggered by PHPUnit calling into test code, suppressed using operator) in %s:%d
+this deprecation must be reported
+Test Passed (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testReportedDeprecation)
+Test Finished (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest::testReportedDeprecation)
+Test Suite Finished (PHPUnit\TestFixture\ErrorHandler\DeprecationFilter\DeprecationFilterTest, 2 tests)
+Test Suite Finished (default, 2 tests)
+Test Suite Finished (%sphpunit.xml, 2 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Event/Emitter/DispatchingEmitterTest.php
+++ b/tests/unit/Event/Emitter/DispatchingEmitterTest.php
@@ -2137,6 +2137,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
         $suppressed        = false;
         $ignoredByBaseline = false;
         $ignoredByTest     = false;
+        $ignoredByFilter   = false;
         $trigger           = IssueTrigger::from(null, null);
 
         $emitter->testTriggeredPhpDeprecation(
@@ -2147,6 +2148,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
             $suppressed,
             $ignoredByBaseline,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger,
         );
 
@@ -2162,6 +2164,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
         $this->assertSame($suppressed, $event->wasSuppressed());
         $this->assertSame($ignoredByBaseline, $event->ignoredByBaseline());
         $this->assertSame($ignoredByTest, $event->ignoredByTest());
+        $this->assertSame($ignoredByFilter, $event->ignoredByFilter());
         $this->assertSame($trigger, $event->trigger());
     }
 
@@ -2196,6 +2199,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
         $suppressed        = false;
         $ignoredByBaseline = false;
         $ignoredByTest     = false;
+        $ignoredByFilter   = false;
         $trigger           = IssueTrigger::from(null, null);
         $stackTrace        = 'stack-trace';
 
@@ -2207,6 +2211,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
             $suppressed,
             $ignoredByBaseline,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger,
             $stackTrace,
         );
@@ -2223,6 +2228,7 @@ final class DispatchingEmitterTest extends Framework\TestCase
         $this->assertSame($suppressed, $event->wasSuppressed());
         $this->assertSame($ignoredByBaseline, $event->ignoredByBaseline());
         $this->assertSame($ignoredByTest, $event->ignoredByTest());
+        $this->assertSame($ignoredByFilter, $event->ignoredByFilter());
         $this->assertSame($trigger, $event->trigger());
         $this->assertSame($stackTrace, $event->stackTrace());
     }

--- a/tests/unit/Event/Events/Test/Issue/DeprecationTriggeredTest.php
+++ b/tests/unit/Event/Events/Test/Issue/DeprecationTriggeredTest.php
@@ -32,6 +32,7 @@ final class DeprecationTriggeredTest extends AbstractEventTestCase
         $suppressed        = false;
         $ignoredByBaseline = false;
         $ignoredByTest     = false;
+        $ignoredByFilter   = false;
         $trigger           = IssueTrigger::from(null, null);
         $stackTrace        = 'stack trace';
 
@@ -44,6 +45,7 @@ final class DeprecationTriggeredTest extends AbstractEventTestCase
             $suppressed,
             $ignoredByBaseline,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger,
             $stackTrace,
         );
@@ -56,6 +58,7 @@ final class DeprecationTriggeredTest extends AbstractEventTestCase
         $this->assertSame($suppressed, $event->wasSuppressed());
         $this->assertSame($ignoredByBaseline, $event->ignoredByBaseline());
         $this->assertSame($ignoredByTest, $event->ignoredByTest());
+        $this->assertSame($ignoredByFilter, $event->ignoredByFilter());
         $this->assertSame('Test Triggered Deprecation (FooTest::testBar, unknown if issue was triggered in first-party code or third-party code) in file:1' . PHP_EOL . 'message', $event->asString());
         $this->assertSame($trigger, $event->trigger());
         $this->assertSame($stackTrace, $event->stackTrace());
@@ -71,6 +74,7 @@ final class DeprecationTriggeredTest extends AbstractEventTestCase
             1,
             false,
             true,
+            false,
             false,
             IssueTrigger::from(null, null),
             'stack trace',
@@ -91,12 +95,33 @@ final class DeprecationTriggeredTest extends AbstractEventTestCase
             false,
             false,
             true,
+            false,
             IssueTrigger::from(null, null),
             'stack trace',
         );
 
         $this->assertTrue($event->ignoredByTest());
         $this->assertSame('Test Triggered Deprecation (FooTest::testBar, unknown if issue was triggered in first-party code or third-party code, ignored by test) in file:1' . PHP_EOL . 'message', $event->asString());
+    }
+
+    public function testCanBeIgnoredByFilter(): void
+    {
+        $event = new DeprecationTriggered(
+            $this->telemetryInfo(),
+            $this->testValueObject(),
+            'message',
+            'file',
+            1,
+            false,
+            false,
+            false,
+            true,
+            IssueTrigger::from(null, null),
+            'stack trace',
+        );
+
+        $this->assertTrue($event->ignoredByFilter());
+        $this->assertSame('Test Triggered Deprecation (FooTest::testBar, unknown if issue was triggered in first-party code or third-party code, ignored by filter) in file:1' . PHP_EOL . 'message', $event->asString());
     }
 
     public function testCanBeSuppressed(): void
@@ -108,6 +133,7 @@ final class DeprecationTriggeredTest extends AbstractEventTestCase
             'file',
             1,
             true,
+            false,
             false,
             false,
             IssueTrigger::from(null, null),

--- a/tests/unit/Event/Events/Test/Issue/PhpDeprecationTriggeredTest.php
+++ b/tests/unit/Event/Events/Test/Issue/PhpDeprecationTriggeredTest.php
@@ -32,6 +32,7 @@ final class PhpDeprecationTriggeredTest extends AbstractEventTestCase
         $suppressed        = false;
         $ignoredByBaseline = false;
         $ignoredByTest     = false;
+        $ignoredByFilter   = false;
         $trigger           = IssueTrigger::from(null, null);
 
         $event = new PhpDeprecationTriggered(
@@ -43,6 +44,7 @@ final class PhpDeprecationTriggeredTest extends AbstractEventTestCase
             $suppressed,
             $ignoredByBaseline,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger,
         );
 
@@ -54,6 +56,7 @@ final class PhpDeprecationTriggeredTest extends AbstractEventTestCase
         $this->assertSame($suppressed, $event->wasSuppressed());
         $this->assertSame($ignoredByBaseline, $event->ignoredByBaseline());
         $this->assertSame($ignoredByTest, $event->ignoredByTest());
+        $this->assertSame($ignoredByFilter, $event->ignoredByFilter());
         $this->assertSame('Test Triggered PHP Deprecation (FooTest::testBar, unknown if issue was triggered in first-party code or third-party code) in file:1' . PHP_EOL . 'message', $event->asString());
         $this->assertSame($trigger, $event->trigger());
     }
@@ -68,6 +71,7 @@ final class PhpDeprecationTriggeredTest extends AbstractEventTestCase
             1,
             false,
             true,
+            false,
             false,
             IssueTrigger::from(null, null),
         );
@@ -87,11 +91,31 @@ final class PhpDeprecationTriggeredTest extends AbstractEventTestCase
             false,
             false,
             true,
+            false,
             IssueTrigger::from(null, null),
         );
 
         $this->assertTrue($event->ignoredByTest());
         $this->assertSame('Test Triggered PHP Deprecation (FooTest::testBar, unknown if issue was triggered in first-party code or third-party code, ignored by test) in file:1' . PHP_EOL . 'message', $event->asString());
+    }
+
+    public function testCanBeIgnoredByFilter(): void
+    {
+        $event = new PhpDeprecationTriggered(
+            $this->telemetryInfo(),
+            $this->testValueObject(),
+            'message',
+            'file',
+            1,
+            false,
+            false,
+            false,
+            true,
+            IssueTrigger::from(null, null),
+        );
+
+        $this->assertTrue($event->ignoredByFilter());
+        $this->assertSame('Test Triggered PHP Deprecation (FooTest::testBar, unknown if issue was triggered in first-party code or third-party code, ignored by filter) in file:1' . PHP_EOL . 'message', $event->asString());
     }
 
     public function testCanBeSuppressed(): void
@@ -103,6 +127,7 @@ final class PhpDeprecationTriggeredTest extends AbstractEventTestCase
             'file',
             1,
             true,
+            false,
             false,
             false,
             IssueTrigger::from(null, null),

--- a/tests/unit/Framework/TestRunner/ErrorHandlerBootstrapperTest.php
+++ b/tests/unit/Framework/TestRunner/ErrorHandlerBootstrapperTest.php
@@ -15,9 +15,12 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestRunner\ErrorHandlerBootstrapper;
+use PHPUnit\Runner\DeprecationFilter;
 use PHPUnit\Runner\ErrorHandler;
 use PHPUnit\Runner\IssueTriggerResolver\DefaultResolver;
 use PHPUnit\Runner\IssueTriggerResolver\Resolver;
+use PHPUnit\TestFixture\DeprecationFilter\FilterA;
+use PHPUnit\TestFixture\DeprecationFilter\FilterB;
 use PHPUnit\TestFixture\IssueTriggerResolver\ResolverA;
 use PHPUnit\TestFixture\IssueTriggerResolver\ResolverB;
 use PHPUnit\TextUI\CliArguments\Builder;
@@ -86,6 +89,64 @@ final class ErrorHandlerBootstrapperTest extends TestCase
         foreach ($resolvers as $resolver) {
             $this->assertInstanceOf(Resolver::class, $resolver);
         }
+    }
+
+    #[TestDox('Leaves no deprecation filters registered when configuration is empty')]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBootstrapsWithoutDeprecationFilters(): void
+    {
+        ErrorHandlerBootstrapper::bootstrap($this->configurationFromFixture('empty-source.xml'));
+
+        $this->assertSame([], $this->reflectProperty('deprecationFilters'));
+    }
+
+    #[TestDox('Registers configured deprecation filters in the configured order')]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBootstrapsDeprecationFiltersInConfiguredOrder(): void
+    {
+        ErrorHandlerBootstrapper::bootstrap($this->configurationFromFixture('with-deprecation-filters.xml'));
+
+        $filters = $this->reflectProperty('deprecationFilters');
+
+        $this->assertCount(2, $filters);
+        $this->assertInstanceOf(FilterA::class, $filters[0]);
+        $this->assertInstanceOf(FilterB::class, $filters[1]);
+
+        foreach ($filters as $filter) {
+            $this->assertInstanceOf(DeprecationFilter::class, $filter);
+        }
+    }
+
+    #[TestDox('Ignores a configured deprecation filter class that does not exist')]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testIgnoresNonexistentDeprecationFilterClass(): void
+    {
+        ErrorHandlerBootstrapper::bootstrap($this->configurationFromFixture('with-nonexistent-deprecation-filter.xml'));
+
+        $this->assertSame([], $this->reflectProperty('deprecationFilters'));
+    }
+
+    #[TestDox('Ignores a configured deprecation filter class that does not implement the interface')]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testIgnoresDeprecationFilterNotImplementingTheInterface(): void
+    {
+        ErrorHandlerBootstrapper::bootstrap($this->configurationFromFixture('with-invalid-deprecation-filter.xml'));
+
+        $this->assertSame([], $this->reflectProperty('deprecationFilters'));
+    }
+
+    #[TestDox('Ignores a configured deprecation filter with an empty class name')]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testIgnoresDeprecationFilterWithEmptyClassName(): void
+    {
+        ErrorHandlerBootstrapper::bootstrap($this->configurationFromFixture('with-empty-deprecation-filter-classname.xml'));
+
+        $this->assertSame([], $this->reflectProperty('deprecationFilters'));
     }
 
     private function configurationFromFixture(string $filename): Configuration

--- a/tests/unit/Framework/TestRunner/_files/with-deprecation-filters.xml
+++ b/tests/unit/Framework/TestRunner/_files/with-deprecation-filters.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+>
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className="PHPUnit\TestFixture\DeprecationFilter\FilterA"/>
+            <deprecationFilter className="PHPUnit\TestFixture\DeprecationFilter\FilterB"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/unit/Framework/TestRunner/_files/with-empty-deprecation-filter-classname.xml
+++ b/tests/unit/Framework/TestRunner/_files/with-empty-deprecation-filter-classname.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+>
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className=""/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/unit/Framework/TestRunner/_files/with-invalid-deprecation-filter.xml
+++ b/tests/unit/Framework/TestRunner/_files/with-invalid-deprecation-filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+>
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className="PHPUnit\TestFixture\DeprecationFilter\NotADeprecationFilter"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/unit/Framework/TestRunner/_files/with-nonexistent-deprecation-filter.xml
+++ b/tests/unit/Framework/TestRunner/_files/with-nonexistent-deprecation-filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../../phpunit.xsd"
+>
+    <source>
+        <deprecationFilters>
+            <deprecationFilter className="PHPUnit\TestFixture\DeprecationFilter\NonExistentFilter"/>
+        </deprecationFilters>
+    </source>
+</phpunit>

--- a/tests/unit/Logging/TestDox/TestResult/TestResultCollectorTest.php
+++ b/tests/unit/Logging/TestDox/TestResult/TestResultCollectorTest.php
@@ -196,7 +196,7 @@ final class TestResultCollectorTest extends TestCase
 
         $deprecation = $this->testMethod('testOne');
         $collector->testPrepared(new Prepared($info, $deprecation));
-        $collector->testTriggeredDeprecation(new DeprecationTriggered($info, $deprecation, 'message', 'file.php', 1, false, false, false, $trigger, 'trace'));
+        $collector->testTriggeredDeprecation(new DeprecationTriggered($info, $deprecation, 'message', 'file.php', 1, false, false, false, false, $trigger, 'trace'));
         $collector->testFinished(new Finished($info, $deprecation, 1));
 
         $notice = $this->testMethod('testTwo');
@@ -211,7 +211,7 @@ final class TestResultCollectorTest extends TestCase
 
         $phpDeprecation = $this->testMethod('testFour');
         $collector->testPrepared(new Prepared($info, $phpDeprecation));
-        $collector->testTriggeredPhpDeprecation(new PhpDeprecationTriggered($info, $phpDeprecation, 'message', 'file.php', 1, false, false, false, $trigger));
+        $collector->testTriggeredPhpDeprecation(new PhpDeprecationTriggered($info, $phpDeprecation, 'message', 'file.php', 1, false, false, false, false, $trigger));
         $collector->testFinished(new Finished($info, $phpDeprecation, 1));
 
         $phpNotice = $this->testMethod('testFive');
@@ -263,6 +263,7 @@ final class TestResultCollectorTest extends TestCase
                 false,
                 false,
                 true,
+                false,
                 IssueTrigger::from(null, null),
                 'trace',
             ),
@@ -281,7 +282,7 @@ final class TestResultCollectorTest extends TestCase
 
         $collector->testPrepared(new Prepared($this->telemetryInfo(), $test));
         $collector->testTriggeredDeprecation(
-            new DeprecationTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true, false, IssueTrigger::from(null, null), 'trace'),
+            new DeprecationTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true, false, false, IssueTrigger::from(null, null), 'trace'),
         );
         $collector->testTriggeredNotice(
             new NoticeTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true),
@@ -290,7 +291,7 @@ final class TestResultCollectorTest extends TestCase
             new WarningTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true),
         );
         $collector->testTriggeredPhpDeprecation(
-            new PhpDeprecationTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true, false, IssueTrigger::from(null, null)),
+            new PhpDeprecationTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true, false, false, IssueTrigger::from(null, null)),
         );
         $collector->testTriggeredPhpNotice(
             new PhpNoticeTriggered($this->telemetryInfo(), $test, 'message', 'file.php', 1, false, true),
@@ -353,7 +354,7 @@ final class TestResultCollectorTest extends TestCase
         $phpt      = new Phpt('Foo.phpt');
 
         $collector->testTriggeredDeprecation(
-            new DeprecationTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false, false, IssueTrigger::from(null, null), 'trace'),
+            new DeprecationTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false, false, false, IssueTrigger::from(null, null), 'trace'),
         );
         $collector->testTriggeredNotice(
             new NoticeTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false),
@@ -362,7 +363,7 @@ final class TestResultCollectorTest extends TestCase
             new WarningTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false),
         );
         $collector->testTriggeredPhpDeprecation(
-            new PhpDeprecationTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false, false, IssueTrigger::from(null, null)),
+            new PhpDeprecationTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false, false, false, IssueTrigger::from(null, null)),
         );
         $collector->testTriggeredPhpNotice(
             new PhpNoticeTriggered($this->telemetryInfo(), $phpt, 'message', 'file.php', 1, false, false),

--- a/tests/unit/Runner/DeprecationCollector/InIsolationCollectorTest.php
+++ b/tests/unit/Runner/DeprecationCollector/InIsolationCollectorTest.php
@@ -105,6 +105,7 @@ final class InIsolationCollectorTest extends TestCase
             $suppressed,
             false,
             false,
+            false,
             IssueTrigger::from(null, null),
             'stack trace',
         );

--- a/tests/unit/Runner/IssueFilterTest.php
+++ b/tests/unit/Runner/IssueFilterTest.php
@@ -89,6 +89,24 @@ final class IssueFilterTest extends TestCase
         );
     }
 
+    public function testDoesNotProcessDeprecationIgnoredByFilter(): void
+    {
+        $filter = new IssueFilter($this->source());
+
+        $this->assertFalse(
+            $filter->shouldBeProcessed($this->deprecationEvent(ignoredByFilter: true)),
+        );
+    }
+
+    public function testDoesNotProcessPhpDeprecationIgnoredByFilter(): void
+    {
+        $filter = new IssueFilter($this->source());
+
+        $this->assertFalse(
+            $filter->shouldBeProcessed($this->phpDeprecationEvent(ignoredByFilter: true)),
+        );
+    }
+
     public function testDoesNotProcessSelfDeprecationWhenIgnored(): void
     {
         $filter = new IssueFilter($this->source(ignoreSelfDeprecations: true));
@@ -413,7 +431,7 @@ final class IssueFilterTest extends TestCase
         );
     }
 
-    private function deprecationEvent(bool $suppressed = false, bool $ignoredByTest = false, ?IssueTrigger $trigger = null): DeprecationTriggered
+    private function deprecationEvent(bool $suppressed = false, bool $ignoredByTest = false, bool $ignoredByFilter = false, ?IssueTrigger $trigger = null): DeprecationTriggered
     {
         return new DeprecationTriggered(
             $this->telemetryInfo(),
@@ -424,6 +442,7 @@ final class IssueFilterTest extends TestCase
             $suppressed,
             false,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger ?? IssueTrigger::from(null, null),
             'stack trace',
         );
@@ -440,12 +459,13 @@ final class IssueFilterTest extends TestCase
             $suppressed,
             false,
             false,
+            false,
             IssueTrigger::from(null, null),
             'stack trace',
         );
     }
 
-    private function phpDeprecationEvent(bool $suppressed = false, bool $ignoredByTest = false, ?IssueTrigger $trigger = null): PhpDeprecationTriggered
+    private function phpDeprecationEvent(bool $suppressed = false, bool $ignoredByTest = false, bool $ignoredByFilter = false, ?IssueTrigger $trigger = null): PhpDeprecationTriggered
     {
         return new PhpDeprecationTriggered(
             $this->telemetryInfo(),
@@ -456,6 +476,7 @@ final class IssueFilterTest extends TestCase
             $suppressed,
             false,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger ?? IssueTrigger::from(null, null),
         );
     }

--- a/tests/unit/TextUI/Configuration/Value/SourceTest.php
+++ b/tests/unit/TextUI/Configuration/Value/SourceTest.php
@@ -885,6 +885,72 @@ final class SourceTest extends TestCase
         $this->assertSame($resolvers, $source->issueTriggerResolvers());
     }
 
+    public function testDeprecationFiltersDefaultsToEmpty(): void
+    {
+        $source = new Source(
+            null,
+            false,
+            FilterDirectoryCollection::fromArray([]),
+            FilterFileCollection::fromArray([]),
+            FilterDirectoryCollection::fromArray([]),
+            FilterFileCollection::fromArray([]),
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            [
+                'functions' => [],
+                'methods'   => [],
+            ],
+            false,
+            false,
+            false,
+            true,
+        );
+
+        $this->assertSame([], $source->deprecationFilters());
+    }
+
+    public function testHasDeprecationFilters(): void
+    {
+        $filters = ['FirstFilter', 'SecondFilter'];
+
+        $source = new Source(
+            null,
+            false,
+            FilterDirectoryCollection::fromArray([]),
+            FilterFileCollection::fromArray([]),
+            FilterDirectoryCollection::fromArray([]),
+            FilterFileCollection::fromArray([]),
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            [
+                'functions' => [],
+                'methods'   => [],
+            ],
+            false,
+            false,
+            false,
+            true,
+            [],
+            $filters,
+        );
+
+        $this->assertSame($filters, $source->deprecationFilters());
+    }
+
     public function testMayNotBeEmpty(): void
     {
         $source = new Source(

--- a/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
@@ -242,6 +242,18 @@ final class LoaderTest extends TestCase
         );
     }
 
+    public function testDeprecationFiltersAreReadCorrectlyAndEmptyClassNamesAreIgnored(): void
+    {
+        $source = $this->configuration('configuration_deprecation_filters.xml')->source();
+
+        $this->assertSame(
+            [
+                'PHPUnit\TestFixture\DeprecationFilter\FilterA',
+            ],
+            $source->deprecationFilters(),
+        );
+    }
+
     public function testBranchCoverageConfigurationIsReadCorrectly(): void
     {
         $codeCoverage = $this->configuration('configuration_codecoverage_branchcoverage.xml')->codeCoverage();

--- a/tests/unit/TextUI/Output/Default/ProgressPrinterTest.php
+++ b/tests/unit/TextUI/Output/Default/ProgressPrinterTest.php
@@ -334,6 +334,19 @@ final class ProgressPrinterTest extends TestCase
         $this->assertStringStartsWith('.', $buffer());
     }
 
+    public function testTriggeredDeprecationIsIgnoredWhenIgnoredByFilter(): void
+    {
+        [$printer, $buffer] = $this->printer();
+        $progress           = $this->progressPrinter($printer);
+
+        $progress->testRunnerExecutionStarted($this->executionStarted(1));
+        $progress->testPrepared();
+        $progress->testTriggeredDeprecation($this->deprecationEvent(ignoredByFilter: true));
+        $progress->testFinished();
+
+        $this->assertStringStartsWith('.', $buffer());
+    }
+
     public function testTriggeredDeprecationIsIgnoredWhenSelfAndIgnoreSelf(): void
     {
         [$printer, $buffer] = $this->printer();
@@ -420,6 +433,19 @@ final class ProgressPrinterTest extends TestCase
         $progress->testRunnerExecutionStarted($this->executionStarted(1));
         $progress->testPrepared();
         $progress->testTriggeredPhpDeprecation($this->phpDeprecationEvent(ignoredByTest: true));
+        $progress->testFinished();
+
+        $this->assertStringStartsWith('.', $buffer());
+    }
+
+    public function testTriggeredPhpDeprecationIsIgnoredWhenIgnoredByFilter(): void
+    {
+        [$printer, $buffer] = $this->printer();
+        $progress           = $this->progressPrinter($printer);
+
+        $progress->testRunnerExecutionStarted($this->executionStarted(1));
+        $progress->testPrepared();
+        $progress->testTriggeredPhpDeprecation($this->phpDeprecationEvent(ignoredByFilter: true));
         $progress->testFinished();
 
         $this->assertStringStartsWith('.', $buffer());
@@ -835,6 +861,7 @@ final class ProgressPrinterTest extends TestCase
         bool $suppressed = false,
         bool $ignoredByBaseline = false,
         bool $ignoredByTest = false,
+        bool $ignoredByFilter = false,
         ?IssueTrigger $trigger = null,
     ): DeprecationTriggered {
         return new DeprecationTriggered(
@@ -846,6 +873,7 @@ final class ProgressPrinterTest extends TestCase
             $suppressed,
             $ignoredByBaseline,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger ?? IssueTrigger::from(null, null),
             'stack trace',
         );
@@ -855,6 +883,7 @@ final class ProgressPrinterTest extends TestCase
         bool $suppressed = false,
         bool $ignoredByBaseline = false,
         bool $ignoredByTest = false,
+        bool $ignoredByFilter = false,
         ?IssueTrigger $trigger = null,
     ): PhpDeprecationTriggered {
         return new PhpDeprecationTriggered(
@@ -866,6 +895,7 @@ final class ProgressPrinterTest extends TestCase
             $suppressed,
             $ignoredByBaseline,
             $ignoredByTest,
+            $ignoredByFilter,
             $trigger ?? IssueTrigger::from(null, null),
         );
     }


### PR DESCRIPTION
Since PHPUnit 13.2, PHPUnit takes ownership of the error-handler stack during a test run (see #5845). As a consequence, an error handler registered before PHPUnit runs, for example in a bootstrap file, can no longer silently drop deprecations before PHPUnit observes them. PHPUnit now observes, classifies, baselines, deduplicates, and reports every deprecation itself.

This is a deliberate and, in my opinion, correct change: deciding whether a deprecation is reported, ignored, or fails the suite is PHPUnit's responsibility, and that decision needs to be made consistently in one place so that the baseline, `--display-deprecations`, `failOnDeprecation`, deduplication, and the issue-trigger classification all agree.

However, this removed a capability that large, long-lived projects relied on. As discussed in #6705, Drupal needs to ignore deprecations using project-level rules, not one by one. Their real-world configuration uses roughly six regular expressions to suppress on the order of 3.5-4 million deprecation messages emitted across their test suite (cross-module return-type deprecations, a small set of test modules they will fix later, a few unavoidable internal/forward-compatibility warnings, and so on). Neither the hash-based baseline nor the per-test `#[IgnoreDeprecations]` attribute is a practical fit for numbers like that.

The existing escape hatch for this, letting a bootstrap error handler suppress issues before PHPUnit sees them, necessarily moves the decision outside of PHPUnit, which is exactly what 13.2 set out to fix, and means PHPUnit can no longer guarantee that its reporting reflects what actually happened.

This pull request introduces deprecation filters: user-supplied objects that decide, for each deprecation, whether PHPUnit should ignore it, with the decision made inside PHPUnit, after it has already observed and classified the deprecation.

You implement the `PHPUnit\Runner\DeprecationFilter\Filter` interface:

```php
use PHPUnit\Event\Code\IssueTrigger\IssueTrigger;
use PHPUnit\Runner\DeprecationFilter;

final class MyDeprecationFilter implements DeprecationFilter
{
    public function ignores(string $message, string $file, int $line, IssueTrigger $trigger): bool
    {
        // Return true to ignore this deprecation, false to let PHPUnit process it.
        return str_contains($message, 'might add "..." as a native return type');
    }
}
```

and register it in your XML configuration, alongside the existing `<source>` options:

```xml
<source>
    <deprecationFilters>
        <deprecationFilter className="App\Tests\MyDeprecationFilter"/>
    </deprecationFilters>
</source>
```

You can register more than one filter; a deprecation is ignored if any registered filter returns `true`. Each filter receives the deprecation message, the file and line, and the resolved issue-trigger classification (self/direct/indirect), so it can match on the message text, on a path, or on how the deprecation was triggered.

Because the filter runs inside PHPUnit, the result is recorded as a first-class outcome of the run rather than hidden from it. A filtered deprecation behaves exactly like one ignored via `#[IgnoreDeprecations]`:

- it does not appear in the test progress or the deprecation summary,
- it is not counted and does not trigger `failOnDeprecation`,
- but it is still observed and classified, so reporting stays internally consistent.

Crucially, this does not require disabling PHPUnit's own error-handler ownership, and it does not emit a "reporting integrity cannot be guaranteed" warning on every run (see #6708), because integrity is in fact preserved: PHPUnit still makes the decision. The filter simply expresses the project's policy about which deprecations are currently acceptable.

For a project like Drupal, this means the bespoke bootstrap deprecation handler can be replaced by a single registered filter that reads their existing ignore file, layering "project-level ignored deprecations" cleanly on top of the baseline and the per-test ignore mechanisms.