### PR TITLE
Do not build the source map for a child process when identifyIssueTrigger is disabled

### DIFF
--- a/src/Framework/TestRunner/SeparateProcessTestRunner.php
+++ b/src/Framework/TestRunner/SeparateProcessTestRunner.php
@@ -172,7 +172,7 @@ final class SeparateProcessTestRunner
             return self::$sourceMapFile;
         }
 
-        if (!ConfigurationRegistry::get()->source()->notEmpty()) {
+        if (!ConfigurationRegistry::get()->source()->notEmpty() || !ConfigurationRegistry::get()->source()->identifyIssueTrigger()) {
             self::$sourceMapFile = '';
 
             return self::$sourceMapFile;


### PR DESCRIPTION
With `<source identifyIssueTrigger="false">`, PHPUnit still builds the source map before running any `#[RunInSeparateProcess]` test, even though neither the parent nor the child ever needs it in that mode. `identifyIssueTrigger` was introduced to avoid exactly this filesystem walk (#6488), but `SeparateProcessTestRunner::sourceMapFileForChildProcess()` only checked `Source::notEmpty()`, not `Source::identifyIssueTrigger()`, unlike `ErrorHandler::instance()`, which already gates on both.

This adds the same `identifyIssueTrigger()` check to `sourceMapFileForChildProcess()`, so the map is skipped whenever issue-trigger identification is disabled, isolated tests included.

Verified against the full unit and end-to-end suites, both green.

I used an AI coding assistant (Claude Code) to investigate this issue, write the fix, and run the tests. I reviewed the change and the results before opening this PR.

Fixes #6904