### PR TITLE
Add negated string assertions for ignoring line endings

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -2405,6 +2405,14 @@ abstract class Assert
     }
 
     /**
+     * @throws ExpectationFailedException
+     */
+    final public static function assertStringNotContainsStringIgnoringLineEndings(string $needle, string $haystack, string $message = ''): void
+    {
+        self::assertThat($haystack, new LogicalNot(new StringContains($needle, false, true)), $message);
+    }
+
+    /**
      * Asserts that two strings are equal except for line endings.
      *
      * @throws ExpectationFailedException
@@ -2412,6 +2420,22 @@ abstract class Assert
     final public static function assertStringEqualsStringIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
     {
         self::assertThat($actual, new StringEqualsStringIgnoringLineEndings($expected), $message);
+    }
+
+    /**
+     * Asserts that two strings are not equal except for line endings.
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertStringNotEqualsStringIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
+    {
+        self::assertThat(
+            $actual,
+            new LogicalNot(
+                self::stringEqualsStringIgnoringLineEndings($expected),
+            ),
+            $message,
+        );
     }
 
     /**

--- a/src/Framework/Assert/Functions.php
+++ b/src/Framework/Assert/Functions.php
@@ -2638,6 +2638,20 @@ if (!function_exists('PHPUnit\Framework\assertStringContainsStringIgnoringLineEn
     }
 }
 
+if (!function_exists('PHPUnit\Framework\assertStringNotContainsStringIgnoringLineEndings')) {
+    /**
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertStringNotContainsStringIgnoringLineEndings
+     */
+    function assertStringNotContainsStringIgnoringLineEndings(string $needle, string $haystack, string $message = ''): void
+    {
+        Assert::assertStringNotContainsStringIgnoringLineEndings($needle, $haystack, $message);
+    }
+}
+
 if (!function_exists('PHPUnit\Framework\assertStringEqualsStringIgnoringLineEndings')) {
     /**
      * Asserts that two strings are equal except for line endings.
@@ -2651,6 +2665,22 @@ if (!function_exists('PHPUnit\Framework\assertStringEqualsStringIgnoringLineEndi
     function assertStringEqualsStringIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
     {
         Assert::assertStringEqualsStringIgnoringLineEndings($expected, $actual, $message);
+    }
+}
+
+if (!function_exists('PHPUnit\Framework\assertStringNotEqualsStringIgnoringLineEndings')) {
+    /**
+     * Asserts that two strings are not equal except for line endings.
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertStringNotEqualsStringIgnoringLineEndings
+     */
+    function assertStringNotEqualsStringIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
+    {
+        Assert::assertStringNotEqualsStringIgnoringLineEndings($expected, $actual, $message);
     }
 }
 

--- a/tests/unit/Framework/Assert/assertStringNotContainsStringIgnoringLineEndingsTest.php
+++ b/tests/unit/Framework/Assert/assertStringNotContainsStringIgnoringLineEndingsTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertStringNotContainsStringIgnoringLineEndings')]
+#[TestDox('assertStringNotContainsStringIgnoringLineEndings()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertStringNotContainsStringIgnoringLineEndingsTest extends TestCase
+{
+    #[DataProviderExternal(assertStringContainsStringIgnoringLineEndingsTest::class, 'failureProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(string $needle, string $haystack): void
+    {
+        $this->assertStringNotContainsStringIgnoringLineEndings($needle, $haystack);
+    }
+
+    #[DataProviderExternal(assertStringContainsStringIgnoringLineEndingsTest::class, 'successProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $needle, string $haystack): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertStringNotContainsStringIgnoringLineEndings($needle, $haystack);
+    }
+}

--- a/tests/unit/Framework/Assert/assertStringNotEqualsStringIgnoringLineEndingsTest.php
+++ b/tests/unit/Framework/Assert/assertStringNotEqualsStringIgnoringLineEndingsTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework;
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\Attributes\TestDox;
+
+#[CoversMethod(Assert::class, 'assertStringNotEqualsStringIgnoringLineEndings')]
+#[CoversMethod(Assert::class, 'stringEqualsStringIgnoringLineEndings')]
+#[TestDox('assertStringNotEqualsStringIgnoringLineEndings()')]
+#[Small]
+#[Group('framework')]
+#[Group('framework/assertions')]
+final class assertStringNotEqualsStringIgnoringLineEndingsTest extends TestCase
+{
+    #[DataProviderExternal(assertStringEqualsStringIgnoringLineEndingsTest::class, 'failureProvider')]
+    public function testSucceedsWhenConstraintEvaluatesToTrue(string $expected, string $actual): void
+    {
+        $this->assertStringNotEqualsStringIgnoringLineEndings($expected, $actual);
+    }
+
+    #[DataProviderExternal(assertStringEqualsStringIgnoringLineEndingsTest::class, 'successProvider')]
+    public function testFailsWhenConstraintEvaluatesToFalse(string $expected, string $actual): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this->assertStringNotEqualsStringIgnoringLineEndings($expected, $actual);
+    }
+}


### PR DESCRIPTION
## Summary

The `IgnoringLineEndings` assertion family was missing its negated counterparts. Every other string assertion family already provides both positive and negative variants:

- `assertStringContainsString` / `assertStringNotContainsString`
- `assertStringContainsStringIgnoringCase` / `assertStringNotContainsStringIgnoringCase`
- `assertStringEqualsStringIgnoringWhitespace` / `assertStringNotEqualsStringIgnoringWhitespace`

This adds the two missing methods:

- `assertStringNotContainsStringIgnoringLineEndings()`
- `assertStringNotEqualsStringIgnoringLineEndings()`

## Changes

- `src/Framework/Assert.php` — two new assertion methods
- `src/Framework/Assert/Functions.php` — corresponding global function wrappers
- Two new unit tests mirroring the existing whitespace negation test pattern with `DataProviderExternal`

## Testing

Verified with red/green cycle on the line-endings assertion tests:

- Without the implementation: 6 errors, 11 failures (34 tests)
- With the implementation: 34 tests, 51 assertions — all pass

Full `tests/unit/Framework/Assert/` suite also passes (1676 tests).