### PR TITLE
fix: Renamed and moved events for issues triggered outside of tests

### DIFF
--- a/src/Framework/TestRunner/DeprecationTriggered.php
+++ b/src/Framework/TestRunner/DeprecationTriggered.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Telemetry\Event;
+
+class PhpunitDeprecationTriggered extends Event
+{
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message, $file, $line);
+    }
+}

--- a/src/Framework/TestRunner/Issue/DeprecationTriggered.php
+++ b/src/Framework/TestRunner/Issue/DeprecationTriggered.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Event\TestRunner\Issue;
+
+use PHPUnit\Event\Telemetry\Event;
+
+class DeprecationTriggered extends Event
+{
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message, $file, $line);
+    }
+}

--- a/src/Framework/TestRunner/Issue/NoticeTriggered.php
+++ b/src/Framework/TestRunner/Issue/NoticeTriggered.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Event\TestRunner\Issue;
+
+use PHPUnit\Event\Telemetry\Event;
+
+class NoticeTriggered extends Event
+{
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message, $file, $line);
+    }
+}

--- a/src/Framework/TestRunner/Issue/WarningTriggered.php
+++ b/src/Framework/TestRunner/Issue/WarningTriggered.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Event\TestRunner\Issue;
+
+use PHPUnit\Event\Telemetry\Event;
+
+class WarningTriggered extends Event
+{
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message, $file, $line);
+    }
+}

--- a/src/Framework/TestRunner/NoticeTriggered.php
+++ b/src/Framework/TestRunner/NoticeTriggered.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Telemetry\Event;
+
+class PhpunitNoticeTriggered extends Event
+{
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message, $file, $line);
+    }
+}

--- a/src/Framework/TestRunner/WarningTriggered.php
+++ b/src/Framework/TestRunner/WarningTriggered.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Event\TestRunner;
+
+use PHPUnit\Event\Telemetry\Event;
+
+class PhpunitWarningTriggered extends Event
+{
+    public function __construct(string $message, string $file, int $line)
+    {
+        parent::__construct($message, $file, $line);
+    }
+}


### PR DESCRIPTION
## Problem
The existing events for `E_USER_DEPRECATION`, `E_USER_NOTICE`, and `E_USER_WARNING` triggered outside of tests had the same names as existing event classes that represent something entirely different.

## Solution
Renamed the existing events to `PhpunitDeprecationTriggered`, `PhpunitNoticeTriggered`, and `PhpunitWarningTriggered` and moved the new events to the `TestRunner\Issue` namespace.

## Testing
Run the existing test suite to ensure that the changes do not break any tests.

---
*Closes #6580*

> 🤖 Generated by AutoGit
> *(Contribution guidelines followed)*