### PR TITLE
Guard against recursive previous error handler forwarding

### DIFF
--- a/src/Runner/ErrorHandler.php
+++ b/src/Runner/ErrorHandler.php
@@ -74,6 +74,7 @@ final class ErrorHandler
     private ExcludeList $excludeList;
     private bool $enabled                     = false;
     private ?int $originalErrorReportingLevel = null;
+    private bool $isForwarding                = false;
 
     /**
      * @var ?callable
@@ -291,8 +292,14 @@ final class ErrorHandler
 
         if ($errorString === '' || $errorFile === '' || $errorLine < 1) {
             // @codeCoverageIgnoreStart
-            if ($this->previousNonTestCaseErrorHandler !== null) {
-                ($this->previousNonTestCaseErrorHandler)($errorNumber, $errorString, $errorFile, $errorLine);
+            if ($this->previousNonTestCaseErrorHandler !== null && !$this->isForwarding) {
+                $this->isForwarding = true;
+
+                try {
+                    ($this->previousNonTestCaseErrorHandler)($errorNumber, $errorString, $errorFile, $errorLine);
+                } finally {
+                    $this->isForwarding = false;
+                }
             }
 
             return true;
@@ -306,8 +313,14 @@ final class ErrorHandler
          *
          * @see https://github.com/sebastianbergmann/phpunit/issues/6817
          */
-        if ($this->previousNonTestCaseErrorHandler !== null) {
-            ($this->previousNonTestCaseErrorHandler)($errorNumber, $errorString, $errorFile, $errorLine);
+        if ($this->previousNonTestCaseErrorHandler !== null && !$this->isForwarding) {
+            $this->isForwarding = true;
+
+            try {
+                ($this->previousNonTestCaseErrorHandler)($errorNumber, $errorString, $errorFile, $errorLine);
+            } finally {
+                $this->isForwarding = false;
+            }
         }
 
         /**
@@ -1002,7 +1015,7 @@ final class ErrorHandler
 
     private function forwardToPreviousErrorHandler(int $errorNumber, string $errorString, string $errorFile, int $errorLine): bool
     {
-        if ($this->previousErrorHandler === null) {
+        if ($this->previousErrorHandler === null || $this->isForwarding) {
             return false;
         }
 
@@ -1026,9 +1039,13 @@ final class ErrorHandler
             $restoreRequired = true;
         }
 
+        $this->isForwarding = true;
+
         try {
             return (bool) ($this->previousErrorHandler)($errorNumber, $errorString, $errorFile, $errorLine);
         } finally {
+            $this->isForwarding = false;
+
             if ($restoreRequired) {
                 error_reporting($errorReportingLevel);
             }

--- a/tests/end-to-end/error-handler/previous-error-handler-recursion.phpt
+++ b/tests/end-to-end/error-handler/previous-error-handler-recursion.phpt
@@ -1,0 +1,28 @@
+--TEST--
+PHPUnit does not enter an infinite loop when previous error handler calls it back
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-cache-result';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = __DIR__ . '/_files/PreviousErrorHandlerTest.php';
+
+require __DIR__ . '/../../bootstrap.php';
+
+use PHPUnit\Runner\ErrorHandler;
+
+set_error_handler(static function (int $errno, string $errstr, string $errfile, int $errline): bool {
+    return ErrorHandler::instance()->__invoke($errno, $errstr, $errfile, $errline);
+});
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       PHP %s
+
+N                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+OK, but there were issues!
+Tests: 1, Assertions: 1, Notices: 1.


### PR DESCRIPTION
#### Summary

Fix an infinite recursion in `PHPUnit\Runner\ErrorHandler` when PHPUnit forwards an issue to a previously registered error handler and that handler re-enters PHPUnit's error handling.

#### Problem

PHPUnit since 75d896e4aa3a0a1eb7e60364103fef818ba7f108 changed its error handling so that a previously registered error handler is invoked before PHPUnit records an issue. This is important for compatibility with handlers that convert PHP warnings, notices, or deprecations into exceptions: in those cases, the error should become normal control flow observed by the test runner rather than being reported as a PHPUnit issue.

However, this forwarding can create a recursive call cycle when the previous handler triggers another PHP issue or otherwise calls back into PHPUnit's `ErrorHandler` while PHPUnit is already forwarding an issue to it. In that situation, PHPUnit can repeatedly forward between handlers instead of reporting the warning normally, which may lead to a hang, stack exhaustion, or a segmentation fault depending on the environment.

A real-world example of this showed up in a functional test using `mlocati/ip-lib` for CIDR parsing together with Symfony's error handling bridge. That combination interacts with PHP's error-handler stack while warnings are being processed, and with PHPUnit's previous-handler forwarding in place it could trigger the recursive error-handler path. The observed result was that the test process no longer completed reliably and could hang indefinitely or crash instead of producing a normal PHPUnit warning/error report.