### PR TITLE
Allow doubling properties that do not declare property hooks

### DIFF
--- a/src/Framework/MockObject/Exception/PropertyCannotBeDoubledException.php
+++ b/src/Framework/MockObject/Exception/PropertyCannotBeDoubledException.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use function sprintf;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class PropertyCannotBeDoubledException extends \PHPUnit\Framework\Exception implements Exception
+{
+    public function __construct(string $type, string $propertyName, string $reason)
+    {
+        parent::__construct(
+            sprintf(
+                'Trying to double property "%s" of class "%s" with doubleProperties(), but %s',
+                $propertyName,
+                $type,
+                $reason,
+            ),
+        );
+    }
+}

--- a/src/Framework/MockObject/Generator/Generator.php
+++ b/src/Framework/MockObject/Generator/Generator.php
@@ -79,6 +79,7 @@ final class Generator
      * @param class-string            $type
      * @param ?list<non-empty-string> $methods
      * @param array<mixed>            $arguments
+     * @param list<non-empty-string>  $doubledProperties
      *
      * @throws ClassIsAnonymousException
      * @throws ClassIsEnumerationException
@@ -91,7 +92,7 @@ final class Generator
      * @throws RuntimeException
      * @throws UnknownTypeException
      */
-    public function testDouble(string $type, bool $mockObject, ?array $methods = [], array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $returnValueGeneration = true): MockObject|Stub
+    public function testDouble(string $type, bool $mockObject, ?array $methods = [], array $arguments = [], string $mockClassName = '', bool $callOriginalConstructor = true, bool $callOriginalClone = true, bool $returnValueGeneration = true, array $doubledProperties = []): MockObject|Stub
     {
         if ($type === Traversable::class) {
             $type = Iterator::class;
@@ -108,6 +109,7 @@ final class Generator
             $methods,
             $mockClassName,
             $callOriginalClone,
+            $doubledProperties,
         );
 
         $object = $this->instantiate(
@@ -200,6 +202,7 @@ final class Generator
     /**
      * @param class-string            $type
      * @param ?list<non-empty-string> $methods
+     * @param list<non-empty-string>  $doubledProperties
      *
      * @throws ClassIsAnonymousException
      * @throws ClassIsEnumerationException
@@ -211,7 +214,7 @@ final class Generator
      *
      * @see https://github.com/sebastianbergmann/phpunit/issues/5476
      */
-    public function generate(string $type, bool $mockObject, ?array $methods = null, string $mockClassName = '', bool $callOriginalClone = true): DoubledClass
+    public function generate(string $type, bool $mockObject, ?array $methods = null, string $mockClassName = '', bool $callOriginalClone = true, array $doubledProperties = []): DoubledClass
     {
         if ($mockClassName !== '') {
             return $this->generateCodeForTestDoubleClass(
@@ -220,6 +223,7 @@ final class Generator
                 $methods,
                 $mockClassName,
                 $callOriginalClone,
+                $doubledProperties,
             );
         }
 
@@ -227,7 +231,8 @@ final class Generator
             $type .
             ($mockObject ? 'MockObject' : 'TestStub') .
             serialize($methods) .
-            serialize($callOriginalClone),
+            serialize($callOriginalClone) .
+            serialize($doubledProperties),
         );
 
         if (!isset(self::$cache[$key])) {
@@ -237,6 +242,7 @@ final class Generator
                 $methods,
                 $mockClassName,
                 $callOriginalClone,
+                $doubledProperties,
             );
         }
 
@@ -341,6 +347,7 @@ final class Generator
     /**
      * @param class-string            $type
      * @param ?list<non-empty-string> $explicitMethods
+     * @param list<non-empty-string>  $doubledProperties
      *
      * @throws ClassIsAnonymousException
      * @throws ClassIsEnumerationException
@@ -349,7 +356,7 @@ final class Generator
      * @throws ReflectionException
      * @throws RuntimeException
      */
-    private function generateCodeForTestDoubleClass(string $type, bool $mockObject, ?array $explicitMethods, string $mockClassName, bool $callOriginalClone): DoubledClass
+    private function generateCodeForTestDoubleClass(string $type, bool $mockObject, ?array $explicitMethods, string $mockClassName, bool $callOriginalClone, array $doubledProperties): DoubledClass
     {
         $classTemplate         = $this->loadTemplate('test_double_class.tpl');
         $additionalInterfaces  = [];
@@ -480,7 +487,7 @@ final class Generator
         }
 
         /** @var ReflectionClass<object> $class */
-        $propertiesWithHooks = $this->properties($class);
+        $propertiesWithHooks = $this->properties($class, $doubledProperties);
         $configurableMethods = $this->configurableMethods($mockMethods, $propertiesWithHooks);
 
         $mockedMethods = '';
@@ -864,10 +871,11 @@ final class Generator
 
     /**
      * @param ReflectionClass<object> $class
+     * @param list<non-empty-string>  $doubledProperties
      *
      * @return list<HookedProperty>
      */
-    private function properties(ReflectionClass $class): array
+    private function properties(ReflectionClass $class, array $doubledProperties): array
     {
         $mapper     = new ReflectionMapper;
         $properties = [];
@@ -882,6 +890,20 @@ final class Generator
             }
 
             if (!$property->hasHooks()) {
+                if (!in_array($property->getName(), $doubledProperties, true)) {
+                    continue;
+                }
+
+                $properties[] = new HookedProperty(
+                    $property->getName(),
+                    $mapper->fromPropertyType($property),
+                    true,
+                    true,
+                    false,
+                    false,
+                    null,
+                );
+
                 continue;
             }
 

--- a/src/Framework/MockObject/TestDoubleBuilder.php
+++ b/src/Framework/MockObject/TestDoubleBuilder.php
@@ -41,6 +41,11 @@ abstract class TestDoubleBuilder
     protected bool $returnValueGeneration = true;
 
     /**
+     * @var list<non-empty-string>
+     */
+    protected array $doubledProperties = [];
+
+    /**
      * @param class-string<T> $type
      */
     public function __construct(string $type)
@@ -86,6 +91,64 @@ abstract class TestDoubleBuilder
         }
 
         $this->methods = array_merge($this->methods, $methods);
+
+        return $this;
+    }
+
+    /**
+     * Specifies properties that do not declare property hooks for which property hooks should be doubled.
+     *
+     * @param list<non-empty-string> $properties
+     *
+     * @throws PropertyCannotBeDoubledException
+     * @throws ReflectionException
+     *
+     * @return $this
+     */
+    public function doubleProperties(array $properties): static
+    {
+        try {
+            $reflector = new ReflectionClass($this->type);
+
+            // @codeCoverageIgnoreStart
+        } catch (\ReflectionException $e) {
+            throw new ReflectionException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e,
+            );
+            // @codeCoverageIgnoreEnd
+        }
+
+        foreach ($properties as $propertyName) {
+            if (!$reflector->hasProperty($propertyName)) {
+                throw new PropertyCannotBeDoubledException($this->type, $propertyName, 'it does not exist');
+            }
+
+            $property = $reflector->getProperty($propertyName);
+
+            if (!$property->isPublic()) {
+                throw new PropertyCannotBeDoubledException($this->type, $propertyName, 'it is not public');
+            }
+
+            if ($property->isStatic()) {
+                throw new PropertyCannotBeDoubledException($this->type, $propertyName, 'it is static');
+            }
+
+            if ($property->isReadOnly()) {
+                throw new PropertyCannotBeDoubledException($this->type, $propertyName, 'it is readonly');
+            }
+
+            if ($property->isFinal()) {
+                throw new PropertyCannotBeDoubledException($this->type, $propertyName, 'it is final');
+            }
+
+            if (!$property->hasType()) {
+                throw new PropertyCannotBeDoubledException($this->type, $propertyName, 'it does not declare a type');
+            }
+        }
+
+        $this->doubledProperties = array_merge($this->doubledProperties, $properties);
 
         return $this;
     }
@@ -183,6 +246,7 @@ abstract class TestDoubleBuilder
             $this->originalConstructor,
             $this->originalClone,
             $this->returnValueGeneration,
+            $this->doubledProperties,
         );
     }
 }

--- a/tests/_files/mock-object/ExtendableClassWithPropertiesThatCannotBeDoubled.php
+++ b/tests/_files/mock-object/ExtendableClassWithPropertiesThatCannotBeDoubled.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\MockObject;
+
+class ExtendableClassWithPropertiesThatCannotBeDoubled
+{
+    public static string $staticProperty = 'value';
+    public readonly string $readonlyProperty;
+    final public string $finalProperty;
+    public $untypedProperty;
+    protected string $protectedProperty = 'value';
+
+    public function __construct()
+    {
+        $this->readonlyProperty = 'value';
+        $this->finalProperty    = 'value';
+    }
+}

--- a/tests/_files/mock-object/ExtendableClassWithPropertiesWithoutHooks.php
+++ b/tests/_files/mock-object/ExtendableClassWithPropertiesWithoutHooks.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\MockObject;
+
+class ExtendableClassWithPropertiesWithoutHooks
+{
+    public string $property      = 'original value';
+    public string $otherProperty = 'original value';
+}

--- a/tests/end-to-end/test-doubles/generator/extendable_class_with_doubled_property_without_hooks.phpt
+++ b/tests/end-to-end/test-doubles/generator/extendable_class_with_doubled_property_without_hooks.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Extendable class with doubled property that does not declare property hooks
+--FILE--
+<?php declare(strict_types=1);
+class Foo
+{
+    public string $bar = 'value';
+}
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+$generator = new \PHPUnit\Framework\MockObject\Generator\Generator;
+
+$testDoubleClass = $generator->generate(
+    type: Foo::class,
+    mockObject: false,
+    methods: [],
+    mockClassName: 'TestStubFoo',
+    doubledProperties: ['bar'],
+);
+
+print $testDoubleClass->classCode();
+--EXPECT--
+declare(strict_types=1);
+
+class TestStubFoo extends Foo implements PHPUnit\Framework\MockObject\StubInternal
+{
+    use PHPUnit\Framework\MockObject\StubApi;
+    use PHPUnit\Framework\MockObject\Method;
+    use PHPUnit\Framework\MockObject\DoubledCloneMethod;
+
+    public string $bar {
+        get {
+            return $this->__phpunit_getInvocationHandler()->invoke(
+                new \PHPUnit\Framework\MockObject\Invocation(
+                    'TestStubFoo', '$bar::get', [], 'string', $this
+                )
+            );
+        }
+
+        set (string $value) {
+            $this->__phpunit_getInvocationHandler()->invoke(
+                new \PHPUnit\Framework\MockObject\Invocation(
+                    'TestStubFoo', '$bar::set', [$value], 'void', $this
+                )
+            );
+        }
+    }
+}

--- a/tests/unit/Framework/MockObject/Creation/MockBuilderTest.php
+++ b/tests/unit/Framework/MockObject/Creation/MockBuilderTest.php
@@ -20,10 +20,12 @@ use PHPUnit\Framework\MockObject\Generator\DuplicateMethodException;
 use PHPUnit\Framework\MockObject\Generator\InvalidClassNameException;
 use PHPUnit\Framework\MockObject\Generator\InvalidMethodNameException;
 use PHPUnit\Framework\MockObject\Generator\NameAlreadyInUseException;
+use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\ExtendableClass;
 use PHPUnit\TestFixture\MockObject\ExtendableClassCallingMethodInConstructor;
 use PHPUnit\TestFixture\MockObject\ExtendableClassWithConstructorArguments;
+use PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesWithoutHooks;
 use PHPUnit\TestFixture\MockObject\InterfaceWithReturnTypeDeclaration;
 
 #[CoversClass(MockBuilder::class)]
@@ -117,5 +119,17 @@ final class MockBuilderTest extends TestCase
         $double->expects($this->once())->method('reset');
 
         $double->second();
+    }
+
+    #[TestDox('doubleProperties() can be used to configure an expectation for a property that does not declare hooks')]
+    public function testExpectationCanBeConfiguredForSetHookForPropertyWithoutHooksWhenPropertyIsDoubled(): void
+    {
+        $double = $this->getMockBuilder(ExtendableClassWithPropertiesWithoutHooks::class)
+            ->doubleProperties(['property'])
+            ->getMock();
+
+        $double->expects($this->once())->method(PropertyHook::set('property'))->with('value');
+
+        $double->property = 'value';
     }
 }

--- a/tests/unit/Framework/MockObject/Creation/TestStubBuilderTest.php
+++ b/tests/unit/Framework/MockObject/Creation/TestStubBuilderTest.php
@@ -17,12 +17,17 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Generator\NameAlreadyInUseException;
+use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\ExtendableClass;
 use PHPUnit\TestFixture\MockObject\ExtendableClassWithConstructorArguments;
+use PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesThatCannotBeDoubled;
+use PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesWithoutHooks;
 use PHPUnit\TestFixture\MockObject\InterfaceWithReturnTypeDeclaration;
 
 #[CoversClass(TestStubBuilder::class)]
+#[CoversClass(TestDoubleBuilder::class)]
+#[CoversClass(PropertyCannotBeDoubledException::class)]
 #[CoversMethod(TestCase::class, 'getStubBuilder')]
 #[Group('test-doubles')]
 #[Group('test-doubles/creation')]
@@ -88,5 +93,89 @@ final class TestStubBuilderTest extends TestCase
             ->getStub();
 
         $this->assertTrue($double->constructorCalled);
+    }
+
+    #[TestDox('doubleProperties() can be used to double a property that does not declare hooks')]
+    public function testGetHookForPropertyWithoutHooksCanBeConfiguredWhenPropertyIsDoubled(): void
+    {
+        $double = $this->getStubBuilder(ExtendableClassWithPropertiesWithoutHooks::class)
+            ->doubleProperties(['property'])
+            ->getStub();
+
+        $double->method(PropertyHook::get('property'))->willReturn('value');
+
+        $this->assertSame('value', $double->property);
+    }
+
+    #[TestDox('doubleProperties() does not affect properties that are not doubled')]
+    public function testPropertyThatIsNotDoubledBehavesLikeRegularProperty(): void
+    {
+        $double = $this->getStubBuilder(ExtendableClassWithPropertiesWithoutHooks::class)
+            ->doubleProperties(['property'])
+            ->getStub();
+
+        $double->otherProperty = 'value';
+
+        $this->assertSame('value', $double->otherProperty);
+    }
+
+    #[TestDox('doubleProperties() cannot be used for a property that does not exist')]
+    public function testPropertyThatDoesNotExistCannotBeDoubled(): void
+    {
+        $this->expectException(PropertyCannotBeDoubledException::class);
+        $this->expectExceptionMessageIs('Trying to double property "doesNotExist" of class "PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesWithoutHooks" with doubleProperties(), but it does not exist');
+
+        $this->getStubBuilder(ExtendableClassWithPropertiesWithoutHooks::class)
+            ->doubleProperties(['doesNotExist']);
+    }
+
+    #[TestDox('doubleProperties() cannot be used for a property that is not public')]
+    public function testPropertyThatIsNotPublicCannotBeDoubled(): void
+    {
+        $this->expectException(PropertyCannotBeDoubledException::class);
+        $this->expectExceptionMessageIs('Trying to double property "protectedProperty" of class "PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesThatCannotBeDoubled" with doubleProperties(), but it is not public');
+
+        $this->getStubBuilder(ExtendableClassWithPropertiesThatCannotBeDoubled::class)
+            ->doubleProperties(['protectedProperty']);
+    }
+
+    #[TestDox('doubleProperties() cannot be used for a property that is static')]
+    public function testPropertyThatIsStaticCannotBeDoubled(): void
+    {
+        $this->expectException(PropertyCannotBeDoubledException::class);
+        $this->expectExceptionMessageIs('Trying to double property "staticProperty" of class "PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesThatCannotBeDoubled" with doubleProperties(), but it is static');
+
+        $this->getStubBuilder(ExtendableClassWithPropertiesThatCannotBeDoubled::class)
+            ->doubleProperties(['staticProperty']);
+    }
+
+    #[TestDox('doubleProperties() cannot be used for a property that is readonly')]
+    public function testPropertyThatIsReadonlyCannotBeDoubled(): void
+    {
+        $this->expectException(PropertyCannotBeDoubledException::class);
+        $this->expectExceptionMessageIs('Trying to double property "readonlyProperty" of class "PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesThatCannotBeDoubled" with doubleProperties(), but it is readonly');
+
+        $this->getStubBuilder(ExtendableClassWithPropertiesThatCannotBeDoubled::class)
+            ->doubleProperties(['readonlyProperty']);
+    }
+
+    #[TestDox('doubleProperties() cannot be used for a property that is final')]
+    public function testPropertyThatIsFinalCannotBeDoubled(): void
+    {
+        $this->expectException(PropertyCannotBeDoubledException::class);
+        $this->expectExceptionMessageIs('Trying to double property "finalProperty" of class "PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesThatCannotBeDoubled" with doubleProperties(), but it is final');
+
+        $this->getStubBuilder(ExtendableClassWithPropertiesThatCannotBeDoubled::class)
+            ->doubleProperties(['finalProperty']);
+    }
+
+    #[TestDox('doubleProperties() cannot be used for a property that does not declare a type')]
+    public function testPropertyThatDoesNotDeclareTypeCannotBeDoubled(): void
+    {
+        $this->expectException(PropertyCannotBeDoubledException::class);
+        $this->expectExceptionMessageIs('Trying to double property "untypedProperty" of class "PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesThatCannotBeDoubled" with doubleProperties(), but it does not declare a type');
+
+        $this->getStubBuilder(ExtendableClassWithPropertiesThatCannotBeDoubled::class)
+            ->doubleProperties(['untypedProperty']);
     }
 }

--- a/tests/unit/Framework/MockObject/Generator/GeneratorTest.php
+++ b/tests/unit/Framework/MockObject/Generator/GeneratorTest.php
@@ -17,8 +17,10 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\TestFixture\MockObject\ExtendableClass;
 use PHPUnit\TestFixture\MockObject\ExtendableClassWithConstructorArguments;
+use PHPUnit\TestFixture\MockObject\ExtendableClassWithPropertiesWithoutHooks;
 use PHPUnit\TestFixture\MockObject\InterfaceExtendingThrowable;
 use PHPUnit\TestFixture\MockObject\InterfaceExtendingTraversable;
+use ReflectionProperty;
 use Traversable;
 
 #[CoversClass(Generator::class)]
@@ -77,5 +79,39 @@ final class GeneratorTest extends TestCase
         $double = (new Generator)->testDouble(InterfaceExtendingThrowable::class, false);
 
         $this->assertInstanceOf(InterfaceExtendingThrowable::class, $double);
+    }
+
+    public function testDoublesPropertyWithoutHooksWhenPropertyIsListedForDoubling(): void
+    {
+        $double = (new Generator)->testDouble(
+            ExtendableClassWithPropertiesWithoutHooks::class,
+            false,
+            [],
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['property'],
+        );
+
+        $this->assertTrue(new ReflectionProperty($double, 'property')->hasHooks());
+        $this->assertFalse(new ReflectionProperty($double, 'otherProperty')->hasHooks());
+    }
+
+    public function testGeneratesCodeForClassWithDoubledPropertyWithoutHooksWhenClassNameIsSpecified(): void
+    {
+        $doubledClass = (new Generator)->generate(
+            ExtendableClassWithPropertiesWithoutHooks::class,
+            false,
+            [],
+            'TestStubWithDoubledPropertyWithoutHooks',
+            true,
+            ['property'],
+        );
+
+        $this->assertStringContainsString('$property::get', $doubledClass->classCode());
+        $this->assertStringContainsString('$property::set', $doubledClass->classCode());
+        $this->assertStringNotContainsString('$otherProperty::get', $doubledClass->classCode());
     }
 }


### PR DESCRIPTION
This pull request implements the remaining part of #6546.

PHPUnit automatically doubles the property hooks of a doubled class or interface: reading from and writing to a hooked property can be configured and verified just like calling a doubled method. Properties that do not declare hooks, however, could not participate in this: on a test double, they behave like regular properties, and there was no way to configure behavior for them or to verify how the tested code interacts with them.

PHP itself allows a child class to add hooks to a property that its parent class declared without hooks. This pull request makes that capability available for test doubles as an explicit opt-in:

```php
$message = $this->getMockBuilder(Message::class)
    ->doubleProperties(['recipient'])
    ->getMock();

$message
    ->expects($this->once())
    ->method(PropertyHook::set('recipient'))
    ->with('user@example.com');
```

The new `doubleProperties()` method is available on both `getMockBuilder()` and `getStubBuilder()`. A property that has been opted in supports everything hooked properties already support: `PropertyHook::get()` and `PropertyHook::set()` can be used to configure return values, callbacks, and expectations.

## Why opt-in?

Doubling a hook-less property changes how it behaves: writes no longer store a value and reads no longer return it, `$double->arrayProperty[] = $item` and references to the property stop working. Assigning values to public properties of test doubles is a widespread pattern (see #6545), so doubling every property unconditionally would break existing test suites. With the opt-in, nothing changes for existing code: properties that are not listed in `doubleProperties()` continue to behave exactly as before.

## Limitations

A property can only be doubled when it exists, is public, is not static, is not readonly, is not final, and declares a type. `doubleProperties()` fails with a clear error message when one of these requirements is not met.