### PR TITLE
Add `#[RequiresClass]` attribute

### DIFF
--- a/ChangeLog-13.4.md
+++ b/ChangeLog-13.4.md
@@ -15,6 +15,7 @@ All notable changes of the PHPUnit 13.4 release series are documented in this fi
 * [#6960](https://github.com/sebastianbergmann/phpunit/pull/6960): Record the order in which methods of mock objects are invoked
 * `--coverage-jsonl` CLI option and `<jsonl>` element for the XML configuration file to write a code coverage report in JSONL format, one JSON object per line, that reports uncovered code rather than every executable line
 * `requireCoverageMetadataOnSmallTests`, `requireCoverageMetadataOnMediumTests`, and `requireCoverageMetadataOnLargeTests` attributes for the XML configuration file to require code coverage metadata depending on the size of a test; these have precedence over `requireCoverageMetadata`
+* `#[RequiresClass]` attribute to skip a test if a class does not exist
 
 ### Deprecated
 

--- a/src/Framework/Attributes/RequiresClass.php
+++ b/src/Framework/Attributes/RequiresClass.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Attributes;
+
+use Attribute;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final readonly class RequiresClass
+{
+    /**
+     * @var class-string
+     */
+    private string $className;
+
+    /**
+     * @param class-string $className
+     */
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+}

--- a/src/Metadata/Api/Requirements.php
+++ b/src/Metadata/Api/Requirements.php
@@ -16,6 +16,7 @@ use function addcslashes;
 use function array_column;
 use function array_key_exists;
 use function assert;
+use function class_exists;
 use function extension_loaded;
 use function function_exists;
 use function in_array;
@@ -27,6 +28,7 @@ use function sprintf;
 use function substr_count;
 use PHPUnit\Event\Facade;
 use PHPUnit\Metadata\Parser\Registry;
+use PHPUnit\Metadata\RequiresClass;
 use PHPUnit\Metadata\RequiresEnvironmentVariable;
 use PHPUnit\Metadata\RequiresFunction;
 use PHPUnit\Metadata\RequiresMethod;
@@ -206,6 +208,17 @@ final readonly class Requirements
                         'Method %s::%s() is required.',
                         $metadata->className(),
                         $metadata->methodName(),
+                    );
+                }
+            }
+
+            if ($metadata->isRequiresClass()) {
+                assert($metadata instanceof RequiresClass);
+
+                if (!class_exists($metadata->className())) {
+                    $notSatisfied[] = sprintf(
+                        'Class %s is required.',
+                        $metadata->className(),
                     );
                 }
             }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -344,6 +344,22 @@ abstract readonly class Metadata
     }
 
     /**
+     * @param class-string $className
+     */
+    public static function requiresClassOnClass(string $className): RequiresClass
+    {
+        return new RequiresClass(Level::CLASS_LEVEL, $className);
+    }
+
+    /**
+     * @param class-string $className
+     */
+    public static function requiresClassOnMethod(string $className): RequiresClass
+    {
+        return new RequiresClass(Level::METHOD_LEVEL, $className);
+    }
+
+    /**
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
@@ -979,6 +995,14 @@ abstract readonly class Metadata
      * @phpstan-assert-if-true RequiresMethod $this
      */
     public function isRequiresMethod(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @phpstan-assert-if-true RequiresClass $this
+     */
+    public function isRequiresClass(): bool
     {
         return false;
     }

--- a/src/Metadata/MetadataCollection.php
+++ b/src/Metadata/MetadataCollection.php
@@ -521,6 +521,16 @@ final readonly class MetadataCollection implements Countable, IteratorAggregate
         );
     }
 
+    public function isRequiresClass(): self
+    {
+        return new self(
+            ...array_filter(
+                $this->metadata,
+                static fn (Metadata $metadata): bool => $metadata->isRequiresClass(),
+            ),
+        );
+    }
+
     public function isRequiresFunction(): self
     {
         return new self(

--- a/src/Metadata/Parser/AttributeParser.php
+++ b/src/Metadata/Parser/AttributeParser.php
@@ -66,6 +66,7 @@ use PHPUnit\Framework\Attributes\PostCondition;
 use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\Repeat;
+use PHPUnit\Framework\Attributes\RequiresClass;
 use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresFunction;
 use PHPUnit\Framework\Attributes\RequiresMethod;
@@ -376,6 +377,13 @@ final readonly class AttributeParser implements Parser
                         $attributeInstance->className(),
                         $attributeInstance->methodName(),
                     );
+
+                    break;
+
+                case RequiresClass::class:
+                    assert($attributeInstance instanceof RequiresClass);
+
+                    $result[] = Metadata::requiresClassOnClass($attributeInstance->className());
 
                     break;
 
@@ -848,6 +856,13 @@ final readonly class AttributeParser implements Parser
                         $attributeInstance->className(),
                         $attributeInstance->methodName(),
                     );
+
+                    break;
+
+                case RequiresClass::class:
+                    assert($attributeInstance instanceof RequiresClass);
+
+                    $result[] = Metadata::requiresClassOnMethod($attributeInstance->className());
 
                     break;
 

--- a/src/Metadata/RequiresClass.php
+++ b/src/Metadata/RequiresClass.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata;
+
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class RequiresClass extends Metadata
+{
+    /**
+     * @var class-string
+     */
+    private string $className;
+
+    /**
+     * @param class-string $className
+     */
+    protected function __construct(Level $level, string $className)
+    {
+        parent::__construct($level);
+
+        $this->className = $className;
+    }
+
+    public function isRequiresClass(): true
+    {
+        return true;
+    }
+
+    /**
+     * @return class-string
+     */
+    public function className(): string
+    {
+        return $this->className;
+    }
+}

--- a/tests/_files/Metadata/Attribute/tests/RequiresClassTest.php
+++ b/tests/_files/Metadata/Attribute/tests/RequiresClassTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\Metadata\Attribute;
+
+use PHPUnit\Framework\Attributes\RequiresClass;
+use PHPUnit\Framework\TestCase;
+
+#[RequiresClass(TestCase::class)]
+final class RequiresClassTest extends TestCase
+{
+    #[RequiresClass(self::class)]
+    public function testOne(): void
+    {
+    }
+}

--- a/tests/_files/RequirementsTest.php
+++ b/tests/_files/RequirementsTest.php
@@ -9,6 +9,7 @@
  */
 namespace PHPUnit\TestFixture;
 
+use PHPUnit\Framework\Attributes\RequiresClass;
 use PHPUnit\Framework\Attributes\RequiresFunction;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
@@ -76,6 +77,11 @@ final class RequirementsTest extends TestCase
     {
     }
 
+    #[RequiresClass('DoesNotExist')]
+    public function testRequiresNonExistentClass(): void
+    {
+    }
+
     #[RequiresPhpExtension('testExt')]
     public function testTen(): void
     {
@@ -94,6 +100,7 @@ final class RequirementsTest extends TestCase
     #[RequiresFunction('testFuncOne')]
     #[RequiresFunction('testFunc2')]
     #[RequiresMethod('DoesNotExist', 'doesNotExist')]
+    #[RequiresClass('DoesNotExist')]
     #[RequiresPhpExtension('testExtOne')]
     #[RequiresPhpExtension('testExt2')]
     #[RequiresPhpExtension('testExtThree', '>= 2.0.0')]
@@ -109,6 +116,11 @@ final class RequirementsTest extends TestCase
 
     #[RequiresMethod(ReflectionMethod::class, 'setAccessible')]
     public function testExistingMethod(): void
+    {
+    }
+
+    #[RequiresClass(TestCase::class)]
+    public function testExistingClass(): void
     {
     }
 

--- a/tests/end-to-end/_files/requires_class/SomeTest.php
+++ b/tests/end-to-end/_files/requires_class/SomeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TestFixture\requires_class;
+
+use PHPUnit\Framework\Attributes\RequiresClass;
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    #[RequiresClass(TestCase::class)]
+    public function testExistingClass(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[RequiresClass(self::class)]
+    public function testTheTestClassItself(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    #[RequiresClass('PHPUnit\TestFixture\requires_class\ClassThatDoesNotExist')]
+    public function testShouldNotRunClassDoesNotExist(): void
+    {
+        $this->fail();
+    }
+}

--- a/tests/end-to-end/_files/requires_class/phpunit.xml
+++ b/tests/end-to-end/_files/requires_class/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../../phpunit.xsd"
+         colors="false"
+         recordTestRunHistory="false">
+    <testsuites>
+        <testsuite name="requires_class">
+            <file>SomeTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/end-to-end/metadata/requires-class.phpt
+++ b/tests/end-to-end/metadata/requires-class.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Tests are correctly ran based on class requirements
+--FILE--
+<?php declare(strict_types=1);
+$_SERVER['argv'][] = '--do-not-record-test-run-history';
+$_SERVER['argv'][] = '--configuration';
+$_SERVER['argv'][] = __DIR__ . '/../_files/requires_class/phpunit.xml';
+$_SERVER['argv'][] = '--display-skipped';
+
+require __DIR__ . '/../../bootstrap.php';
+
+(new PHPUnit\TextUI\Application)->run($_SERVER['argv']);
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Runtime: %s
+Configuration: %s
+
+..S                                                                 3 / 3 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 skipped test:
+
+1) PHPUnit\TestFixture\requires_class\SomeTest::testShouldNotRunClassDoesNotExist
+Class PHPUnit\TestFixture\requires_class\ClassThatDoesNotExist is required.
+
+OK, but some tests were skipped!
+Tests: 3, Assertions: 2, Skipped: 1.

--- a/tests/unit/Metadata/Api/RequirementsTest.php
+++ b/tests/unit/Metadata/Api/RequirementsTest.php
@@ -37,6 +37,9 @@ final class RequirementsTest extends TestCase
             ['testNine',           [
                 'Function testFunc() is required.',
             ]],
+            ['testRequiresNonExistentClass', [
+                'Class DoesNotExist is required.',
+            ]],
             ['testTen',            [
                 'PHP extension testExt is required, but it is not loaded.',
             ]],
@@ -57,6 +60,7 @@ final class RequirementsTest extends TestCase
                 'Function testFuncOne() is required.',
                 'Function testFunc2() is required.',
                 'Method DoesNotExist::doesNotExist() is required.',
+                'Class DoesNotExist is required.',
                 'PHP extension testExtOne is required, but it is not loaded.',
                 'PHP extension testExt2 is required, but it is not loaded.',
                 'PHP extension testExtThree >= 2.0.0 is required, but it is not loaded.',

--- a/tests/unit/Metadata/MetadataCollectionTest.php
+++ b/tests/unit/Metadata/MetadataCollectionTest.php
@@ -412,6 +412,14 @@ final class MetadataCollectionTest extends TestCase
         $this->assertTrue($collection->asArray()[0]->isRequiresMethod());
     }
 
+    public function test_Can_be_filtered_for_RequiresClass(): void
+    {
+        $collection = $this->collectionWithOneOfEach()->isRequiresClass();
+
+        $this->assertCount(1, $collection);
+        $this->assertTrue($collection->asArray()[0]->isRequiresClass());
+    }
+
     public function test_Can_be_filtered_for_RequiresFunction(): void
     {
         $collection = $this->collectionWithOneOfEach()->isRequiresFunction();
@@ -686,6 +694,7 @@ final class MetadataCollectionTest extends TestCase
                 Metadata::preCondition(0),
                 Metadata::preserveGlobalStateOnClass(true),
                 Metadata::requiresMethodOnClass('', ''),
+                Metadata::requiresClassOnClass(''),
                 Metadata::requiresFunctionOnClass(''),
                 Metadata::requiresOperatingSystemFamilyOnClass(''),
                 Metadata::requiresOperatingSystemOnClass(''),

--- a/tests/unit/Metadata/MetadataTest.php
+++ b/tests/unit/Metadata/MetadataTest.php
@@ -70,6 +70,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -146,6 +147,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -220,6 +222,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -293,6 +296,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -367,6 +371,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -441,6 +446,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -515,6 +521,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -591,6 +598,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -666,6 +674,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -740,6 +749,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -817,6 +827,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -892,6 +903,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -967,6 +979,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1042,6 +1055,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1117,6 +1131,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1193,6 +1208,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1266,6 +1282,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1339,6 +1356,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1416,6 +1434,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1493,6 +1512,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1570,6 +1590,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1645,6 +1666,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1726,6 +1748,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1802,6 +1825,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1879,6 +1903,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -1957,6 +1982,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2030,6 +2056,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2103,6 +2130,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2176,6 +2204,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2250,6 +2279,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2324,6 +2354,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2400,6 +2431,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2476,6 +2508,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2553,6 +2586,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2627,6 +2661,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2700,6 +2735,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2773,6 +2809,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2846,6 +2883,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2918,6 +2956,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -2990,6 +3029,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3064,6 +3104,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3139,6 +3180,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3210,6 +3252,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3283,6 +3326,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3358,6 +3402,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3434,6 +3479,7 @@ final class MetadataTest extends TestCase
         $this->assertTrue($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3501,6 +3547,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertTrue($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3569,6 +3616,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertTrue($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3644,6 +3692,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertTrue($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3720,6 +3769,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertTrue($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3796,6 +3846,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertTrue($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3871,6 +3922,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertTrue($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -3897,6 +3949,158 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isWithoutErrorHandler());
 
         $this->assertSame('f', $metadata->functionName());
+
+        $this->assertTrue($metadata->isMethodLevel());
+        $this->assertFalse($metadata->isClassLevel());
+    }
+
+    public function testCanBeRequiresClassOnClass(): void
+    {
+        $metadata = Metadata::requiresClassOnClass('C');
+
+        $this->assertFalse($metadata->isAfter());
+        $this->assertFalse($metadata->isAfterClass());
+        $this->assertFalse($metadata->isAllowMockObjectsWithoutExpectations());
+        $this->assertFalse($metadata->isBackupGlobals());
+        $this->assertFalse($metadata->isBackupStaticProperties());
+        $this->assertFalse($metadata->isBeforeClass());
+        $this->assertFalse($metadata->isBefore());
+        $this->assertFalse($metadata->isCoversNamespace());
+        $this->assertFalse($metadata->isCoversClass());
+        $this->assertFalse($metadata->isCoversClassesThatExtendClass());
+        $this->assertFalse($metadata->isCoversClassesThatImplementInterface());
+        $this->assertFalse($metadata->isCoversDirectory());
+        $this->assertFalse($metadata->isCoversDirectoryRecursively());
+        $this->assertFalse($metadata->isCoversFile());
+        $this->assertFalse($metadata->isCoversFunction());
+        $this->assertFalse($metadata->isCoversMethod());
+        $this->assertFalse($metadata->isCoversNothing());
+        $this->assertFalse($metadata->isCoversTrait());
+        $this->assertFalse($metadata->isDataProvider());
+        $this->assertFalse($metadata->isDataProviderClosure());
+        $this->assertFalse($metadata->isDependsOnClass());
+        $this->assertFalse($metadata->isDependsOnMethod());
+        $this->assertFalse($metadata->isDisableReturnValueGenerationForTestDoubles());
+        $this->assertFalse($metadata->isDoesNotPerformAssertions());
+        $this->assertFalse($metadata->isExcludeGlobalVariableFromBackup());
+        $this->assertFalse($metadata->isExcludeStaticPropertyFromBackup());
+        $this->assertFalse($metadata->isGroup());
+        $this->assertFalse($metadata->isIgnoreDeprecations());
+        $this->assertFalse($metadata->isIgnorePhpunitDeprecations());
+        $this->assertFalse($metadata->isIgnorePHPUnitWarnings());
+        $this->assertFalse($metadata->isInvalidAttribute());
+        $this->assertFalse($metadata->isRepeat());
+        $this->assertFalse($metadata->isRetry());
+        $this->assertFalse($metadata->isRunInSeparateProcess());
+        $this->assertFalse($metadata->isRunTestsInSeparateProcesses());
+        $this->assertFalse($metadata->isTest());
+        $this->assertFalse($metadata->isPreCondition());
+        $this->assertFalse($metadata->isPostCondition());
+        $this->assertFalse($metadata->isPreserveGlobalState());
+        $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertTrue($metadata->isRequiresClass());
+        $this->assertFalse($metadata->isRequiresFunction());
+        $this->assertFalse($metadata->isRequiresOperatingSystem());
+        $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
+        $this->assertFalse($metadata->isRequiresPhp());
+        $this->assertFalse($metadata->isRequiresPhpExtension());
+        $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPhpunitExtension());
+        $this->assertFalse($metadata->isRequiresEnvironmentVariable());
+        $this->assertFalse($metadata->isWithEnvironmentVariable());
+        $this->assertFalse($metadata->isRequiresSetting());
+        $this->assertFalse($metadata->isTestDox());
+        $this->assertFalse($metadata->isTestDoxFormatter());
+        $this->assertFalse($metadata->isTestWith());
+        $this->assertFalse($metadata->isUsesNamespace());
+        $this->assertFalse($metadata->isUsesClass());
+        $this->assertFalse($metadata->isUsesClassesThatExtendClass());
+        $this->assertFalse($metadata->isUsesClassesThatImplementInterface());
+        $this->assertFalse($metadata->isUsesDirectory());
+        $this->assertFalse($metadata->isUsesDirectoryRecursively());
+        $this->assertFalse($metadata->isUsesFile());
+        $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isUsesMethod());
+        $this->assertFalse($metadata->isUsesTrait());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
+
+        $this->assertSame('C', $metadata->className());
+
+        $this->assertTrue($metadata->isClassLevel());
+        $this->assertFalse($metadata->isMethodLevel());
+    }
+
+    public function testCanBeRequiresClassOnMethod(): void
+    {
+        $metadata = Metadata::requiresClassOnMethod('C');
+
+        $this->assertFalse($metadata->isAfter());
+        $this->assertFalse($metadata->isAfterClass());
+        $this->assertFalse($metadata->isAllowMockObjectsWithoutExpectations());
+        $this->assertFalse($metadata->isBackupGlobals());
+        $this->assertFalse($metadata->isBackupStaticProperties());
+        $this->assertFalse($metadata->isBeforeClass());
+        $this->assertFalse($metadata->isBefore());
+        $this->assertFalse($metadata->isCoversNamespace());
+        $this->assertFalse($metadata->isCoversClass());
+        $this->assertFalse($metadata->isCoversClassesThatExtendClass());
+        $this->assertFalse($metadata->isCoversClassesThatImplementInterface());
+        $this->assertFalse($metadata->isCoversDirectory());
+        $this->assertFalse($metadata->isCoversDirectoryRecursively());
+        $this->assertFalse($metadata->isCoversFile());
+        $this->assertFalse($metadata->isCoversFunction());
+        $this->assertFalse($metadata->isCoversMethod());
+        $this->assertFalse($metadata->isCoversNothing());
+        $this->assertFalse($metadata->isCoversTrait());
+        $this->assertFalse($metadata->isDataProvider());
+        $this->assertFalse($metadata->isDataProviderClosure());
+        $this->assertFalse($metadata->isDependsOnClass());
+        $this->assertFalse($metadata->isDependsOnMethod());
+        $this->assertFalse($metadata->isDisableReturnValueGenerationForTestDoubles());
+        $this->assertFalse($metadata->isDoesNotPerformAssertions());
+        $this->assertFalse($metadata->isExcludeGlobalVariableFromBackup());
+        $this->assertFalse($metadata->isExcludeStaticPropertyFromBackup());
+        $this->assertFalse($metadata->isGroup());
+        $this->assertFalse($metadata->isIgnoreDeprecations());
+        $this->assertFalse($metadata->isIgnorePhpunitDeprecations());
+        $this->assertFalse($metadata->isIgnorePHPUnitWarnings());
+        $this->assertFalse($metadata->isInvalidAttribute());
+        $this->assertFalse($metadata->isRepeat());
+        $this->assertFalse($metadata->isRetry());
+        $this->assertFalse($metadata->isRunInSeparateProcess());
+        $this->assertFalse($metadata->isRunTestsInSeparateProcesses());
+        $this->assertFalse($metadata->isTest());
+        $this->assertFalse($metadata->isPreCondition());
+        $this->assertFalse($metadata->isPostCondition());
+        $this->assertFalse($metadata->isPreserveGlobalState());
+        $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertTrue($metadata->isRequiresClass());
+        $this->assertFalse($metadata->isRequiresFunction());
+        $this->assertFalse($metadata->isRequiresOperatingSystem());
+        $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
+        $this->assertFalse($metadata->isRequiresPhp());
+        $this->assertFalse($metadata->isRequiresPhpExtension());
+        $this->assertFalse($metadata->isRequiresPhpunit());
+        $this->assertFalse($metadata->isRequiresPhpunitExtension());
+        $this->assertFalse($metadata->isRequiresEnvironmentVariable());
+        $this->assertFalse($metadata->isWithEnvironmentVariable());
+        $this->assertFalse($metadata->isRequiresSetting());
+        $this->assertFalse($metadata->isTestDox());
+        $this->assertFalse($metadata->isTestDoxFormatter());
+        $this->assertFalse($metadata->isTestWith());
+        $this->assertFalse($metadata->isUsesNamespace());
+        $this->assertFalse($metadata->isUsesClass());
+        $this->assertFalse($metadata->isUsesClassesThatExtendClass());
+        $this->assertFalse($metadata->isUsesClassesThatImplementInterface());
+        $this->assertFalse($metadata->isUsesDirectory());
+        $this->assertFalse($metadata->isUsesDirectoryRecursively());
+        $this->assertFalse($metadata->isUsesFile());
+        $this->assertFalse($metadata->isUsesFunction());
+        $this->assertFalse($metadata->isUsesMethod());
+        $this->assertFalse($metadata->isUsesTrait());
+        $this->assertFalse($metadata->isWithoutErrorHandler());
+
+        $this->assertSame('C', $metadata->className());
 
         $this->assertTrue($metadata->isMethodLevel());
         $this->assertFalse($metadata->isClassLevel());
@@ -3946,6 +4150,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertTrue($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4021,6 +4226,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertTrue($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4096,6 +4302,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertTrue($metadata->isRequiresOperatingSystemFamily());
@@ -4171,6 +4378,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertTrue($metadata->isRequiresOperatingSystemFamily());
@@ -4251,6 +4459,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4331,6 +4540,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4406,6 +4616,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4491,6 +4702,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4568,6 +4780,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4653,6 +4866,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4735,6 +4949,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4810,6 +5025,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4890,6 +5106,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -4965,6 +5182,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5040,6 +5258,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5116,6 +5335,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5192,6 +5412,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5268,6 +5489,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5344,6 +5566,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5420,6 +5643,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5496,6 +5720,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5571,6 +5796,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5646,6 +5872,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5722,6 +5949,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5800,6 +6028,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5875,6 +6104,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -5950,6 +6180,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6025,6 +6256,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6100,6 +6332,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6174,6 +6407,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6250,6 +6484,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6327,6 +6562,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6404,6 +6640,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6481,6 +6718,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6556,6 +6794,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6628,6 +6867,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());
@@ -6703,6 +6943,7 @@ final class MetadataTest extends TestCase
         $this->assertFalse($metadata->isPostCondition());
         $this->assertFalse($metadata->isPreserveGlobalState());
         $this->assertFalse($metadata->isRequiresMethod());
+        $this->assertFalse($metadata->isRequiresClass());
         $this->assertFalse($metadata->isRequiresFunction());
         $this->assertFalse($metadata->isRequiresOperatingSystem());
         $this->assertFalse($metadata->isRequiresOperatingSystemFamily());

--- a/tests/unit/Metadata/Parser/AttributeParserTest.php
+++ b/tests/unit/Metadata/Parser/AttributeParserTest.php
@@ -48,6 +48,7 @@ use PHPUnit\Framework\Attributes\Medium;
 use PHPUnit\Framework\Attributes\PostCondition;
 use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RequiresClass;
 use PHPUnit\Framework\Attributes\RequiresEnvironmentVariable;
 use PHPUnit\Framework\Attributes\RequiresFunction;
 use PHPUnit\Framework\Attributes\RequiresMethod;
@@ -125,6 +126,7 @@ use PHPUnit\Metadata\InvalidAttribute;
 #[CoversClass(PreCondition::class)]
 #[CoversClass(PreserveGlobalState::class)]
 #[CoversClass(RequiresFunction::class)]
+#[CoversClass(RequiresClass::class)]
 #[CoversClass(RequiresMethod::class)]
 #[CoversClass(RequiresOperatingSystemFamily::class)]
 #[CoversClass(RequiresOperatingSystem::class)]

--- a/tests/unit/Metadata/Parser/AttributeParserTestCase.php
+++ b/tests/unit/Metadata/Parser/AttributeParserTestCase.php
@@ -56,6 +56,7 @@ use PHPUnit\TestFixture\Metadata\Attribute\PhpunitAttributeThatDoesNotExistTest;
 use PHPUnit\TestFixture\Metadata\Attribute\PreserveGlobalStateTest;
 use PHPUnit\TestFixture\Metadata\Attribute\ProcessIsolationTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RepeatTest;
+use PHPUnit\TestFixture\Metadata\Attribute\RequiresClassTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresEnvironmentVariableTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresFunctionTest;
 use PHPUnit\TestFixture\Metadata\Attribute\RequiresMethodTest;
@@ -322,6 +323,16 @@ abstract class AttributeParserTestCase extends TestCase
         $this->assertTrue($metadata->asArray()[0]->isRequiresMethod());
         $this->assertSame('ClassName', $metadata->asArray()[0]->className());
         $this->assertSame('methodName', $metadata->asArray()[0]->methodName());
+    }
+
+    #[TestDox('Parses #[RequiresClass] attribute on class')]
+    public function test_parses_RequiresClass_attribute_on_class(): void
+    {
+        $metadata = $this->parser()->forClass(RequiresClassTest::class)->isRequiresClass();
+
+        $this->assertCount(1, $metadata);
+        $this->assertTrue($metadata->asArray()[0]->isRequiresClass());
+        $this->assertSame(TestCase::class, $metadata->asArray()[0]->className());
     }
 
     #[TestDox('Parses #[RequiresFunction] attribute on class')]
@@ -983,6 +994,16 @@ abstract class AttributeParserTestCase extends TestCase
         $this->assertTrue($metadata->asArray()[0]->isRequiresMethod());
         $this->assertSame('AnotherClassName', $metadata->asArray()[0]->className());
         $this->assertSame('anotherMethodName', $metadata->asArray()[0]->methodName());
+    }
+
+    #[TestDox('Parses #[RequiresClass] attribute on method')]
+    public function test_parses_RequiresClass_attribute_on_method(): void
+    {
+        $metadata = $this->parser()->forMethod(RequiresClassTest::class, 'testOne')->isRequiresClass();
+
+        $this->assertCount(1, $metadata);
+        $this->assertTrue($metadata->asArray()[0]->isRequiresClass());
+        $this->assertSame(RequiresClassTest::class, $metadata->asArray()[0]->className());
     }
 
     #[TestDox('Parses #[RequiresFunction] attribute on method')]


### PR DESCRIPTION
## Summary

Adds a new `#[RequiresClass]` attribute that skips a test when a given class does not exist, completing the `Requires*` family of attributes:

- `#[RequiresFunction]` — skips when a function does not exist
- `#[RequiresMethod]` — skips when a method does not exist
- `#[RequiresClass]` — skips when a class does not exist (new)

## Usage

```php
#[RequiresClass('Vendor\Package\OptionalClass')]
public function testSomething(): void
{
    // ...
}
```

When `Vendor\Package\OptionalClass `does not exist, the test is skipped with:
Class `Vendor\Package\OptionalClass` is required.
The attribute is repeatable and can be used on both test classes and test methods.

## Changes
- `src/Framework/Attributes/RequiresClass.php` — new attribute
- `src/Metadata/RequiresClass.php` — new metadata object
- `src/Metadata/Metadata.php` — `requiresClassOnClass()` / `requiresClassOnMethod()` factories and `isRequiresClass()`
- `src/Metadata/MetadataCollection.php` — `isRequiresClass()` filter
- `src/Metadata/Parser/AttributeParser.php` — parses the attribute at class and method level
- `src/Metadata/Api/Requirements.php` — checks `class_exists()` and reports unsatisfied requirement
- `ChangeLog-13.4.md` — changelog entry

## Tests
- Unit tests for metadata parsing (class and method level), metadata filtering, and requirement evaluation
- End-to-end test (tests/end-to-end/metadata/requires-class.phpt)
- Full unit suite passes, PHPStan and php-cs-fixer are clean