### PR TITLE
Do not generate a return statement in the constructor of a test double

### DIFF
--- a/ChangeLog-12.5.md
+++ b/ChangeLog-12.5.md
@@ -2,6 +2,12 @@
 
 All notable changes of the PHPUnit 12.5 release series are documented in this file using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
+## [12.5.31] - 2026-MM-DD
+
+### Fixed
+
+* [#6797](https://github.com/sebastianbergmann/phpunit/issues/6797): Creating a test double for an interface (or class) that declares a constructor triggers a deprecation on PHP 8.6
+
 ## [12.5.30] - 2026-06-15
 
 ### Fixed
@@ -266,6 +272,7 @@ All notable changes of the PHPUnit 12.5 release series are documented in this fi
 * [#6380](https://github.com/sebastianbergmann/phpunit/pull/6380): Allow `Throwable` in `expectExceptionObject()`
 * A PHPUnit notice is now emitted for test methods that create a mock object but do not configure an expectation for it
 
+[12.5.31]: https://github.com/sebastianbergmann/phpunit/compare/12.5.30...12.5
 [12.5.30]: https://github.com/sebastianbergmann/phpunit/compare/12.5.29...12.5.30
 [12.5.29]: https://github.com/sebastianbergmann/phpunit/compare/12.5.28...12.5.29
 [12.5.28]: https://github.com/sebastianbergmann/phpunit/compare/12.5.27...12.5.28

--- a/src/Framework/MockObject/Generator/DoubledMethod.php
+++ b/src/Framework/MockObject/Generator/DoubledMethod.php
@@ -21,6 +21,7 @@ use function preg_replace;
 use function str_contains;
 use function strlen;
 use function strpos;
+use function strtolower;
 use function substr;
 use function substr_count;
 use function trim;
@@ -180,7 +181,7 @@ final class DoubledMethod
         $deprecation  = $this->deprecation;
         $returnResult = '';
 
-        if (!$this->returnType->isNever() && !$this->returnType->isVoid()) {
+        if (strtolower($this->methodName) !== '__construct' && !$this->returnType->isNever() && !$this->returnType->isVoid()) {
             $returnResult = <<<'EOT'
 
 

--- a/tests/end-to-end/mock-objects/generator/4139.phpt
+++ b/tests/end-to-end/mock-objects/generator/4139.phpt
@@ -59,7 +59,5 @@ class %s implements PHPUnit\Framework\MockObject\MockObjectInternal, InterfaceWi
                 'InterfaceWithConstructor', '__construct', $__phpunit_arguments, '', $this
             )
         );
-
-        return $__phpunit_result;
     }
 }


### PR DESCRIPTION
When an interface (or class) that declares a `__construct()` method is doubled, the generated constructor ends with `return $__phpunit_result;`. A constructor cannot declare a return type, so `ReflectionMapper` resolves it to `UnknownType` (neither `void` nor `never`) and `DoubledMethod::generateCode()` emits the return statement. On PHP 8.6 this triggers the `Returning a value from a constructor is deprecated` deprecation.

This suppresses the return statement when the generated method is a constructor. The existing generator test for #4139 (which doubles an interface declaring a constructor) is updated to the corrected output; it fails before this change and passes after.

Closes #6797
