### PR TITLE
Persistent worker for native parallel test execution

### DIFF
--- a/src/Runner/Parallel/Exception/WorkerException.php
+++ b/src/Runner/Parallel/Exception/WorkerException.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Parallel;
+
+use PHPUnit\Exception;
+use RuntimeException;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class WorkerException extends RuntimeException implements Exception
+{
+}

--- a/src/Runner/Parallel/PersistentWorker.php
+++ b/src/Runner/Parallel/PersistentWorker.php
@@ -21,6 +21,7 @@ use function is_resource;
 use function json_encode;
 use function random_bytes;
 use function serialize;
+use function str_ends_with;
 use function sys_get_temp_dir;
 use function tempnam;
 use function trim;
@@ -188,6 +189,12 @@ final class PersistentWorker
      * identified by the given nonce has finished. Any unrelated output the
      * worker may have written to the channel is skipped. Returns false if the
      * worker terminated before reporting completion.
+     *
+     * The marker is the last thing the worker writes on its line, followed by
+     * a newline. Stray output that the test produced on the control channel
+     * without a trailing newline therefore fuses with the marker as a prefix
+     * of the same line; matching the marker as a suffix tolerates this instead
+     * of being defeated by it.
      */
     private function awaitResult(string $nonce): bool
     {
@@ -204,7 +211,7 @@ final class PersistentWorker
         $expected = self::DONE_PREFIX . $nonce;
 
         while (($line = fgets($stdout)) !== false) {
-            if (trim($line) === $expected) {
+            if (str_ends_with(trim($line), $expected)) {
                 return true;
             }
         }

--- a/src/Runner/Parallel/PersistentWorker.php
+++ b/src/Runner/Parallel/PersistentWorker.php
@@ -151,7 +151,9 @@ final class PersistentWorker
         @unlink($resultFile);
 
         if ($serializedResult === false) {
+            // @codeCoverageIgnoreStart
             $serializedResult = '';
+            // @codeCoverageIgnoreEnd
         }
 
         $this->processor->process($test, $serializedResult, '', $nonce);
@@ -228,11 +230,15 @@ final class PersistentWorker
         if (defined('PHPUNIT_COMPOSER_INSTALL')) {
             $composerAutoload = var_export(PHPUNIT_COMPOSER_INSTALL, true);
         } else {
+            // @codeCoverageIgnoreStart
             $composerAutoload = '\'\'';
+            // @codeCoverageIgnoreEnd
         }
 
         if (defined('__PHPUNIT_PHAR__')) {
+            // @codeCoverageIgnoreStart
             $phar = var_export(__PHPUNIT_PHAR__, true);
+            // @codeCoverageIgnoreEnd
         } else {
             $phar = '\'\'';
         }
@@ -240,7 +246,9 @@ final class PersistentWorker
         if (CodeCoverage::instance()->isActive()) {
             $coverage = 'true';
         } else {
+            // @codeCoverageIgnoreStart
             $coverage = 'false';
+            // @codeCoverageIgnoreEnd
         }
 
         $includePath = var_export(get_include_path(), true);
@@ -295,7 +303,9 @@ final class PersistentWorker
     private function sourceMapFileForChildProcess(): string
     {
         if (!ConfigurationRegistry::get()->source()->notEmpty()) {
+            // @codeCoverageIgnoreStart
             return '';
+            // @codeCoverageIgnoreEnd
         }
 
         $path = tempnam(sys_get_temp_dir(), 'phpunit_');

--- a/src/Runner/Parallel/PersistentWorker.php
+++ b/src/Runner/Parallel/PersistentWorker.php
@@ -1,0 +1,319 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Parallel;
+
+use function assert;
+use function base64_encode;
+use function bin2hex;
+use function defined;
+use function fgets;
+use function file_get_contents;
+use function get_include_path;
+use function hrtime;
+use function is_resource;
+use function json_encode;
+use function random_bytes;
+use function serialize;
+use function sys_get_temp_dir;
+use function tempnam;
+use function trim;
+use function unlink;
+use function var_export;
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestRunner\ChildProcessResultProcessor;
+use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
+use PHPUnit\TextUI\Configuration\SourceMapper;
+use PHPUnit\Util\PHP\Job;
+use PHPUnit\Util\PHP\JobRunner;
+use PHPUnit\Util\PHP\RunningJob;
+use ReflectionClass;
+use SebastianBergmann\Template\Template;
+
+/**
+ * A worker process that boots PHPUnit once and then executes an arbitrary
+ * number of tests, each in response to a command received on its control
+ * channel (its standard input).
+ *
+ * Unlike the SeparateProcessTestRunner, which spawns one process per test for
+ * isolation, a PersistentWorker amortizes the cost of bootstrapping PHPUnit
+ * across all of the tests it runs. The tests executed by a single worker share
+ * one process and therefore do not get the per-test global-state isolation that
+ * process isolation provides; this is the trade-off that makes the worker
+ * suitable as a building block for parallel test execution.
+ *
+ * The result of each test is transported back to the parent process using the
+ * very same serialized envelope that process isolation uses, so that the
+ * ChildProcessResultProcessor can reconstitute it unchanged.
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class PersistentWorker
+{
+    /**
+     * Marker written by the worker to its control channel to signal that a
+     * test has finished and its result has been written to the result file.
+     * Must be kept in sync with templates/worker.tpl.
+     */
+    private const string DONE_PREFIX = 'PHPUNIT_WORKER_DONE:';
+    private readonly JobRunner $jobRunner;
+    private readonly ChildProcessResultProcessor $processor;
+    private ?RunningJob $job = null;
+
+    /**
+     * @var list<string>
+     */
+    private array $temporaryFiles = [];
+
+    public function __construct(JobRunner $jobRunner, ChildProcessResultProcessor $processor)
+    {
+        $this->jobRunner = $jobRunner;
+        $this->processor = $processor;
+    }
+
+    /**
+     * @throws WorkerException
+     */
+    public function start(): void
+    {
+        $this->job = $this->jobRunner->start(new Job($this->buildWorkerCode()));
+    }
+
+    /**
+     * @throws WorkerException
+     */
+    public function run(TestCase $test): void
+    {
+        assert($this->job !== null);
+
+        $class = new ReflectionClass($test);
+        $file  = $class->getFileName();
+
+        assert($file !== false);
+
+        $offset     = hrtime();
+        $nonce      = bin2hex(random_bytes(16));
+        $resultFile = tempnam(sys_get_temp_dir(), 'phpunit_');
+
+        if ($resultFile === false) {
+            // @codeCoverageIgnoreStart
+            throw new WorkerException('Unable to create temporary file for the worker result');
+            // @codeCoverageIgnoreEnd
+        }
+
+        $command = [
+            'command'           => 'run',
+            'file'              => $file,
+            'className'         => $class->getName(),
+            'methodName'        => $test->name(),
+            'data'              => base64_encode(serialize($test->providedData())),
+            'dataName'          => $test->dataName(),
+            'dependencyInput'   => base64_encode(serialize($test->dependencyInput())),
+            'repetition'        => $test->repetition(),
+            'totalRepetitions'  => $test->totalRepetitions(),
+            'attempt'           => $test->attempt(),
+            'maxAttempts'       => $test->maxAttempts(),
+            'offsetSeconds'     => $offset[0],
+            'offsetNanoseconds' => $offset[1],
+            'resultFile'        => $resultFile,
+            'nonce'             => $nonce,
+        ];
+
+        $encodedCommand = json_encode($command);
+
+        assert($encodedCommand !== false);
+
+        $this->job->write($encodedCommand . "\n");
+
+        if (!$this->awaitResult($nonce)) {
+            $result    = $this->job->wait();
+            $this->job = null;
+
+            @unlink($resultFile);
+
+            $this->processor->process($test, '', $result->stderr(), $nonce);
+
+            return;
+        }
+
+        $serializedResult = file_get_contents($resultFile);
+
+        @unlink($resultFile);
+
+        if ($serializedResult === false) {
+            $serializedResult = '';
+        }
+
+        $this->processor->process($test, $serializedResult, '', $nonce);
+    }
+
+    public function stop(): void
+    {
+        if ($this->job !== null) {
+            $encodedCommand = json_encode(['command' => 'stop']);
+
+            assert($encodedCommand !== false);
+
+            $this->job->write($encodedCommand . "\n");
+            $this->job->closeStdin();
+
+            $result = $this->job->wait();
+
+            EventFacade::emitter()->childProcessFinished($result->stdout(), $result->stderr());
+
+            $this->job = null;
+        }
+
+        foreach ($this->temporaryFiles as $temporaryFile) {
+            @unlink($temporaryFile);
+        }
+
+        $this->temporaryFiles = [];
+    }
+
+    /**
+     * Read the worker's control channel until it reports that the test
+     * identified by the given nonce has finished. Any unrelated output the
+     * worker may have written to the channel is skipped. Returns false if the
+     * worker terminated before reporting completion.
+     */
+    private function awaitResult(string $nonce): bool
+    {
+        assert($this->job !== null);
+
+        $stdout = $this->job->stdout();
+
+        if (!is_resource($stdout)) {
+            // @codeCoverageIgnoreStart
+            return false;
+            // @codeCoverageIgnoreEnd
+        }
+
+        $expected = self::DONE_PREFIX . $nonce;
+
+        while (($line = fgets($stdout)) !== false) {
+            if (trim($line) === $expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws WorkerException
+     *
+     * @return non-empty-string
+     */
+    private function buildWorkerCode(): string
+    {
+        $configuration = ConfigurationRegistry::get();
+
+        $bootstrap = '';
+
+        if ($configuration->hasBootstrap()) {
+            $bootstrap = $configuration->bootstrap();
+        }
+
+        if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+            $composerAutoload = var_export(PHPUNIT_COMPOSER_INSTALL, true);
+        } else {
+            $composerAutoload = '\'\'';
+        }
+
+        if (defined('__PHPUNIT_PHAR__')) {
+            $phar = var_export(__PHPUNIT_PHAR__, true);
+        } else {
+            $phar = '\'\'';
+        }
+
+        if (CodeCoverage::instance()->isActive()) {
+            $coverage = 'true';
+        } else {
+            $coverage = 'false';
+        }
+
+        $includePath = var_export(get_include_path(), true);
+        $includePath = "'." . $includePath . ".'";
+
+        $template = new Template(__DIR__ . '/templates/worker.tpl');
+
+        $template->setVar(
+            [
+                'composerAutoload'               => $composerAutoload,
+                'phar'                           => $phar,
+                'collectCodeCoverageInformation' => $coverage,
+                'iniSettings'                    => '',
+                'include_path'                   => $includePath,
+                'serializedConfiguration'        => $this->saveConfigurationForChildProcess(),
+                'sourceMapFile'                  => $this->sourceMapFileForChildProcess(),
+                'bootstrap'                      => $bootstrap,
+            ],
+        );
+
+        $code = $template->render();
+
+        assert($code !== '');
+
+        return $code;
+    }
+
+    /**
+     * @throws WorkerException
+     */
+    private function saveConfigurationForChildProcess(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'phpunit_');
+
+        if ($path === false) {
+            // @codeCoverageIgnoreStart
+            throw new WorkerException('Unable to create temporary file for the worker configuration');
+            // @codeCoverageIgnoreEnd
+        }
+
+        if (!ConfigurationRegistry::saveTo($path)) {
+            // @codeCoverageIgnoreStart
+            throw new WorkerException('Unable to write the worker configuration to a temporary file');
+            // @codeCoverageIgnoreEnd
+        }
+
+        $this->temporaryFiles[] = $path;
+
+        return $path;
+    }
+
+    private function sourceMapFileForChildProcess(): string
+    {
+        if (!ConfigurationRegistry::get()->source()->notEmpty()) {
+            return '';
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'phpunit_');
+
+        if ($path === false) {
+            // @codeCoverageIgnoreStart
+            return '';
+            // @codeCoverageIgnoreEnd
+        }
+
+        if (!SourceMapper::saveTo($path, ConfigurationRegistry::get()->source())) {
+            // @codeCoverageIgnoreStart
+            return '';
+            // @codeCoverageIgnoreEnd
+        }
+
+        $this->temporaryFiles[] = $path;
+
+        return $path;
+    }
+}

--- a/src/Runner/Parallel/templates/worker.tpl
+++ b/src/Runner/Parallel/templates/worker.tpl
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+use PHPUnit\Event\Facade;
+use PHPUnit\Framework\TestRunner\ChildProcessOutputCollector;
+use PHPUnit\Framework\TestRunner\ErrorHandlerBootstrapper;
+use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
+use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
+use PHPUnit\TextUI\Configuration\PhpHandler;
+use PHPUnit\TextUI\Configuration\SourceMapper;
+use PHPUnit\TestRunner\TestResult\PassedTests;
+use PHPUnit\Util\DifferBuilder;
+
+// The real standard output is captured as the worker's control channel before
+// STDOUT is potentially redirected to capture the output produced by tests.
+$__phpunit_worker_control = fopen('php://fd/1', 'wb');
+
+// php://stdout does not obey output buffering. Any output would break
+// unserialization of child process results in the parent process.
+if (!defined('STDOUT')) {
+    define('STDOUT', fopen('php://temp', 'w+b'));
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+
+{iniSettings}
+ini_set('display_errors', 'stderr');
+if (get_include_path() !== '{include_path}') {
+    set_include_path('{include_path}');
+}
+
+$__phpunit_composerAutoload = {composerAutoload};
+$__phpunit_phar             = {phar};
+
+ob_start();
+
+if ($__phpunit_composerAutoload) {
+    require_once $__phpunit_composerAutoload;
+
+    define('PHPUNIT_COMPOSER_INSTALL', $__phpunit_composerAutoload);
+} else if ($__phpunit_phar) {
+    require $__phpunit_phar;
+}
+
+ConfigurationRegistry::loadFrom('{serializedConfiguration}');
+
+DifferBuilder::configureComparatorFactory();
+
+if ('{sourceMapFile}' !== '') {
+    SourceMapper::loadFrom('{sourceMapFile}', ConfigurationRegistry::get()->source());
+}
+
+(new PhpHandler)->handle(ConfigurationRegistry::get()->php());
+
+if ('{bootstrap}' !== '') {
+    require_once '{bootstrap}';
+}
+
+$__phpunit_configuration = ConfigurationRegistry::get();
+
+if ({collectCodeCoverageInformation}) {
+    CodeCoverage::instance()->init($__phpunit_configuration, CodeCoverageFilterRegistry::instance(), true);
+}
+
+ErrorHandlerBootstrapper::bootstrap($__phpunit_configuration);
+
+ob_end_clean();
+
+function __phpunit_worker_run_test(object $command): string
+{
+    $dispatcher = Facade::instance()->initForIsolation(
+        PHPUnit\Event\Telemetry\HRTime::fromSecondsAndNanoseconds(
+            $command->offsetSeconds,
+            $command->offsetNanoseconds
+        ),
+    );
+
+    require_once $command->file;
+
+    $className  = $command->className;
+    $methodName = $command->methodName;
+
+    $test = new $className($methodName);
+
+    $test->setData($command->dataName, unserialize(base64_decode($command->data)));
+    $test->setDependencyInput(unserialize(base64_decode($command->dependencyInput)));
+    $test->setRepetition($command->repetition, $command->totalRepetitions);
+    $test->setAttempt($command->attempt, $command->maxAttempts);
+    $test->setInIsolation(true);
+
+    $test->run();
+
+    $output = ChildProcessOutputCollector::collect($test);
+
+    $codeCoverage = null;
+
+    if (CodeCoverage::instance()->isActive()) {
+        $codeCoverage = CodeCoverage::instance()->codeCoverage();
+    }
+
+    $result = $command->nonce . serialize(
+        (object) [
+            'testResult'    => $test->result(),
+            'status'        => $test->status(),
+            'codeCoverage'  => $codeCoverage,
+            'numAssertions' => $test->numberOfAssertionsPerformed(),
+            'output'        => $output,
+            'events'        => $dispatcher->flush(),
+            'passedTests'   => PassedTests::instance(),
+        ]
+    );
+
+    // Per-test code coverage has been collected for this command and is about
+    // to be shipped to the parent process. It is cleared here so that the next
+    // test executed by this worker does not ship it a second time.
+    if (CodeCoverage::instance()->isActive()) {
+        CodeCoverage::instance()->codeCoverage()->clear();
+    }
+
+    // Reset the stream that captures test output so that the next test does
+    // not inherit the output of the test that has just finished.
+    if (@rewind(STDOUT)) {
+        @ftruncate(STDOUT, 0);
+    }
+
+    return $result;
+}
+
+$__phpunit_input = fopen('php://stdin', 'rb');
+
+while (($__phpunit_line = fgets($__phpunit_input)) !== false) {
+    $__phpunit_line = trim($__phpunit_line);
+
+    if ($__phpunit_line === '') {
+        continue;
+    }
+
+    $__phpunit_command = json_decode($__phpunit_line);
+
+    if ($__phpunit_command->command === 'stop') {
+        break;
+    }
+
+    $__phpunit_result = __phpunit_worker_run_test($__phpunit_command);
+
+    file_put_contents($__phpunit_command->resultFile, $__phpunit_result);
+
+    fwrite($__phpunit_worker_control, 'PHPUNIT_WORKER_DONE:' . $__phpunit_command->nonce . "\n");
+    fflush($__phpunit_worker_control);
+}

--- a/tests/_files/parallel-worker/WorkerFirstTest.php
+++ b/tests/_files/parallel-worker/WorkerFirstTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ParallelWorker;
+
+use PHPUnit\Framework\TestCase;
+
+final class WorkerFirstTest extends TestCase
+{
+    public function testStartsTheProcessLocalCounter(): void
+    {
+        $this->assertSame(1, WorkerProcessProbe::increment());
+    }
+}

--- a/tests/_files/parallel-worker/WorkerProcessProbe.php
+++ b/tests/_files/parallel-worker/WorkerProcessProbe.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ParallelWorker;
+
+/**
+ * Holds process-local state so that tests can assert whether they are executed
+ * in the same process as a previous test.
+ */
+final class WorkerProcessProbe
+{
+    private static int $counter = 0;
+
+    public static function increment(): int
+    {
+        self::$counter++;
+
+        return self::$counter;
+    }
+
+    public static function value(): int
+    {
+        return self::$counter;
+    }
+}

--- a/tests/_files/parallel-worker/WorkerSecondTest.php
+++ b/tests/_files/parallel-worker/WorkerSecondTest.php
@@ -9,10 +9,25 @@
  */
 namespace PHPUnit\TestFixture\ParallelWorker;
 
+use function fopen;
+use function fwrite;
 use PHPUnit\Framework\TestCase;
 
 final class WorkerSecondTest extends TestCase
 {
+    public function testThatWritesStrayOutputWithoutANewlineToTheControlChannel(): void
+    {
+        // Writes directly to the worker's control channel (file descriptor 1)
+        // without a trailing newline, so that the stray output fuses with the
+        // completion marker the worker appends on the same line. The parent
+        // must still recognise the marker.
+        $controlChannel = fopen('php://fd/1', 'wb');
+
+        fwrite($controlChannel, 'stray output without a trailing newline');
+
+        $this->assertTrue(true);
+    }
+
     public function testSeesTheStateLeftBehindByTheFirstTest(): void
     {
         // Passes only when this test shares a process with WorkerFirstTest,

--- a/tests/_files/parallel-worker/WorkerSecondTest.php
+++ b/tests/_files/parallel-worker/WorkerSecondTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ParallelWorker;
+
+use PHPUnit\Framework\TestCase;
+
+final class WorkerSecondTest extends TestCase
+{
+    public function testSeesTheStateLeftBehindByTheFirstTest(): void
+    {
+        // Passes only when this test shares a process with WorkerFirstTest,
+        // which is what running both tests in one persistent worker provides.
+        $this->assertSame(1, WorkerProcessProbe::value());
+        $this->assertSame(2, WorkerProcessProbe::increment());
+    }
+
+    public function testThatFails(): void
+    {
+        $this->assertTrue(false, 'intentional failure inside a persistent worker');
+    }
+
+    public function testThatKillsTheWorkerProcess(): void
+    {
+        // Terminates the worker before it can report a result, exercising the
+        // parent's handling of a worker that dies in the middle of a test.
+        exit(1);
+    }
+}

--- a/tests/unit/Runner/Parallel/PersistentWorkerTest.php
+++ b/tests/unit/Runner/Parallel/PersistentWorkerTest.php
@@ -71,6 +71,24 @@ final class PersistentWorkerTest extends TestCase
         );
     }
 
+    public function testRecognizesCompletionEvenWhenATestLeavesStrayOutputOnTheControlChannel(): void
+    {
+        $worker = $this->worker();
+
+        $worker->start();
+
+        $stray = new WorkerSecondTest('testThatWritesStrayOutputWithoutANewlineToTheControlChannel');
+
+        $worker->run($stray);
+
+        $worker->stop();
+
+        // The completion marker fuses with the stray output the test wrote to
+        // the control channel without a trailing newline; the worker is only
+        // reported as succeeding if the parent still recognizes the marker.
+        $this->assertTrue($stray->status()->isSuccess());
+    }
+
     public function testReportsAnErrorWhenTheWorkerDiesWhileRunningATest(): void
     {
         $worker = $this->worker();

--- a/tests/unit/Runner/Parallel/PersistentWorkerTest.php
+++ b/tests/unit/Runner/Parallel/PersistentWorkerTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\Parallel;
+
+use PHPUnit\Event\Emitter;
+use PHPUnit\Event\Facade;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Large;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestRunner\ChildProcessResultProcessor;
+use PHPUnit\Runner\CodeCoverage;
+use PHPUnit\TestFixture\ParallelWorker\WorkerFirstTest;
+use PHPUnit\TestFixture\ParallelWorker\WorkerSecondTest;
+use PHPUnit\TestRunner\TestResult\PassedTests;
+use PHPUnit\Util\PHP\Job;
+use PHPUnit\Util\PHP\JobRunner;
+
+#[CoversClass(PersistentWorker::class)]
+#[UsesClass(JobRunner::class)]
+#[UsesClass(Job::class)]
+#[Large]
+final class PersistentWorkerTest extends TestCase
+{
+    public function testRunsMultipleTestsFromDifferentClassesInOneProcess(): void
+    {
+        $worker = $this->worker();
+
+        $worker->start();
+
+        $first  = new WorkerFirstTest('testStartsTheProcessLocalCounter');
+        $second = new WorkerSecondTest('testSeesTheStateLeftBehindByTheFirstTest');
+
+        $worker->run($first);
+        $worker->run($second);
+
+        $worker->stop();
+
+        $this->assertTrue($first->status()->isSuccess());
+        $this->assertSame(1, $first->numberOfAssertionsPerformed());
+
+        // The second test only passes if it ran in the same process as the
+        // first one, which is what reusing a single worker provides.
+        $this->assertTrue($second->status()->isSuccess());
+        $this->assertSame(2, $second->numberOfAssertionsPerformed());
+    }
+
+    public function testReportsFailingTestsBackToTheParentProcess(): void
+    {
+        $worker = $this->worker();
+
+        $worker->start();
+
+        $failing = new WorkerSecondTest('testThatFails');
+
+        $worker->run($failing);
+
+        $worker->stop();
+
+        $this->assertTrue($failing->status()->isFailure());
+        $this->assertStringContainsString(
+            'intentional failure inside a persistent worker',
+            $failing->status()->message(),
+        );
+    }
+
+    public function testReportsAnErrorWhenTheWorkerDiesWhileRunningATest(): void
+    {
+        $worker = $this->worker();
+
+        $worker->start();
+
+        $crashing = new WorkerSecondTest('testThatKillsTheWorkerProcess');
+
+        $worker->run($crashing);
+
+        $worker->stop();
+
+        $this->assertTrue($crashing->status()->isError());
+    }
+
+    private function worker(): PersistentWorker
+    {
+        $processor = new ChildProcessResultProcessor(
+            new Facade,
+            $this->createStub(Emitter::class),
+            new PassedTests,
+            new CodeCoverage,
+        );
+
+        return new PersistentWorker(new JobRunner($processor), $processor);
+    }
+}


### PR DESCRIPTION
This is the next step towards native parallel test execution in PHPUnit, building on the async-capable `JobRunner` that was implemented separately in d667e2d9e14449f29360d2b96da8296bb498e1bf.

Rather than introducing a new subsystem, the changes proposed here generalize the existing process isolation implementation, which already runs a test in a separate process and faithfully reconstitutes its outcome in the parent, from "one synchronous child per test" toward "a reusable worker that runs many tests."

This PR does not wire anything into the CLI. There is no scheduler, worker pool, or `--parallel` option here. Sequential execution remains the only behavior a user can trigger, and process isolation is unchanged.

This work depends on the `JobRunner` refactor that split process spawning (`proc_open()`) from reaping (`proc_close()`) via the `RunningJob` handle, and added `JobRunner::start()` to spawn a long-lived process whose stdin stays open as a control channel. That change is already on `main`; this PR leverages it.

### Design notes / trade-offs

- Tests run by one worker share a process and therefore do not get per-test global-state isolation; this is what allows the bootstrap cost to be amortized
- Code coverage is cleared per command; each envelope ships only that test's coverage, which the parent merges
- `PassedTests` is shipped cumulatively, which is harmless because its import is idempotent
- Concurrency uses `proc_open()` and `stream_select()` only, so there is no new runtime requirement beyond what process isolation already needs