### PR TITLE
Remove dependency on ext-xml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ env.PHP_VERSION }}
-          extensions: none, ctype, curl, dom, json, libxml, mbstring, openssl, phar, tokenizer, xml, xmlwriter, pcntl
+          extensions: none, ctype, curl, dom, json, libxml, mbstring, openssl, phar, tokenizer, xmlwriter, pcntl
           coverage: none
           tools: none
 
@@ -208,7 +208,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, phar, tokenizer, xml, xmlwriter, pcntl
+      PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, phar, tokenizer, xmlwriter, pcntl
       PHP_INI_VALUES: memory_limit=-1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
     strategy:
@@ -288,7 +288,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, pdo, phar, tokenizer, xml, xmlwriter, pcntl
+      PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, pdo, phar, tokenizer, xmlwriter, pcntl
       PHP_INI_VALUES: zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
     strategy:
@@ -396,7 +396,7 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: xdebug
-          extensions: none, ctype, curl, dom, json, libxml, mbstring, pdo, phar, tokenizer, xml, xmlwriter, pcntl
+          extensions: none, ctype, curl, dom, json, libxml, mbstring, pdo, phar, tokenizer, xmlwriter, pcntl
           ini-values: zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
           tools: none
 
@@ -458,7 +458,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PHP_EXTENSIONS: none, ctype, dom, json, fileinfo, iconv, libxml, mbstring, phar, tokenizer, xml, xmlwriter, pcntl
+      PHP_EXTENSIONS: none, ctype, dom, json, fileinfo, iconv, libxml, mbstring, phar, tokenizer, xmlwriter, pcntl
       PHP_INI_VALUES: phar.readonly=0, zend.assertions=1
 
     steps:
@@ -521,7 +521,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PHP_EXTENSIONS: none, ctype, curl, dom, json, fileinfo, iconv, libxml, mbstring, phar, tokenizer, xml, xmlwriter, pcntl
+      PHP_EXTENSIONS: none, ctype, curl, dom, json, fileinfo, iconv, libxml, mbstring, phar, tokenizer, xmlwriter, pcntl
       PHP_INI_VALUES: phar.readonly=0, zend.assertions=1
 
     strategy:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
 
     env:
-      PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, pdo, phar, tokenizer, xml, xmlwriter
+      PHP_EXTENSIONS: none, ctype, curl, dom, json, libxml, mbstring, openssl, pdo, phar, tokenizer, xmlwriter
       PHP_INI_VALUES: memory_limit=-1, zend.assertions=1, error_reporting=-1, log_errors_max_len=0, display_errors=On
 
     strategy:

--- a/build/templates/binary-phar-autoload.php.in
+++ b/build/templates/binary-phar-autoload.php.in
@@ -30,7 +30,7 @@ if (version_compare('8.4.1', PHP_VERSION, '>')) {
     die(1);
 }
 
-$requiredExtensions = ['ctype', 'dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
+$requiredExtensions = ['ctype', 'dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xmlwriter'];
 
 $unavailableExtensions = array_filter(
     $requiredExtensions,

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
-        "ext-xml": "*",
         "ext-xmlwriter": "*",
         "myclabs/deep-copy": "^1.13.4",
         "phar-io/manifest": "^2.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdd1cf0b879485ea837501dd977847ec",
+    "content-hash": "1fbfbe4e5602e48408140696b6b6591b",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -1847,7 +1847,6 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
-        "ext-xml": "*",
         "ext-xmlwriter": "*"
     },
     "platform-dev": {},

--- a/phpunit
+++ b/phpunit
@@ -71,7 +71,7 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
 
 require PHPUNIT_COMPOSER_INSTALL;
 
-$requiredExtensions = ['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xml', 'xmlwriter'];
+$requiredExtensions = ['dom', 'json', 'libxml', 'mbstring', 'tokenizer', 'xmlwriter'];
 
 $unavailableExtensions = array_filter(
     $requiredExtensions,


### PR DESCRIPTION
PHPUnit is not actually using the ext-xml extension. Its own test suite passes for a minimal PHP 8.5 build with the following configure line:

    ./configure --disable-all --enable-option-checking=fatal --enable-werror --enable-ctype --enable-tokenizer --enable-mbstring --enable-dom --with-libxml --enable-xmlwriter --enable-phar --enable-filter

with the following extensions loaded

    [PHP Modules]
    Core
    ctype
    date
    dom
    filter
    hash
    json
    lexbor
    libxml
    mbstring
    pcre
    Phar
    random
    Reflection
    SPL
    standard
    tokenizer
    uri
    xmlwriter
    Zend OPcache

    [Zend Modules]
    Zend OPcache