### PR TITLE
Apply test selection and global state backup settings in parallel workers

### DIFF
--- a/src/Framework/TestBuilder.php
+++ b/src/Framework/TestBuilder.php
@@ -191,6 +191,29 @@ final readonly class TestBuilder
     }
 
     /**
+     * Applies to a test case the configuration that build() derives from the
+     * metadata of the test method and from the configuration of the test
+     * runner: process isolation, the preservation of global state, and the
+     * backup of global variables and static properties.
+     *
+     * This is for test cases that are not built here but recreated from their
+     * description, in a worker process of a parallel test run, so that such a
+     * test case is configured exactly as it would be in a sequential run.
+     *
+     * @param class-string<TestCase> $className
+     * @param non-empty-string       $methodName
+     */
+    public function configure(TestCase $test, string $className, string $methodName): void
+    {
+        $this->configureTestCase(
+            $test,
+            $this->shouldTestMethodBeRunInSeparateProcess($className, $methodName),
+            $this->shouldGlobalStateBePreserved($className, $methodName),
+            $this->backupSettings($className, $methodName),
+        );
+    }
+
+    /**
      * @param non-empty-string       $methodName
      * @param class-string<TestCase> $className
      * @param array<ProvidedData>    $data

--- a/src/Runner/Parallel/DataProviderSuiteDescriptor.php
+++ b/src/Runner/Parallel/DataProviderSuiteDescriptor.php
@@ -43,7 +43,11 @@ final readonly class DataProviderSuiteDescriptor extends TestDescriptor
     {
         $members = [];
 
-        foreach ($suite->tests() as $member) {
+        // The suite is iterated, not asked for its tests: iterating applies
+        // the filter that test selection (--filter, --group, …) injected into
+        // it, so that only the tests a sequential run would have run travel to
+        // the worker.
+        foreach ($suite as $member) {
             $members[] = TestDescriptor::from($member, $className);
         }
 

--- a/src/Runner/Parallel/RepeatSuiteDescriptor.php
+++ b/src/Runner/Parallel/RepeatSuiteDescriptor.php
@@ -49,7 +49,11 @@ final readonly class RepeatSuiteDescriptor extends TestDescriptor
     {
         $repetitions = [];
 
-        foreach ($suite->tests() as $repetition) {
+        // The suite is iterated, not asked for its tests: iterating applies
+        // the filter that test selection (--filter, --group, …) injected into
+        // it, so that only the repetitions a sequential run would have run
+        // travel to the worker.
+        foreach ($suite as $repetition) {
             assert($repetition instanceof TestCase);
 
             $repetitions[] = TestCaseDescriptor::fromTestCase($repetition, $className);

--- a/src/Runner/Parallel/RetrySuiteDescriptor.php
+++ b/src/Runner/Parallel/RetrySuiteDescriptor.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Runner\Parallel;
 
 use function assert;
 use function count;
+use function iterator_to_array;
 use PHPUnit\Framework\RetryTestSuite;
 use PHPUnit\Framework\TestCase;
 
@@ -44,7 +45,11 @@ final readonly class RetrySuiteDescriptor extends TestDescriptor
      */
     public static function fromTestSuite(RetryTestSuite $suite, string $className): self
     {
-        $aggregated = $suite->tests();
+        // The suite is iterated, not asked for its tests: iterating applies
+        // the filter that test selection (--filter, --group, …) injected into
+        // it, so that a test the selection excluded does not travel to the
+        // worker.
+        $aggregated = iterator_to_array($suite, false);
 
         assert(count($aggregated) === 1 && $aggregated[0] instanceof TestCase);
 

--- a/src/Runner/Parallel/TestCaseDescriptor.php
+++ b/src/Runner/Parallel/TestCaseDescriptor.php
@@ -14,6 +14,7 @@ use function is_array;
 use function serialize;
 use function sprintf;
 use function unserialize;
+use PHPUnit\Framework\TestBuilder;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -137,6 +138,11 @@ final readonly class TestCaseDescriptor extends TestDescriptor
         $test->setDependencyInput($dependencyInput);
         $test->setRepetition($this->repetition, $this->totalRepetitions);
         $test->setAttempt($this->attempt, $this->maxAttempts);
+
+        // The settings that TestBuilder derives from metadata and configuration
+        // do not travel with the descriptor: they are derived again here, from
+        // the same sources, which are available in the worker process as well.
+        (new TestBuilder)->configure($test, $className, $this->methodName);
 
         return $test;
     }

--- a/src/TextUI/ParallelTestRunner.php
+++ b/src/TextUI/ParallelTestRunner.php
@@ -938,6 +938,14 @@ final class ParallelTestRunner
     private function collect(TestSuite $suite, array &$byClass, array &$phpt, array &$standalone, int &$index): void
     {
         foreach ($suite as $test) {
+            // A suite that test selection (--filter, --group, …) has emptied
+            // runs nothing in a sequential run: TestSuite::run() returns early
+            // for an empty suite. It must therefore become neither a unit of
+            // its own nor a member of a class unit here.
+            if ($test instanceof TestSuite && $test->isEmpty()) {
+                continue;
+            }
+
             // The repetitions of a repeated PHPT test and the attempts of a
             // retried PHPT test are orchestrated by their suite's runTests()
             // method and must run sequentially, so the suite runs as one unit

--- a/tests/end-to-end/parallel/selection/_files/FirstSelectionTest.php
+++ b/tests/end-to-end/parallel/selection/_files/FirstSelectionTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ParallelSelection;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+final class FirstSelectionTest extends TestCase
+{
+    public static function provider(): array
+    {
+        return [
+            'one'   => [1],
+            'two'   => [2],
+            'three' => [3],
+        ];
+    }
+
+    #[Group('alpha')]
+    public function testFirstPlain(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('provider')]
+    #[Group('beta')]
+    public function testFirstWithDataProvider(int $value): void
+    {
+        $this->assertGreaterThan(0, $value);
+    }
+}

--- a/tests/end-to-end/parallel/selection/_files/SecondSelectionTest.php
+++ b/tests/end-to-end/parallel/selection/_files/SecondSelectionTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ParallelSelection;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+final class SecondSelectionTest extends TestCase
+{
+    public static function provider(): array
+    {
+        return [
+            'four' => ['four'],
+            'five' => ['five'],
+        ];
+    }
+
+    #[Group('beta')]
+    public function testSecondPlain(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[DataProvider('provider')]
+    #[Group('alpha')]
+    public function testSecondWithDataProvider(string $value): void
+    {
+        $this->assertNotEmpty($value);
+    }
+}

--- a/tests/end-to-end/parallel/selection/exclude-group-in-parallel.phpt
+++ b/tests/end-to-end/parallel/selection/exclude-group-in-parallel.phpt
@@ -1,0 +1,32 @@
+--TEST--
+phpunit --parallel=2 --exclude-group excludes the same tests as a sequential run
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--parallel=2';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--exclude-group';
+$_SERVER['argv'][] = 'beta';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First plain
+
+Second Selection (PHPUnit\TestFixture\ParallelSelection\SecondSelection)
+ ✔ Second with data provider with data set "four"
+ ✔ Second with data provider with data set "five"
+
+OK (3 tests, 3 assertions)

--- a/tests/end-to-end/parallel/selection/exclude-group.phpt
+++ b/tests/end-to-end/parallel/selection/exclude-group.phpt
@@ -1,0 +1,31 @@
+--TEST--
+phpunit --exclude-group excludes the tests of a data provider method that belong to the group
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--exclude-group';
+$_SERVER['argv'][] = 'beta';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+...                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First plain
+
+Second Selection (PHPUnit\TestFixture\ParallelSelection\SecondSelection)
+ ✔ Second with data provider with data set "four"
+ ✔ Second with data provider with data set "five"
+
+OK (3 tests, 3 assertions)

--- a/tests/end-to-end/parallel/selection/filter-data-set-in-parallel.phpt
+++ b/tests/end-to-end/parallel/selection/filter-data-set-in-parallel.phpt
@@ -1,0 +1,28 @@
+--TEST--
+phpunit --parallel=2 --filter selects the same single data set as a sequential run
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--parallel=2';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testFirstWithDataProvider#two';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First with data provider with data set "two"
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/parallel/selection/filter-data-set.phpt
+++ b/tests/end-to-end/parallel/selection/filter-data-set.phpt
@@ -1,0 +1,27 @@
+--TEST--
+phpunit --filter selects a single data set of a data provider method
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testFirstWithDataProvider#two';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+.                                                                   1 / 1 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First with data provider with data set "two"
+
+OK (1 test, 1 assertion)

--- a/tests/end-to-end/parallel/selection/filter-in-parallel.phpt
+++ b/tests/end-to-end/parallel/selection/filter-in-parallel.phpt
@@ -1,0 +1,29 @@
+--TEST--
+phpunit --parallel=2 --filter selects the same tests as a sequential run
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--parallel=2';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testSecondWithDataProvider';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+Second Selection (PHPUnit\TestFixture\ParallelSelection\SecondSelection)
+ ✔ Second with data provider with data set "four"
+ ✔ Second with data provider with data set "five"
+
+OK (2 tests, 2 assertions)

--- a/tests/end-to-end/parallel/selection/filter-matching-nothing-in-parallel.phpt
+++ b/tests/end-to-end/parallel/selection/filter-matching-nothing-in-parallel.phpt
@@ -1,0 +1,21 @@
+--TEST--
+phpunit --parallel=2 --filter that matches no test runs no test, just like a sequential run
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--parallel=2';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testThatDoesNotExist';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+No tests executed!

--- a/tests/end-to-end/parallel/selection/filter-matching-nothing.phpt
+++ b/tests/end-to-end/parallel/selection/filter-matching-nothing.phpt
@@ -1,0 +1,20 @@
+--TEST--
+phpunit --filter that matches no test runs no test
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testThatDoesNotExist';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+No tests executed!

--- a/tests/end-to-end/parallel/selection/filter.phpt
+++ b/tests/end-to-end/parallel/selection/filter.phpt
@@ -1,0 +1,28 @@
+--TEST--
+phpunit --filter selects the tests of a data provider method and nothing from a class without a selected test
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testSecondWithDataProvider';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+..                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+Second Selection (PHPUnit\TestFixture\ParallelSelection\SecondSelection)
+ ✔ Second with data provider with data set "four"
+ ✔ Second with data provider with data set "five"
+
+OK (2 tests, 2 assertions)

--- a/tests/end-to-end/parallel/selection/group-in-parallel.phpt
+++ b/tests/end-to-end/parallel/selection/group-in-parallel.phpt
@@ -1,0 +1,33 @@
+--TEST--
+phpunit --parallel=2 --group selects the same tests as a sequential run
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--parallel=2';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--group';
+$_SERVER['argv'][] = 'beta';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+....                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First with data provider with data set "one"
+ ✔ First with data provider with data set "two"
+ ✔ First with data provider with data set "three"
+
+Second Selection (PHPUnit\TestFixture\ParallelSelection\SecondSelection)
+ ✔ Second plain
+
+OK (4 tests, 4 assertions)

--- a/tests/end-to-end/parallel/selection/group.phpt
+++ b/tests/end-to-end/parallel/selection/group.phpt
@@ -1,0 +1,32 @@
+--TEST--
+phpunit --group selects the tests of a data provider method that belong to the group
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--group';
+$_SERVER['argv'][] = 'beta';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+....                                                                4 / 4 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First with data provider with data set "one"
+ ✔ First with data provider with data set "two"
+ ✔ First with data provider with data set "three"
+
+Second Selection (PHPUnit\TestFixture\ParallelSelection\SecondSelection)
+ ✔ Second plain
+
+OK (4 tests, 4 assertions)

--- a/tests/end-to-end/parallel/selection/repeat-with-filter-in-parallel.phpt
+++ b/tests/end-to-end/parallel/selection/repeat-with-filter-in-parallel.phpt
@@ -1,0 +1,35 @@
+--TEST--
+phpunit --parallel=2 --repeat 2 --filter repeats the same data sets as a sequential run
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--parallel=2';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--repeat';
+$_SERVER['argv'][] = '2';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testFirstWithDataProvider';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+......                                                              6 / 6 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First with data provider with data set "one" (repetition 1 of 2)
+ ✔ First with data provider with data set "one" (repetition 2 of 2)
+ ✔ First with data provider with data set "two" (repetition 1 of 2)
+ ✔ First with data provider with data set "two" (repetition 2 of 2)
+ ✔ First with data provider with data set "three" (repetition 1 of 2)
+ ✔ First with data provider with data set "three" (repetition 2 of 2)
+
+OK (6 tests, 6 assertions)

--- a/tests/end-to-end/parallel/selection/repeat-with-filter.phpt
+++ b/tests/end-to-end/parallel/selection/repeat-with-filter.phpt
@@ -1,0 +1,34 @@
+--TEST--
+phpunit --repeat 2 --filter repeats only the data sets of the selected data provider method
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--testdox';
+$_SERVER['argv'][] = '--repeat';
+$_SERVER['argv'][] = '2';
+$_SERVER['argv'][] = '--filter';
+$_SERVER['argv'][] = 'testFirstWithDataProvider';
+$_SERVER['argv'][] = __DIR__ . '/_files/';
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime:       %s
+
+......                                                              6 / 6 (100%)
+
+Time: %s, Memory: %s
+
+First Selection (PHPUnit\TestFixture\ParallelSelection\FirstSelection)
+ ✔ First with data provider with data set "one" (repetition 1 of 2)
+ ✔ First with data provider with data set "one" (repetition 2 of 2)
+ ✔ First with data provider with data set "two" (repetition 1 of 2)
+ ✔ First with data provider with data set "two" (repetition 2 of 2)
+ ✔ First with data provider with data set "three" (repetition 1 of 2)
+ ✔ First with data provider with data set "three" (repetition 2 of 2)
+
+OK (6 tests, 6 assertions)

--- a/tests/unit/Framework/TestBuilderTest.php
+++ b/tests/unit/Framework/TestBuilderTest.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Framework;
 
 use function iterator_to_array;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\TestCase\GlobalStateCapture;
 use PHPUnit\TestFixture\TestBuilder\TestWithBackupExcludeListAttributes;
@@ -26,6 +27,21 @@ use ReflectionProperty;
 #[Small]
 final class TestBuilderTest extends TestCase
 {
+    /**
+     * @return array<string, array{class-string<TestCase>, non-empty-string}>
+     */
+    public static function provider(): array
+    {
+        return [
+            'without metadata for isolation'                    => [TestWithoutIsolationAttributes::class, 'testOne'],
+            'with class-level metadata for isolation'           => [TestWithClassLevelIsolationAttributes::class, 'testOne'],
+            'with method-level metadata for isolation'          => [TestWithMethodLevelIsolationAttributes::class, 'testOne'],
+            'with inherited class-level metadata for isolation' => [TestWithInheritedClassLevelIsolationAttributes::class, 'testOne'],
+            'with metadata for excluding global state'          => [TestWithBackupExcludeListAttributes::class, 'testOne'],
+            'with data provider'                                => [TestWithDataProvider::class, 'testOne'],
+        ];
+    }
+
     public function testBuildsTestWithoutMetadataForIsolation(): void
     {
         $test = (new TestBuilder)->build(
@@ -131,5 +147,80 @@ final class TestBuilderTest extends TestCase
         $this->assertSame(TestWithDataProvider::class, $test->className());
         $this->assertSame('testOne', $test->methodName());
         $this->assertTrue($test->testData()->hasDataFromDataProvider());
+    }
+
+    public function testConfiguresTestWithClassLevelMetadataForIsolation(): void
+    {
+        $test = new TestWithClassLevelIsolationAttributes('testOne');
+
+        (new TestBuilder)->configure($test, TestWithClassLevelIsolationAttributes::class, 'testOne');
+
+        $this->assertTrue(new ReflectionProperty(TestCase::class, 'runTestInSeparateProcess')->getValue($test));
+
+        $globalStateCapture = new ReflectionProperty(TestCase::class, 'globalStateCapture')->getValue($test);
+
+        $this->assertTrue(new ReflectionProperty(GlobalStateCapture::class, 'backupGlobals')->getValue($globalStateCapture));
+        $this->assertTrue(new ReflectionProperty(GlobalStateCapture::class, 'backupStaticProperties')->getValue($globalStateCapture));
+    }
+
+    public function testConfiguresTestWithMetadataForExcludingGlobalStateFromBackup(): void
+    {
+        $test = new TestWithBackupExcludeListAttributes('testOne');
+
+        (new TestBuilder)->configure($test, TestWithBackupExcludeListAttributes::class, 'testOne');
+
+        $globalStateCapture = new ReflectionProperty(TestCase::class, 'globalStateCapture')->getValue($test);
+
+        $this->assertSame(
+            ['variable'],
+            new ReflectionProperty(GlobalStateCapture::class, 'backupGlobalsExcludeList')->getValue($globalStateCapture),
+        );
+
+        $this->assertSame(
+            [TestWithBackupExcludeListAttributes::class => ['firstProperty', 'secondProperty']],
+            new ReflectionProperty(GlobalStateCapture::class, 'backupStaticPropertiesExcludeList')->getValue($globalStateCapture),
+        );
+    }
+
+    /**
+     * @param class-string<TestCase> $className
+     * @param non-empty-string       $methodName
+     */
+    #[DataProvider('provider')]
+    public function testConfiguresTestTheSameWayAsItBuildsIt(string $className, string $methodName): void
+    {
+        $built = (new TestBuilder)->build(new ReflectionClass($className), $methodName);
+
+        if ($built instanceof DataProviderTestSuite) {
+            $built = iterator_to_array($built)[0];
+        }
+
+        $this->assertInstanceOf(TestCase::class, $built);
+
+        $configured = new $className($methodName);
+
+        (new TestBuilder)->configure($configured, $className, $methodName);
+
+        $this->assertSame(
+            $this->configurationOf($built),
+            $this->configurationOf($configured),
+        );
+    }
+
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    private function configurationOf(TestCase $test): array
+    {
+        $globalStateCapture = new ReflectionProperty(TestCase::class, 'globalStateCapture')->getValue($test);
+
+        return [
+            'runTestInSeparateProcess'          => new ReflectionProperty(TestCase::class, 'runTestInSeparateProcess')->getValue($test),
+            'preserveGlobalState'               => new ReflectionProperty(TestCase::class, 'preserveGlobalState')->getValue($test),
+            'backupGlobals'                     => new ReflectionProperty(GlobalStateCapture::class, 'backupGlobals')->getValue($globalStateCapture),
+            'backupGlobalsExcludeList'          => new ReflectionProperty(GlobalStateCapture::class, 'backupGlobalsExcludeList')->getValue($globalStateCapture),
+            'backupStaticProperties'            => new ReflectionProperty(GlobalStateCapture::class, 'backupStaticProperties')->getValue($globalStateCapture),
+            'backupStaticPropertiesExcludeList' => new ReflectionProperty(GlobalStateCapture::class, 'backupStaticPropertiesExcludeList')->getValue($globalStateCapture),
+        ];
     }
 }


### PR DESCRIPTION
Hi Sebastian,

you asked whether native parallel test execution would be usable for TYPO3 CMS, so we tried it out on the core test suites. Thank you for the invitation, it was an interesting exercise, and this pull request offers back the two fixes we needed to get there.

Short answer to your question: **yes**. With the two fixes below, the whole TYPO3 core unit suite (11694 tests) passes with `--parallel` with the same test and assertion counts as a sequential run, and the functional suites pass as well. In our CI, two parallel functional jobs replace four sequential ones and the slowest job goes from 342s to 211s.

The first two commits are the fixes, the last two only add tests and are kept separate so you can drop or rewrite them on their own.

Your distribution unit is what makes this work for us: one test class per worker is exactly the isolation unit our testing framework already uses, since it derives both the test instance directory and the test database name from the test class name. So workers do not collide on either, and we needed no change at all to that part.

## The two fixes

**1. Test selection was not applied to the tests executed in workers**

`--filter`, `--group` and `--exclude-group` were silently ignored for every test living inside a data provider, repeat or retry suite. Selecting a single test method of a class ran all 107 tests of that class; a `--filter` on our whole unit suite ran 7774 tests instead of 11.

The cause is that the descriptors asked the suite for its tests, and `TestSuite::tests()` returns the raw array, while selection is a filter iterator that only applies when the suite is iterated, as `TestSuite::takeTests()` does in a sequential run. Plain test methods were filtered correctly, which is what made this hard to spot.

The descriptors now iterate the suite. The collection walk additionally skips a suite that the selection has emptied, for which `TestSuite::run()` returns early in a sequential run.

This one mattered a lot to us: our whole database matrix builds on `--exclude-group not-<dbms>`, so a SQLite job was executing the MySQL-only tests.

**2. Per test global state backup was not applied to the tests executed in workers**

A test case recreated from its descriptor never received the settings `TestBuilder` derives from metadata and configuration, so `backupGlobals` and `backupStaticProperties` had no effect inside a worker and state leaked from one test of a class to the next. A single test class run with `--parallel 2` was enough to show it, so no interaction between classes is needed to trigger it. The `--globals-backup` and `--static-backup` options and the `#[BackupGlobals]` attribute were equally ineffective.

The descriptor now delegates to `TestBuilder` to derive those settings again in the worker, where the metadata and the configuration are available as well. `preserveGlobalState` and the exclude lists take the same path and are covered by the same change.

## Verification

Both fixes were checked against sequential runs and against your own suites:

- For each of `--filter`, `--group`, `--exclude-group`, `--repeat` and `--retry`, the parallel run now selects the same tests as the sequential one, and the full `--testdox` output is identical, not only the counts.
- On PHPUnit's own unit suite, `--testsuite unit --parallel 4 --filter toString` went from 2720 tests with 528 errors to the 9 tests a sequential run selects.
- For the state backup, a class whose first test writes `$GLOBALS` and whose second asserts it is clean now passes in parallel, as does the static property equivalent and the class level attribute variant.
- `tests/end-to-end`, `tests/end-to-end/parallel` and `tests/unit` show the same failures before and after both changes, and the failing sets are identical file by file. The five failures under `tests/end-to-end/parallel` (`exclusivity`, `stop-on-clean`, and three `stop-on-failure` variants) are pre-existing on the branch here and untouched by this.
- `php-cs-fixer --dry-run` and `phpstan` are clean on the changed files.

## The two test commits, offered separately

The last two commits only add tests, and they are deliberately kept apart from the two fixes so you can drop or rewrite either of them without touching the rest.

**`Add tests for test selection in parallel test runs`** adds `tests/end-to-end/parallel/selection/`: six pairs of PHPT files sharing one fixture. Each pair runs the same selection sequentially and with `--parallel=2`, and both files of a pair pin the *same* `--EXPECTF--` block, so a `diff` of a pair shows only the `--TEST--` sentence and the added `--parallel=2` line. The sequential file documents what a selection selects, the parallel file asserts a parallel run selects the same. The pairs cover `--filter` on a data provider method, `--filter` on a single data set, `--group`, `--exclude-group`, a `--filter` that matches nothing, and `--repeat` combined with `--filter`. They use `--testdox`, so the expectation names the selected tests rather than only counting them.

The fixture is data provider driven on purpose: a plain test method was selected correctly even before the fix, so a fixture of plain test methods would pass either way and prove nothing. Reverting the selection fix makes all six parallel files fail and leaves all six sequential ones passing; each of the six then runs the whole fixture of 7 tests instead of the 2, 1, 4, 3, 0 and 6 tests the selection asks for.

**`Add tests for the configuration of test cases recreated in a worker`** covers `TestBuilder::configure()` in `tests/unit/Framework/TestBuilderTest.php`, reusing the fixtures already there. Besides two tests pinning concrete settings, the main one asserts that `configure()` leaves a manually instantiated test case configured exactly as `build()` leaves the test case it builds for the same class and method, across every fixture, including the data provider one. Making the method a no-op fails all eight cases.

That second commit is what closes the Codecov report on this pull request: the six lines of `configure()` were the missing ones, and they are missed because that method only ever runs in a worker process. The one line reported missing in `ParallelTestRunner` is already covered by the selection tests above, `filter-matching-nothing-in-parallel.phpt` in particular, since a selection that matches nothing is exactly what empties a suite. Patch coverage of both files is 100% with the two commits in place. The `tests/unit` suite grows by the eight new cases and is otherwise unchanged, and the failing set of `tests/end-to-end/parallel` is the same before and after.

## Notes from using it, take or leave

- Extensions are bootstrapped only in the parent process, without a warning. It does not affect us, we use none, but it is the one thing a user cannot discover from the outside.
- Installing the branch with Composer needs `"no-api": true` on the repository entry, otherwise the GitHub API rate limit for anonymous requests turns into a `Could not authenticate against github.com` error in containers that have no token. Only relevant while this is a branch, but it cost us a moment.
- An XML configuration setting would be welcome eventually, so a suite can declare its own parallelism instead of every call site repeating it. Not a blocker, `--parallel` on the command line is fine.

Three kinds of change were needed on our side, and I mention them because two of them are arguably a compliment to the feature: test cases that flush a shared Redis or Memcached daemon now carry `#[DoNotRunInParallel]`, and parallel execution exposed several of our test cases that registered a shared scratch directory for recursive deletion and so removed the fixtures of other test cases. The latter was a real defect of ours that sequential execution had been hiding.

The evaluation on our side is at https://review.typo3.org/c/Packages/TYPO3.CMS/+/95337 for reference. It is a work in progress change that we do not intend to merge, it only exists to try this out and to gather the numbers above.

Happy to adjust anything here, in particular the comment wording, or to split the two commits into separate pull requests if you prefer.
