### PR TITLE
More resilient expectation in log-events-verbose-text.phpt

### DIFF
--- a/tests/end-to-end/cli/log-events-verbose-text.phpt
+++ b/tests/end-to-end/cli/log-events-verbose-text.phpt
@@ -51,12 +51,12 @@ unlink($traceFile);
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Assertion Succeeded (Constraint: is identical to Array &0 [
-                                                              0 => 1,
-                                                              'foo' => 2,
-                                                          ], Value: Array &0 [
-                                                              0 => 1,
-                                                              'foo' => 2,
-                                                          ])
+                                                         %s    0 => 1,
+                                                         %s    'foo' => 2,
+                                                         %s], Value: Array &0 [
+                                                         %s    0 => 1,
+                                                         %s    'foo' => 2,
+                                                         %s])
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Passed (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [%s:%s:%s.%s / %s:%s:%s.%s] [%s bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)


### PR DESCRIPTION
I've started getting this on the 10.5 build with xdebug:

```
1) /home/runner/work/php-latest-builds/php-latest-builds/tests/end-to-end/cli/log-events-verbose-text.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 [00:00:00.053333085 / 00:00:00.000200747] [10485760 bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [00:00:00.053541916 / 00:00:00.000208831] [10485760 bytes] Test Prepared (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [00:00:00.053687098 / 00:00:00.000145182] [10485760 bytes] Assertion Succeeded (Constraint: is identical to Array &0 [
-                                                              0 => 1,
-                                                              'foo' => 2,
-                                                          ], Value: Array &0 [
-                                                              0 => 1,
-                                                              'foo' => 2,
-                                                          ])
+                                                               0 => 1,
+                                                               'foo' => 2,
+                                                           ], Value: Array &0 [
+                                                               0 => 1,
+                                                               'foo' => 2,
+                                                           ])
 [00:00:00.053964438 / 00:00:00.000277340] [10485760 bytes] Test Passed (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [00:00:00.054267606 / 00:00:00.000303168] [10485760 bytes] Test Finished (PHPUnit\TestFixture\LogEventsText\Test::testExportArray)
 [00:00:00.054469054 / 00:00:00.000201448] [10485760 bytes] Test Preparation Started (PHPUnit\TestFixture\LogEventsText\Test::testExportObject)

/home/runner/work/php-latest-builds/php-latest-builds/tests/end-to-end/cli/log-events-verbose-text.phpt:54
```

I had seen it before and previously blacklisted the build. Today I took some more time to investigate and I figured I could apply the same fix as e47fce350da16af30dd5833b6fb544732161f898.