### PR TITLE
Test caret/asterisk version operator completeness

### DIFF
--- a/tests/end-to-end/regression/6451.phpt
+++ b/tests/end-to-end/regression/6451.phpt
@@ -13,7 +13,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-....                                                                4 / 4 (100%)
+......                                                              6 / 6 (100%)
 
 Time: %s, Memory: %s
 
@@ -26,4 +26,4 @@ There were 3 PHPUnit test runner warnings:
 3) Version requirement ">= 1" used by PHPUnit\TestFixture\Issue6451\Issue6451Test::testIncompletePhpExtensionVersion() is incomplete, expected a version that consists of major, minor, and patch level ("8.5.0" instead of "8.5", for example)
 
 OK, but there were issues!
-Tests: 4, Assertions: 4, PHPUnit Warnings: 6.
+Tests: 6, Assertions: 6, PHPUnit Warnings: 6.

--- a/tests/end-to-end/regression/6451.phpt
+++ b/tests/end-to-end/regression/6451.phpt
@@ -13,7 +13,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-......                                                              6 / 6 (100%)
+..%c%c..                                                              6 / 6 (100%)
 
 Time: %s, Memory: %s
 
@@ -26,4 +26,4 @@ There were 3 PHPUnit test runner warnings:
 3) Version requirement ">= 1" used by PHPUnit\TestFixture\Issue6451\Issue6451Test::testIncompletePhpExtensionVersion() is incomplete, expected a version that consists of major, minor, and patch level ("8.5.0" instead of "8.5", for example)
 
 OK, but there were issues!
-Tests: 6, Assertions: 6, PHPUnit Warnings: 6.
+Tests: 6, Assertions: 6, PHPUnit Warnings: 6.%A

--- a/tests/end-to-end/regression/6451.phpt
+++ b/tests/end-to-end/regression/6451.phpt
@@ -13,7 +13,7 @@ PHPUnit %s by Sebastian Bergmann and contributors.
 
 Runtime: %s
 
-..%c%c..                                                              6 / 6 (100%)
+...S..                                                              6 / 6 (100%)
 
 Time: %s, Memory: %s
 
@@ -26,4 +26,4 @@ There were 3 PHPUnit test runner warnings:
 3) Version requirement ">= 1" used by PHPUnit\TestFixture\Issue6451\Issue6451Test::testIncompletePhpExtensionVersion() is incomplete, expected a version that consists of major, minor, and patch level ("8.5.0" instead of "8.5", for example)
 
 OK, but there were issues!
-Tests: 6, Assertions: 6, PHPUnit Warnings: 6.%A
+Tests: 6, Assertions: 5, PHPUnit Warnings: 6, Skipped: 1.

--- a/tests/end-to-end/regression/6451/Issue6451Test.php
+++ b/tests/end-to-end/regression/6451/Issue6451Test.php
@@ -28,6 +28,18 @@ final class Issue6451Test extends TestCase
         $this->assertTrue(true);
     }
 
+    #[RequiresPhp('^8.5')]
+    public function testIncompletePhpunitCaretVersion(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[RequiresPhp('8.5.*')]
+    public function testIncompletePhpunitAsteriskVersion(): void
+    {
+        $this->assertTrue(true);
+    }
+
     #[RequiresPhpExtension('json', '>= 1')]
     public function testIncompletePhpExtensionVersion(): void
     {

--- a/tests/end-to-end/regression/6451/Issue6451Test.php
+++ b/tests/end-to-end/regression/6451/Issue6451Test.php
@@ -28,13 +28,13 @@ final class Issue6451Test extends TestCase
         $this->assertTrue(true);
     }
 
-    #[RequiresPhp('^8.5')]
+    #[RequiresPhp('^8.3')]
     public function testIncompletePhpunitCaretVersion(): void
     {
         $this->assertTrue(true);
     }
 
-    #[RequiresPhp('8.5.*')]
+    #[RequiresPhp('8.3.*')]
     public function testIncompletePhpunitAsteriskVersion(): void
     {
         $this->assertTrue(true);


### PR DESCRIPTION
looking at https://github.com/sebastianbergmann/version-requirement/commit/fe6db86867cd73d4ec425c96743e963defd0bdcd#diff-48dfada243c3603061caeb6193619a86b2168a8e709da0903ceb85a50b86a0f0R61-R66 made me wonder whether the current stable phpunit release handles constraints like `8.5.*` or `^8.5` as complete or incomplete