### PR TITLE
Enter the test-case context before checking a test's requirements

### DIFF
--- a/ChangeLog-13.2.md
+++ b/ChangeLog-13.2.md
@@ -7,6 +7,7 @@ All notable changes of the PHPUnit 13.2 release series are documented in this fi
 ### Fixed
 
 * [#6768](https://github.com/sebastianbergmann/phpunit/issues/6768): Negative priorities for hook methods are rejected by static analysis
+* [#6778](https://github.com/sebastianbergmann/phpunit/issues/6778): Deprecation triggered outside of tests cannot be ignored
 
 ## [13.2.1] - 2026-06-15
 

--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -50,15 +50,15 @@ final readonly class TestBuilder
 
         $data = null;
 
-        if ($this->requirementsSatisfied($className, $methodName) &&
-            !$this->filterExcludesMethod($className, $methodName)) {
-            try {
-                ErrorHandler::instance()->enterTestCaseContext($className, $methodName);
+        try {
+            ErrorHandler::instance()->enterTestCaseContext($className, $methodName);
 
+            if ($this->requirementsSatisfied($className, $methodName) &&
+                !$this->filterExcludesMethod($className, $methodName)) {
                 $data = (new DataProvider)->providedData($className, $methodName);
-            } finally {
-                ErrorHandler::instance()->leaveTestCaseContext();
             }
+        } finally {
+            ErrorHandler::instance()->leaveTestCaseContext();
         }
 
         if ($data !== null && $data !== []) {

--- a/tests/end-to-end/regression/6778.phpt
+++ b/tests/end-to-end/regression/6778.phpt
@@ -1,0 +1,34 @@
+--TEST--
+https://github.com/sebastianbergmann/phpunit/issues/6778
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/6778/phpunit.xml';
+$_SERVER['argv'][] = '--display-deprecations';
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+D                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+1 test triggered 1 deprecation:
+
+1) %sDeprecatedClass.php:%d
+triggered while autoloading a class during requirement checking
+
+Triggered by:
+
+* PHPUnit\TestFixture\Issue6778\RequiresMethodTest::testSomething
+  %sRequiresMethodTest.php:%d
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Deprecations: 1.

--- a/tests/end-to-end/regression/6778/bootstrap.php
+++ b/tests/end-to-end/regression/6778/bootstrap.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+\spl_autoload_register(static function (string $class): void
+{
+    if ($class === 'PHPUnit\TestFixture\Issue6778\DeprecatedClass') {
+        require __DIR__ . '/src/DeprecatedClass.php';
+    }
+});

--- a/tests/end-to-end/regression/6778/phpunit.xml
+++ b/tests/end-to-end/regression/6778/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+         bootstrap="bootstrap.php"
+>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/regression/6778/src/DeprecatedClass.php
+++ b/tests/end-to-end/regression/6778/src/DeprecatedClass.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6778;
+
+use const E_USER_DEPRECATED;
+use function trigger_error;
+
+@trigger_error('triggered while autoloading a class during requirement checking', E_USER_DEPRECATED);
+
+final class DeprecatedClass
+{
+    public function foo(): void
+    {
+    }
+}

--- a/tests/end-to-end/regression/6778/tests/RequiresMethodTest.php
+++ b/tests/end-to-end/regression/6778/tests/RequiresMethodTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Issue6778;
+
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RequiresMethodTest extends TestCase
+{
+    #[Test]
+    #[RequiresMethod(DeprecatedClass::class, 'foo')]
+    public function testSomething(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This fixes a regression introduced in 13.2.0.

When a deprecation is triggered while PHPUnit evaluates a test's requirements — for example, a `#[RequiresMethod]` attribute whose `method_exists()` check autoloads a class that triggers a deprecation as a side effect of being loaded — the deprecation is reported as having been *"triggered outside of tests"*. As a result it cannot be silenced with `#[IgnoreDeprecations]`, it is not written to a generated baseline, and it makes the suite fail under `--fail-on-deprecation`. The same code did not report this deprecation in 13.1.

The cause is in `TestBuilder::build()`: `requirementsSatisfied()` (which performs the requirement checks, and therefore the autoloading) is called *before* `ErrorHandler::enterTestCaseContext()`. Since 13.2 has an error handler active for the non-test-case context during test building, a deprecation triggered there is emitted immediately as "outside of tests" instead of being deferred to the test it belongs to.

This moves the `enterTestCaseContext()`/`leaveTestCaseContext()` window so it also covers `requirementsSatisfied()` and `filterExcludesMethod()`. The deprecation is then deferred and replayed in the context of the test — exactly as already happens for deprecations triggered in data providers — so it is attributed to the test, honours `#[IgnoreDeprecations]`, and is written to the baseline.

A regression test (`tests/end-to-end/regression/6778`) is included; it fails before this change ("triggered outside of tests") and passes after. The full `end-to-end` test suite remains green.

Closes #6778
