### PR TITLE
Do not search directories that are excluded from the source

### DIFF
--- a/ChangeLog-12.5.md
+++ b/ChangeLog-12.5.md
@@ -7,6 +7,7 @@ All notable changes of the PHPUnit 12.5 release series are documented in this fi
 ### Fixed
 
 * [#6904](https://github.com/sebastianbergmann/phpunit/issues/6904): `SourceMap` is built in child process even though `identifyIssueTrigger` is disabled
+* Directories that are excluded from the source are searched when the source map is built, which aborts the test run when such a directory cannot be read
 
 ## [12.5.33] - 2026-07-28
 

--- a/src/TextUI/Configuration/SourceMapper.php
+++ b/src/TextUI/Configuration/SourceMapper.php
@@ -9,11 +9,19 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use const DIRECTORY_SEPARATOR;
+use function array_diff;
+use function array_keys;
+use function basename;
+use function dirname;
 use function file_get_contents;
 use function file_put_contents;
 use function is_array;
+use function is_dir;
 use function realpath;
+use function scandir;
 use function serialize;
+use function str_starts_with;
 use function unserialize;
 use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 use SplObjectStorage;
@@ -77,10 +85,12 @@ final class SourceMapper
 
         $files = [];
 
-        $directories = $this->aggregateDirectories($source->includeDirectories());
+        $directories         = $this->aggregateDirectories($source->includeDirectories());
+        $excludedDirectories = $this->aggregateDirectories($source->excludeDirectories());
+        $doNotSearch         = $this->directoriesThatDoNotHaveToBeSearched($excludedDirectories, $directories);
 
         foreach ($directories as $path => [$prefixes, $suffixes]) {
-            foreach ((new FileIteratorFacade)->getFilesAsArray($path, $suffixes, $prefixes) as $file) {
+            foreach ((new FileIteratorFacade)->getFilesAsArray($path, $suffixes, $prefixes, $doNotSearch) as $file) {
                 $file = realpath($file);
 
                 if (!$file) {
@@ -101,9 +111,11 @@ final class SourceMapper
             $files[$file] = true;
         }
 
-        $directories = $this->aggregateDirectories($source->excludeDirectories());
+        foreach ($excludedDirectories as $path => [$prefixes, $suffixes]) {
+            if (!$this->hasFilesIn($files, $path)) {
+                continue;
+            }
 
-        foreach ($directories as $path => [$prefixes, $suffixes]) {
             foreach ((new FileIteratorFacade)->getFilesAsArray($path, $suffixes, $prefixes) as $file) {
                 $file = realpath($file);
 
@@ -136,6 +148,106 @@ final class SourceMapper
         self::$files[$source] = $files;
 
         return $files;
+    }
+
+    /**
+     * @param array<string,array{list<string>,list<string>}> $excludedDirectories
+     * @param array<string,array{list<string>,list<string>}> $includedDirectories
+     *
+     * @return list<string>
+     */
+    private function directoriesThatDoNotHaveToBeSearched(array $excludedDirectories, array $includedDirectories): array
+    {
+        $directories = [];
+
+        foreach ($excludedDirectories as $path => [$excludedPrefixes, $excludedSuffixes]) {
+            $path = realpath($path);
+
+            if ($path === false) {
+                continue;
+            }
+
+            foreach ($includedDirectories as [$prefixes, $suffixes]) {
+                if (!$this->excludesAll($excludedPrefixes, $prefixes) || !$this->excludesAll($excludedSuffixes, $suffixes)) {
+                    continue 2;
+                }
+            }
+
+            if ($this->hasSiblingWithSameNamePrefix($path)) {
+                continue;
+            }
+
+            $directories[] = $path;
+        }
+
+        return $directories;
+    }
+
+    /**
+     * @param list<string> $excludedFilters
+     * @param list<string> $includedFilters
+     */
+    private function excludesAll(array $excludedFilters, array $includedFilters): bool
+    {
+        if ($excludedFilters === []) {
+            return true;
+        }
+
+        if ($includedFilters === []) {
+            return false;
+        }
+
+        return array_diff($includedFilters, $excludedFilters) === [];
+    }
+
+    /**
+     * @param array<non-empty-string, true> $files
+     */
+    private function hasFilesIn(array $files, string $directory): bool
+    {
+        $directory = realpath($directory);
+
+        if ($directory === false) {
+            return false;
+        }
+
+        $directory .= DIRECTORY_SEPARATOR;
+
+        foreach (array_keys($files) as $file) {
+            if (str_starts_with($file, $directory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Directories are excluded by path prefix, so excluding "tests" would exclude "tests-integration" as well.
+     */
+    private function hasSiblingWithSameNamePrefix(string $directory): bool
+    {
+        $entries = scandir(dirname($directory));
+
+        // @codeCoverageIgnoreStart
+        if ($entries === false) {
+            return true;
+        }
+        // @codeCoverageIgnoreEnd
+
+        $name = basename($directory);
+
+        foreach ($entries as $entry) {
+            if ($entry === $name || $entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            if (str_starts_with($entry, $name) && is_dir(dirname($directory) . DIRECTORY_SEPARATOR . $entry)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/unit/TextUI/SourceMapperTest.php
+++ b/tests/unit/TextUI/SourceMapperTest.php
@@ -9,7 +9,19 @@
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use const DIRECTORY_SEPARATOR;
 use const PHP_OS_FAMILY;
+use function chmod;
+use function file_put_contents;
+use function is_readable;
+use function mkdir;
+use function octdec;
+use function realpath;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+use DirectoryIterator;
 use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -19,6 +31,8 @@ use PHPUnit\Framework\Attributes\Small;
 #[Small]
 final class SourceMapperTest extends AbstractSourceFilterTestCase
 {
+    private ?string $directory = null;
+
     public static function provider(): Generator
     {
         yield 'file included using file' => [
@@ -344,9 +358,124 @@ final class SourceMapperTest extends AbstractSourceFilterTestCase
         ];
     }
 
+    protected function tearDown(): void
+    {
+        if ($this->directory === null) {
+            return;
+        }
+
+        $this->removeDirectory($this->directory);
+
+        $this->directory = null;
+    }
+
     #[DataProvider('provider')]
     public function testDeterminesWhetherFileIsIncluded(array $expected, Source $source): void
     {
         $this->assertEquals($expected, (new SourceMapper)->map($source));
+    }
+
+    public function testDoesNotSearchExcludedDirectory(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('Cannot test this behaviour on Windows');
+        }
+
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('source-mapper_', true);
+
+        mkdir($this->directory . DIRECTORY_SEPARATOR . 'excluded', octdec('777'), true);
+        mkdir($this->directory . DIRECTORY_SEPARATOR . 'excluded' . DIRECTORY_SEPARATOR . 'unreadable', octdec('0'));
+        file_put_contents($this->directory . DIRECTORY_SEPARATOR . 'Included.php', '<?php');
+
+        if (is_readable($this->directory . DIRECTORY_SEPARATOR . 'excluded' . DIRECTORY_SEPARATOR . 'unreadable')) {
+            $this->markTestSkipped('Cannot make a directory unreadable in this environment');
+        }
+
+        $source = self::createSource(
+            includeDirectories: FilterDirectoryCollection::fromArray([
+                new FilterDirectory($this->directory, '', '.php'),
+            ]),
+            excludeDirectories: FilterDirectoryCollection::fromArray([
+                new FilterDirectory($this->directory . DIRECTORY_SEPARATOR . 'excluded', '', '.php'),
+            ]),
+        );
+
+        $this->assertSame(
+            [
+                realpath($this->directory . DIRECTORY_SEPARATOR . 'Included.php') => true,
+            ],
+            (new SourceMapper)->map($source),
+        );
+    }
+
+    public function testDoesNotExcludeDirectoryWhoseNameBeginsWithTheNameOfAnExcludedDirectory(): void
+    {
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('source-mapper_', true);
+
+        mkdir($this->directory . DIRECTORY_SEPARATOR . 'tests', octdec('777'), true);
+        mkdir($this->directory . DIRECTORY_SEPARATOR . 'tests-integration');
+        file_put_contents($this->directory . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'Excluded.php', '<?php');
+        file_put_contents($this->directory . DIRECTORY_SEPARATOR . 'tests-integration' . DIRECTORY_SEPARATOR . 'Included.php', '<?php');
+
+        $source = self::createSource(
+            includeDirectories: FilterDirectoryCollection::fromArray([
+                new FilterDirectory($this->directory, '', '.php'),
+            ]),
+            excludeDirectories: FilterDirectoryCollection::fromArray([
+                new FilterDirectory($this->directory . DIRECTORY_SEPARATOR . 'tests', '', '.php'),
+            ]),
+        );
+
+        $this->assertSame(
+            [
+                realpath($this->directory . DIRECTORY_SEPARATOR . 'tests-integration' . DIRECTORY_SEPARATOR . 'Included.php') => true,
+            ],
+            (new SourceMapper)->map($source),
+        );
+    }
+
+    public function testIgnoresExcludedDirectoryThatDoesNotExist(): void
+    {
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('source-mapper_', true);
+
+        mkdir($this->directory);
+        file_put_contents($this->directory . DIRECTORY_SEPARATOR . 'Included.php', '<?php');
+
+        $source = self::createSource(
+            includeDirectories: FilterDirectoryCollection::fromArray([
+                new FilterDirectory($this->directory, '', '.php'),
+            ]),
+            excludeDirectories: FilterDirectoryCollection::fromArray([
+                new FilterDirectory($this->directory . DIRECTORY_SEPARATOR . 'does-not-exist', '', '.php'),
+            ]),
+        );
+
+        $this->assertSame(
+            [
+                realpath($this->directory . DIRECTORY_SEPARATOR . 'Included.php') => true,
+            ],
+            (new SourceMapper)->map($source),
+        );
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        chmod($directory, octdec('777'));
+
+        foreach (new DirectoryIterator($directory) as $entry) {
+            if ($entry->isDot()) {
+                continue;
+            }
+
+            if ($entry->isDir()) {
+                $this->removeDirectory($entry->getPathname());
+
+                continue;
+            }
+
+            unlink($entry->getPathname());
+        }
+
+        rmdir($directory);
     }
 }


### PR DESCRIPTION
## The bug

`SourceMapper::map()` searches every directory of `<source><include>`, and then searches every directory of `<source><exclude>` to remove the files it has just collected from them. Both searches enter directories that cannot contribute a file to the map. `RecursiveDirectoryIterator` throws when it cannot open a directory, so a single unreadable or disappearing directory below an excluded path aborts the whole test run.

### Steps to reproduce

```
project
├── build
│   └── unreadable      (mode 000)
├── phpunit.xml
├── src
│   └── Example.php
└── tests
    └── ExampleTest.php
```

`phpunit.xml`:

```xml
<source>
    <include>
        <directory>.</directory>
    </include>
    <exclude>
        <directory>build</directory>
    </exclude>
</source>
```

`ExampleTest` carries `#[RunTestsInSeparateProcesses]`, so the source map is written for the child process.

### What happens

```
PHPUnit 12.5.33 by Sebastian Bergmann and contributors.

An error occurred inside PHPUnit.

Message:  RecursiveDirectoryIterator::__construct(…/build/unreadable): Failed to open directory: Permission denied
Location: …/php-file-iterator/src/ExcludeIterator.php:62

#5 …/src/TextUI/Configuration/SourceMapper.php(83)
#6 …/src/TextUI/Configuration/SourceMapper.php(40)
#7 …/src/Framework/TestRunner/SeparateProcessTestRunner.php(190)
```

### What I expected

`build` is excluded from the source, so what it contains should not affect the run.

### Where this comes from

In a monorepo, several `composer update` runs work in parallel below the directory that one test run walks. Composer creates and removes a temporary extraction directory, and PHPUnit walks it in the moment between the two. The directory is gone when `opendir()` is called, the test run of that package dies with the message above, and the job is red for a reason that has nothing to do with the tests.

## The change

* The included directories are now searched with the excluded directories handed to the file iterator, so an excluded tree is not entered. This is done for an excluded directory only when its filters remove everything the include filters collect there, and only when no sibling directory has the excluded path as a prefix, because `ExcludeIterator` matches on the path prefix.
* The excluded directories are searched only when the map holds a file below them, which is never the case for a directory that was already skipped.

`TestSuiteMapper` already hands the excluded directories to the file iterator for `<testsuites>`, so this makes `<source>` behave the same way.

## Tests

* `testDoesNotSearchExcludedDirectory` fails on `12.5` with the exception above and passes with this change.
* `testDoesNotExcludeDirectoryWhoseNameBeginsWithTheNameOfAnExcludedDirectory` passes with and without this change. It protects the existing behaviour: without the prefix guard, excluding `tests` would also drop `tests-integration` from the map.
* `testIgnoresExcludedDirectoryThatDoesNotExist` covers an excluded directory that does not exist on disk, which is where both `realpath()` results are false.
* The fixtures are created below `sys_get_temp_dir()`. The first test skips on Windows and when the unreadable directory cannot be created.

## Checks

* `./phpunit --testsuite unit`: OK, 4056 tests, 12127 assertions.
* `./phpunit --testsuite end-to-end`: 813 tests, one failure, `defaulttestsuite-using-testsuite-without-name.phpt`, which fails the same way on `12.5` without this change in my checkout because `tests/_files/tests` does not exist there.
* `./tools/php-cs-fixer fix`: 0 of 2226 files fixed.
* `./tools/phpstan analyse`: no errors.

## Note

The prefix guard would not be needed if `ExcludeIterator::accept()` compared on the directory boundary, that is `$path === $exclude || str_starts_with($path, $exclude . DIRECTORY_SEPARATOR)`. I can send that to `php-file-iterator` separately if you prefer that route.

## Use of an LLM-based coding assistant

I used Claude Code for this change: it reproduced the failure, wrote the patch and the tests, and ran the checks listed above. I reviewed the result, and I am able to explain and defend it.
