### PR TITLE
Improve error message for invalid version constraint in attribute

### DIFF
--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -91,6 +91,7 @@ use PHPUnit\Framework\Attributes\UsesTrait;
 use PHPUnit\Framework\Attributes\WithEnvironmentVariable;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Metadata\InvalidAttributeException;
+use PHPUnit\Metadata\InvalidVersionRequirementException;
 use PHPUnit\Metadata\Metadata;
 use PHPUnit\Metadata\MetadataCollection;
 use PHPUnit\Metadata\Version\Requirement;
@@ -994,7 +995,17 @@ final readonly class AttributeParser implements Parser
             );
         }
 
-        return Requirement::from($versionRequirement);
+        try {
+            return Requirement::from($versionRequirement);
+        } catch (InvalidVersionRequirementException) {
+            throw new InvalidVersionRequirementException(
+                sprintf(
+                    'Test %s has attribute with invalid version constraint argument ("%s")',
+                    $this->testAsString($testClassName, $testMethodName),
+                    $versionRequirement,
+                ),
+            );
+        }
     }
 
     /**

--- a/tests/end-to-end/event/_files/InvalidVersionConstraintNoVersionTest.php
+++ b/tests/end-to-end/event/_files/InvalidVersionConstraintNoVersionTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Event;
+
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\TestCase;
+
+final class InvalidVersionConstraintNoVersionTest extends TestCase
+{
+    #[RequiresPhp('invalid-version')]
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/event/invalid-version-constraint-no-version.phpt
+++ b/tests/end-to-end/event/invalid-version-constraint-no-version.phpt
@@ -12,7 +12,7 @@ require __DIR__ . '/../../bootstrap.php';
 --EXPECTF--
 An error occurred inside PHPUnit.
 
-Message:  (no message)
-Location: %s%eRequirement.php:%d
+Message:  Test method PHPUnit\TestFixture\Event\InvalidVersionConstraintNoVersionTest::testOne has attribute with invalid version constraint argument ("invalid-version")
+Location: %s%eAttributeParser.php:%d
 
 %a

--- a/tests/end-to-end/event/invalid-version-constraint-no-version.phpt
+++ b/tests/end-to-end/event/invalid-version-constraint-no-version.phpt
@@ -1,0 +1,18 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6356
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/InvalidVersionConstraintNoVersionTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+An error occurred inside PHPUnit.
+
+Message:  (no message)
+Location: %s%eRequirement.php:%d
+
+%a


### PR DESCRIPTION
Currently, on both 12 and 13, when having `#[RequiresPhp('invalid-version')]`, all the information displayed is:
```
An error occurred inside PHPUnit.

Message:  (no message)
Location: (...)/vendor/phpunit/phpunit/src/Metadata/Version/Requirement.php:51
#bactrace
```
This PR will change it to:
```
An error occurred inside PHPUnit.

Message:  Test method PHPUnit\TestFixture\Event\InvalidVersionConstraintNoVersionTest::testOne has attribute with invalid version constraint argument ("invalid-version")
Location: (...)AttributeParser.php
```