### PR TITLE
Allow ordering tests by the time their source files were last modified

### DIFF
--- a/phpunit.xsd
+++ b/phpunit.xsd
@@ -135,6 +135,10 @@
             <xs:enumeration value="duration-ascending,defects"/>
             <xs:enumeration value="duration-descending"/>
             <xs:enumeration value="duration-descending,defects"/>
+            <xs:enumeration value="modified-ascending"/>
+            <xs:enumeration value="modified-ascending,defects"/>
+            <xs:enumeration value="modified-descending"/>
+            <xs:enumeration value="modified-descending,defects"/>
             <xs:enumeration value="random"/>
             <xs:enumeration value="random,defects"/>
             <xs:enumeration value="reverse"/>

--- a/src/Runner/ExecutionOrder/ReorderPipeline.php
+++ b/src/Runner/ExecutionOrder/ReorderPipeline.php
@@ -11,6 +11,7 @@ namespace PHPUnit\Runner\ExecutionOrder;
 
 use PHPUnit\Framework\Test;
 use PHPUnit\Runner\ExecutionOrder\Stage\ByDuration;
+use PHPUnit\Runner\ExecutionOrder\Stage\ByModificationTime;
 use PHPUnit\Runner\ExecutionOrder\Stage\BySize;
 use PHPUnit\Runner\ExecutionOrder\Stage\DefectsFirst;
 use PHPUnit\Runner\ExecutionOrder\Stage\Randomize;
@@ -145,6 +146,14 @@ final readonly class ReorderPipeline
 
         if ($order === TestSuiteSorter::ORDER_SIZE_DESCENDING) {
             return new BySize(Direction::Descending);
+        }
+
+        if ($order === TestSuiteSorter::ORDER_MODIFIED_ASCENDING) {
+            return new ByModificationTime(Direction::Ascending);
+        }
+
+        if ($order === TestSuiteSorter::ORDER_MODIFIED_DESCENDING) {
+            return new ByModificationTime(Direction::Descending);
         }
 
         // @codeCoverageIgnoreStart

--- a/src/Runner/ExecutionOrder/Stage/ByModificationTime.php
+++ b/src/Runner/ExecutionOrder/Stage/ByModificationTime.php
@@ -1,0 +1,207 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Runner\ExecutionOrder\Stage;
+
+use function array_key_exists;
+use function filemtime;
+use function is_file;
+use function max;
+use function usort;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\ExecutionOrder\Context;
+use PHPUnit\Runner\ExecutionOrder\Direction;
+use PHPUnit\Runner\ExecutionOrder\ReorderStage;
+use PHPUnit\Runner\Phpt\TestCase as PhptTestCase;
+use PHPUnit\Util\Reflection;
+use ReflectionClass;
+
+/**
+ * Sorts tests by the time their source files were last modified.
+ *
+ * The source files of a test are the files a change to which can change what
+ * the test does: the file that declares the test class, the files that declare
+ * the classes it extends, and the files that declare the traits any of them
+ * use. The most recent modification among them decides. For a PHPT test, the
+ * .phpt file is the test.
+ *
+ * The modification time of a test suite is the most recent modification time
+ * among the tests it contains, so that a test suite is as new as the newest
+ * test in it. This propagates upwards through arbitrarily deeply nested test
+ * suites.
+ *
+ * A test whose modification time cannot be determined weighs zero, just like a
+ * test that ByDuration knows nothing about, and is therefore sorted last when
+ * sorting from newest to oldest.
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class ByModificationTime implements ReorderStage
+{
+    private readonly Direction $direction;
+
+    /**
+     * @var array<string, non-negative-int>
+     */
+    private array $weights = [];
+
+    /**
+     * @var array<class-string, non-negative-int>
+     */
+    private array $weightsOfClasses = [];
+
+    /**
+     * @var array<non-empty-string, non-negative-int>
+     */
+    private array $modificationTimes = [];
+
+    public function __construct(Direction $direction)
+    {
+        $this->direction = $direction;
+    }
+
+    /**
+     * @param list<Test> $tests
+     *
+     * @return list<Test>
+     */
+    public function apply(array $tests, Context $context): array
+    {
+        if ($this->direction === Direction::Ascending) {
+            usort(
+                $tests,
+                fn (Test $left, Test $right) => $this->weight($left) <=> $this->weight($right),
+            );
+
+            return $tests;
+        }
+
+        usort(
+            $tests,
+            fn (Test $left, Test $right) => $this->weight($right) <=> $this->weight($left),
+        );
+
+        return $tests;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+        if ($this->direction === Direction::Ascending) {
+            return 'modified-ascending';
+        }
+
+        return 'modified-descending';
+    }
+
+    /**
+     * @return non-negative-int
+     */
+    private function weight(Test $test): int
+    {
+        if ($test instanceof TestSuite) {
+            return $this->weightOfTestSuite($test);
+        }
+
+        if ($test instanceof PhptTestCase) {
+            return $this->modificationTime($test->file());
+        }
+
+        if ($test instanceof TestCase) {
+            return $this->weightOfClass($test::class);
+        }
+
+        // @codeCoverageIgnoreStart
+        return 0;
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * The tests of a test suite are reordered before the test suite itself is
+     * reordered within its parent, so the weight of a test suite that is nested
+     * in another one has usually been computed before it is needed. Remembering
+     * it keeps the tree from being walked once per level.
+     *
+     * @return non-negative-int
+     */
+    private function weightOfTestSuite(TestSuite $testSuite): int
+    {
+        $sortId = $testSuite->sortId();
+
+        if (array_key_exists($sortId, $this->weights)) {
+            return $this->weights[$sortId];
+        }
+
+        $weight = 0;
+
+        foreach ($testSuite->tests() as $test) {
+            $weight = max($weight, $this->weight($test));
+        }
+
+        $this->weights[$sortId] = $weight;
+
+        return $weight;
+    }
+
+    /**
+     * @param class-string<TestCase> $className
+     *
+     * @return non-negative-int
+     */
+    private function weightOfClass(string $className): int
+    {
+        if (array_key_exists($className, $this->weightsOfClasses)) {
+            return $this->weightsOfClasses[$className];
+        }
+
+        $weight = 0;
+
+        foreach (Reflection::sourceFilesOf(new ReflectionClass($className)) as $file) {
+            $weight = max($weight, $this->modificationTime($file));
+        }
+
+        $this->weightsOfClasses[$className] = $weight;
+
+        return $weight;
+    }
+
+    /**
+     * Returns zero when the file does not exist or cannot be stat'ed.
+     *
+     * @param non-empty-string $file
+     *
+     * @return non-negative-int
+     */
+    private function modificationTime(string $file): int
+    {
+        if (array_key_exists($file, $this->modificationTimes)) {
+            return $this->modificationTimes[$file];
+        }
+
+        $modificationTime = 0;
+
+        if (is_file($file)) {
+            $result = @filemtime($file);
+
+            if ($result !== false && $result > 0) {
+                $modificationTime = $result;
+            }
+        }
+
+        $this->modificationTimes[$file] = $modificationTime;
+
+        return $modificationTime;
+    }
+}

--- a/src/Runner/Phpt/TestCase.php
+++ b/src/Runner/Phpt/TestCase.php
@@ -464,6 +464,16 @@ final readonly class TestCase implements Reorderable, SelfDescribing, Test
         return $this->filename;
     }
 
+    /**
+     * The file that declares this test.
+     *
+     * @return non-empty-string
+     */
+    public function file(): string
+    {
+        return $this->filename;
+    }
+
     public function sortId(): string
     {
         return $this->filename;

--- a/src/Runner/TestIndex/TestIndexEntry.php
+++ b/src/Runner/TestIndex/TestIndexEntry.php
@@ -9,7 +9,6 @@
  */
 namespace PHPUnit\Runner\TestIndex;
 
-use function array_keys;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\Api\Groups;
 use PHPUnit\Metadata\Parser\Registry as MetadataRegistry;
@@ -57,7 +56,14 @@ final readonly class TestIndexEntry
     {
         $dependencies = [];
 
-        foreach (self::sourceFilesOf($class) as $file) {
+        /*
+         * The source files a test class is made of are what decides whether an
+         * entry is still valid. PHPUnit's own files are not among them, which
+         * is what keeps a change to PHPUnit itself from invalidating every
+         * entry at once. That a different version of PHPUnit means a different
+         * index is already established by the version the index records.
+         */
+        foreach (Reflection::sourceFilesOf($class) as $file) {
             $hash = $hasher->hash($file);
 
             if ($hash === null) {
@@ -201,62 +207,5 @@ final readonly class TestIndexEntry
         }
 
         return true;
-    }
-
-    /**
-     * Which test methods a test class has, and which metadata they carry, is
-     * not decided by the file that declares the class alone: test methods are
-     * collected from parent classes as well, see Reflection::
-     * filterAndSortMethods(), and both classes and traits may contribute them.
-     * The file that declares each of those is therefore part of the entry.
-     *
-     * Interfaces are not considered: they cannot contribute a test method to a
-     * concrete test class.
-     *
-     * The walk stops at TestCase, which PHPUnit declares itself: Reflection::
-     * filterAndSortMethods() never treats a method declared by TestCase or by
-     * Assert, the class it extends, as a test method, so neither of them can
-     * contribute anything an entry is derived from. Leaving them out is what
-     * keeps a change to PHPUnit itself from invalidating every entry at once.
-     * That a different version of PHPUnit means a different index is already
-     * established by the version the index records.
-     *
-     * @param ReflectionClass<TestCase> $class
-     *
-     * @return list<non-empty-string>
-     */
-    private static function sourceFilesOf(ReflectionClass $class): array
-    {
-        $files   = [];
-        $current = $class;
-
-        while ($current !== false) {
-            if ($current->getName() === TestCase::class) {
-                break;
-            }
-
-            self::collectSourceFilesOf($current, $files);
-
-            $current = $current->getParentClass();
-        }
-
-        return array_keys($files);
-    }
-
-    /**
-     * @param ReflectionClass<object>       $class
-     * @param array<non-empty-string, true> $files
-     */
-    private static function collectSourceFilesOf(ReflectionClass $class, array &$files): void
-    {
-        $file = $class->getFileName();
-
-        if ($file !== false && $file !== '') {
-            $files[$file] = true;
-        }
-
-        foreach ($class->getTraits() as $trait) {
-            self::collectSourceFilesOf($trait, $files);
-        }
     }
 }

--- a/src/Runner/TestSuiteSorter.php
+++ b/src/Runner/TestSuiteSorter.php
@@ -36,6 +36,8 @@ final class TestSuiteSorter
     public const int ORDER_SIZE_ASCENDING      = 5;
     public const int ORDER_DURATION_DESCENDING = 6;
     public const int ORDER_SIZE_DESCENDING     = 7;
+    public const int ORDER_MODIFIED_ASCENDING  = 8;
+    public const int ORDER_MODIFIED_DESCENDING = 9;
     private readonly TestRunHistory $testRunHistory;
 
     public function __construct(TestRunHistory $testRunHistory = new NullTestRunHistory)

--- a/src/TextUI/Configuration/ExecutionOrderParser.php
+++ b/src/TextUI/Configuration/ExecutionOrderParser.php
@@ -40,6 +40,8 @@ final readonly class ExecutionOrderParser
         'duration',
         'duration-ascending',
         'duration-descending',
+        'modified-ascending',
+        'modified-descending',
         'random',
         'reverse',
         'size',
@@ -117,6 +119,16 @@ final readonly class ExecutionOrderParser
 
                 case 'duration-descending':
                     $executionOrder = TestSuiteSorter::ORDER_DURATION_DESCENDING;
+
+                    break;
+
+                case 'modified-ascending':
+                    $executionOrder = TestSuiteSorter::ORDER_MODIFIED_ASCENDING;
+
+                    break;
+
+                case 'modified-descending':
+                    $executionOrder = TestSuiteSorter::ORDER_MODIFIED_DESCENDING;
 
                     break;
 

--- a/src/TextUI/Help.php
+++ b/src/TextUI/Help.php
@@ -279,7 +279,7 @@ final class Help
                 ['arg' => '--do-not-warn-when-php-is-not-configured-for-development', 'desc' => 'Do not trigger a test runner warning when PHP is not configured for development'],
                 ['spacer' => ''],
 
-                ['arg' => '--order-by <order>', 'desc' => 'Run tests in order: default|defects|duration-ascending|duration-descending|random|reverse|size-ascending|size-descending'],
+                ['arg' => '--order-by <order>', 'desc' => 'Run tests in order: default|defects|duration-ascending|duration-descending|modified-ascending|modified-descending|random|reverse|size-ascending|size-descending'],
                 ['arg' => '--resolve-dependencies', 'desc' => 'Reorder tests to resolve dependencies between them (default)'],
                 ['arg' => '--ignore-dependencies', 'desc' => 'Do not reorder tests to resolve dependencies between them'],
                 ['arg' => '--random-order', 'desc' => 'Alias for "--order-by random"'],

--- a/src/Util/Reflection.php
+++ b/src/Util/Reflection.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\Util;
 
+use function array_keys;
 use function array_merge;
 use function array_reverse;
 use function assert;
@@ -83,6 +84,62 @@ final readonly class Reflection
     public static function methodsDeclaredDirectlyInTestClass(ReflectionClass $class): array
     {
         return self::filterAndSortMethods($class, null, false);
+    }
+
+    /**
+     * The files that declare what a test class is made of: the file that
+     * declares the class itself, the files that declare the classes it
+     * extends, and the files that declare the traits any of them use.
+     *
+     * Test methods, and the metadata they carry, are not contributed by the
+     * file that declares the class alone: they are collected from parent
+     * classes as well, see filterAndSortMethods(), and both classes and traits
+     * may contribute them.
+     *
+     * The walk stops at TestCase, which PHPUnit declares itself: a method
+     * declared by TestCase, or by Assert, the class it extends, is never
+     * treated as a test method, so neither of them can contribute anything.
+     *
+     * Interfaces are not considered: they cannot contribute a test method to a
+     * concrete test class.
+     *
+     * @param ReflectionClass<TestCase> $class
+     *
+     * @return list<non-empty-string>
+     */
+    public static function sourceFilesOf(ReflectionClass $class): array
+    {
+        $files   = [];
+        $current = $class;
+
+        while ($current !== false) {
+            if ($current->getName() === TestCase::class) {
+                break;
+            }
+
+            self::collectSourceFilesOf($current, $files);
+
+            $current = $current->getParentClass();
+        }
+
+        return array_keys($files);
+    }
+
+    /**
+     * @param ReflectionClass<object>       $class
+     * @param array<non-empty-string, true> $files
+     */
+    private static function collectSourceFilesOf(ReflectionClass $class, array &$files): void
+    {
+        $file = $class->getFileName();
+
+        if ($file !== false && $file !== '') {
+            $files[$file] = true;
+        }
+
+        foreach ($class->getTraits() as $trait) {
+            self::collectSourceFilesOf($trait, $files);
+        }
     }
 
     /**

--- a/tests/end-to-end/_files/output-cli-help-color.txt
+++ b/tests/end-to-end/_files/output-cli-help-color.txt
@@ -176,7 +176,7 @@
                                        development
 
   [32m--order-by [36m<order>[0m                  [0m Run tests in order:
-                                       default|defects|duration-ascending|duration-descending|random|reverse|size-ascending|size-descending
+                                       default|defects|duration-ascending|duration-descending|modified-ascending|modified-descending|random|reverse|size-ascending|size-descending
   [32m--resolve-dependencies              [0m Reorder tests to resolve dependencies
                                        between them (default)
   [32m--ignore-dependencies               [0m Do not reorder tests to resolve

--- a/tests/end-to-end/_files/output-cli-usage.txt
+++ b/tests/end-to-end/_files/output-cli-usage.txt
@@ -107,7 +107,7 @@ Execution:
   --do-not-warn-when-php-is-not-configured-for-development
                                        Do not trigger a test runner warning when PHP is not configured for development
 
-  --order-by <order>                   Run tests in order: default|defects|duration-ascending|duration-descending|random|reverse|size-ascending|size-descending
+  --order-by <order>                   Run tests in order: default|defects|duration-ascending|duration-descending|modified-ascending|modified-descending|random|reverse|size-ascending|size-descending
   --resolve-dependencies               Reorder tests to resolve dependencies between them (default)
   --ignore-dependencies                Do not reorder tests to resolve dependencies between them
   --random-order                       Alias for "--order-by random"

--- a/tests/end-to-end/execution-order/executionorder-xml-modified-descending.phpt
+++ b/tests/end-to-end/execution-order/executionorder-xml-modified-descending.phpt
@@ -1,0 +1,89 @@
+--TEST--
+executionOrder="modified-descending" in phpunit.xml: Suite with test classes whose files were modified at different times
+--FILE--
+<?php declare(strict_types=1);
+$fixtures = __DIR__ . '/fixture/test-classes-with-different-modification-times';
+$sandbox  = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+@mkdir($sandbox);
+
+/*
+ * The modification time of a file in a working copy is the time it was checked
+ * out, so the fixtures are copied to a directory of their own, where their
+ * modification times can be set explicitly.
+ */
+$modificationTimes = [
+    'OldTest'    => 1704067200,
+    'MiddleTest' => 1735689600,
+    'NewTest'    => 1767225600,
+];
+
+foreach ($modificationTimes as $test => $modificationTime) {
+    copy($fixtures . '/' . $test . '.php', $sandbox . '/' . $test . '.php');
+    touch($sandbox . '/' . $test . '.php', $modificationTime);
+}
+
+file_put_contents(
+    $sandbox . '/phpunit.xml',
+    <<<'XML'
+    <?xml version="1.0" encoding="UTF-8"?>
+    <phpunit executionOrder="modified-descending">
+        <testsuites>
+            <testsuite name="default">
+                <directory>.</directory>
+            </testsuite>
+        </testsuites>
+    </phpunit>
+    XML
+);
+
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = $sandbox . '/phpunit.xml';
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--debug';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--CLEAN--
+<?php declare(strict_types=1);
+$sandbox = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+foreach (glob($sandbox . '/*') as $file) {
+    unlink($file);
+}
+
+rmdir($sandbox);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (3 tests)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (3 tests)
+Test Suite Started (%s, 3 tests)
+Test Suite Started (default, 3 tests)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest, 1 test)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest, 1 test)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest, 1 test)
+Test Suite Finished (default, 3 tests)
+Test Suite Finished (%s, 3 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-different-modification-times/MiddleTest.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-different-modification-times/MiddleTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class MiddleTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-different-modification-times/NewTest.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-different-modification-times/NewTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class NewTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-different-modification-times/OldTest.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-different-modification-times/OldTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class OldTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/AlsoInheritingTest.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/AlsoInheritingTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+require_once __DIR__ . '/BaseTestCase.php';
+
+#[CoversNothing]
+final class AlsoInheritingTest extends BaseTestCase
+{
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/BaseTestCase.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/BaseTestCase.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/TestMethods.php';
+
+abstract class BaseTestCase extends TestCase
+{
+    use TestMethods;
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/InheritingTest.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/InheritingTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+require_once __DIR__ . '/BaseTestCase.php';
+
+#[CoversNothing]
+final class InheritingTest extends BaseTestCase
+{
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/OwnTest.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/OwnTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class OwnTest extends TestCase
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/TestMethods.php
+++ b/tests/end-to-end/execution-order/fixture/test-classes-with-modified-parent-class/TestMethods.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass;
+
+trait TestMethods
+{
+    public function testOne(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTwo(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/end-to-end/execution-order/order-by-modified-ascending-test-classes.phpt
+++ b/tests/end-to-end/execution-order/order-by-modified-ascending-test-classes.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Order by modification time ascending: Suite with test classes whose files were modified at different times
+--FILE--
+<?php declare(strict_types=1);
+$fixtures = __DIR__ . '/fixture/test-classes-with-different-modification-times';
+$sandbox  = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+@mkdir($sandbox);
+
+/*
+ * The modification time of a file in a working copy is the time it was checked
+ * out, so the fixtures are copied to a directory of their own, where their
+ * modification times can be set explicitly.
+ */
+$modificationTimes = [
+    'OldTest'    => 1704067200,
+    'MiddleTest' => 1735689600,
+    'NewTest'    => 1767225600,
+];
+
+foreach ($modificationTimes as $test => $modificationTime) {
+    copy($fixtures . '/' . $test . '.php', $sandbox . '/' . $test . '.php');
+    touch($sandbox . '/' . $test . '.php', $modificationTime);
+}
+
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--order-by';
+$_SERVER['argv'][] = 'modified-ascending';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = $sandbox;
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--CLEAN--
+<?php declare(strict_types=1);
+$sandbox = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+foreach (glob($sandbox . '/*.php') as $file) {
+    unlink($file);
+}
+
+rmdir($sandbox);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (3 tests)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (3 tests)
+Test Suite Started (CLI Arguments, 3 tests)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest, 1 test)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest, 1 test)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest, 1 test)
+Test Suite Finished (CLI Arguments, 3 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/execution-order/order-by-modified-descending-phpt-tests.phpt
+++ b/tests/end-to-end/execution-order/order-by-modified-descending-phpt-tests.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Order by modification time descending: Suite with PHPT tests whose files were modified at different times
+--FILE--
+<?php declare(strict_types=1);
+$sandbox = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+@mkdir($sandbox);
+
+/*
+ * A PHPT test is its file, so the fixtures are written to a directory of their
+ * own, where their modification times can be set explicitly.
+ */
+$modificationTimes = [
+    'old'    => 1704067200,
+    'middle' => 1735689600,
+    'new'    => 1767225600,
+];
+
+foreach ($modificationTimes as $name => $modificationTime) {
+    file_put_contents(
+        $sandbox . '/' . $name . '.phpt',
+        <<<PHPT
+        --TEST--
+        {$name}
+        --FILE--
+        <?php declare(strict_types=1);
+        print '{$name}';
+        --EXPECT--
+        {$name}
+        PHPT
+    );
+
+    touch($sandbox . '/' . $name . '.phpt', $modificationTime);
+}
+
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--order-by';
+$_SERVER['argv'][] = 'modified-descending';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = $sandbox;
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--CLEAN--
+<?php declare(strict_types=1);
+$sandbox = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+foreach (glob($sandbox . '/*.phpt') as $file) {
+    unlink($file);
+}
+
+rmdir($sandbox);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (3 tests)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (3 tests)
+Test Suite Started (CLI Arguments, 3 tests)
+Test Preparation Started (%s%enew.phpt)
+Test Prepared (%s%enew.phpt)
+Child Process Started (FILE section of a PHPT test)
+Child Process Finished (FILE section of a PHPT test)
+Test Passed (%s%enew.phpt)
+Test Finished (%s%enew.phpt)
+Test Preparation Started (%s%emiddle.phpt)
+Test Prepared (%s%emiddle.phpt)
+Child Process Started (FILE section of a PHPT test)
+Child Process Finished (FILE section of a PHPT test)
+Test Passed (%s%emiddle.phpt)
+Test Finished (%s%emiddle.phpt)
+Test Preparation Started (%s%eold.phpt)
+Test Prepared (%s%eold.phpt)
+Child Process Started (FILE section of a PHPT test)
+Child Process Finished (FILE section of a PHPT test)
+Test Passed (%s%eold.phpt)
+Test Finished (%s%eold.phpt)
+Test Suite Finished (CLI Arguments, 3 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/execution-order/order-by-modified-descending-test-classes-with-modified-parent-class.phpt
+++ b/tests/end-to-end/execution-order/order-by-modified-descending-test-classes-with-modified-parent-class.phpt
@@ -1,0 +1,89 @@
+--TEST--
+Order by modification time descending: Suite with test classes whose parent class was modified
+--FILE--
+<?php declare(strict_types=1);
+$fixtures = __DIR__ . '/fixture/test-classes-with-modified-parent-class';
+$sandbox  = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+@mkdir($sandbox);
+
+/*
+ * The modification time of a file in a working copy is the time it was checked
+ * out, so the fixtures are copied to a directory of their own, where their
+ * modification times can be set explicitly.
+ *
+ * AlsoInheritingTest and InheritingTest inherit their test methods from
+ * BaseTestCase, which uses a trait. Their own files are the oldest of the five,
+ * the files of the class they extend and of the trait it uses are the newest.
+ */
+$modificationTimes = [
+    'AlsoInheritingTest' => 1704067200,
+    'InheritingTest'     => 1704067200,
+    'OwnTest'            => 1735689600,
+    'BaseTestCase'       => 1767225600,
+    'TestMethods'        => 1767225600,
+];
+
+foreach ($modificationTimes as $class => $modificationTime) {
+    copy($fixtures . '/' . $class . '.php', $sandbox . '/' . $class . '.php');
+    touch($sandbox . '/' . $class . '.php', $modificationTime);
+}
+
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--order-by';
+$_SERVER['argv'][] = 'modified-descending';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = $sandbox;
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--CLEAN--
+<?php declare(strict_types=1);
+$sandbox = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+foreach (glob($sandbox . '/*.php') as $file) {
+    unlink($file);
+}
+
+rmdir($sandbox);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (5 tests)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (5 tests)
+Test Suite Started (CLI Arguments, 5 tests)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testOne)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testTwo)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testTwo)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testTwo)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest::testTwo)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\AlsoInheritingTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest, 2 tests)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testOne)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testTwo)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testTwo)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testTwo)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest::testTwo)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\InheritingTest, 2 tests)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\OwnTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\OwnTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\OwnTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\OwnTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\OwnTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\ModifiedParentClass\OwnTest, 1 test)
+Test Suite Finished (CLI Arguments, 5 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/end-to-end/execution-order/order-by-modified-descending-test-classes.phpt
+++ b/tests/end-to-end/execution-order/order-by-modified-descending-test-classes.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Order by modification time descending: Suite with test classes whose files were modified at different times
+--FILE--
+<?php declare(strict_types=1);
+$fixtures = __DIR__ . '/fixture/test-classes-with-different-modification-times';
+$sandbox  = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+@mkdir($sandbox);
+
+/*
+ * The modification time of a file in a working copy is the time it was checked
+ * out, so the fixtures are copied to a directory of their own, where their
+ * modification times can be set explicitly.
+ */
+$modificationTimes = [
+    'OldTest'    => 1704067200,
+    'MiddleTest' => 1735689600,
+    'NewTest'    => 1767225600,
+];
+
+foreach ($modificationTimes as $test => $modificationTime) {
+    copy($fixtures . '/' . $test . '.php', $sandbox . '/' . $test . '.php');
+    touch($sandbox . '/' . $test . '.php', $modificationTime);
+}
+
+$_SERVER['argv'][] = '--no-configuration';
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--order-by';
+$_SERVER['argv'][] = 'modified-descending';
+$_SERVER['argv'][] = '--debug';
+$_SERVER['argv'][] = $sandbox;
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--CLEAN--
+<?php declare(strict_types=1);
+$sandbox = sys_get_temp_dir() . '/' . basename(__FILE__, '.phpt');
+
+foreach (glob($sandbox . '/*.php') as $file) {
+    unlink($file);
+}
+
+rmdir($sandbox);
+--EXPECTF--
+PHPUnit Started (PHPUnit %s using %s)
+Test Runner Configured
+Event Facade Sealed
+Test Suite Loaded (3 tests)
+Test Runner Started
+Test Suite Sorted
+Test Runner Execution Started (3 tests)
+Test Suite Started (CLI Arguments, 3 tests)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\NewTest, 1 test)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\MiddleTest, 1 test)
+Test Suite Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest, 1 test)
+Test Preparation Started (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Prepared (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Passed (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest::testOne)
+Test Suite Finished (PHPUnit\TestFixture\ExecutionOrder\DifferentModificationTimes\OldTest, 1 test)
+Test Suite Finished (CLI Arguments, 3 tests)
+Test Runner Execution Finished
+Test Runner Finished
+PHPUnit Finished (Shell Exit Code: 0)

--- a/tests/unit/Runner/ExecutionOrder/ReorderPipelineTest.php
+++ b/tests/unit/Runner/ExecutionOrder/ReorderPipelineTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\ExecutionOrder\Stage\ByDuration;
+use PHPUnit\Runner\ExecutionOrder\Stage\ByModificationTime;
 use PHPUnit\Runner\ExecutionOrder\Stage\BySize;
 use PHPUnit\Runner\ExecutionOrder\Stage\DefectsFirst;
 use PHPUnit\Runner\ExecutionOrder\Stage\Randomize;
@@ -26,6 +27,7 @@ use PHPUnit\Runner\TestSuiteSorter;
 
 #[CoversClass(ReorderPipeline::class)]
 #[UsesClass(ByDuration::class)]
+#[UsesClass(ByModificationTime::class)]
 #[UsesClass(BySize::class)]
 #[UsesClass(DefaultDefectWeightPolicy::class)]
 #[UsesClass(DefectsFirst::class)]
@@ -86,6 +88,20 @@ final class ReorderPipelineTest extends TestCase
             'duration descending' => [
                 ['duration-descending'],
                 TestSuiteSorter::ORDER_DURATION_DESCENDING,
+                TestSuiteSorter::ORDER_DEFAULT,
+                false,
+            ],
+
+            'modified ascending' => [
+                ['modified-ascending'],
+                TestSuiteSorter::ORDER_MODIFIED_ASCENDING,
+                TestSuiteSorter::ORDER_DEFAULT,
+                false,
+            ],
+
+            'modified descending' => [
+                ['modified-descending'],
+                TestSuiteSorter::ORDER_MODIFIED_DESCENDING,
                 TestSuiteSorter::ORDER_DEFAULT,
                 false,
             ],

--- a/tests/unit/TextUI/Configuration/Cli/BuilderTest.php
+++ b/tests/unit/TextUI/Configuration/Cli/BuilderTest.php
@@ -1315,6 +1315,28 @@ final class BuilderTest extends TestCase
         $this->assertFalse($configuration->hasResolveDependencies());
     }
 
+    #[TestDox('--order-by modified-ascending')]
+    public function testOrderByModifiedAscending(): void
+    {
+        $configuration = (new Builder)->fromParameters(['--order-by', 'modified-ascending']);
+
+        $this->assertTrue($configuration->hasExecutionOrder());
+        $this->assertSame(TestSuiteSorter::ORDER_MODIFIED_ASCENDING, $configuration->executionOrder());
+        $this->assertFalse($configuration->hasExecutionOrderDefects());
+        $this->assertFalse($configuration->hasResolveDependencies());
+    }
+
+    #[TestDox('--order-by modified-descending')]
+    public function testOrderByModifiedDescending(): void
+    {
+        $configuration = (new Builder)->fromParameters(['--order-by', 'modified-descending']);
+
+        $this->assertTrue($configuration->hasExecutionOrder());
+        $this->assertSame(TestSuiteSorter::ORDER_MODIFIED_DESCENDING, $configuration->executionOrder());
+        $this->assertFalse($configuration->hasExecutionOrderDefects());
+        $this->assertFalse($configuration->hasResolveDependencies());
+    }
+
     #[TestDox('--order-by random')]
     public function testOrderByRandom(): void
     {

--- a/tests/unit/TextUI/Configuration/ExecutionOrderParserTest.php
+++ b/tests/unit/TextUI/Configuration/ExecutionOrderParserTest.php
@@ -41,10 +41,13 @@ final class ExecutionOrderParserTest extends TestCase
             'reverse'             => ['reverse', TestSuiteSorter::ORDER_REVERSED, TestSuiteSorter::ORDER_DEFAULT, false],
             'duration-ascending'  => ['duration-ascending', TestSuiteSorter::ORDER_DURATION_ASCENDING, TestSuiteSorter::ORDER_DEFAULT, false],
             'duration-descending' => ['duration-descending', TestSuiteSorter::ORDER_DURATION_DESCENDING, TestSuiteSorter::ORDER_DEFAULT, false],
+            'modified-ascending'  => ['modified-ascending', TestSuiteSorter::ORDER_MODIFIED_ASCENDING, TestSuiteSorter::ORDER_DEFAULT, false],
+            'modified-descending' => ['modified-descending', TestSuiteSorter::ORDER_MODIFIED_DESCENDING, TestSuiteSorter::ORDER_DEFAULT, false],
             'size-ascending'      => ['size-ascending', TestSuiteSorter::ORDER_SIZE_ASCENDING, TestSuiteSorter::ORDER_DEFAULT, false],
             'size-descending'     => ['size-descending', TestSuiteSorter::ORDER_SIZE_DESCENDING, TestSuiteSorter::ORDER_DEFAULT, false],
 
             'main order and defects'          => ['size-ascending,defects', TestSuiteSorter::ORDER_SIZE_ASCENDING, TestSuiteSorter::ORDER_DEFECTS_FIRST, false],
+            'modification time and defects'   => ['modified-descending,defects', TestSuiteSorter::ORDER_MODIFIED_DESCENDING, TestSuiteSorter::ORDER_DEFECTS_FIRST, false],
             'dependencies and main order'     => ['depends,reverse', TestSuiteSorter::ORDER_REVERSED, TestSuiteSorter::ORDER_DEFAULT, true],
             'dependencies, order, defects'    => ['depends,duration-ascending,defects', TestSuiteSorter::ORDER_DURATION_ASCENDING, TestSuiteSorter::ORDER_DEFECTS_FIRST, true],
             'no dependencies, order, defects' => ['no-depends,random,defects', TestSuiteSorter::ORDER_RANDOMIZED, TestSuiteSorter::ORDER_DEFECTS_FIRST, false],

--- a/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
+++ b/tests/unit/TextUI/Configuration/Xml/LoaderTest.php
@@ -50,6 +50,8 @@ final class LoaderTest extends TestCase
             'executionOrder reverse'             => ['executionOrder', 'reverse', TestSuiteSorter::ORDER_REVERSED],
             'executionOrder duration-ascending'  => ['executionOrder', 'duration-ascending', TestSuiteSorter::ORDER_DURATION_ASCENDING],
             'executionOrder duration-descending' => ['executionOrder', 'duration-descending', TestSuiteSorter::ORDER_DURATION_DESCENDING],
+            'executionOrder modified-ascending'  => ['executionOrder', 'modified-ascending', TestSuiteSorter::ORDER_MODIFIED_ASCENDING],
+            'executionOrder modified-descending' => ['executionOrder', 'modified-descending', TestSuiteSorter::ORDER_MODIFIED_DESCENDING],
             'executionOrder size-ascending'      => ['executionOrder', 'size-ascending', TestSuiteSorter::ORDER_SIZE_ASCENDING],
             'executionOrder size-descending'     => ['executionOrder', 'size-descending', TestSuiteSorter::ORDER_SIZE_DESCENDING],
             'cacheDirectory absolute path'       => ['cacheDirectory', '/path/to/cache', '/path/to/cache'],


### PR DESCRIPTION
While a test is being written, it might be at the end of the queue. Running the whole test suite to find out whether the test that was just changed passes means waiting for everything that was not changed to run first, and `--stop-on-failure` does not help: it stops at the first failure, not at the first interesting one.

The orders PHPUnit offers today do not express "the work I am doing right now". `duration-ascending` and `defects` describe what happened during the previous test run, `size-*` describes what a test declares about itself, and `random` and `reverse` do not describe anything.

The changes proposed here introduce two new orders for the `--order-by` CLI option and the `executionOrder` attribute in the XML configuration file:

* `modified-descending` runs the most recently modified tests first
* `modified-ascending` runs the least recently modified tests first

```
$ phpunit --order-by modified-descending --stop-on-failure
```

The tests you have just worked on run first, and the run stops at the first failure among them. As with every other order, it can be combined with moving previously defective tests to the front:

```
$ phpunit --order-by modified-descending,defects
```

## What counts as a modification

The order is based on the source files a test is made of, not just on the file that happens to declare its class: the class file, the files of the classes it extends, and the files of the traits any of them use. Changing an abstract base test class or a shared trait therefore moves every test class built on it to the front, which is what you want when you have just changed something they share. For a PHPT test, the `.phpt` file is the test. A test suite is as new as the newest test in it, so directories and `<testsuite>` elements sort sensibly too.

Unlike ordering by defects or by duration, this needs no test run history, so it works on the very first run and with `--do-not-record-test-run-history`.

## What it is not

The modification time of a file records when it was last written, not who wrote it or why. Checking out a branch, cloning a repository, installing dependencies and deploying files all rewrite it. On a continuous integration server, where every file is usually written at the same time, this order carries no information at all.

This is a tool for local development, and the documentation says so: it belongs on the command line, not in a project's committed XML configuration file.

Note also that many file systems store modification times with a resolution of one second, so tests whose files were written during the same second are equally new. Tests that are equally new keep the order they had before.