### PR TITLE
Improve error message when configured code coverage file list is empty

### DIFF
--- a/src/Runner/CodeCoverage.php
+++ b/src/Runner/CodeCoverage.php
@@ -541,7 +541,7 @@ final class CodeCoverage
 
         EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(
             sprintf(
-                'Configured source filter (include-path: %s) does not match any files, code coverage will not be processed',
+                'No files to cover found in configured source filter (include-path: %s), code coverage will not be processed',
                 implode(', ', $paths),
             ),
         );


### PR DESCRIPTION
Fixes #4440

## Problem

When running PHPUnit with code coverage in a project where the configured source directories contain no PHP files, the warning message `Configured source filter (include-path: %s) does not match any files, code coverage will not be processed` is shown. This is misleading because it implies the filter configuration is incorrect, when in fact the configuration is fine — there are simply no files to cover.

## Fix

Changed the warning message in `src/Runner/CodeCoverage.php` from:
```
Configured source filter (include-path: %s) does not match any files, code coverage will not be processed
```
to:
```
No files to cover found in configured source filter (include-path: %s), code coverage will not be processed
```

This makes it clear that the issue is that no files were found, not that the configuration is wrong.

/claim #4440